### PR TITLE
Experiment#1 : Deeper compact 

### DIFF
--- a/MLX_EXPERIMENT_NOTES.md
+++ b/MLX_EXPERIMENT_NOTES.md
@@ -1,0 +1,60 @@
+# MLX Experiment Notes
+
+These are local Apple Silicon experiment notes from the Codex exploration branch.
+They are not leaderboard-quality results, because they used capped validation via
+`VAL_MAX_BATCHES` for faster iteration.
+
+## Useful Local Knob
+
+- `VAL_MAX_BATCHES`
+  - Local-only helper for faster smoke tests.
+  - `0` means full validation.
+  - Small values like `16` or `64` are useful for quick comparisons on a laptop.
+
+## Best Local Direction So Far
+
+The strongest local result we found was:
+
+```bash
+RUN_ID=mlx_mlp1_layers11_ab300 \
+ITERATIONS=300 \
+TRAIN_BATCH_TOKENS=8192 \
+VAL_LOSS_EVERY=0 \
+VAL_BATCH_SIZE=524288 \
+VAL_MAX_BATCHES=64 \
+MLP_MULT=1 \
+NUM_LAYERS=11 \
+.venv/bin/python train_gpt_mlx.py
+```
+
+Observed result:
+
+- `serialized_model_int8_zlib: 10418730 bytes`
+- `final_int8_zlib_roundtrip_exact val_bpb: 2.30746143`
+
+## Key Comparisons
+
+Best comparison set so far used: `TRAIN_BATCH_TOKENS=8192`, `VAL_BATCH_SIZE=524288`, `VAL_MAX_BATCHES=64`.
+
+| Config | Compressed Bytes | Roundtrip `val_bpb` | Notes |
+|---|---:|---:|---|
+| Baseline (`MLP_MULT=2`, `NUM_LAYERS=9`, `ITERATIONS=200`) | 11258346 | 2.44989649 | Strong quality baseline |
+| Compact MLP (`MLP_MULT=1`, `NUM_LAYERS=9`, `ITERATIONS=200`) | 8303583 | 2.47262920 | Much smaller, but worse |
+| Deeper compact (`MLP_MULT=1`, `NUM_LAYERS=11`, `ITERATIONS=200`) | 9984744 | 2.44481887 | Beat baseline while staying smaller |
+| Deeper compact (`MLP_MULT=1`, `NUM_LAYERS=12`, `ITERATIONS=200`) | 10736033 | 2.46008228 | Worse than 11 layers |
+| Deeper compact (`MLP_MULT=1`, `NUM_LAYERS=11`, `NUM_KV_HEADS=2`, `ITERATIONS=200`) | 10759634 | 2.45219887 | KV-head reduction hurt |
+| Deeper compact (`MLP_MULT=1`, `NUM_LAYERS=11`, `ITERATIONS=300`) | 10418730 | 2.30746143 | Current best local result |
+
+## Dead Ends We Tested
+
+- Embedding factorization (`EMBED_RANK`)
+  - Helped in tiny smoke tests.
+  - Lost to baseline in longer runs.
+
+- Post-training magnitude pruning
+  - Barely changed compressed size.
+  - Slightly hurt `val_bpb`.
+
+## Recommended Next Step
+
+Use `MLP_MULT=1` and `NUM_LAYERS=11` as the local working baseline and scale training from there.

--- a/train_gpt_mlx.py
+++ b/train_gpt_mlx.py
@@ -52,6 +52,7 @@ class Hyperparameters:
     val_loss_every: int = int(os.environ.get("VAL_LOSS_EVERY", 0))
     # Validation always uses the full fineweb_val split.
     val_batch_size: int = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_max_batches: int = int(os.environ.get("VAL_MAX_BATCHES", 0))
     train_log_every: int = int(os.environ.get("TRAIN_LOG_EVERY", 200))
     train_batch_tokens: int = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
     grad_accum_steps: int = int(os.environ.get("GRAD_ACCUM_STEPS", 8))
@@ -774,10 +775,14 @@ def eval_val(
     val_batch_seqs = val_batch_tokens // args.train_seq_len
     total_seqs = (val_tokens.size - 1) // args.train_seq_len
     total_batches = max((total_seqs + val_batch_seqs - 1) // val_batch_seqs, 1)
+    if args.val_max_batches > 0:
+        total_batches = min(total_batches, args.val_max_batches)
     total_loss_sum = 0.0
     total_tokens = 0.0
     total_bytes = 0.0
     for batch_idx, batch_seq_start in enumerate(range(0, total_seqs, val_batch_seqs), start=1):
+        if batch_idx > total_batches:
+            break
         batch_seq_end = min(batch_seq_start + val_batch_seqs, total_seqs)
         raw_start = batch_seq_start * args.train_seq_len
         raw_end = batch_seq_end * args.train_seq_len + 1
@@ -933,7 +938,7 @@ def main() -> None:
     log(
         f"iterations:{args.iterations} train_batch_tokens:{args.train_batch_tokens} grad_accum_steps:{args.grad_accum_steps} "
         f"microbatch_tokens:{args.microbatch_tokens} microbatch_batch_size:{args.microbatch_tokens // args.train_seq_len} "
-        f"val_batch_size:{args.val_batch_size} "
+        f"val_batch_size:{args.val_batch_size} val_max_batches:{args.val_max_batches} "
         f"warmup_steps:{args.warmup_steps} max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
     )
     log(f"mlx_max_microbatch_tokens:{args.mlx_max_microbatch_tokens}")


### PR DESCRIPTION
 MLX Experiment Notes

These are local Apple Silicon experiment notes from the Codex exploration branch.
They are not leaderboard-quality results, because they used capped validation via
`VAL_MAX_BATCHES` for faster iteration.

## Useful Local Knob

- `VAL_MAX_BATCHES`
  - Local-only helper for faster smoke tests.
  - `0` means full validation.
  - Small values like `16` or `64` are useful for quick comparisons on a laptop.

## Best Local Direction So Far

The strongest local result we found was:

```bash
RUN_ID=mlx_mlp1_layers11_ab300 \
ITERATIONS=300 \
TRAIN_BATCH_TOKENS=8192 \
VAL_LOSS_EVERY=0 \
VAL_BATCH_SIZE=524288 \
VAL_MAX_BATCHES=64 \
MLP_MULT=1 \
NUM_LAYERS=11 \
.venv/bin/python train_gpt_mlx.py
```

Observed result:

- `serialized_model_int8_zlib: 10418730 bytes`
- `final_int8_zlib_roundtrip_exact val_bpb: 2.30746143`

## Key Comparisons

Best comparison set so far used: `TRAIN_BATCH_TOKENS=8192`, `VAL_BATCH_SIZE=524288`, `VAL_MAX_BATCHES=64`.

| Config | Compressed Bytes | Roundtrip `val_bpb` | Notes |
|---|---:|---:|---|
| Baseline (`MLP_MULT=2`, `NUM_LAYERS=9`, `ITERATIONS=200`) | 11258346 | 2.44989649 | Strong quality baseline |
| Compact MLP (`MLP_MULT=1`, `NUM_LAYERS=9`, `ITERATIONS=200`) | 8303583 | 2.47262920 | Much smaller, but worse |
| Deeper compact (`MLP_MULT=1`, `NUM_LAYERS=11`, `ITERATIONS=200`) | 9984744 | 2.44481887 | Beat baseline while staying smaller |
| Deeper compact (`MLP_MULT=1`, `NUM_LAYERS=12`, `ITERATIONS=200`) | 10736033 | 2.46008228 | Worse than 11 layers |
| Deeper compact (`MLP_MULT=1`, `NUM_LAYERS=11`, `NUM_KV_HEADS=2`, `ITERATIONS=200`) | 10759634 | 2.45219887 | KV-head reduction hurt |
| Deeper compact (`MLP_MULT=1`, `NUM_LAYERS=11`, `ITERATIONS=300`) | 10418730 | 2.30746143 | Current best local result |

## Dead Ends We Tested

- Embedding factorization (`EMBED_RANK`)
  - Helped in tiny smoke tests.
  - Lost to baseline in longer runs.

- Post-training magnitude pruning
  - Barely changed compressed size.
  - Slightly hurt `val_bpb`.

## Recommended Next Step

Use `MLP_MULT=1` and `NUM_LAYERS=11` as the local working baseline and scale training from there.