### PR TITLE
Keep tied embeddings in fp32

### DIFF
--- a/train_gpt.py
+++ b/train_gpt.py
@@ -514,10 +514,14 @@ class CastedLinear(nn.Linear):
 
 
 def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
-    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    # Keep the high-leverage tied embedding plus small/control parameters in fp32.
     with torch.no_grad():
         for name, param in module.named_parameters():
-            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+            if (
+                name == "tok_emb.weight"
+                or param.ndim < 2
+                or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+            ) and param.dtype != torch.float32:
                 param.data = param.data.float()
 
 
@@ -698,7 +702,7 @@ class GPT(nn.Module):
                 nn.init.zeros_(module.weight)
 
     def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
-        x = self.tok_emb(input_ids)
+        x = F.embedding(input_ids, self.tok_emb.weight).to(dtype=torch.bfloat16)
         x = F.rms_norm(x, (x.size(-1),))
         x0 = x
         skips: list[Tensor] = []
@@ -715,7 +719,7 @@ class GPT(nn.Module):
         x = self.final_norm(x).reshape(-1, x.size(-1))
         targets = target_ids.reshape(-1)
         if self.tie_embeddings:
-            logits_proj = F.linear(x, self.tok_emb.weight)
+            logits_proj = F.linear(x, self.tok_emb.weight.to(dtype=x.dtype))
         else:
             if self.lm_head is None:
                 raise RuntimeError("lm_head is required when tie_embeddings=False")

--- a/train_gpt_mlx.py
+++ b/train_gpt_mlx.py
@@ -405,7 +405,7 @@ class GPT(nn.Module):
             b.mlp.proj.weight = mx.zeros_like(b.mlp.proj.weight)
         self.tok_emb.weight = (
             mx.random.normal(self.tok_emb.weight.shape, dtype=mx.float32) * tied_embed_init_std
-        ).astype(COMPUTE_DTYPE)
+        )
 
     def softcap(self, logits: mx.array) -> mx.array:
         c = self.logit_softcap


### PR DESCRIPTION
## Summary
- keep `tok_emb.weight` as an fp32 master parameter in both the CUDA and MLX trainers
- cast embedding activations and tied-head weights back to bf16 only at compute time
- align tied embeddings with the existing fp32-master treatment already used for linear weights

## Why
The tied embedding is one of the highest-leverage parameters in this baseline because it is both the input embedding table and the output head. The baseline currently trains it directly in bf16, unlike the linear weights, which keep fp32 master weights and cast on use.

## Local test
I ran the MLX path locally on Apple Silicon with a fixed smoke config and a patched subset validation harness (`20` steps, `4x256` model, first `16` validation sequences) to compare directionally identical runs.

Baseline log:
- pre-quant: `val_bpb 3.7256`
- int8 roundtrip: `val_bpb 3.73939058`
- quantized artifact: `1824906` bytes

This patch:
- pre-quant: `val_bpb 3.7250`
- int8 roundtrip: `val_bpb 3.73832186`
- quantized artifact: `1825080` bytes

So the local smoke improved both pre-quant and post-quant validation while keeping the compressed artifact essentially unchanged.