### PR TITLE
Submission: Top-Heavy FFN Allocation + Packed Int6 Export | pending eval

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,164 @@
+# Parameter Golf Notes
+
+## Repo Rules
+
+### Exact 16 MB Artifact Definition
+
+- The hard cap is **decimal** `16,000,000` bytes, not `16 MiB`.
+- The counted artifact is:
+  - `len(train_gpt.py in UTF-8 bytes)`
+  - plus the **compressed model bytes**
+- The README is explicit that counted code should live in `train_gpt.py`.
+- No network calls, dataset access, or external downloads are allowed during evaluation.
+- Evaluation itself also has a separate runtime cap: under 10 minutes on `8xH100`.
+
+Source:
+- `README.md`, FAQ section and submission process.
+
+## Exact Eval Metric
+
+From `train_gpt.py`:
+
+1. Validation loss is average token cross-entropy in **natural log units**:
+   - `val_loss = sum(token_ce) / num_val_tokens`
+2. Convert to bits per token:
+   - `bits_per_token = val_loss / ln(2)`
+3. Compute tokenizer-aware bytes represented by each target token:
+   - base UTF-8 byte length of the SentencePiece token
+   - plus one extra byte for a leading space when the piece starts with `▁` and the previous token is not a boundary token
+4. Convert to tokens per byte:
+   - `tokens_per_byte = num_val_tokens / num_val_bytes`
+5. Final metric:
+   - `val_bpb = bits_per_token * tokens_per_byte`
+
+Important implementation detail:
+- Baseline validation uses **non-overlapping** chunks of length `TRAIN_SEQ_LEN` (or `EVAL_SEQ_LEN` in some PRs).
+- Many strong PRs improve score further with **sliding-window eval**, but the underlying `val_bpb` formula above stays the same.
+
+Relevant code:
+- `train_gpt.py`: `build_sentencepiece_luts`, `load_validation_tokens`, `eval_val`
+
+## Baseline Architecture
+
+Baseline config from README, baseline record, and root `train_gpt.py`:
+
+- Decoder-only GPT
+- `VOCAB_SIZE=1024`
+- `NUM_LAYERS=9`
+- `MODEL_DIM=512`
+- `NUM_HEADS=8`
+- `NUM_KV_HEADS=4` (GQA)
+- `MLP_MULT=2` so FFN hidden size is `1024`
+- tied input/output embeddings
+- RoPE attention
+- RMSNorm
+- `relu^2` MLP
+- zero-initialized attention and MLP output projections
+- encoder/decoder-style skip reuse:
+  - first half of blocks store skips
+  - second half re-inject them in reverse order with learned skip weights
+
+Exact baseline parameter count:
+
+- `17,059,912` parameters
+
+Baseline record metrics:
+
+- Pre-quant `val_bpb`: `1.2172`
+- Post-quant roundtrip `val_bpb`: `1.22436570`
+- Artifact size: `15,863,489` bytes
+
+Sources:
+- `README.md`
+- `records/track_10min_16mb/2026-03-17_NaiveBaseline/README.md`
+- `records/track_10min_16mb/2026-03-17_NaiveBaseline/train.log`
+
+## Leaderboard Snapshot Seen
+
+### Committed README Leaderboard
+
+- `1.2060` — `2048 seq length`
+- `1.2197` — `fp16 Embed`
+- `1.2244` — `Naive Baseline`
+- notable non-record:
+  - `1.2074` — `4-Hour Baseline`
+
+### Live PR State Pulled From GitHub API
+
+README is already stale relative to open PRs. Strongest current public PRs I found are:
+
+- `#106` — `1.15824056`
+  - title: `record: 1.158`
+  - branch indicates it is an exact-export follow-up to PR #88
+- `#88` — `1.16050360`
+  - `Int6 MLP3x + MTP + Sliding Window Eval`
+- `#99` — `1.16050360`
+  - `Int6 MLP3x + Late-K Passthrough + SlidingWindow`
+- `#102` — `1.1618`
+  - `Int6 MLP3x + Tuned LR + SmearGate + SlidingWindow`
+- `#89` — `1.1622`
+  - `NorMuon + int6 STE + SWA + sliding window`
+
+Notes:
+
+- I excluded obviously non-standard or special-case titles like the `val-only` PRs when summarizing the strongest standard submissions.
+- The main repo leaderboard has not yet caught up to the live PR frontier.
+
+## What Top PRs Already Tried
+
+Across the strongest public submissions, the field is converging on a pretty clear recipe:
+
+- **fp16 tied embedding passthrough**
+  - embedding/head quantization is highly sensitive
+- **mixed low-bit export**
+  - especially `int6` for large matrices
+- **artifact compression tricks**
+  - mostly `zstd`-based in the top PRs
+- **uniform 9x512 body with wider FFN**
+  - especially `MLP 3x` instead of baseline `2x`
+- **sliding-window eval**
+  - commonly stride `64` or `512`
+- **optimizer retuning**
+  - lower LR, higher Muon momentum, longer warmdown
+- **long-context training**
+  - `TRAIN_SEQ_LEN=2048` and `4096`
+- **MTP auxiliary loss**
+  - small extra head, often excluded from exported artifact
+- **late-stage quantization-awareness**
+  - QAT or fake quant / STE
+- **selective preservation of sensitive layers**
+  - e.g. fp16 late `K` projections
+- **SWA / EMA / NorMuon**
+  - modest training-dynamics improvements
+- **small architectural extras**
+  - e.g. SmearGate
+
+## Negative Results / Approaches Mentioned As Weak
+
+From PR READMEs:
+
+- depth recurrence / looped transformers often had:
+  - worse throughput
+  - larger quantization gaps
+  - too few effective steps in 10 minutes
+- SwiGLU often improved per-step quality but hurt total steps enough to lose overall
+- MoE was too slow at this scale
+- aggressive pruning often compounded quantization error
+- per-group quantization sometimes bloated artifact size
+- generic QAT helped less than hoped unless very carefully targeted
+
+## Main Gap I See
+
+Top public PRs are overwhelmingly using the same **uniform 9x512 backbone** and competing on:
+
+- export format
+- eval strategy
+- minor training-dynamics tweaks
+
+I did **not** find a top-5 PR using systematic **layer-wise / top-heavy parameter allocation** in the OpenELM sense, where later layers get wider FFNs than early layers at the same total parameter budget.
+
+That looks like the cleanest open lane:
+
+- theoretically motivated
+- different from the current top cluster
+- compatible with the proven low-bit + sliding-eval infrastructure

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,53 @@
+### Approach
+
+This submission focuses on **parameter allocation**, not just export format. The current public frontier is clustered around a uniform `9 x 512` backbone with stronger quantization and evaluation tricks. I kept the proven surrounding recipe, but replaced the uniform `3x` FFN with **OpenELM-style layer-wise scaling** so later blocks get larger FFNs and earlier blocks get smaller ones at the same overall budget.
+
+The exact FFN schedule is:
+
+`768, 960, 1152, 1344, 1536, 1728, 1920, 2112, 2304`
+
+The motivation is that, under a strict parameter budget, later layers are closer to the next-token loss and should benefit more from extra capacity than early layers. This is especially attractive in the Parameter Golf setting because the challenge is strongly **parameter-limited** relative to the 10-minute 8xH100 compute budget. Chinchilla-style reasoning says the available training compute could support a much larger model than the 16 MB artifact allows, so the right move is to spend the byte budget as efficiently as possible inside the model rather than leaving it uniformly distributed.
+
+To support that architecture cleanly, I also implemented an **exact packed-int6 export path** with per-row fp16 scales. This keeps the submission self-contained and avoids relying on an external `zstd` dependency at evaluation time. I keep the tied embedding in fp16 because that tensor is especially quantization-sensitive and serves as both the input embedding and output projection.
+
+Finally, the trainer includes **sliding-window evaluation** and a **CPU `DRY_RUN=1` mode** so the full train/export/eval pipeline can be verified locally without CUDA. Because I do not currently have GPU credits, I am not claiming a score yet and am leaving final eval metrics pending.
+
+### Key Design Decisions
+
+- Use **top-heavy FFN allocation** instead of a uniform `3x` FFN so later layers get more of the parameter budget.
+- Keep the proven **9-layer, 512-dim, tied-embedding, GQA** backbone for a controlled comparison against public baselines.
+- Export large matrices as **packed int6 + per-row fp16 scale + zlib** to make the artifact fully self-contained.
+- Keep `tok_emb.weight` in **fp16** because it is the most quantization-sensitive tensor in public submissions.
+- Retain **sliding-window eval** because it is allowed by the rules and is consistently helpful in public runs.
+- Use **seed 42** by default and add a **10-step CPU dry-run** path for reproducibility without GPUs.
+
+### What I Expect to Underperform / Risks
+
+- The main risk is that layer-wise FFN scaling is theoretically motivated but not yet validated on this exact challenge objective.
+- Packed int6 + zlib is self-contained, but the trained checkpoint still needs to prove it compresses comfortably under the 16 MB cap.
+- If this challenge is dominated more by export/eval tricks than by parameter placement, the gain over a strong uniform-FFN baseline may be modest.
+
+### Results
+
+| Metric | Value |
+|---|---|
+| Baseline eval loss | `1.22436570` val_bpb (repo baseline) |
+| Final eval loss | Pending — training to be run once compute credits are granted |
+| Parameter count | `21,778,504` |
+| Artifact size | Measured init-export: `4,273,390` bytes total; dense-random stress probe: `16,549,133` bytes total |
+| Training time (estimated on 8×H100) | Expected to fit the 600s budget; public 21.8M-parameter 9x512 runs report roughly `45–57 ms/step`, implying about `10k–13k` steps in 10 minutes |
+
+### Reproducibility
+
+Seed: `42`.
+
+Dry-run verified locally with:
+
+`DRY_RUN=1 RUN_ID=topheavy_dryrun python train_gpt.py`
+
+Full 8xH100 train/eval pending compute access.
+
+### References
+
+- Hoffmann et al., *Training Compute-Optimal Large Language Models*, 2022
+- Mehta et al., *OpenELM*, 2024

--- a/records/track_10min_16mb/2026-03-19_TopHeavyFFN_PackedInt6_PendingEval/README.md
+++ b/records/track_10min_16mb/2026-03-19_TopHeavyFFN_PackedInt6_PendingEval/README.md
@@ -1,0 +1,118 @@
+# Top-Heavy FFN + Packed Int6 Export
+
+## Status
+
+This folder is **PR-ready but eval-pending**.
+
+We do **not** currently have GPU access, so there is no 8xH100 training log yet and no claimed leaderboard score. What is included here is:
+
+- a standalone `train_gpt.py`
+- a real CPU `DRY_RUN=1` smoke log
+- exact local measurements for parameter count and export-size sanity checks
+
+## Core Idea
+
+The strongest public PRs are converging on the same lane:
+
+- uniform `9 x 512` backbone
+- wider `3x` FFN
+- low-bit export
+- sliding-window eval
+
+This submission keeps the proven surrounding infrastructure, but changes **where the parameters live**.
+
+Instead of a uniform `3x` FFN in every block, it uses **OpenELM-style layer-wise scaling** so later layers get larger FFNs and early layers get smaller ones, while keeping the same overall parameter budget:
+
+`768, 960, 1152, 1344, 1536, 1728, 1920, 2112, 2304`
+
+The motivation is simple:
+
+- under a fixed artifact budget, later layers are closer to the loss and should benefit more from extra capacity
+- early layers mostly need to build local lexical/syntactic features and can be narrower
+- the 10-minute training budget makes it especially important to allocate parameters where gradients are most direct
+
+## Design Choices
+
+- **Top-heavy FFN allocation**
+  - Primary novelty. Same total FFN budget as a uniform `3x` model, but shifted toward later layers.
+- **Tied embeddings**
+  - Baseline-efficient parameter sharing still matters at this scale.
+- **Packed int6 export**
+  - Large 2D matrices are stored as exact packed 6-bit values with per-row fp16 scales.
+  - This avoids relying on an external `zstd` dependency during evaluation.
+- **FP16 embedding passthrough**
+  - The tied embedding / output head is the most quantization-sensitive tensor.
+- **Sliding-window eval**
+  - Included because it is legal under the rules and consistently improves token context at scoring time.
+- **Tuned short-horizon training defaults**
+  - Lower LR, higher Muon momentum, longer warmdown, and gradient clipping follow the public lessons from early strong submissions.
+- **CPU dry-run mode**
+  - `DRY_RUN=1` swaps in synthetic data and a tiny smoke-test architecture so contributors can verify the full train/export/eval path locally without CUDA.
+
+## Local Measurements
+
+Exact full-submission architecture:
+
+- Parameter count: `21,778,504`
+- FFN schedule: `768,960,1152,1344,1536,1728,1920,2112,2304`
+- Code size: `60,837` bytes
+
+Measured export-path sanity checks:
+
+- Init export, packed int6 + zlib:
+  - model bytes: `4,212,553`
+  - total bytes: `4,273,390`
+- Dense-random stress probe, packed int6 + zlib:
+  - total bytes: `16,549,133`
+
+Interpretation:
+
+- The init export is a correctness check, not a realistic trained-artifact estimate.
+- The dense-random probe is intentionally pessimistic.
+- Final trained artifact size remains **pending compute**.
+
+## Baseline Reference
+
+Public baseline from the repo:
+
+- Baseline `val_bpb`: `1.22436570`
+- Baseline artifact size: `15,863,489` bytes
+
+## Risks
+
+- The layer-wise FFN schedule is well-motivated, but it has not yet been validated on this exact challenge distribution.
+- Packed int6 + zlib is self-contained, but the final trained model still needs to demonstrate enough compressibility to stay comfortably below the cap.
+- Because the current frontier already uses strong eval-time tricks, the gain from better parameter allocation may be modest unless it also improves quantization robustness.
+
+## Reproducibility
+
+Seed defaults to `42`.
+
+CPU smoke test:
+
+```bash
+DRY_RUN=1 RUN_ID=topheavy_dryrun python train_gpt.py
+```
+
+Intended real run once compute is available:
+
+```bash
+RUN_ID=topheavy_ffn_packed_int6 \
+SEED=42 \
+MAX_WALLCLOCK_SECONDS=600 \
+VAL_LOSS_EVERY=0 \
+TRAIN_LOG_EVERY=200 \
+EVAL_STRIDE=64 \
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+## Files
+
+- `train_gpt.py` — standalone trainer and exporter
+- `submission.json` — pending-eval metadata
+- `dry_run.log` — verified local 10-step CPU smoke run
+
+## References
+
+- Hoffmann et al., *Training Compute-Optimal Large Language Models* (Chinchilla), 2022
+- Mehta et al., *OpenELM*, 2024

--- a/records/track_10min_16mb/2026-03-19_TopHeavyFFN_PackedInt6_PendingEval/dry_run.log
+++ b/records/track_10min_16mb/2026-03-19_TopHeavyFFN_PackedInt6_PendingEval/dry_run.log
@@ -1,0 +1,1476 @@
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: To keep readable for newcomers, let's make sure `train_gpt.py` and `train_gpt_mlx.py` never are longer than 1500 lines.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 42))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 0))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", train_seq_len))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.7))
+
+    # CPU-only smoke-test mode for local verification without the real dataset.
+    dry_run = bool(int(os.environ.get("DRY_RUN", "0")))
+    dry_run_steps = int(os.environ.get("DRY_RUN_STEPS", 10))
+    dry_run_total_tokens = int(os.environ.get("DRY_RUN_TOTAL_TOKENS", 131_072))
+    dry_run_device = os.environ.get("DRY_RUN_DEVICE", "cpu")
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 3))
+    mlp_hidden_base = int(os.environ.get("MLP_HIDDEN_BASE", str(mlp_mult * model_dim)))
+    use_top_heavy_ffn = bool(int(os.environ.get("USE_TOP_HEAVY_FFN", "1")))
+    mlp_scale_min = float(os.environ.get("MLP_SCALE_MIN", 0.5))
+    mlp_scale_max = float(os.environ.get("MLP_SCALE_MAX", 1.5))
+    mlp_hidden_multiple = int(os.environ.get("MLP_HIDDEN_MULTIPLE", 64))
+    mlp_hidden_schedule = os.environ.get("MLP_HIDDEN_SCHEDULE", "")
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 1.0))
+
+
+def round_to_multiple(value: int, multiple: int) -> int:
+    if multiple <= 1:
+        return max(1, value)
+    return max(multiple, int(multiple * round(value / multiple)))
+
+
+def build_top_heavy_mlp_schedule(args: Hyperparameters) -> list[int]:
+    if args.mlp_hidden_schedule:
+        schedule = [int(chunk) for chunk in args.mlp_hidden_schedule.split(",") if chunk.strip()]
+        if len(schedule) != args.num_layers:
+            raise ValueError(
+                f"MLP_HIDDEN_SCHEDULE must provide {args.num_layers} entries, got {len(schedule)}"
+            )
+        return schedule
+    if not args.use_top_heavy_ffn:
+        return [args.mlp_hidden_base for _ in range(args.num_layers)]
+    if args.num_layers == 1:
+        return [round_to_multiple(args.mlp_hidden_base, args.mlp_hidden_multiple)]
+
+    schedule = []
+    for layer_idx in range(args.num_layers):
+        frac = layer_idx / (args.num_layers - 1)
+        scale = args.mlp_scale_min + (args.mlp_scale_max - args.mlp_scale_min) * frac
+        hidden = round_to_multiple(int(round(args.mlp_hidden_base * scale)), args.mlp_hidden_multiple)
+        schedule.append(hidden)
+    return schedule
+
+
+def autocast_context(device: torch.device, enabled: bool = True):
+    if not enabled or device.type != "cuda":
+        return contextlib.nullcontext()
+    return torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True)
+
+
+def decompress_zlib_blob(blob: bytes) -> bytes:
+    decompressor = zlib.decompressobj()
+    out = io.BytesIO()
+    out.write(decompressor.decompress(blob))
+    out.write(decompressor.flush())
+    return out.getvalue()
+
+# -----------------------------
+# MUON OPTIMIZER 
+# -----------------------------
+# 
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def build_synthetic_luts(vocab_size: int, device: torch.device) -> tuple[Tensor, Tensor, Tensor]:
+    # Dry-run mode does not care about true tokenizer bytes, only that the metric
+    # plumbing stays exercised end-to-end. Treat every token as one byte.
+    return (
+        torch.ones((vocab_size,), dtype=torch.int16, device=device),
+        torch.zeros((vocab_size,), dtype=torch.bool, device=device),
+        torch.zeros((vocab_size,), dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.eval_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, EVAL_SEQ_LEN={args.eval_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.eval_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.eval_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.eval_seq_len
+            raw_end = batch_seq_end * args.eval_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.eval_seq_len)
+            y = local[1:].reshape(-1, args.eval_seq_len)
+            with autocast_context(device):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    seq_len = args.eval_seq_len
+    stride = args.eval_stride
+    if stride <= 0 or stride >= seq_len:
+        return eval_val(
+            args,
+            base_model,
+            rank,
+            world_size,
+            device,
+            grad_accum_steps=1,
+            val_tokens=val_tokens,
+            base_bytes_lut=base_bytes_lut,
+            has_leading_space_lut=has_leading_space_lut,
+            is_boundary_token_lut=is_boundary_token_lut,
+        )
+
+    total_tokens = val_tokens.numel()
+    starts: list[int] = []
+    pos = 0
+    while pos + seq_len < total_tokens:
+        starts.append(pos)
+        pos += stride
+    total_windows = len(starts)
+    win_start = (total_windows * rank) // world_size
+    win_end = (total_windows * (rank + 1)) // world_size
+    score_offset = seq_len - stride
+
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    with torch.inference_mode():
+        for wi in range(win_start, win_end):
+            s = starts[wi]
+            window = val_tokens[s : s + seq_len + 1].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = window[:-1].unsqueeze(0)
+            y = window[1:].unsqueeze(0)
+            with autocast_context(device):
+                logits = base_model.forward_logits(x)
+            tail_logits = logits[0, score_offset:, :].float()
+            tail_targets = y[0, score_offset:]
+            per_token_loss = F.cross_entropy(tail_logits, tail_targets, reduction="none")
+            val_loss_sum += per_token_loss.to(torch.float64).sum()
+            val_token_count += float(stride)
+
+            tail_prev = x[0, score_offset:]
+            tail_tgt = y[0, score_offset:]
+            token_bytes = base_bytes_lut[tail_tgt].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tail_tgt] & ~is_boundary_token_lut[tail_prev]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    base_model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16/fp32, at that same precision.
+# We therefore quantize large matrices to exact packed int6 and zlib-compress the result.
+# Packing the 6-bit values ourselves keeps the artifact self-contained: there is no need
+# for an external compression library such as zstd during evaluation.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+    ).split(",")
+    if pattern
+)
+KEEP_FLOAT_FP16_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "KEEP_FLOAT_FP16_NAME_PATTERNS",
+        "tok_emb.weight",
+    ).split(",")
+    if pattern
+)
+KEEP_FLOAT_MAX_NUMEL = 65_536
+KEEP_FLOAT_STORE_DTYPE = torch.float16
+PER_ROW_SCALE_DTYPE = torch.float16
+LOWBIT_BITS = int(os.environ.get("LOWBIT_BITS", 6))
+if LOWBIT_BITS != 6:
+    raise ValueError(f"This export path currently supports LOWBIT_BITS=6 only, got {LOWBIT_BITS}")
+LOWBIT_CLIP_RANGE = (1 << (LOWBIT_BITS - 1)) - 1
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS):
+        return t.float().contiguous()
+    if any(pattern in name for pattern in KEEP_FLOAT_FP16_NAME_PATTERNS):
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=KEEP_FLOAT_STORE_DTYPE).contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim != 2:
+        raise ValueError(f"Packed int6 export expects matrices, got shape {tuple(t32.shape)}")
+    scale = (t32.abs().amax(dim=1) / LOWBIT_CLIP_RANGE).clamp_min(1.0 / LOWBIT_CLIP_RANGE)
+    q = torch.clamp(torch.round(t32 / scale[:, None]), -LOWBIT_CLIP_RANGE, LOWBIT_CLIP_RANGE).to(torch.int8)
+    return q.contiguous(), scale.to(dtype=PER_ROW_SCALE_DTYPE).contiguous()
+
+def pack_signed_lowbit_tensor(q: Tensor) -> tuple[Tensor, int]:
+    flat = (q.reshape(-1).to(torch.int16) + LOWBIT_CLIP_RANGE).to(torch.uint8)
+    original_numel = int(flat.numel())
+    pad = (-original_numel) % 4
+    if pad:
+        flat = torch.cat((flat, torch.zeros((pad,), dtype=torch.uint8)), dim=0)
+    groups = flat.view(-1, 4).to(torch.int32)
+    a, b, c, d = groups.unbind(dim=1)
+    byte0 = a | ((b & 0x03) << 6)
+    byte1 = ((b >> 2) & 0x0F) | ((c & 0x0F) << 4)
+    byte2 = ((c >> 4) & 0x03) | (d << 2)
+    packed = torch.stack((byte0, byte1, byte2), dim=1).to(torch.uint8).reshape(-1).contiguous()
+    return packed, original_numel
+
+def unpack_signed_lowbit_tensor(packed: Tensor, original_numel: int) -> Tensor:
+    groups = packed.reshape(-1, 3).to(torch.int32)
+    byte0, byte1, byte2 = groups.unbind(dim=1)
+    a = byte0 & 0x3F
+    b = ((byte0 >> 6) & 0x03) | ((byte1 & 0x0F) << 2)
+    c = ((byte1 >> 4) & 0x0F) | ((byte2 & 0x03) << 4)
+    d = (byte2 >> 2) & 0x3F
+    flat = torch.stack((a, b, c, d), dim=1).reshape(-1)[:original_numel]
+    return (flat.to(torch.int16) - LOWBIT_CLIP_RANGE).to(torch.int8).contiguous()
+
+def quantize_state_dict_lowbit(state_dict: dict[str, Tensor]):
+    # Export format:
+    # - exact packed int6 for large 2D float tensors
+    # - fp16 passthrough for embeddings / small tensors
+    # - exact passthrough for non-floats
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    shapes: dict[str, list[int]] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        (
+            "param_count",
+            "num_tensors",
+            "num_float_tensors",
+            "num_nonfloat_tensors",
+            "baseline_tensor_bytes",
+            "packed_payload_bytes",
+        ),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["packed_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        if t.numel() <= KEEP_FLOAT_MAX_NUMEL or t.ndim != 2 or any(pattern in name for pattern in KEEP_FLOAT_FP16_NAME_PATTERNS):
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["packed_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        packed_q, original_numel = pack_signed_lowbit_tensor(q)
+        quantized[name] = packed_q
+        scales[name] = s
+        shapes[name] = list(t.shape)
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        qmeta[name] = {
+            "scheme": "per_row_packed_lowbit",
+            "bits": LOWBIT_BITS,
+            "clip_range": LOWBIT_CLIP_RANGE,
+            "numel": original_numel,
+        }
+        stats["packed_payload_bytes"] += tensor_nbytes(packed_q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "packed_lowbit_rowwise_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "shapes": shapes,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+        "qmeta": qmeta,
+    }
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_lowbit(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, packed_q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        shape = tuple(int(v) for v in obj["shapes"][name])
+        original_numel = int(obj["qmeta"][name]["numel"])
+        q = unpack_signed_lowbit_tensor(packed_q, original_numel).view(shape)
+        s = obj["scales"][name]
+        s = s.to(dtype=torch.float32)
+        out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING 
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+class SyntheticTokenStream:
+    def __init__(self, vocab_size: int, total_tokens: int, seed: int):
+        generator = torch.Generator(device="cpu")
+        generator.manual_seed(seed)
+        self.tokens = torch.randint(vocab_size, (total_tokens,), generator=generator, dtype=torch.int64)
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        end = self.pos + n
+        if end <= self.tokens.numel():
+            chunk = self.tokens[self.pos:end]
+            self.pos = end % self.tokens.numel()
+            return chunk
+        head = self.tokens[self.pos:]
+        tail = self.tokens[: end - self.tokens.numel()]
+        self.pos = end - self.tokens.numel()
+        return torch.cat((head, tail), dim=0)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+
+class SyntheticTokenLoader(DistributedTokenLoader):
+    def __init__(self, vocab_size: int, total_tokens: int, rank: int, world_size: int, device: torch.device, seed: int):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = SyntheticTokenStream(vocab_size=vocab_size, total_tokens=total_tokens, seed=seed)
+
+
+def make_synthetic_validation_tokens(vocab_size: int, seq_len: int, total_tokens: int, seed: int) -> Tensor:
+    usable = max(seq_len, ((total_tokens - 1) // seq_len) * seq_len)
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(seed)
+    return torch.randint(vocab_size, (usable + 1,), generator=generator, dtype=torch.int64)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, self.weight.to(x.dtype), bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    # relu^2 keeps the fast baseline activation, while layer-wise hidden sizes let us
+    # spend more parameters near the logits where the loss is attached most directly.
+    def __init__(self, dim: int, hidden: int):
+        super().__init__()
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_hidden: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_hidden)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_hidden_schedule: list[int],
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.mlp_hidden_schedule = list(mlp_hidden_schedule)
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    self.mlp_hidden_schedule[i],
+                    rope_base,
+                    qk_gain_init,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+
+        # First half stores skips; second half reuses them in reverse order.
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        logits = self.forward_logits(input_ids).reshape(-1, self.tok_emb.num_embeddings)
+        targets = target_ids.reshape(-1)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    if args.dry_run:
+        args.num_layers = min(args.num_layers, 2)
+        args.model_dim = min(args.model_dim, 128)
+        args.num_heads = min(args.num_heads, 4)
+        args.num_kv_heads = min(args.num_kv_heads, args.num_heads)
+        args.mlp_hidden_base = min(args.mlp_hidden_base, 384)
+        args.mlp_hidden_multiple = min(args.mlp_hidden_multiple, 32)
+        args.dry_run_total_tokens = min(args.dry_run_total_tokens, 4_096)
+        args.train_seq_len = min(args.train_seq_len, 32)
+        args.eval_seq_len = min(args.eval_seq_len, 32)
+        args.train_batch_tokens = min(args.train_batch_tokens, 1_024)
+        args.val_batch_size = min(args.val_batch_size, 1_024)
+        args.eval_stride = min(max(args.eval_stride, 1), max(args.eval_seq_len // 4, 1))
+    if torch.cuda.is_available() and not args.dry_run:
+        zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + DEVICE SETUP
+    # -----------------------------
+
+    distributed = (not args.dry_run) and "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0")) if distributed else 0
+    world_size = int(os.environ.get("WORLD_SIZE", "1")) if distributed else 1
+    local_rank = int(os.environ.get("LOCAL_RANK", "0")) if distributed else 0
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if not args.dry_run and 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 1 if args.dry_run else 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if args.dry_run:
+        device = torch.device(args.dry_run_device)
+    else:
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA is required unless DRY_RUN=1")
+        device = torch.device("cuda", local_rank)
+        torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    if device.type == "cuda":
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+        from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+        enable_cudnn_sdp(False)
+        enable_flash_sdp(True)
+        enable_mem_efficient_sdp(False)
+        enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    if device.type == "cuda":
+        log0(
+            subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+            console=False,
+        )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    if device.type == "cuda":
+        torch.cuda.manual_seed_all(args.seed)
+
+    if args.dry_run:
+        val_tokens = make_synthetic_validation_tokens(
+            vocab_size=args.vocab_size,
+            seq_len=args.eval_seq_len,
+            total_tokens=args.dry_run_total_tokens,
+            seed=args.seed + 1,
+        )
+        base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_synthetic_luts(args.vocab_size, device)
+        dataset_dir = Path("<synthetic>")
+        actual_train_files = 0
+        log0("val_bpb:enabled tokenizer_kind=synthetic")
+    else:
+        if not args.tokenizer_path.endswith(".model"):
+            raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+        sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+        if int(sp.vocab_size()) != args.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+            )
+        dataset_dir = Path(args.data_path).resolve()
+        actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+        val_tokens = load_validation_tokens(args.val_files, args.eval_seq_len)
+        base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+            sp, args.vocab_size, device
+        )
+        log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    mlp_hidden_schedule = build_top_heavy_mlp_schedule(args)
+    model_dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_hidden_schedule=mlp_hidden_schedule,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+    ).to(device=device, dtype=model_dtype)
+    if device.type == "cuda":
+        for module in base_model.modules():
+            if isinstance(module, CastedLinear):
+                module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    if device.type == "cuda" and not args.dry_run:
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    else:
+        compiled_model = base_model
+    train_model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+    eval_model: nn.Module = base_model
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    use_fused_adam = device.type == "cuda"
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=use_fused_adam,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=use_fused_adam,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=use_fused_adam,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    if device.type == "cuda":
+        log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    else:
+        log0("sdp_backends:cpu_dry_run")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"eval_seq_len:{args.eval_seq_len} eval_stride:{args.eval_stride} "
+        f"iterations:{args.dry_run_steps if args.dry_run else args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"mlp_hidden_schedule:{','.join(str(v) for v in mlp_hidden_schedule)}")
+    log0(
+        f"use_top_heavy_ffn:{int(args.use_top_heavy_ffn)} "
+        f"mlp_hidden_base:{args.mlp_hidden_base} "
+        f"mlp_scale_range:[{args.mlp_scale_min:.2f},{args.mlp_scale_max:.2f}]"
+    )
+    log0(f"seed:{args.seed}")
+    if args.dry_run:
+        log0(f"dry_run:1 dry_run_steps:{args.dry_run_steps} dry_run_total_tokens:{args.dry_run_total_tokens}")
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    if args.dry_run:
+        train_loader = SyntheticTokenLoader(
+            vocab_size=args.vocab_size,
+            total_tokens=args.dry_run_total_tokens,
+            rank=rank,
+            world_size=world_size,
+            device=device,
+            seed=args.seed,
+        )
+    else:
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = None
+    if args.max_wallclock_seconds > 0 and not args.dry_run:
+        max_wallclock_ms = 1000.0 * args.max_wallclock_seconds
+    total_iterations = args.dry_run_steps if args.dry_run else args.iterations
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(total_iterations - args.warmdown_iters, 0)
+            if warmdown_start <= step < total_iterations:
+                return max((total_iterations - step) / max(args.warmdown_iters, 1), 0.0)
+            return 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    warmup_steps = 0 if args.dry_run else args.warmup_steps
+    if warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        train_model.train()
+        for warmup_step in range(warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    train_model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with autocast_context(device):
+                    warmup_loss = train_model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            train_model.require_backward_grad_sync = True
+        if args.dry_run:
+            train_loader = SyntheticTokenLoader(
+                vocab_size=args.vocab_size,
+                total_tokens=args.dry_run_total_tokens,
+                rank=rank,
+                world_size=world_size,
+                device=device,
+                seed=args.seed,
+            )
+        else:
+            train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == total_iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            if device.type == "cuda":
+                torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                eval_model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{total_iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            if device.type == "cuda":
+                torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < total_iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{total_iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                train_model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with autocast_context(device):
+                loss = train_model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{total_iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    if device.type == "cuda":
+        log0(
+            f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+            f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+        )
+    else:
+        log0("peak memory allocated: cpu_dry_run")
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed packed-int6 artifact and validate the round-tripped weights.
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_lowbit(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.lowbit.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.lowbit.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["packed_payload_bytes"], 1)
+        log0(
+            f"Serialized model packed_int6+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['packed_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size packed_int6+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.lowbit.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(decompress_zlib_blob(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_lowbit(quant_state), strict=True)
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        eval_model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    log0(
+        f"final_packed_int6_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_packed_int6_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if args.eval_stride > 0:
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        slide_val_loss, slide_val_bpb = eval_val_sliding(
+            args,
+            eval_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+        )
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+        log0(
+            f"sliding_window_eval val_loss:{slide_val_loss:.4f} val_bpb:{slide_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"sliding_window_eval_exact val_loss:{slide_val_loss:.8f} val_bpb:{slide_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
+Running Python 3.10.5 (tags/v3.10.5:f377153, Jun  6 2022, 16:14:13) [MSC v.1929 64 bit (AMD64)]
+Running PyTorch 2.7.1+cpu
+====================================================================================================
+val_bpb:enabled tokenizer_kind=synthetic
+train_loader:dataset:<synthetic> train_shards:0
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024\fineweb_val_*.bin tokens:4064
+model_params:459912
+world_size:1 grad_accum_steps:1
+sdp_backends:cpu_dry_run
+attention_mode:gqa num_heads:4 num_kv_heads:4
+tie_embeddings:True embed_lr:0.03 head_lr:0.0 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:1024 train_seq_len:32 eval_seq_len:32 eval_stride:8 iterations:10 warmup_steps:20 max_wallclock_seconds:600.000
+mlp_hidden_schedule:192,576
+use_top_heavy_ffn:1 mlp_hidden_base:384 mlp_scale_range:[0.50,1.50]
+seed:42
+dry_run:1 dry_run_steps:10 dry_run_total_tokens:4096
+step:1/10 train_loss:6.9308 train_time:853ms step_avg:853.12ms
+step:2/10 train_loss:6.9307 train_time:1724ms step_avg:862.08ms
+step:3/10 train_loss:6.9324 train_time:2542ms step_avg:847.46ms
+step:4/10 train_loss:6.9345 train_time:3371ms step_avg:842.71ms
+step:5/10 train_loss:6.9077 train_time:4209ms step_avg:841.81ms
+step:6/10 train_loss:6.9160 train_time:5134ms step_avg:855.72ms
+step:7/10 train_loss:6.9220 train_time:5989ms step_avg:855.60ms
+step:8/10 train_loss:6.9264 train_time:6847ms step_avg:855.83ms
+step:9/10 train_loss:6.8997 train_time:7706ms step_avg:856.22ms
+step:10/10 train_loss:6.9099 train_time:8541ms step_avg:854.13ms
+step:10/10 val_loss:6.9339 val_bpb:10.0035 train_time:8542ms step_avg:854.20ms
+peak memory allocated: cpu_dry_run
+Serialized model: 1847889 bytes
+Code size: 60837 bytes
+Total submission size: 1908726 bytes
+Serialized model packed_int6+zlib: 598395 bytes (payload:739232 raw_torch:746971 payload_ratio:2.49x)
+Total submission size packed_int6+zlib: 659232 bytes
+final_packed_int6_zlib_roundtrip val_loss:6.9339 val_bpb:10.0035 eval_time:110ms
+final_packed_int6_zlib_roundtrip_exact val_loss:6.93390232 val_bpb:10.00350650
+sliding_window_eval val_loss:6.9340 val_bpb:10.0036 stride:8 eval_time:2088ms
+sliding_window_eval_exact val_loss:6.93397372 val_bpb:10.00360949

--- a/records/track_10min_16mb/2026-03-19_TopHeavyFFN_PackedInt6_PendingEval/submission.json
+++ b/records/track_10min_16mb/2026-03-19_TopHeavyFFN_PackedInt6_PendingEval/submission.json
@@ -1,0 +1,21 @@
+{
+  "author": "Ashish Pandey",
+  "github_id": "mr-ashish-panday",
+  "name": "Top-Heavy FFN + Packed Int6 Export (pending eval)",
+  "blurb": "Pending-compute submission built around OpenELM-style layer-wise FFN scaling on the 9x512 backbone, exact packed-int6 export, fp16 tied-embedding passthrough, and sliding-window evaluation. Seed-42 dry-run verified locally; full 8xH100 training and eval pending.",
+  "date": "2026-03-19T18:30:00Z",
+  "status": "pending_eval",
+  "baseline_val_bpb": 1.2243657,
+  "val_loss": null,
+  "val_bpb": null,
+  "step_stop": null,
+  "wallclock_seconds": null,
+  "bytes_total": null,
+  "bytes_model_packed_int6_zlib": null,
+  "bytes_code": 60837,
+  "init_export_bytes_total": 4273390,
+  "init_export_bytes_model_packed_int6_zlib": 4212553,
+  "dense_random_probe_bytes_total": 16549133,
+  "parameter_count": 21778504,
+  "seed": 42
+}

--- a/records/track_10min_16mb/2026-03-19_TopHeavyFFN_PackedInt6_PendingEval/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-19_TopHeavyFFN_PackedInt6_PendingEval/train_gpt.py
@@ -1,0 +1,1437 @@
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: To keep readable for newcomers, let's make sure `train_gpt.py` and `train_gpt_mlx.py` never are longer than 1500 lines.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 42))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 0))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", train_seq_len))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.7))
+
+    # CPU-only smoke-test mode for local verification without the real dataset.
+    dry_run = bool(int(os.environ.get("DRY_RUN", "0")))
+    dry_run_steps = int(os.environ.get("DRY_RUN_STEPS", 10))
+    dry_run_total_tokens = int(os.environ.get("DRY_RUN_TOTAL_TOKENS", 131_072))
+    dry_run_device = os.environ.get("DRY_RUN_DEVICE", "cpu")
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 3))
+    mlp_hidden_base = int(os.environ.get("MLP_HIDDEN_BASE", str(mlp_mult * model_dim)))
+    use_top_heavy_ffn = bool(int(os.environ.get("USE_TOP_HEAVY_FFN", "1")))
+    mlp_scale_min = float(os.environ.get("MLP_SCALE_MIN", 0.5))
+    mlp_scale_max = float(os.environ.get("MLP_SCALE_MAX", 1.5))
+    mlp_hidden_multiple = int(os.environ.get("MLP_HIDDEN_MULTIPLE", 64))
+    mlp_hidden_schedule = os.environ.get("MLP_HIDDEN_SCHEDULE", "")
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 1.0))
+
+
+def round_to_multiple(value: int, multiple: int) -> int:
+    if multiple <= 1:
+        return max(1, value)
+    return max(multiple, int(multiple * round(value / multiple)))
+
+
+def build_top_heavy_mlp_schedule(args: Hyperparameters) -> list[int]:
+    if args.mlp_hidden_schedule:
+        schedule = [int(chunk) for chunk in args.mlp_hidden_schedule.split(",") if chunk.strip()]
+        if len(schedule) != args.num_layers:
+            raise ValueError(
+                f"MLP_HIDDEN_SCHEDULE must provide {args.num_layers} entries, got {len(schedule)}"
+            )
+        return schedule
+    if not args.use_top_heavy_ffn:
+        return [args.mlp_hidden_base for _ in range(args.num_layers)]
+    if args.num_layers == 1:
+        return [round_to_multiple(args.mlp_hidden_base, args.mlp_hidden_multiple)]
+
+    schedule = []
+    for layer_idx in range(args.num_layers):
+        frac = layer_idx / (args.num_layers - 1)
+        scale = args.mlp_scale_min + (args.mlp_scale_max - args.mlp_scale_min) * frac
+        hidden = round_to_multiple(int(round(args.mlp_hidden_base * scale)), args.mlp_hidden_multiple)
+        schedule.append(hidden)
+    return schedule
+
+
+def autocast_context(device: torch.device, enabled: bool = True):
+    if not enabled or device.type != "cuda":
+        return contextlib.nullcontext()
+    return torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True)
+
+
+def decompress_zlib_blob(blob: bytes) -> bytes:
+    decompressor = zlib.decompressobj()
+    out = io.BytesIO()
+    out.write(decompressor.decompress(blob))
+    out.write(decompressor.flush())
+    return out.getvalue()
+
+# -----------------------------
+# MUON OPTIMIZER 
+# -----------------------------
+# 
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def build_synthetic_luts(vocab_size: int, device: torch.device) -> tuple[Tensor, Tensor, Tensor]:
+    # Dry-run mode does not care about true tokenizer bytes, only that the metric
+    # plumbing stays exercised end-to-end. Treat every token as one byte.
+    return (
+        torch.ones((vocab_size,), dtype=torch.int16, device=device),
+        torch.zeros((vocab_size,), dtype=torch.bool, device=device),
+        torch.zeros((vocab_size,), dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.eval_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, EVAL_SEQ_LEN={args.eval_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.eval_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.eval_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.eval_seq_len
+            raw_end = batch_seq_end * args.eval_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.eval_seq_len)
+            y = local[1:].reshape(-1, args.eval_seq_len)
+            with autocast_context(device):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    seq_len = args.eval_seq_len
+    stride = args.eval_stride
+    if stride <= 0 or stride >= seq_len:
+        return eval_val(
+            args,
+            base_model,
+            rank,
+            world_size,
+            device,
+            grad_accum_steps=1,
+            val_tokens=val_tokens,
+            base_bytes_lut=base_bytes_lut,
+            has_leading_space_lut=has_leading_space_lut,
+            is_boundary_token_lut=is_boundary_token_lut,
+        )
+
+    total_tokens = val_tokens.numel()
+    starts: list[int] = []
+    pos = 0
+    while pos + seq_len < total_tokens:
+        starts.append(pos)
+        pos += stride
+    total_windows = len(starts)
+    win_start = (total_windows * rank) // world_size
+    win_end = (total_windows * (rank + 1)) // world_size
+    score_offset = seq_len - stride
+
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    with torch.inference_mode():
+        for wi in range(win_start, win_end):
+            s = starts[wi]
+            window = val_tokens[s : s + seq_len + 1].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = window[:-1].unsqueeze(0)
+            y = window[1:].unsqueeze(0)
+            with autocast_context(device):
+                logits = base_model.forward_logits(x)
+            tail_logits = logits[0, score_offset:, :].float()
+            tail_targets = y[0, score_offset:]
+            per_token_loss = F.cross_entropy(tail_logits, tail_targets, reduction="none")
+            val_loss_sum += per_token_loss.to(torch.float64).sum()
+            val_token_count += float(stride)
+
+            tail_prev = x[0, score_offset:]
+            tail_tgt = y[0, score_offset:]
+            token_bytes = base_bytes_lut[tail_tgt].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tail_tgt] & ~is_boundary_token_lut[tail_prev]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    base_model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16/fp32, at that same precision.
+# We therefore quantize large matrices to exact packed int6 and zlib-compress the result.
+# Packing the 6-bit values ourselves keeps the artifact self-contained: there is no need
+# for an external compression library such as zstd during evaluation.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+    ).split(",")
+    if pattern
+)
+KEEP_FLOAT_FP16_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "KEEP_FLOAT_FP16_NAME_PATTERNS",
+        "tok_emb.weight",
+    ).split(",")
+    if pattern
+)
+KEEP_FLOAT_MAX_NUMEL = 65_536
+KEEP_FLOAT_STORE_DTYPE = torch.float16
+PER_ROW_SCALE_DTYPE = torch.float16
+LOWBIT_BITS = int(os.environ.get("LOWBIT_BITS", 6))
+if LOWBIT_BITS != 6:
+    raise ValueError(f"This export path currently supports LOWBIT_BITS=6 only, got {LOWBIT_BITS}")
+LOWBIT_CLIP_RANGE = (1 << (LOWBIT_BITS - 1)) - 1
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS):
+        return t.float().contiguous()
+    if any(pattern in name for pattern in KEEP_FLOAT_FP16_NAME_PATTERNS):
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=KEEP_FLOAT_STORE_DTYPE).contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim != 2:
+        raise ValueError(f"Packed int6 export expects matrices, got shape {tuple(t32.shape)}")
+    scale = (t32.abs().amax(dim=1) / LOWBIT_CLIP_RANGE).clamp_min(1.0 / LOWBIT_CLIP_RANGE)
+    q = torch.clamp(torch.round(t32 / scale[:, None]), -LOWBIT_CLIP_RANGE, LOWBIT_CLIP_RANGE).to(torch.int8)
+    return q.contiguous(), scale.to(dtype=PER_ROW_SCALE_DTYPE).contiguous()
+
+def pack_signed_lowbit_tensor(q: Tensor) -> tuple[Tensor, int]:
+    flat = (q.reshape(-1).to(torch.int16) + LOWBIT_CLIP_RANGE).to(torch.uint8)
+    original_numel = int(flat.numel())
+    pad = (-original_numel) % 4
+    if pad:
+        flat = torch.cat((flat, torch.zeros((pad,), dtype=torch.uint8)), dim=0)
+    groups = flat.view(-1, 4).to(torch.int32)
+    a, b, c, d = groups.unbind(dim=1)
+    byte0 = a | ((b & 0x03) << 6)
+    byte1 = ((b >> 2) & 0x0F) | ((c & 0x0F) << 4)
+    byte2 = ((c >> 4) & 0x03) | (d << 2)
+    packed = torch.stack((byte0, byte1, byte2), dim=1).to(torch.uint8).reshape(-1).contiguous()
+    return packed, original_numel
+
+def unpack_signed_lowbit_tensor(packed: Tensor, original_numel: int) -> Tensor:
+    groups = packed.reshape(-1, 3).to(torch.int32)
+    byte0, byte1, byte2 = groups.unbind(dim=1)
+    a = byte0 & 0x3F
+    b = ((byte0 >> 6) & 0x03) | ((byte1 & 0x0F) << 2)
+    c = ((byte1 >> 4) & 0x0F) | ((byte2 & 0x03) << 4)
+    d = (byte2 >> 2) & 0x3F
+    flat = torch.stack((a, b, c, d), dim=1).reshape(-1)[:original_numel]
+    return (flat.to(torch.int16) - LOWBIT_CLIP_RANGE).to(torch.int8).contiguous()
+
+def quantize_state_dict_lowbit(state_dict: dict[str, Tensor]):
+    # Export format:
+    # - exact packed int6 for large 2D float tensors
+    # - fp16 passthrough for embeddings / small tensors
+    # - exact passthrough for non-floats
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    shapes: dict[str, list[int]] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        (
+            "param_count",
+            "num_tensors",
+            "num_float_tensors",
+            "num_nonfloat_tensors",
+            "baseline_tensor_bytes",
+            "packed_payload_bytes",
+        ),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["packed_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        if t.numel() <= KEEP_FLOAT_MAX_NUMEL or t.ndim != 2 or any(pattern in name for pattern in KEEP_FLOAT_FP16_NAME_PATTERNS):
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["packed_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        packed_q, original_numel = pack_signed_lowbit_tensor(q)
+        quantized[name] = packed_q
+        scales[name] = s
+        shapes[name] = list(t.shape)
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        qmeta[name] = {
+            "scheme": "per_row_packed_lowbit",
+            "bits": LOWBIT_BITS,
+            "clip_range": LOWBIT_CLIP_RANGE,
+            "numel": original_numel,
+        }
+        stats["packed_payload_bytes"] += tensor_nbytes(packed_q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "packed_lowbit_rowwise_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "shapes": shapes,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+        "qmeta": qmeta,
+    }
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_lowbit(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, packed_q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        shape = tuple(int(v) for v in obj["shapes"][name])
+        original_numel = int(obj["qmeta"][name]["numel"])
+        q = unpack_signed_lowbit_tensor(packed_q, original_numel).view(shape)
+        s = obj["scales"][name]
+        s = s.to(dtype=torch.float32)
+        out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING 
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+class SyntheticTokenStream:
+    def __init__(self, vocab_size: int, total_tokens: int, seed: int):
+        generator = torch.Generator(device="cpu")
+        generator.manual_seed(seed)
+        self.tokens = torch.randint(vocab_size, (total_tokens,), generator=generator, dtype=torch.int64)
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        end = self.pos + n
+        if end <= self.tokens.numel():
+            chunk = self.tokens[self.pos:end]
+            self.pos = end % self.tokens.numel()
+            return chunk
+        head = self.tokens[self.pos:]
+        tail = self.tokens[: end - self.tokens.numel()]
+        self.pos = end - self.tokens.numel()
+        return torch.cat((head, tail), dim=0)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+
+class SyntheticTokenLoader(DistributedTokenLoader):
+    def __init__(self, vocab_size: int, total_tokens: int, rank: int, world_size: int, device: torch.device, seed: int):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = SyntheticTokenStream(vocab_size=vocab_size, total_tokens=total_tokens, seed=seed)
+
+
+def make_synthetic_validation_tokens(vocab_size: int, seq_len: int, total_tokens: int, seed: int) -> Tensor:
+    usable = max(seq_len, ((total_tokens - 1) // seq_len) * seq_len)
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(seed)
+    return torch.randint(vocab_size, (usable + 1,), generator=generator, dtype=torch.int64)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, self.weight.to(x.dtype), bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    # relu^2 keeps the fast baseline activation, while layer-wise hidden sizes let us
+    # spend more parameters near the logits where the loss is attached most directly.
+    def __init__(self, dim: int, hidden: int):
+        super().__init__()
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_hidden: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_hidden)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_hidden_schedule: list[int],
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.mlp_hidden_schedule = list(mlp_hidden_schedule)
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    self.mlp_hidden_schedule[i],
+                    rope_base,
+                    qk_gain_init,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+
+        # First half stores skips; second half reuses them in reverse order.
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        logits = self.forward_logits(input_ids).reshape(-1, self.tok_emb.num_embeddings)
+        targets = target_ids.reshape(-1)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    if args.dry_run:
+        args.num_layers = min(args.num_layers, 2)
+        args.model_dim = min(args.model_dim, 128)
+        args.num_heads = min(args.num_heads, 4)
+        args.num_kv_heads = min(args.num_kv_heads, args.num_heads)
+        args.mlp_hidden_base = min(args.mlp_hidden_base, 384)
+        args.mlp_hidden_multiple = min(args.mlp_hidden_multiple, 32)
+        args.dry_run_total_tokens = min(args.dry_run_total_tokens, 4_096)
+        args.train_seq_len = min(args.train_seq_len, 32)
+        args.eval_seq_len = min(args.eval_seq_len, 32)
+        args.train_batch_tokens = min(args.train_batch_tokens, 1_024)
+        args.val_batch_size = min(args.val_batch_size, 1_024)
+        args.eval_stride = min(max(args.eval_stride, 1), max(args.eval_seq_len // 4, 1))
+    if torch.cuda.is_available() and not args.dry_run:
+        zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + DEVICE SETUP
+    # -----------------------------
+
+    distributed = (not args.dry_run) and "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0")) if distributed else 0
+    world_size = int(os.environ.get("WORLD_SIZE", "1")) if distributed else 1
+    local_rank = int(os.environ.get("LOCAL_RANK", "0")) if distributed else 0
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if not args.dry_run and 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 1 if args.dry_run else 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if args.dry_run:
+        device = torch.device(args.dry_run_device)
+    else:
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA is required unless DRY_RUN=1")
+        device = torch.device("cuda", local_rank)
+        torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    if device.type == "cuda":
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+        from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+        enable_cudnn_sdp(False)
+        enable_flash_sdp(True)
+        enable_mem_efficient_sdp(False)
+        enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    if device.type == "cuda":
+        log0(
+            subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+            console=False,
+        )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    if device.type == "cuda":
+        torch.cuda.manual_seed_all(args.seed)
+
+    if args.dry_run:
+        val_tokens = make_synthetic_validation_tokens(
+            vocab_size=args.vocab_size,
+            seq_len=args.eval_seq_len,
+            total_tokens=args.dry_run_total_tokens,
+            seed=args.seed + 1,
+        )
+        base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_synthetic_luts(args.vocab_size, device)
+        dataset_dir = Path("<synthetic>")
+        actual_train_files = 0
+        log0("val_bpb:enabled tokenizer_kind=synthetic")
+    else:
+        if not args.tokenizer_path.endswith(".model"):
+            raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+        sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+        if int(sp.vocab_size()) != args.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+            )
+        dataset_dir = Path(args.data_path).resolve()
+        actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+        val_tokens = load_validation_tokens(args.val_files, args.eval_seq_len)
+        base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+            sp, args.vocab_size, device
+        )
+        log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    mlp_hidden_schedule = build_top_heavy_mlp_schedule(args)
+    model_dtype = torch.bfloat16 if device.type == "cuda" else torch.float32
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_hidden_schedule=mlp_hidden_schedule,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+    ).to(device=device, dtype=model_dtype)
+    if device.type == "cuda":
+        for module in base_model.modules():
+            if isinstance(module, CastedLinear):
+                module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    if device.type == "cuda" and not args.dry_run:
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    else:
+        compiled_model = base_model
+    train_model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+    eval_model: nn.Module = base_model
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    use_fused_adam = device.type == "cuda"
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=use_fused_adam,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=use_fused_adam,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=use_fused_adam,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    if device.type == "cuda":
+        log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    else:
+        log0("sdp_backends:cpu_dry_run")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"eval_seq_len:{args.eval_seq_len} eval_stride:{args.eval_stride} "
+        f"iterations:{args.dry_run_steps if args.dry_run else args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"mlp_hidden_schedule:{','.join(str(v) for v in mlp_hidden_schedule)}")
+    log0(
+        f"use_top_heavy_ffn:{int(args.use_top_heavy_ffn)} "
+        f"mlp_hidden_base:{args.mlp_hidden_base} "
+        f"mlp_scale_range:[{args.mlp_scale_min:.2f},{args.mlp_scale_max:.2f}]"
+    )
+    log0(f"seed:{args.seed}")
+    if args.dry_run:
+        log0(f"dry_run:1 dry_run_steps:{args.dry_run_steps} dry_run_total_tokens:{args.dry_run_total_tokens}")
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    if args.dry_run:
+        train_loader = SyntheticTokenLoader(
+            vocab_size=args.vocab_size,
+            total_tokens=args.dry_run_total_tokens,
+            rank=rank,
+            world_size=world_size,
+            device=device,
+            seed=args.seed,
+        )
+    else:
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = None
+    if args.max_wallclock_seconds > 0 and not args.dry_run:
+        max_wallclock_ms = 1000.0 * args.max_wallclock_seconds
+    total_iterations = args.dry_run_steps if args.dry_run else args.iterations
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(total_iterations - args.warmdown_iters, 0)
+            if warmdown_start <= step < total_iterations:
+                return max((total_iterations - step) / max(args.warmdown_iters, 1), 0.0)
+            return 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    warmup_steps = 0 if args.dry_run else args.warmup_steps
+    if warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        train_model.train()
+        for warmup_step in range(warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    train_model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with autocast_context(device):
+                    warmup_loss = train_model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            train_model.require_backward_grad_sync = True
+        if args.dry_run:
+            train_loader = SyntheticTokenLoader(
+                vocab_size=args.vocab_size,
+                total_tokens=args.dry_run_total_tokens,
+                rank=rank,
+                world_size=world_size,
+                device=device,
+                seed=args.seed,
+            )
+        else:
+            train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == total_iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            if device.type == "cuda":
+                torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                eval_model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{total_iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            if device.type == "cuda":
+                torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < total_iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{total_iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                train_model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with autocast_context(device):
+                loss = train_model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{total_iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    if device.type == "cuda":
+        log0(
+            f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+            f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+        )
+    else:
+        log0("peak memory allocated: cpu_dry_run")
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed packed-int6 artifact and validate the round-tripped weights.
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_lowbit(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.lowbit.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.lowbit.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["packed_payload_bytes"], 1)
+        log0(
+            f"Serialized model packed_int6+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['packed_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size packed_int6+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.lowbit.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(decompress_zlib_blob(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_lowbit(quant_state), strict=True)
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        eval_model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+    log0(
+        f"final_packed_int6_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_packed_int6_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if args.eval_stride > 0:
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        slide_val_loss, slide_val_bpb = eval_val_sliding(
+            args,
+            eval_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+        )
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+        log0(
+            f"sliding_window_eval val_loss:{slide_val_loss:.4f} val_bpb:{slide_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"sliding_window_eval_exact val_loss:{slide_val_loss:.8f} val_bpb:{slide_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Approach

This submission focuses on **parameter allocation**, not just export format. The current public frontier is clustered around a uniform `9 x 512` backbone with stronger quantization and evaluation tricks. I kept the proven surrounding recipe, but replaced the uniform `3x` FFN with **OpenELM-style layer-wise scaling** so later blocks get larger FFNs and earlier blocks get smaller ones at the same overall budget.

The exact FFN schedule is:

`768, 960, 1152, 1344, 1536, 1728, 1920, 2112, 2304`

The motivation is that, under a strict parameter budget, later layers are closer to the next-token loss and should benefit more from extra capacity than early layers. This is especially attractive in the Parameter Golf setting because the challenge is strongly **parameter-limited** relative to the 10-minute 8xH100 compute budget. Chinchilla-style reasoning says the available training compute could support a much larger model than the 16 MB artifact allows, so the right move is to spend the byte budget as efficiently as possible inside the model rather than leaving it uniformly distributed.

To support that architecture cleanly, I also implemented an **exact packed-int6 export path** with per-row fp16 scales. This keeps the submission self-contained and avoids relying on an external `zstd` dependency at evaluation time. I keep the tied embedding in fp16 because that tensor is especially quantization-sensitive and serves as both the input embedding and output projection.

Finally, the trainer includes **sliding-window evaluation** and a **CPU `DRY_RUN=1` mode** so the full train/export/eval pipeline can be verified locally without CUDA. Because I do not currently have GPU credits, I am not claiming a score yet and am leaving final eval metrics pending.

### Key Design Decisions

- Use **top-heavy FFN allocation** instead of a uniform `3x` FFN so later layers get more of the parameter budget.
- Keep the proven **9-layer, 512-dim, tied-embedding, GQA** backbone for a controlled comparison against public baselines.
- Export large matrices as **packed int6 + per-row fp16 scale + zlib** to make the artifact fully self-contained.
- Keep `tok_emb.weight` in **fp16** because it is the most quantization-sensitive tensor in public submissions.
- Retain **sliding-window eval** because it is allowed by the rules and is consistently helpful in public runs.
- Use **seed 42** by default and add a **10-step CPU dry-run** path for reproducibility without GPUs.

### What I Expect to Underperform / Risks

- The main risk is that layer-wise FFN scaling is theoretically motivated but not yet validated on this exact challenge objective.
- Packed int6 + zlib is self-contained, but the trained checkpoint still needs to prove it compresses comfortably under the 16 MB cap.
- If this challenge is dominated more by export/eval tricks than by parameter placement, the gain over a strong uniform-FFN baseline may be modest.

### Results

| Metric | Value |
|---|---|
| Baseline eval loss | `1.22436570` val_bpb (repo baseline) |
| Final eval loss | Pending — training to be run once compute credits are granted |
| Parameter count | `21,778,504` |
| Artifact size | Measured init-export: `4,273,390` bytes total; dense-random stress probe: `16,549,133` bytes total |
| Training time (estimated on 8×H100) | Expected to fit the 600s budget; public 21.8M-parameter 9x512 runs report roughly `45–57 ms/step`, implying about `10k–13k` steps in 10 minutes |

### Reproducibility

Seed: `42`.

Dry-run verified locally with:

`DRY_RUN=1 RUN_ID=topheavy_dryrun python train_gpt.py`

Full 8xH100 train/eval pending compute access.

### References

- Hoffmann et al., *Training Compute-Optimal Large Language Models*, 2022
- Mehta et al., *OpenELM*, 2024
