### PR TITLE
Add MLX heavy-share research harness for Parameter Golf

### DIFF
--- a/notes/codex_research_context.md
+++ b/notes/codex_research_context.md
@@ -1,0 +1,245 @@
+# Codex Research Context
+
+Last updated: 2026-03-18
+
+## Objective
+
+This repo is for the Parameter Golf challenge:
+- optimize final compressed-model performance under a strict `16,000,000` byte artifact cap
+- leaderboard runs must finish within `10` minutes on `8xH100`
+- current working assumption for architecture research: keep tokenizer fixed for now
+
+For fixed tokenizer experiments:
+- use `val_loss` as the main local metric
+- `val_bpb` is equivalent up to a constant on the fixed validation split
+- use `train_loss` only as a sanity/debug signal, not as the main ranking metric
+
+## Current Local Setup
+
+Primary local research path:
+- [train_gpt_mlx.py](/Users/soumil/Desktop/parameter-golf/train_gpt_mlx.py)
+
+Important local adjustments already made:
+- added `VAL_MAX_TOKENS` to support a mini-val path on a fixed prefix of the validation split
+- added configurable AttnRes modes:
+  - `ATTNRES_MODE=full`
+  - `ATTNRES_MODE=block`
+  - `ATTNRES_MODE=hybrid`
+- added AttnRes knobs:
+  - `ATTNRES_BLOCK_SIZE`
+  - `ATTNRES_LOCAL_BLEND`
+
+Why mini-val was added:
+- full local validation was too slow for architecture screening
+- one full-val control run spent more than ~4m45s in final eval after training had finished
+- mini-val makes local iteration practical
+
+Current mini-val protocol:
+- `VAL_MAX_TOKENS=4194304`
+- `ITERATIONS=200` for short screens
+- `TRAIN_BATCH_TOKENS=8192`
+- `VAL_LOSS_EVERY=0`
+- `VAL_BATCH_SIZE=8192`
+- single local train shard currently available
+- for local Mac research runs, set `MAX_WALLCLOCK_SECONDS=0`
+
+Note on baseline controls:
+- AttnRes lives in the working-tree version of `train_gpt_mlx.py`
+- for apples-to-apples baseline controls, a temporary baseline copy was generated from `HEAD`
+- if needed again, recreate a clean baseline script from git `HEAD` rather than manually editing the working tree
+
+## AttnRes Hypothesis
+
+Question being tested:
+- can a constrained AttnRes variant show enough local promise to justify further investment?
+
+Important framing:
+- AttnRes is *not* currently assumed to be the main source of leaderboard gains
+- it is being treated as a possible helper or stabilizer, especially for more aggressive backbones later
+
+## AttnRes Results So Far
+
+Short local screen, `200` steps, mini-val, seed `1337`:
+
+- baseline mini-val roundtrip `val_loss`: `3.97771597`
+- block AttnRes roundtrip `val_loss`: `4.03348017`
+- hybrid AttnRes roundtrip `val_loss`: `3.90412021`
+
+Interpretation:
+- naive `full` depth AttnRes is already considered a weak direction
+- `block` lost clearly in the first screen and is deprioritized for now
+- `hybrid` is the only AttnRes variant that has shown positive signal so far
+
+Tradeoff observed:
+- `hybrid` improved mini-val loss at `200` steps
+- `hybrid` also appears slower than baseline
+- next question is whether the gain survives longer training
+
+Current/next AttnRes check:
+- `1000`-step mini-val baseline vs `1000`-step mini-val hybrid
+- same seed, same local protocol
+
+Stage-1 result on the first `1000`-step comparison:
+- baseline completed all `1000` steps and reached roundtrip mini-val `val_loss: 3.29495144`
+- hybrid hit the default wallclock cap at step `859`, but still reached roundtrip mini-val `val_loss: 3.25895929`
+- this is promising enough to keep hybrid alive, but the next local runs should be uncapped so comparisons are not truncated by the default `600s` limit
+
+Decision rule:
+- if `hybrid` still wins at `1000` steps, keep AttnRes alive
+- if the gain disappears, deprioritize AttnRes and move on
+
+## Main Architecture Priorities
+
+Current belief about likely primary gain sources:
+
+1. Effective depth with parameter sharing / recurrence
+- best fit to the challenge
+- spends compute instead of bytes
+- shared parameters often compress better
+
+2. Latent memory / eval-time memory
+- good match for a byte-constrained challenge
+- likely most useful once attached to a recurrent or shared-depth backbone
+
+3. Compressibility-aware architecture
+- repeated structure, shared matrices, low-rank/shared parameterization, and small control tensors should help both model quality per byte and final zlib artifact size
+
+4. Residual routing / AttnRes
+- secondary lever
+- more interesting if it helps a deeper tied/recurrent model work better
+
+## Main Research Families
+
+### Family A: Residual Routing / AttnRes
+
+Variants already considered:
+- baseline control
+- full AttnRes
+- block AttnRes
+- hybrid AttnRes
+
+Potential further AttnRes variants if hybrid survives:
+- selective AttnRes only in deeper layers
+- AttnRes only before MLP
+- hybrid with different `ATTNRES_LOCAL_BLEND`
+- block + hybrid only if hybrid looks strong enough to justify one more branch
+
+### Family B: Effective Depth / Weight Sharing / Recurrence
+
+This is currently the highest-priority non-AttnRes family.
+
+Planned variants:
+- one shared block repeated many times
+- small cycle of unique blocks repeated, e.g. 3 blocks repeated over depth
+- separate encoder-shared and decoder-shared stacks
+- shared-depth with iteration/depth-step conditioning
+
+Why this matters:
+- likely the strongest path to "more model per byte"
+- likely more important than AttnRes alone
+
+### Family C: Latent Memory
+
+This should be explored after or alongside a promising recurrent/shared-depth backbone.
+
+Planned variants:
+- recurrent memory tokens carried across segments
+- compressed latent summary passed between segments
+- tiny memory cross-attention path with a small fixed latent bank
+- only later: a Titans-lite memory update scheme if simpler memory shows signal
+
+Why not jump straight to full Titans:
+- too much complexity as a first proof step
+- simpler memory mechanisms are better filters
+
+## Other Potential Ideas Not Yet Fully Discussed
+
+These are plausible future directions if the main families do not dominate:
+
+- low-rank factorization of larger shared matrices
+- compressibility-aware training or QAT-style export alignment
+- learned iteration embeddings for recurrent/shared-depth models
+- selective untied "control tensors" on top of heavily shared weights
+- chunkwise recurrent evaluation with longer effective context
+- memory tokens plus shared-depth recurrence
+- stronger skip/bridge structure in the hourglass backbone
+- evaluation-time recurrence schedules that spend more compute at test time than train time
+
+Lower priority for now:
+- tokenizer changes
+- broad hyperparameter brute force
+- anything that confounds architecture research before we know the backbone direction
+
+## Rough Plan
+
+### Phase 0: Local Harness
+- baseline sanity runs
+- mini-val support
+- fast local screen protocol
+
+Status:
+- mostly complete
+
+### Phase 1: Local Architecture Screen
+
+Goal:
+- kill bad ideas cheaply on the Mac
+
+Current order:
+1. close out AttnRes decision
+2. move to recurrence / shared-depth
+3. add latent memory on top of the best backbone
+
+Promotion rules from local screen:
+- better or equal mini-val loss than baseline
+- no major throughput collapse
+- stable training behavior
+
+### Phase 2: CUDA / H100 Pilot
+
+Goal:
+- verify that local winners survive the real competition stack
+
+Promote only a small shortlist:
+- best AttnRes candidate if any
+- best recurrence/shared-depth candidate
+- best latent memory candidate
+- best combo only if it has already shown signal locally
+
+### Phase 3: 8xH100 Funnel
+
+Goal:
+- spend expensive runs only on serious contenders
+
+Sequence:
+- one leaderboard-style calibration run per top candidate
+- a small focused sweep around the best one
+- repeated final verification runs for variance/significance
+
+## Compute Request Timing
+
+Do not wait for every local experiment to finish.
+
+Submit the compute request once we have:
+- a stable local harness
+- a written plan
+- at least one credible non-baseline direction
+
+Reason:
+- request/approval may take time
+- the plan is already legitimate once a first shortlist exists
+
+## Immediate Next Steps
+
+1. finish the `1000`-step mini-val baseline vs hybrid AttnRes comparison
+2. if hybrid survives, run one more seed or one blend ablation
+3. then start Family B: recurrence/shared-depth
+4. once a good shared-depth backbone exists, attach Family C: latent memory
+5. then decide which candidates deserve CUDA/H100 pilots
+
+## Working Belief
+
+Most likely eventual leaderboard candidate:
+- a shared-depth / recurrent backbone
+- possibly with a small latent memory path
+- with AttnRes only if it proves helpful as a supporting mechanism

--- a/notes/compute_request_brief_2026-03-19.md
+++ b/notes/compute_request_brief_2026-03-19.md
@@ -1,0 +1,124 @@
+# Parameter Golf Compute Request Brief
+
+## Objective
+
+Train a better `<=16,000,000` byte artifact for the Parameter Golf challenge under the real `10` minute `8xH100` training cap.
+
+The central lesson from local work is that this is a fixed-time efficiency problem, not just a parameter-count problem. The best path is likely:
+
+1. more useful tokens per second,
+2. more model quality per byte,
+3. only then more elaborate architecture.
+
+## What We Already Learned Locally
+
+Negative map:
+- full-depth AttnRes loses under matched wallclock
+- selective AttnRes is less bad, but still loses to baseline locally
+- naive shared-depth recurrence loses
+- naive latent memory loses
+- naive recurrent memory loses
+- naive widening loses
+- naive PTQ `int4` is too lossy as a direct drop-in
+
+Positive map:
+- quantization is still a real byte lever
+- selective late routing is structurally more plausible than global routing
+- wallclock-aware comparisons matter more than equal-step comparisons
+
+Conclusion:
+- stop spending time on broad naive architecture sweeps
+- prioritize throughput, curriculum, and compression-aware model design
+
+## Proposed Research Tracks
+
+### Track 1: Fixed-Time Training Efficiency
+
+Primary idea:
+- variable sequence length curriculum / dataset decomposition
+
+Rationale:
+- likely the cleanest way to buy more useful training in a hard time budget
+- lower sequence lengths early should improve throughput and optimization
+- full sequence length is still used later and at evaluation
+
+Secondary ideas:
+- optimizer/schedule tuning on the fast baseline backbone
+- H100-native mixed precision / FP8 if feasible
+
+### Track 2: Parameter-Efficient Backbone
+
+Primary idea:
+- shared-backbone recurrence `v2`
+
+Not:
+- naive full block sharing
+
+Instead:
+- share heavy matrices
+- keep tiny per-depth controls unique
+- add stronger step conditioning
+
+Secondary idea:
+- Transformer-XL / compressive segment recurrence style memory
+
+### Track 3: Compression Co-Design
+
+Primary idea:
+- quantization-friendly backbone + export
+
+Not:
+- plain post-training `int4` on an unchanged model
+
+Instead:
+- mixed `4/8-bit`
+- smoother / more quantization-friendly parameter distributions
+- byte savings spent on small targeted capacity increases
+
+## Immediate H100 Plan
+
+Phase 1:
+- reproduce and profile baseline on CUDA
+- measure throughput bottlenecks and actual training volume in the real stack
+
+Phase 2:
+- run sequence-length curriculum experiments first
+- compare under matched wallclock
+
+Phase 3:
+- run small optimizer/schedule sweep on the best fast backbone
+
+Phase 4:
+- only then revisit backbone changes:
+  - shared-trunk recurrence `v2`
+  - segment recurrence
+  - quantization-aware variants
+
+## Why Compute Credits Are Needed
+
+The local Mac work is good for rejecting ideas cheaply, but the actual competition objective depends on:
+- CUDA/H100 throughput,
+- wallclock-limited training dynamics,
+- post-quantized artifact behavior in the real training stack.
+
+Several of the most promising directions are inherently GPU-bound:
+- sequence-length curriculum under large token throughput
+- FP8 / systems efficiency work
+- compression-aware retraining
+- richer shared-backbone variants
+
+## Deliverables We Plan To Produce
+
+- a remote branch with reproducible experiment harness updates
+- short-run CUDA pilot logs
+- clear matched-wallclock comparisons
+- one or two serious candidate branches for full `8xH100` runs
+
+## Current Recommendation
+
+The best next engineering move is:
+
+1. implement variable sequence length curriculum,
+2. validate it locally,
+3. move it to the CUDA path,
+4. request compute for the broader three-track program above.

--- a/notes/experiment_queue.md
+++ b/notes/experiment_queue.md
@@ -1,0 +1,46 @@
+# Autoresearch Experiment Queue
+
+## Current Best
+- Config: heavycycle3 + wd=0.01 + smear(-3.0) + MoD(keep=0.75, core=1)
+- val_bpb: 2.02095 (seed 2026) / 2.02522 (seed 1337)
+- Compressed: ~3.66 MB
+
+## Baseline Command
+```bash
+cd /Users/soumil/Desktop/parameter-golf && \
+DEPTH_SHARE_MODE=cycle DEPTH_UNIQUE_LAYERS=3 DEPTH_SHARE_HEAVY_ONLY=1 \
+MUON_WEIGHT_DECAY=0.01 SMEARGATE=1 SMEARGATE_INIT=-3.0 \
+MOD_KEEP=0.75 MOD_CORE=1 \
+ATTNRES_MODE=none LATENT_MEM_MODE=none \
+MAX_WALLCLOCK_SECONDS=180 VAL_LOSS_EVERY=0 SEED=1337 \
+RUN_ID=baseline_check \
+python train_gpt_mlx.py
+```
+
+## Running
+| ID | Description | Seed | Status |
+|----|-------------|------|--------|
+| auto_01 | WARMDOWN_ITERS=300 | 1337 | running |
+| auto_02 | WARMDOWN_ITERS=200 | 1337 | running |
+
+## Pending (Wave 2+ use best WARMDOWN from Wave 1)
+| Wave | ID | Priority | Type | Description | Changes |
+|------|----|----------|------|-------------|---------|
+| 2 | auto_03 | P1 | hp | SmearGate -4.0 | SMEARGATE_INIT=-4.0 |
+| 2 | auto_04 | P1 | hp | 12 layers / 3 cores | NUM_LAYERS=12 |
+| 3 | auto_05 | P1 | hp | MOD_KEEP 0.625 | MOD_KEEP=0.625 |
+| 3 | auto_06 | P1 | hp | Muon WD 0.02 | MUON_WEIGHT_DECAY=0.02 |
+| 4 | auto_07 | P2 | hp | MLP LoRA rank 8 | MLP_LORA_RANK=8 |
+| 4 | auto_08 | P2 | hp | Grad clip 1.0 | GRAD_CLIP_NORM=1.0 |
+| 5 | auto_09 | P2 | hp | SmearGate -5.0 | SMEARGATE_INIT=-5.0 |
+| 5 | auto_10 | P2 | hp | 2 unique cores | DEPTH_UNIQUE_LAYERS=2 |
+| 6 | auto_11 | P2 | hp | Seq len curriculum | SEQ_LEN_SCHEDULE=linear SEQ_LEN_MIN=256 SEQ_LEN_RAMP_STEPS=5000 |
+| 6 | auto_12 | P2 | hp | Logit softcap 15 | LOGIT_SOFTCAP=15.0 |
+| 7 | auto_13 | P3 | code | NorMuon optimizer | code change |
+| 7 | auto_14 | P3 | code | Progressive residual warmup | code change |
+| 8 | auto_15 | P3 | hp | 15 layers | NUM_LAYERS=15 |
+| - | combo | P4 | combo | Best winners combined | TBD |
+
+## Completed
+| ID | Description | val_bpb | Compressed | vs Best | Seed | Log |
+|----|-------------|---------|------------|---------|------|-----|

--- a/notes/research_handoff_2026-03-20.md
+++ b/notes/research_handoff_2026-03-20.md
@@ -1,0 +1,244 @@
+# Parameter Golf Research Handoff
+
+Date: 2026-03-20
+
+## Objective
+
+Optimize the challenge's real target:
+
+- best post-quantized `val_bpb`
+- under a hard fixed-time training budget
+- under a hard artifact-byte cap
+
+This means the useful currencies are:
+
+- quality gained per second
+- quality gained per stored byte
+- quality retained after quantization/export
+
+The local MLX loop is a filter, not a perfect H100 simulator, but it has been good enough to kill bad ideas and identify one very strong branch.
+
+## Current Best Local Branch
+
+Backbone:
+
+- `DEPTH_SHARE_MODE=cycle`
+- `DEPTH_UNIQUE_LAYERS=3`
+- `DEPTH_SHARE_HEAVY_ONLY=1`
+
+Confirmed stack on top:
+
+- `MUON_WEIGHT_DECAY=0.01`
+- `SMEARGATE=1`
+- `SMEARGATE_INIT=-3.0`
+- `MOD_KEEP=0.75`
+- `MOD_CORE=1`
+
+Interpretation:
+
+- share the expensive attention/MLP cores across depth
+- keep cheap per-layer controls unique
+- add a tiny embedding-level previous-token blend
+- route MLP compute on the middle shared core only, keeping roughly `75%` of tokens active there
+
+## Best Numbers
+
+### Baseline controls
+
+- Baseline `180s`, seed `1337`: `2.16834965`
+  - log: `logs/stage6_seq_base_180s_s1337.txt`
+  - compressed model: `8,558,684` bytes
+- Baseline `180s`, seed `2026`: `2.18171034`
+  - log: `logs/stage6_seq_base_180s_s2026.txt`
+  - compressed model: `8,535,407` bytes
+
+### Heavy-share backbone
+
+- `heavycycle3`, seed `1337`: `2.13989464`
+  - log: `logs/stage8_heavycycle3_180s_s1337.txt`
+  - compressed model: `3,390,661` bytes
+- `heavycycle3`, seed `2026`: `2.13784642`
+  - log: `logs/stage8_heavycycle3_180s_s2026.txt`
+  - compressed model: `3,400,406` bytes
+
+### Add Muon weight decay
+
+- `heavycycle3 + wd=0.01`, seed `1337`: `2.13540884`
+  - log: `logs/stage10_heavycycle3_wd001_180s_s1337.txt`
+  - compressed model: `3,406,265` bytes
+
+### Add SmearGate-lite
+
+- `heavycycle3 + wd + smear(-3.0)`, seed `1337`: `2.12786663`
+  - log: `logs/stage13_heavycycle3_wd001_smearm3_180s_s1337.txt`
+  - compressed model: `3,386,835` bytes
+- `heavycycle3 + wd + smear(-2.0)`, seed `1337`: `2.14924756`
+  - log: `logs/stage13_heavycycle3_wd001_smearm2_180s_s1337.txt`
+  - conclusion: gate must stay conservative
+
+### Add MoD-lite
+
+- `heavycycle3 + wd + smear(-3.0) + mod(keep=0.75, core=1)`, seed `1337`: `2.02522139`
+  - log: `logs/stage16_heavycycle3_wd001_smearm3_mod075_180s_s1337.txt`
+  - compressed model: `3,658,495` bytes
+- same config, seed `2026`: `2.02095004`
+  - log: `logs/stage16_heavycycle3_wd001_smearm3_mod075_180s_s2026.txt`
+  - compressed model: `3,665,283` bytes
+- `keep=0.875`, seed `1337`: `2.02301388`
+  - log: `logs/stage16_heavycycle3_wd001_smearm3_mod0875_180s_s1337.txt`
+  - compressed model: `3,648,012` bytes
+
+Current best local result:
+
+- `2.02095004` at `180s` local matched time
+- branch: `heavycycle3 + wd + smear(-3.0) + mod(0.75, core=1)`
+
+## Important Ablations
+
+### MoD-lite placement
+
+- `core=1` is best
+- `core=2`: `2.03106751`
+  - log: `logs/stage16_heavycycle3_wd001_smearm3_mod075_core2_180s_s1337.txt`
+- `core=0`: `2.07331353`
+  - log: `logs/stage16_heavycycle3_wd001_smearm3_mod075_core0_180s_s1337.txt`
+  - also much slower
+
+Conclusion:
+
+- the gain is not generic "route any layer"
+- the middle shared core is the right place to gate MLP compute
+
+### KV schedule
+
+- uniform `KV_HEAD_SCHEDULE=2`: `2.14991956`
+  - log: `logs/stage14_heavycycle3_wd001_smearm3_kv2_180s_s1337.txt`
+- non-uniform `KV_HEAD_SCHEDULE=4,2,4`: `2.13113807`
+  - log: `logs/stage14_heavycycle3_wd001_smearm3_kv424_180s_s1337.txt`
+
+Conclusion:
+
+- not worth carrying forward vs the current best branch
+
+## Eval / Compression Findings
+
+### Sliding-window eval
+
+On the earlier `heavycycle3` checkpoint:
+
+- flat `1024`: `2.13989464`
+  - log: `logs/eval_stage8_heavycycle3_flat1024_s1337.txt`
+- sliding `1024/256`: `2.13631236`
+  - log: `logs/eval_stage8_heavycycle3_slide256_1024_s1337.txt`
+
+Conclusion:
+
+- sliding eval is likely real and should be carried forward
+- it has not yet been cleanly restacked on the newest MoD-lite branch because long local eval tails were awkward on the Mac
+
+### PTQ mixed low-bit
+
+On the `smear(-3.0)` checkpoint:
+
+- int8 control: `2.12786663`, `3,386,835` bytes
+  - log: `logs/eval_stage15_smearm3_int8_s1337.txt`
+- mixed `MLP 6-bit / attention+embed 8-bit`: `2.17621863`, `2,695,599` bytes
+  - log: `logs/eval_stage15_smearm3_m6mix_default_s1337.txt`
+- same mixed recipe with `INT8_CLIP_PERCENTILE=99.99`: `2.17631718`, `2,695,511` bytes
+  - log: `logs/eval_stage15_smearm3_m6mix_clip9999_s1337.txt`
+
+Conclusion:
+
+- PTQ-only mixed low-bit is not good enough
+- if compression is revisited, it should be training-aware: QAT-lite, quant-noise, or outlier smoothing on GPU
+
+## Dead / Deprioritized Ideas
+
+These were tested locally and are not worth more Mac time right now:
+
+- full AttnRes and most selective AttnRes variants
+- naive latent memory and recurrent memory
+- naive shared-depth recurrence
+- naive width scaling
+- sequence curriculum as a main lever
+- MLP FiLM
+- MLP LoRA / low-rank delta
+- MTP
+- `MLP 3x`
+- aggressive KV reduction as a main idea
+- PTQ-only mixed low-bit export
+
+Representative bad numbers:
+
+- MTP `0.25`: `2.20793677`
+  - log: `logs/stage12_heavycycle3_wd001_mtp2w025_180s_s1337.txt`
+- MTP `0.5`: `2.30722590`
+  - log: `logs/stage12_heavycycle3_wd001_mtp2w05_180s_s1337.txt`
+- `MLP 3x` on `heavycycle3 + wd`: `2.14172339`
+  - log: `logs/stage11_heavycycle3_wd001_mlp3_180s_s1337.txt`
+
+## Current Thesis
+
+The project is no longer in the "broad ideation" phase.
+
+The current working thesis is:
+
+- fast shared-heavy backbone
+- cheap per-layer controls stay unique
+- tiny embedding-side inductive bias helps
+- conditional compute helps a lot if placed carefully
+- export should stay simple unless training-aware compression proves itself
+
+The current branch is not "just heavier tuning." It is a different architecture family:
+
+- shared-heavy / unique-light depth tying
+- cheap local bigram-like bias via SmearGate
+- compute reallocation via MoD-lite
+
+## Recommended Next Steps
+
+### Local, if any
+
+Only two local tasks still look worth doing:
+
+1. clean sliding-window eval on the current best MoD-lite checkpoint
+2. maybe one extra-depth reinvestment test with the same 3 shared cores, only if time remains
+
+Everything else is now lower value than CUDA/H100 porting.
+
+### Immediate next engineering step
+
+Port the current winning branch into `train_gpt.py`:
+
+- heavy shared cores
+- unique-light per-layer wrappers
+- Muon weight decay
+- SmearGate-lite
+- MoD-lite (`mod_core=1`, `mod_keep≈0.75`)
+
+### H100-side priorities
+
+Once the port exists, the next branches should be:
+
+1. confirm the branch under real CUDA wallclock
+2. retest sliding-window eval on the best CUDA checkpoint
+3. explore training-aware compression, not more PTQ calibration
+4. consider FP8 / runtime systems improvements only after the branch is stable
+
+## Suggested H100 Experiment Order
+
+1. PyTorch baseline reproduction
+2. heavycycle3 reproduction
+3. heavycycle3 + wd
+4. heavycycle3 + wd + smear
+5. heavycycle3 + wd + smear + MoD-lite
+6. sliding-window eval on the best checkpoint
+7. QAT-lite / compression-aware branch
+
+## Bottom Line
+
+The local winner is:
+
+- `heavycycle3 + MUON_WEIGHT_DECAY=0.01 + SMEARGATE(init=-3.0) + MoD-lite(keep=0.75, core=1)`
+
+This branch is replicated across two seeds and has a large margin over every earlier local branch. It is now strong enough that the main bottleneck is no longer more local idea search; it is CUDA/H100 validation and making low-bit export work without giving back the gains.

--- a/notes/results_log.md
+++ b/notes/results_log.md
@@ -1,0 +1,32 @@
+# Autoresearch Results Log
+
+## Prior Baselines (from research_handoff)
+| Config | Seed | val_bpb | Compressed | Log |
+|--------|------|---------|------------|-----|
+| vanilla baseline | 1337 | 2.16835 | 8,558,684 | stage6_seq_base_180s_s1337.txt |
+| heavycycle3 | 1337 | 2.13989 | 3,390,661 | stage8_heavycycle3_180s_s1337.txt |
+| hc3+wd0.01 | 1337 | 2.13541 | 3,406,265 | stage10_heavycycle3_wd001_180s_s1337.txt |
+| hc3+wd+smear(-3) | 1337 | 2.12787 | 3,386,835 | stage13_heavycycle3_wd001_smearm3_180s_s1337.txt |
+| **hc3+wd+smear+mod** | **1337** | **2.02522** | **3,658,495** | stage16_..._mod075_180s_s1337.txt |
+| **hc3+wd+smear+mod** | **2026** | **2.02095** | **3,665,283** | stage16_..._mod075_180s_s2026.txt |
+
+## Dead Ideas (do NOT re-test)
+- full AttnRes / most selective AttnRes variants
+- naive latent memory / recurrent memory
+- naive shared-depth recurrence (before heavy-only split)
+- naive width scaling
+- sequence curriculum as main lever
+- MLP FiLM / MLP LoRA / low-rank delta
+- MTP (multi-token prediction)
+- MLP 3x expansion
+- aggressive KV reduction as main idea
+- PTQ-only mixed low-bit export
+- SMEARGATE_INIT=-2.0 (gate too aggressive, val_bpb=2.149)
+- MOD_CORE=0 (val_bpb=2.073, also much slower)
+- MOD_CORE=2 (val_bpb=2.031, worse than core=1)
+- uniform KV_HEAD_SCHEDULE=2 (val_bpb=2.150)
+- non-uniform KV_HEAD_SCHEDULE=4,2,4 (val_bpb=2.131)
+
+## Autoresearch Experiments
+| # | ID | Description | Seed | val_bpb | Compressed | Delta | Status |
+|---|-----|-------------|------|---------|------------|-------|--------|

--- a/notes/runbook_for_local_mlx.md
+++ b/notes/runbook_for_local_mlx.md
@@ -1,0 +1,78 @@
+# Local MLX Run Discipline
+
+## What NOT to touch
+For any run meant to be comparable to prior results, do NOT change these unless explicitly testing them:
+
+- Python path: always `.venv/bin/python3`
+- `TRAIN_BATCH_TOKENS`
+- `GRAD_ACCUM_STEPS`
+- `MLX_MAX_MICROBATCH_TOKENS`
+- `WARMUP_STEPS`
+- `VAL_BATCH_SIZE`
+- `MAX_WALLCLOCK_SECONDS`
+- `VAL_LOSS_EVERY`
+
+If you change those casually, the run is no longer comparable and MLX behavior can change a lot.
+
+## Why the current branch feels "hung"
+The current best branch is compile-heavy. MoD-lite token routing in the MLP path means compile/warmup is much slower than earlier branches. The 180s cap only applies to measured training, not the up-front warmup/compile.
+
+- Long time at `warmup_step:1/20` is **expected**
+- That does **not** mean training is broken
+- The run can still be healthy even if nothing interesting appears for a while
+
+## How to verify a run is alive
+```bash
+ps aux | rg train_gpt_mlx.py
+tail -n 40 logs/<RUN_ID>.txt
+```
+
+Healthy signs:
+- Config block printed in log
+- `warmup_step:1/20` eventually appears
+- Process exists in `ps`
+
+That is enough. Do NOT start improvising fixes mid-run.
+
+## Two modes only
+
+### Benchmark mode
+Used for numbers we compare against prior experiments.
+Do NOT change infrastructure knobs. Use the exact known-good command template.
+
+### Debug mode
+Used only to test whether something launches. Fine to reduce:
+- `WARMUP_STEPS=1`
+- `MAX_WALLCLOCK_SECONDS=30`
+- maybe `VAL_MAX_TOKENS`
+
+But **never compare debug runs to benchmark runs**.
+
+## Known-good benchmark template
+For current best branch comparisons, start from exactly this and only change the variable under test:
+
+```bash
+DEPTH_SHARE_MODE=cycle DEPTH_UNIQUE_LAYERS=3 DEPTH_SHARE_HEAVY_ONLY=1 \
+MUON_WEIGHT_DECAY=0.01 SMEARGATE=1 SMEARGATE_INIT=-3.0 \
+MOD_KEEP=0.75 MOD_CORE=1 ATTNRES_MODE=none \
+MAX_WALLCLOCK_SECONDS=180 VAL_LOSS_EVERY=0 SEED=1337 \
+RUN_ID=<new_run_id> \
+.venv/bin/python3 train_gpt_mlx.py
+```
+
+If testing one thing, change one thing.
+
+## What to NEVER do
+- Don't switch Python binaries
+- Don't tweak batch/chunk settings "to help"
+- Don't interrupt because warmup feels long
+- Don't stack multiple accidental changes in one run
+- Don't trust the terminal pane more than the log file
+
+## Simple rule
+If a run looks wrong, first move:
+1. `inspect logs/<RUN_ID>.txt`
+2. `inspect ps`
+3. Ask for interpretation
+
+NOT "change settings until it works."

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -56,6 +56,8 @@ class Hyperparameters:
     warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
     train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
     train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    val_seq_len = int(os.environ.get("VAL_SEQ_LEN", os.environ.get("TRAIN_SEQ_LEN", 1024)))
+    val_stride = int(os.environ.get("VAL_STRIDE", 0))
     max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
     qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
 
@@ -69,6 +71,13 @@ class Hyperparameters:
     tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
     rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
     logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    depth_share_mode = os.environ.get("DEPTH_SHARE_MODE", "none")
+    depth_unique_layers = int(os.environ.get("DEPTH_UNIQUE_LAYERS", 3))
+    depth_share_heavy_only = bool(int(os.environ.get("DEPTH_SHARE_HEAVY_ONLY", "0")))
+    mod_keep = float(os.environ.get("MOD_KEEP", "1.0"))
+    mod_core = int(os.environ.get("MOD_CORE", "1"))
+    smeargate = bool(int(os.environ.get("SMEARGATE", "0")))
+    smeargate_init = float(os.environ.get("SMEARGATE_INIT", "-2.0"))
 
     # Optimizer hyperparameters.
     embed_lr = float(os.environ.get("EMBED_LR", 0.6))
@@ -85,6 +94,7 @@ class Hyperparameters:
     beta2 = float(os.environ.get("BETA2", 0.95))
     adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
     grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+    muon_weight_decay = float(os.environ.get("MUON_WEIGHT_DECAY", 0.0))
 
 # -----------------------------
 # MUON OPTIMIZER 
@@ -110,10 +120,18 @@ def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -
 
 
 class Muon(torch.optim.Optimizer):
-    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True):
+    def __init__(
+        self,
+        params,
+        lr: float,
+        momentum: float,
+        backend_steps: int,
+        weight_decay: float = 0.0,
+        nesterov: bool = True,
+    ):
         super().__init__(
             params,
-            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov),
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, weight_decay=weight_decay, nesterov=nesterov),
         )
 
     @torch.no_grad()
@@ -134,6 +152,7 @@ class Muon(torch.optim.Optimizer):
             lr = group["lr"]
             momentum = group["momentum"]
             backend_steps = group["backend_steps"]
+            weight_decay = group["weight_decay"]
             nesterov = group["nesterov"]
 
             total_params = sum(int(p.numel()) for p in params)
@@ -162,6 +181,8 @@ class Muon(torch.optim.Optimizer):
             curr = 0
             for p in params:
                 g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                if weight_decay > 0:
+                    p.mul_(1.0 - lr * weight_decay)
                 p.add_(g, alpha=-lr)
                 curr += p.numel()
 
@@ -617,7 +638,7 @@ class MLP(nn.Module):
         return self.proj(x.square())
 
 
-class Block(nn.Module):
+class BlockCore(nn.Module):
     def __init__(
         self,
         dim: int,
@@ -628,20 +649,37 @@ class Block(nn.Module):
         qk_gain_init: float,
     ):
         super().__init__()
-        self.attn_norm = RMSNorm()
-        self.mlp_norm = RMSNorm()
         self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
         self.mlp = MLP(dim, mlp_mult)
+
+
+class Block(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
         self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
         self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
         self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
 
-    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+    def forward(self, x: Tensor, x0: Tensor, core: BlockCore, mod_keep: float = 1.0) -> Tensor:
         mix = self.resid_mix.to(dtype=x.dtype)
         x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
-        attn_out = self.attn(self.attn_norm(x))
+        attn_out = core.attn(self.attn_norm(x))
         x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
-        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        mlp_x = self.mlp_norm(x)
+        if mod_keep < 1.0:
+            flat = mlp_x.reshape(-1, mlp_x.size(-1))
+            k = max(1, int(round(mod_keep * float(flat.size(0)))))
+            scores = flat.float().abs().mean(dim=-1)
+            idx = torch.topk(scores, k, sorted=False).indices
+            sel = core.mlp(flat.index_select(0, idx))
+            mlp_out = torch.zeros_like(flat)
+            mlp_out.index_copy_(0, idx, sel)
+            mlp_out = mlp_out.view_as(mlp_x)
+        else:
+            mlp_out = core.mlp(mlp_x)
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * mlp_out
         return x
 
 
@@ -659,31 +697,44 @@ class GPT(nn.Module):
         logit_softcap: float,
         rope_base: float,
         qk_gain_init: float,
+        depth_share_mode: str,
+        depth_unique_layers: int,
+        depth_share_heavy_only: bool,
+        mod_keep: float,
+        mod_core: int,
+        smeargate: bool,
+        smeargate_init: float,
     ):
         super().__init__()
         if logit_softcap <= 0.0:
             raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        if depth_share_mode not in {"none", "cycle"}:
+            raise ValueError(f"DEPTH_SHARE_MODE must be one of none, cycle; got {depth_share_mode!r}")
+        if depth_unique_layers <= 0:
+            raise ValueError(f"DEPTH_UNIQUE_LAYERS must be positive, got {depth_unique_layers}")
         self.tie_embeddings = tie_embeddings
         self.tied_embed_init_std = tied_embed_init_std
         self.logit_softcap = logit_softcap
+        self.depth_share_mode = depth_share_mode
+        self.depth_share_heavy_only = depth_share_heavy_only
+        self.mod_keep = mod_keep
+        self.mod_core = mod_core
         self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.smeargate_gate = nn.Parameter(torch.full((model_dim,), smeargate_init, dtype=torch.float32)) if smeargate else None
         self.num_encoder_layers = num_layers // 2
         self.num_decoder_layers = num_layers - self.num_encoder_layers
         self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
         self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
-        self.blocks = nn.ModuleList(
-            [
-                Block(
-                    model_dim,
-                    num_heads,
-                    num_kv_heads,
-                    mlp_mult,
-                    rope_base,
-                    qk_gain_init,
-                )
-                for i in range(num_layers)
-            ]
+        if depth_share_mode == "cycle" and depth_share_heavy_only:
+            self.layer_block_indices = [i % depth_unique_layers for i in range(num_layers)]
+            num_unique_cores = depth_unique_layers
+        else:
+            self.layer_block_indices = list(range(num_layers))
+            num_unique_cores = num_layers
+        self.block_cores = nn.ModuleList(
+            [BlockCore(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init) for _ in range(num_unique_cores)]
         )
+        self.blocks = nn.ModuleList([Block(model_dim) for _ in range(num_layers)])
         self.final_norm = RMSNorm()
         self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
         if self.lm_head is not None:
@@ -699,18 +750,23 @@ class GPT(nn.Module):
 
     def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
         x = self.tok_emb(input_ids)
+        if self.smeargate_gate is not None:
+            prev = torch.cat((x[:, :1, :], x[:, :-1, :]), dim=1)
+            gate = torch.sigmoid(self.smeargate_gate.to(dtype=x.dtype))[None, None, :]
+            x = x + gate * (prev - x)
         x = F.rms_norm(x, (x.size(-1),))
         x0 = x
         skips: list[Tensor] = []
 
         # First half stores skips; second half reuses them in reverse order.
         for i in range(self.num_encoder_layers):
-            x = self.blocks[i](x, x0)
+            x = self.blocks[i](x, x0, self.block_cores[self.layer_block_indices[i]], mod_keep=self.mod_keep if self.layer_block_indices[i] == self.mod_core else 1.0)
             skips.append(x)
         for i in range(self.num_decoder_layers):
             if skips:
                 x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
-            x = self.blocks[self.num_encoder_layers + i](x, x0)
+            layer_idx = self.num_encoder_layers + i
+            x = self.blocks[layer_idx](x, x0, self.block_cores[self.layer_block_indices[layer_idx]], mod_keep=self.mod_keep if self.layer_block_indices[layer_idx] == self.mod_core else 1.0)
 
         x = self.final_norm(x).reshape(-1, x.size(-1))
         targets = target_ids.reshape(-1)
@@ -835,6 +891,13 @@ def main() -> None:
         logit_softcap=args.logit_softcap,
         rope_base=args.rope_base,
         qk_gain_init=args.qk_gain_init,
+        depth_share_mode=args.depth_share_mode,
+        depth_unique_layers=args.depth_unique_layers,
+        depth_share_heavy_only=args.depth_share_heavy_only,
+        mod_keep=args.mod_keep,
+        mod_core=args.mod_core,
+        smeargate=args.smeargate,
+        smeargate_init=args.smeargate_init,
     ).to(device).bfloat16()
     for module in base_model.modules():
         if isinstance(module, CastedLinear):
@@ -848,19 +911,20 @@ def main() -> None:
     # - untied lm_head (Adam) uses HEAD_LR
     # - matrix params in transformer blocks use MATRIX_LR via Muon
     # - vectors/scalars use SCALAR_LR via Adam
-    block_named_params = list(base_model.blocks.named_parameters())
+    model_named_params = list(base_model.named_parameters())
     matrix_params = [
         p
-        for name, p in block_named_params
-        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        for name, p in model_named_params
+        if name not in {"tok_emb.weight", "lm_head.weight"}
+        and p.ndim == 2
+        and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
     ]
     scalar_params = [
         p
-        for name, p in block_named_params
-        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        for name, p in model_named_params
+        if name not in {"tok_emb.weight", "lm_head.weight"}
+        and (p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS))
     ]
-    if base_model.skip_weights.numel() > 0:
-        scalar_params.append(base_model.skip_weights)
     token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
     optimizer_tok = torch.optim.Adam(
         [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
@@ -873,6 +937,7 @@ def main() -> None:
         lr=args.matrix_lr,
         momentum=args.muon_momentum,
         backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_weight_decay,
     )
     for group in optimizer_muon.param_groups:
         group["base_lr"] = args.matrix_lr
@@ -897,6 +962,15 @@ def main() -> None:
     log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
     log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
     log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"depth_share_mode:{args.depth_share_mode} depth_unique_layers:{args.depth_unique_layers} "
+        f"depth_share_heavy_only:{int(args.depth_share_heavy_only)} unique_cores:{len(base_model.block_cores)}"
+    )
+    log0(
+        f"mod_keep:{args.mod_keep} mod_core:{args.mod_core} "
+        f"smeargate:{int(args.smeargate)} smeargate_init:{args.smeargate_init} "
+        f"muon_weight_decay:{args.muon_weight_decay}"
+    )
     log0(
         f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
         f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -612,13 +612,16 @@ class CausalSelfAttention(nn.Module):
         q = apply_rotary_emb(q, cos, sin)
         k = apply_rotary_emb(k, cos, sin)
         q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        if self.num_kv_heads != self.num_heads:
+            repeat = self.num_heads // self.num_kv_heads
+            k = k.repeat_interleave(repeat, dim=1)
+            v = v.repeat_interleave(repeat, dim=1)
         y = F.scaled_dot_product_attention(
             q,
             k,
             v,
             attn_mask=None,
             is_causal=True,
-            enable_gqa=(self.num_kv_heads != self.num_heads),
         )
         y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
         return self.proj(y)

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -677,9 +677,9 @@ class Block(nn.Module):
             scores = flat.float().abs().mean(dim=-1)
             idx = torch.topk(scores, k, sorted=False).indices
             sel = core.mlp(flat.index_select(0, idx))
-            mlp_out = torch.zeros_like(flat)
+            mlp_out = torch.zeros(flat.shape, device=flat.device, dtype=sel.dtype)
             mlp_out.index_copy_(0, idx, sel)
-            mlp_out = mlp_out.view_as(mlp_x)
+            mlp_out = mlp_out.view_as(mlp_x).to(dtype=x.dtype)
         else:
             mlp_out = core.mlp(mlp_x)
         x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * mlp_out

--- a/train_gpt_mlx.py
+++ b/train_gpt_mlx.py
@@ -52,10 +52,15 @@ class Hyperparameters:
     val_loss_every: int = int(os.environ.get("VAL_LOSS_EVERY", 0))
     # Validation always uses the full fineweb_val split.
     val_batch_size: int = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_max_tokens: int = int(os.environ.get("VAL_MAX_TOKENS", 0))
     train_log_every: int = int(os.environ.get("TRAIN_LOG_EVERY", 200))
     train_batch_tokens: int = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
     grad_accum_steps: int = int(os.environ.get("GRAD_ACCUM_STEPS", 8))
     train_seq_len: int = int(os.environ.get("TRAIN_SEQ_LEN", os.environ.get("TRAIN_MAX_SEQ_LEN", 1024)))
+    val_seq_len: int = int(os.environ.get("VAL_SEQ_LEN", os.environ.get("TRAIN_SEQ_LEN", os.environ.get("TRAIN_MAX_SEQ_LEN", 1024))))
+    seq_len_schedule: str = os.environ.get("SEQ_LEN_SCHEDULE", "none")
+    seq_len_min: int = int(os.environ.get("SEQ_LEN_MIN", os.environ.get("TRAIN_SEQ_LEN", os.environ.get("TRAIN_MAX_SEQ_LEN", 1024))))
+    seq_len_ramp_steps: int = int(os.environ.get("SEQ_LEN_RAMP_STEPS", 0))
     # Chunk each logical MLX microbatch into smaller sub-batches to reduce peak
     # memory pressure without changing the effective optimizer batch.
     mlx_max_microbatch_tokens: int = int(os.environ.get("MLX_MAX_MICROBATCH_TOKENS", 8_192))
@@ -76,6 +81,18 @@ class Hyperparameters:
     logit_softcap: float = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
     rope_base: float = float(os.environ.get("ROPE_BASE", 10000.0))
     qk_gain_init: float = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    depth_share_mode: str = os.environ.get("DEPTH_SHARE_MODE", "none")
+    depth_unique_layers: int = int(os.environ.get("DEPTH_UNIQUE_LAYERS", 3))
+    depth_step_scale: bool = bool(int(os.environ.get("DEPTH_STEP_SCALE", "1")))
+    depth_share_heavy_only: bool = bool(int(os.environ.get("DEPTH_SHARE_HEAVY_ONLY", "0")))
+    attnres_mode: str = os.environ.get("ATTNRES_MODE", "full")
+    attnres_block_size: int = int(os.environ.get("ATTNRES_BLOCK_SIZE", 3))
+    attnres_local_blend: float = float(os.environ.get("ATTNRES_LOCAL_BLEND", 0.5))
+    attnres_sublayers: str = os.environ.get("ATTNRES_SUBLAYERS", "both")
+    attnres_decoder_last_n: int = int(os.environ.get("ATTNRES_DECODER_LAST_N", 0))
+    latent_mem_mode: str = os.environ.get("LATENT_MEM_MODE", "none")
+    latent_mem_slots: int = int(os.environ.get("LATENT_MEM_SLOTS", 8))
+    latent_mem_layers: int = int(os.environ.get("LATENT_MEM_LAYERS", 2))
 
     # Optimizer. We keep the same per-group defaults as train_gpt.py.
     beta1: float = float(os.environ.get("BETA1", 0.9))
@@ -91,6 +108,7 @@ class Hyperparameters:
     grad_clip_norm: float = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
 
     out_dir: str = os.environ.get("OUT_DIR", "logs")
+    load_model_path: str = os.environ.get("LOAD_MODEL_PATH", "")
 
     @property
     def train_files(self) -> str:
@@ -103,6 +121,14 @@ class Hyperparameters:
     @property
     def microbatch_tokens(self) -> int:
         return self.train_batch_tokens // self.grad_accum_steps
+
+    def train_seq_len_for_step(self, step: int) -> int:
+        if self.seq_len_schedule == "none" or self.seq_len_ramp_steps <= 0 or self.seq_len_min >= self.train_seq_len:
+            return self.train_seq_len
+        if self.seq_len_schedule != "linear":
+            raise ValueError(f"SEQ_LEN_SCHEDULE must be none or linear, got {self.seq_len_schedule!r}")
+        t = min(step, self.seq_len_ramp_steps) / max(self.seq_len_ramp_steps, 1)
+        return max(1, min(self.train_seq_len, int(round(self.seq_len_min + t * (self.train_seq_len - self.seq_len_min)))))
 
     def lr_mul(self, step: int, elapsed_ms: float) -> float:
         if self.warmdown_iters <= 0:
@@ -120,7 +146,7 @@ CONTROL_TENSOR_NAME_PATTERNS = tuple(
     pattern
     for pattern in os.environ.get(
         "CONTROL_TENSOR_NAME_PATTERNS",
-        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,attn_res_query,mlp_res_query,step_scale,step_scales,latent_mem",
     ).split(",")
     if pattern
 )
@@ -347,6 +373,36 @@ class MLP(nn.Module):
         return self.proj(x * x)
 
 
+class LatentSummaryMemory(nn.Module):
+    def __init__(self, dim: int, slots: int):
+        super().__init__()
+        self.latent_mem_queries = mx.random.normal((slots, dim), dtype=mx.float32) * 0.02
+        self.latent_mem_scale = mx.zeros((dim,), dtype=mx.float32)
+        self.score_scale = dim ** -0.5
+
+    def summarize(self, x: mx.array) -> mx.array:
+        x_norm = rms_norm(x)
+        q = self.latent_mem_queries.astype(x.dtype)
+        scores = mx.sum(x_norm[:, :, None, :] * q[None, None, :, :], axis=-1) * self.score_scale
+        weights = mx.softmax(scores.transpose(0, 2, 1), axis=-1)
+        return weights @ x
+
+    def read(self, x: mx.array, memory: mx.array) -> mx.array:
+        scores = (rms_norm(x) @ rms_norm(memory).transpose(0, 2, 1)) * self.score_scale
+        weights = mx.softmax(scores, axis=-1)
+        ctx = weights @ memory
+        return x + self.latent_mem_scale.astype(x.dtype)[None, None, :] * ctx
+
+
+class BlockCore(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int, rope_base: float, qk_gain_init: float):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn.proj.weight = mx.zeros_like(self.attn.proj.weight)
+        self.mlp.proj.weight = mx.zeros_like(self.mlp.proj.weight)
+
+
 class Block(nn.Module):
     def __init__(
         self,
@@ -356,22 +412,67 @@ class Block(nn.Module):
         mlp_mult: int,
         rope_base: float,
         qk_gain_init: float,
+        share_heavy_only: bool = False,
     ):
         super().__init__()
+        self.core = None if share_heavy_only else BlockCore(dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init)
         self.attn_norm = RMSNormNoWeight()
         self.mlp_norm = RMSNormNoWeight()
-        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
-        self.mlp = MLP(dim, mlp_mult)
         self.attn_scale = mx.ones((dim,), dtype=mx.float32)
         self.mlp_scale = mx.ones((dim,), dtype=mx.float32)
         self.resid_mix = mx.array(np.stack((np.ones((dim,), dtype=np.float32), np.zeros((dim,), dtype=np.float32))))
+        self.attn_res_query = mx.zeros((dim,), dtype=mx.float32)
+        self.mlp_res_query = mx.zeros((dim,), dtype=mx.float32)
+        self.attn_res_norm = RMSNormNoWeight()
+        self.mlp_res_norm = RMSNormNoWeight()
 
-    def __call__(self, x: mx.array, x0: mx.array) -> mx.array:
+    def _depth_mix(self, outputs: list, query: mx.array, norm) -> mx.array:
+        """Softmax-weighted combination of prior layer outputs (Attention Residuals).
+        Returns a weighted combination where weights come from softmax attention
+        using the learned pseudo-query against RMSNorm'd layer outputs as keys."""
+        q = query.astype(outputs[0].dtype)
+        stacked = mx.stack(outputs, axis=0)  # (L, B, S, D)
+        scores = mx.sum(norm(stacked) * q[None, None, None, :], axis=-1)
+        weights = mx.softmax(scores, axis=0)[:, :, :, None]
+        return mx.sum(weights * stacked, axis=0)
+
+    def _blend_local(self, local_x: mx.array, mixed_x: mx.array, local_blend: float) -> mx.array:
+        if local_blend <= 0.0:
+            return mixed_x
+        if local_blend >= 1.0:
+            return local_x
+        return local_x * local_blend + mixed_x * (1.0 - local_blend)
+
+    def __call__(
+        self,
+        history_outputs: list,
+        *,
+        attnres_mode: str = "none",
+        local_blend: float = 0.0,
+        use_attnres_attn: bool = True,
+        use_attnres_mlp: bool = True,
+        step_scales: mx.array | None = None,
+        core: BlockCore | None = None,
+    ) -> mx.array:
+        core = self.core if core is None else core
+        x = history_outputs[-1]  # standard residual base (previous layer output)
+        attn_gate = mlp_gate = mx.array(1.0, dtype=x.dtype)
+        if step_scales is not None:
+            gates = step_scales.astype(x.dtype)
+            attn_gate, mlp_gate = gates[0], gates[1]
+        x0 = history_outputs[0]
         mix = self.resid_mix.astype(x.dtype)
-        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
-        attn_out = self.attn(self.attn_norm(x))
-        x = x + self.attn_scale.astype(x.dtype)[None, None, :] * attn_out
-        x = x + self.mlp_scale.astype(x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        attn_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if attnres_mode != "none" and use_attnres_attn:
+            attn_in = self._depth_mix(history_outputs, self.attn_res_query, self.attn_res_norm)
+            attn_in = self._blend_local(x, attn_in, local_blend)
+        attn_out = core.attn(self.attn_norm(attn_in))
+        x = x + (attn_gate * self.attn_scale.astype(x.dtype))[None, None, :] * attn_out
+        mlp_in = x
+        if attnres_mode != "none" and use_attnres_mlp:
+            mlp_in = self._depth_mix(history_outputs + [x], self.mlp_res_query, self.mlp_res_norm)
+            mlp_in = self._blend_local(x, mlp_in, local_blend)
+        x = x + (mlp_gate * self.mlp_scale.astype(x.dtype))[None, None, :] * core.mlp(self.mlp_norm(mlp_in))
         return x
 
 
@@ -382,56 +483,210 @@ class GPT(nn.Module):
     # - tied embeddings for the LM head (the baseline default setup)
     def __init__(self, vocab_size: int, num_layers: int, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int,
                  logit_chunk_tokens: int, logit_softcap: float, rope_base: float, tied_embed_init_std: float,
-                 qk_gain_init: float):
+                 qk_gain_init: float, depth_share_mode: str, depth_unique_layers: int, depth_step_scale: bool, depth_share_heavy_only: bool,
+                 attnres_mode: str, attnres_block_size: int, attnres_local_blend: float,
+                 attnres_sublayers: str, attnres_decoder_last_n: int,
+                 latent_mem_mode: str, latent_mem_slots: int, latent_mem_layers: int):
         super().__init__()
         if logit_softcap <= 0.0:
             raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        if depth_share_mode not in {"none", "cycle", "single", "encdec"}:
+            raise ValueError(f"DEPTH_SHARE_MODE must be one of none, cycle, single, encdec; got {depth_share_mode!r}")
+        if depth_unique_layers <= 0:
+            raise ValueError(f"DEPTH_UNIQUE_LAYERS must be positive, got {depth_unique_layers}")
+        if attnres_mode not in {"none", "full", "block", "hybrid"}:
+            raise ValueError(f"ATTNRES_MODE must be one of none, full, block, hybrid; got {attnres_mode!r}")
+        if attnres_block_size <= 0:
+            raise ValueError(f"ATTNRES_BLOCK_SIZE must be positive, got {attnres_block_size}")
+        if not 0.0 <= attnres_local_blend <= 1.0:
+            raise ValueError(f"ATTNRES_LOCAL_BLEND must be in [0, 1], got {attnres_local_blend}")
+        if attnres_sublayers not in {"both", "attn", "mlp"}:
+            raise ValueError(f"ATTNRES_SUBLAYERS must be one of both, attn, mlp; got {attnres_sublayers!r}")
+        if attnres_decoder_last_n < 0:
+            raise ValueError(f"ATTNRES_DECODER_LAST_N must be non-negative, got {attnres_decoder_last_n}")
+        if latent_mem_mode not in {"none", "summary", "recurrent", "segment"}:
+            raise ValueError(f"LATENT_MEM_MODE must be one of none, summary, recurrent, segment; got {latent_mem_mode!r}")
+        if latent_mem_slots <= 0:
+            raise ValueError(f"LATENT_MEM_SLOTS must be positive, got {latent_mem_slots}")
+        if latent_mem_layers < 0:
+            raise ValueError(f"LATENT_MEM_LAYERS must be non-negative, got {latent_mem_layers}")
         self.logit_chunk_tokens = logit_chunk_tokens
         self.logit_softcap = logit_softcap
+        self.depth_share_mode = depth_share_mode
+        self.depth_unique_layers = depth_unique_layers
+        self.depth_step_scale = depth_step_scale
+        self.depth_share_heavy_only = depth_share_heavy_only
+        self.attnres_mode = attnres_mode
+        self.attnres_block_size = attnres_block_size
+        self.attnres_local_blend = attnres_local_blend
+        self.attnres_sublayers = attnres_sublayers
+        self.attnres_decoder_last_n = attnres_decoder_last_n
+        self.latent_mem_mode = latent_mem_mode
+        self.latent_mem_slots = latent_mem_slots
+        self.latent_mem_layers = latent_mem_layers
 
         self.tok_emb = nn.Embedding(vocab_size, dim)
+        self.num_layers_total = num_layers
         self.num_encoder_layers = num_layers // 2
         self.num_decoder_layers = num_layers - self.num_encoder_layers
         self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
         self.skip_weights = mx.ones((self.num_skip_weights, dim), dtype=mx.float32)
-        self.blocks = [
-            Block(dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init)
-            for i in range(num_layers)
-        ]
+        self.layer_block_indices, num_unique_blocks = self._build_layer_block_indices()
+        self.block_cores = (
+            [BlockCore(dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init) for _ in range(num_unique_blocks)]
+            if self.depth_share_heavy_only else None
+        )
+        self.blocks = [Block(dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init, share_heavy_only=self.depth_share_heavy_only)
+                       for _ in range(self.num_layers_total if self.depth_share_heavy_only else num_unique_blocks)]
+        self.step_scales = (
+            mx.ones((num_layers, 2), dtype=mx.float32)
+            if self.depth_step_scale
+            else None
+        )
+        self.latent_mem = LatentSummaryMemory(dim, latent_mem_slots) if self.latent_mem_mode != "none" and self.latent_mem_layers > 0 else None
         self.final_norm = RMSNormNoWeight()
 
-        for b in self.blocks:
-            b.attn.proj.weight = mx.zeros_like(b.attn.proj.weight)
-            b.mlp.proj.weight = mx.zeros_like(b.mlp.proj.weight)
         self.tok_emb.weight = (
             mx.random.normal(self.tok_emb.weight.shape, dtype=mx.float32) * tied_embed_init_std
         ).astype(COMPUTE_DTYPE)
+
+    def _build_layer_block_indices(self) -> tuple[list[int], int]:
+        if self.depth_share_mode == "none":
+            return list(range(self.num_layers_total)), self.num_layers_total
+        if self.depth_share_mode == "single":
+            return [0] * self.num_layers_total, 1
+        if self.depth_share_mode == "cycle":
+            num_unique = min(self.depth_unique_layers, self.num_layers_total)
+            return [i % num_unique for i in range(self.num_layers_total)], num_unique
+
+        enc_unique = min(self.depth_unique_layers, max(self.num_encoder_layers, 1))
+        dec_unique = min(self.depth_unique_layers, max(self.num_decoder_layers, 1))
+        indices: list[int] = []
+        for i in range(self.num_encoder_layers):
+            indices.append(i % enc_unique)
+        offset = enc_unique
+        for i in range(self.num_decoder_layers):
+            indices.append(offset + (i % dec_unique))
+        return indices, enc_unique + dec_unique
 
     def softcap(self, logits: mx.array) -> mx.array:
         c = self.logit_softcap
         return c * mx.tanh(logits / c)
 
-    def __call__(self, input_ids: mx.array) -> mx.array:
+    def __call__(self, input_ids: mx.array, latent_memory: mx.array | None = None) -> mx.array:
         x = rms_norm(self.tok_emb(input_ids).astype(COMPUTE_DTYPE))
-        x0 = x
-        skips: list[mx.array] = []
+        layer_outputs = [x]  # x0 is entry 0
+        block_outputs = [x]
+        latent_read = None
+
+        def step_scales_for(layer_idx: int) -> mx.array | None:
+            if self.step_scales is None:
+                return None
+            return self.step_scales[layer_idx]
+
+        def block_for(layer_idx: int) -> Block:
+            return self.blocks[layer_idx] if self.depth_share_heavy_only else self.blocks[self.layer_block_indices[layer_idx]]
+
+        def core_for(layer_idx: int) -> BlockCore | None:
+            return self.block_cores[self.layer_block_indices[layer_idx]] if self.block_cores is not None else None
+
+        def history_for_mode() -> list[mx.array]:
+            if self.attnres_mode == "block":
+                return block_outputs + [layer_outputs[-1]]
+            return layer_outputs
+
+        def local_blend() -> float:
+            return self.attnres_local_blend if self.attnres_mode == "hybrid" else 0.0
+
+        def attnres_active(absolute_layer_idx: int) -> bool:
+            if self.attnres_mode == "none":
+                return False
+            if self.attnres_decoder_last_n <= 0:
+                return True
+            if absolute_layer_idx < self.num_encoder_layers:
+                return False
+            decoder_idx = absolute_layer_idx - self.num_encoder_layers
+            return decoder_idx >= self.num_decoder_layers - self.attnres_decoder_last_n
+
+        def use_attnres_attn_for(absolute_layer_idx: int) -> bool:
+            return attnres_active(absolute_layer_idx) and self.attnres_sublayers in {"both", "attn"}
+
+        def use_attnres_mlp_for(absolute_layer_idx: int) -> bool:
+            return attnres_active(absolute_layer_idx) and self.attnres_sublayers in {"both", "mlp"}
 
         for i in range(self.num_encoder_layers):
-            x = self.blocks[i](x, x0)
-            skips.append(x)
-        for i in range(self.num_decoder_layers):
-            # Odd layer counts have one more decoder block than encoder block. The baseline only
-            # applies a skip connection when one exists, then runs the remaining decoder block(s)
-            # without an added skip.
-            if skips:
-                x = x + self.skip_weights[i].astype(x.dtype)[None, None, :] * skips.pop()
-            x = self.blocks[self.num_encoder_layers + i](x, x0)
-        return self.final_norm(x)
+            block = block_for(i)
+            x = block(
+                history_for_mode(),
+                attnres_mode=self.attnres_mode,
+                local_blend=local_blend(),
+                use_attnres_attn=use_attnres_attn_for(i),
+                use_attnres_mlp=use_attnres_mlp_for(i),
+                step_scales=step_scales_for(i),
+                core=core_for(i),
+            )
+            layer_outputs.append(x)
+            if self.attnres_mode == "block" and (
+                (i + 1) % self.attnres_block_size == 0 or i + 1 == self.num_layers_total
+            ):
+                block_outputs.append(x)
 
-    def loss(self, input_ids: mx.array, target_ids: mx.array) -> mx.array:
+        if self.latent_mem is not None:
+            if self.latent_mem_mode == "summary":
+                latent_read = self.latent_mem.summarize(layer_outputs[-1])
+            elif self.latent_mem_mode in {"recurrent", "segment"} and latent_memory is not None:
+                latent_read = mx.broadcast_to(latent_memory.astype(layer_outputs[-1].dtype), (x.shape[0],) + latent_memory.shape[1:])
+
+        skips = list(layer_outputs[1:self.num_encoder_layers + 1])
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = layer_outputs[-1] + self.skip_weights[i].astype(layer_outputs[-1].dtype)[None, None, :] * skips.pop()
+                layer_outputs[-1] = x
+            if latent_read is not None and i >= self.num_decoder_layers - self.latent_mem_layers:
+                x = self.latent_mem.read(layer_outputs[-1], latent_read)
+                layer_outputs[-1] = x
+            absolute_layer_idx = self.num_encoder_layers + i
+            block = block_for(absolute_layer_idx)
+            x = block(
+                history_for_mode(),
+                attnres_mode=self.attnres_mode,
+                local_blend=local_blend(),
+                use_attnres_attn=use_attnres_attn_for(absolute_layer_idx),
+                use_attnres_mlp=use_attnres_mlp_for(absolute_layer_idx),
+                step_scales=step_scales_for(absolute_layer_idx),
+                core=core_for(absolute_layer_idx),
+            )
+            layer_outputs.append(x)
+            if self.attnres_mode == "block" and (
+                (absolute_layer_idx + 1) % self.attnres_block_size == 0
+                or absolute_layer_idx + 1 == self.num_layers_total
+            ):
+                block_outputs.append(x)
+
+        return self.final_norm(layer_outputs[-1])
+
+    def next_memory(self, input_ids: mx.array, latent_memory: mx.array | None = None) -> mx.array:
+        if self.latent_mem is None or self.latent_mem_mode == "none":
+            return mx.zeros((1, self.latent_mem_slots, self.tok_emb.weight.shape[1]), dtype=COMPUTE_DTYPE)
+        if self.latent_mem_mode == "segment":
+            x = self(input_ids, latent_memory=latent_memory)
+            tail = x[-1:, -min(self.latent_mem_slots, x.shape[1]):, :]
+            if tail.shape[1] == self.latent_mem_slots:
+                return tail
+            pad = mx.zeros((1, self.latent_mem_slots - tail.shape[1], tail.shape[2]), dtype=tail.dtype)
+            return mx.concatenate([pad, tail], axis=1)
+        if self.latent_mem_mode != "recurrent":
+            return mx.zeros((1, self.latent_mem_slots, self.tok_emb.weight.shape[1]), dtype=COMPUTE_DTYPE)
+        x = rms_norm(self.tok_emb(input_ids).astype(COMPUTE_DTYPE))
+        summary = mx.mean(self.latent_mem.summarize(x), axis=0, keepdims=True)
+        if latent_memory is None:
+            return summary
+        return 0.5 * latent_memory.astype(summary.dtype) + 0.5 * summary
+
+    def loss(self, input_ids: mx.array, target_ids: mx.array, latent_memory: mx.array | None = None) -> mx.array:
         # Cross-entropy over flattened tokens. We keep optional logit chunking because it is a useful
         # memory knob on Macs, but the common path is chunk_tokens=0 (single matmul + CE).
-        x = self(input_ids).reshape(-1, self.tok_emb.weight.shape[1])
+        x = self(input_ids, latent_memory=latent_memory).reshape(-1, self.tok_emb.weight.shape[1])
         y = target_ids.reshape(-1)
         if self.logit_chunk_tokens <= 0 or x.shape[0] <= self.logit_chunk_tokens:
             logits_proj = x @ self.tok_emb.weight.astype(x.dtype).T
@@ -490,12 +745,16 @@ class SplitOptimizers:
         self.matrix_keys = [
             k
             for k, p in params.items()
-            if k.startswith("blocks.") and p.ndim == 2 and not any(pattern in k for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+            if k != self.embed_key and p.ndim == 2 and not any(pattern in k for pattern in CONTROL_TENSOR_NAME_PATTERNS)
         ]
         self.scalar_keys = [
             k
             for k, p in params.items()
-            if k == "skip_weights" or (k.startswith("blocks.") and (p.ndim < 2 or any(pattern in k for pattern in CONTROL_TENSOR_NAME_PATTERNS)))
+            if k != self.embed_key and (
+                k in {"skip_weights", "step_scales"}
+                or p.ndim < 2
+                or any(pattern in k for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+            )
         ]
 
         self.muon = Muon(self.matrix_keys, params, args)
@@ -548,11 +807,18 @@ MX_DTYPE_FROM_NAME = {
     "bfloat16": mx.bfloat16,
 }
 
-INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+QUANT_MATRIX_BITS = int(os.environ.get("QUANT_MATRIX_BITS", "8"))
+if QUANT_MATRIX_BITS not in {8, 4}:
+    raise ValueError(f"QUANT_MATRIX_BITS must be 8 or 4, got {QUANT_MATRIX_BITS}")
+INT8_KEEP_FLOAT_MAX_NUMEL = int(os.environ.get("INT8_KEEP_FLOAT_MAX_NUMEL", "65536"))
 INT8_KEEP_FLOAT_STORE_DTYPE = np.float16
 INT8_PER_ROW_SCALE_DTYPE = np.float16
-INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_PERCENTILE = float(os.environ.get("INT8_CLIP_PERCENTILE", "99.99984"))
 INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+
+def quant_label() -> str:
+    return "int8" if QUANT_MATRIX_BITS == 8 else f"m{QUANT_MATRIX_BITS}"
 
 
 def _np_float32(arr: mx.array) -> np.ndarray:
@@ -568,22 +834,48 @@ def keep_float_array(name: str, arr: mx.array, passthrough_orig_dtypes: dict[str
     return np.ascontiguousarray(np.array(arr, copy=True))
 
 
-def quantize_float_array(arr: mx.array) -> tuple[np.ndarray, np.ndarray]:
+def pack_int4(values: np.ndarray) -> tuple[np.ndarray, tuple[int, ...]]:
+    q = np.asarray(values, dtype=np.int8, order="C")
+    orig_shape = q.shape
+    flat = q.reshape(-1).astype(np.int16, copy=False) + 8
+    if flat.size % 2:
+        flat = np.pad(flat, (0, 1))
+    packed = ((flat[1::2] << 4) | flat[0::2]).astype(np.uint8, copy=False)
+    return np.ascontiguousarray(packed), orig_shape
+
+
+def unpack_int4(packed: np.ndarray, orig_shape: tuple[int, ...]) -> np.ndarray:
+    packed_u8 = np.asarray(packed, dtype=np.uint8)
+    flat = np.empty((packed_u8.size * 2,), dtype=np.int8)
+    flat[0::2] = (packed_u8 & 0x0F).astype(np.int8, copy=False) - 8
+    flat[1::2] = ((packed_u8 >> 4) & 0x0F).astype(np.int8, copy=False) - 8
+    needed = int(np.prod(orig_shape))
+    return np.ascontiguousarray(flat[:needed].reshape(orig_shape))
+
+
+def quantize_float_array(arr: mx.array) -> tuple[np.ndarray, np.ndarray, dict[str, object]]:
     f32 = _np_float32(arr)
     if f32.ndim == 2:
         # Matrices get one scale per row, which usually tracks output-channel
         # ranges much better than a single tensor-wide scale.
         clip_abs = np.quantile(np.abs(f32), INT8_CLIP_Q, axis=1) if f32.size else np.empty((f32.shape[0],), dtype=np.float32)
         clipped = np.clip(f32, -clip_abs[:, None], clip_abs[:, None])
-        scale = np.maximum(clip_abs / 127.0, 1.0 / 127.0).astype(np.float32, copy=False)
-        q = np.clip(np.round(clipped / scale[:, None]), -127, 127).astype(np.int8, copy=False)
-        return np.ascontiguousarray(q), np.ascontiguousarray(scale.astype(INT8_PER_ROW_SCALE_DTYPE, copy=False))
+        qmax = 127 if QUANT_MATRIX_BITS == 8 else 7
+        scale = np.maximum(clip_abs / qmax, 1.0 / qmax).astype(np.float32, copy=False)
+        q = np.clip(np.round(clipped / scale[:, None]), -qmax, qmax).astype(np.int8, copy=False)
+        meta: dict[str, object] = {"scheme": "per_row", "axis": 0, "bits": QUANT_MATRIX_BITS}
+        if QUANT_MATRIX_BITS == 4:
+            packed, orig_shape = pack_int4(q)
+            meta["packed"] = True
+            meta["orig_shape"] = orig_shape
+            return packed, np.ascontiguousarray(scale.astype(INT8_PER_ROW_SCALE_DTYPE, copy=False)), meta
+        return np.ascontiguousarray(q), np.ascontiguousarray(scale.astype(INT8_PER_ROW_SCALE_DTYPE, copy=False)), meta
 
     # Vectors / scalars use a simpler per-tensor scale.
     clip_abs = float(np.quantile(np.abs(f32).reshape(-1), INT8_CLIP_Q)) if f32.size else 0.0
     scale = np.array(clip_abs / 127.0 if clip_abs > 0.0 else 1.0, dtype=np.float32)
     q = np.clip(np.round(np.clip(f32, -clip_abs, clip_abs) / scale), -127, 127).astype(np.int8, copy=False)
-    return np.ascontiguousarray(q), scale
+    return np.ascontiguousarray(q), scale, {"bits": 8}
 
 
 def quantize_state_dict_int8(flat_state: dict[str, mx.array]) -> tuple[dict[str, object], dict[str, int]]:
@@ -616,15 +908,15 @@ def quantize_state_dict_int8(flat_state: dict[str, mx.array]) -> tuple[dict[str,
             continue
 
         stats["num_float_tensors"] += 1
-        q, s = quantize_float_array(arr)
-        if s.ndim > 0:
-            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        q, s, meta = quantize_float_array(arr)
+        if meta:
+            qmeta[name] = meta
         quantized[name] = q
         scales[name] = s
         dtypes[name] = str(arr.dtype).split(".")[-1]
         stats["int8_payload_bytes"] += int(q.nbytes + s.nbytes)
     obj: dict[str, object] = {
-        "__quant_format__": "int8_clean_per_row_v1",
+        "__quant_format__": f"{quant_label()}_clean_per_row_v1",
         "quantized": quantized,
         "scales": scales,
         "dtypes": dtypes,
@@ -642,10 +934,14 @@ def dequantize_state_dict_int8(quant_obj: dict[str, object]) -> dict[str, mx.arr
     qmeta = quant_obj.get("qmeta", {})
     passthrough_orig_dtypes = quant_obj.get("passthrough_orig_dtypes", {})
     for name, q in quant_obj["quantized"].items():
-        q_np = np.asarray(q, dtype=np.int8)
+        meta = qmeta.get(name, {})
+        if meta.get("bits") == 4 and meta.get("packed"):
+            q_np = unpack_int4(q, tuple(meta["orig_shape"]))
+        else:
+            q_np = np.asarray(q, dtype=np.int8)
         dtype_name = quant_obj["dtypes"][name]
         scale = np.asarray(quant_obj["scales"][name], dtype=np.float32)
-        if qmeta.get(name, {}).get("scheme") == "per_row" or scale.ndim > 0:
+        if meta.get("scheme") == "per_row" or scale.ndim > 0:
             # Broadcast the saved row scale back across trailing dimensions.
             out_arr = q_np.astype(np.float32) * scale.reshape((q_np.shape[0],) + (1,) * (q_np.ndim - 1))
         else:
@@ -734,27 +1030,59 @@ def load_validation_tokens(pattern: str, seq_len: int) -> np.ndarray:
     return tokens[: usable + 1]
 
 
+def maybe_limit_validation_tokens(tokens: np.ndarray, seq_len: int, max_tokens: int) -> np.ndarray:
+    if max_tokens <= 0:
+        return tokens
+    usable = min(((max_tokens // seq_len) * seq_len), tokens.size - 1)
+    if usable <= 0:
+        raise ValueError(f"VAL_MAX_TOKENS={max_tokens} is too small for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
 def loss_and_grad_chunked(
     args: Hyperparameters,
     train_loader: TokenLoader,
     compiled_loss_and_grad,
-) -> tuple[mx.array, dict]:
-    chunk_sizes = token_chunks(args.microbatch_tokens, args.train_seq_len, args.mlx_max_microbatch_tokens)
+    compiled_next_memory,
+    latent_memory: mx.array,
+    seq_len: int,
+) -> tuple[mx.array, dict, mx.array]:
+    chunk_sizes = token_chunks(args.microbatch_tokens, seq_len, args.mlx_max_microbatch_tokens)
     total_tokens = float(sum(chunk_sizes))
     loss_value = mx.array(0.0, dtype=mx.float32)
     grad_accum: dict[str, mx.array] | None = None
     for chunk_tokens in chunk_sizes:
-        x, y = train_loader.next_batch(chunk_tokens, args.train_seq_len)
-        loss, grads = compiled_loss_and_grad(x, y)
+        x, y = train_loader.next_batch(chunk_tokens, seq_len)
+        loss, grads = compiled_loss_and_grad(x, y, latent_memory)
         scale = float(y.size) / total_tokens
         loss_value = loss_value + loss.astype(mx.float32) * scale
         grad_accum = accumulate_flat_grads(grad_accum, grads, scale)
-    return loss_value, tree_unflatten(list(grad_accum.items()))
+        if args.latent_mem_mode in {"recurrent", "segment"}:
+            latent_memory = compiled_next_memory(x, latent_memory)
+    return loss_value, tree_unflatten(list(grad_accum.items())), latent_memory
+
+
+def is_state_array_leaf(value: object) -> bool:
+    return hasattr(value, "dtype") and hasattr(value, "shape") and hasattr(value, "nbytes")
+
+
+def load_flat_state_npz(path: Path) -> dict[str, mx.array]:
+    if not hasattr(mx, "load"):
+        raise RuntimeError("mlx.core does not expose mx.load; cannot load raw .npz checkpoints safely")
+    loaded = mx.load(str(path))
+    if not isinstance(loaded, dict):
+        raise TypeError(f"Expected mx.load({path}) to return a dict, got {type(loaded)!r}")
+    return {str(k): v for k, v in loaded.items()}
+
+
+def init_latent_memory(args: Hyperparameters) -> mx.array:
+    return mx.zeros((1, max(args.latent_mem_slots, 1), args.model_dim), dtype=COMPUTE_DTYPE)
 
 
 def eval_val(
     args: Hyperparameters,
     compiled_loss,
+    compiled_next_memory,
     val_tokens: np.ndarray,
     base_bytes_lut: np.ndarray,
     has_leading_space_lut: np.ndarray,
@@ -764,28 +1092,31 @@ def eval_val(
     # - val_loss: token cross-entropy (natural log)
     # - val_bpb: tokenizer-agnostic compression metric used by the challenge
     val_batch_tokens = args.val_batch_size // args.grad_accum_steps
-    if val_batch_tokens < args.train_seq_len:
+    if val_batch_tokens < args.val_seq_len:
         raise ValueError(
             "VAL_BATCH_SIZE must provide at least one sequence; "
             f"got VAL_BATCH_SIZE={args.val_batch_size}, GRAD_ACCUM_STEPS={args.grad_accum_steps}, "
-            f"TRAIN_SEQ_LEN={args.train_seq_len}"
+            f"VAL_SEQ_LEN={args.val_seq_len}"
         )
-    val_batch_seqs = val_batch_tokens // args.train_seq_len
-    total_seqs = (val_tokens.size - 1) // args.train_seq_len
+    val_batch_seqs = val_batch_tokens // args.val_seq_len
+    total_seqs = (val_tokens.size - 1) // args.val_seq_len
     total_loss = mx.array(0.0, dtype=mx.float32)
     total_tokens = 0.0
     total_bytes = 0.0
+    latent_memory = init_latent_memory(args)
     for batch_seq_start in range(0, total_seqs, val_batch_seqs):
         batch_seq_end = min(batch_seq_start + val_batch_seqs, total_seqs)
-        raw_start = batch_seq_start * args.train_seq_len
-        raw_end = batch_seq_end * args.train_seq_len + 1
+        raw_start = batch_seq_start * args.val_seq_len
+        raw_end = batch_seq_end * args.val_seq_len + 1
         chunk = val_tokens[raw_start:raw_end]
-        x_np = chunk[:-1].reshape(-1, args.train_seq_len)
-        y_np = chunk[1:].reshape(-1, args.train_seq_len)
+        x_np = chunk[:-1].reshape(-1, args.val_seq_len)
+        y_np = chunk[1:].reshape(-1, args.val_seq_len)
         x = mx.array(x_np, dtype=mx.int32)
         y = mx.array(y_np, dtype=mx.int32)
         chunk_token_count = float(y.size)
-        total_loss = total_loss + compiled_loss(x, y).astype(mx.float32) * chunk_token_count
+        total_loss = total_loss + compiled_loss(x, y, latent_memory).astype(mx.float32) * chunk_token_count
+        if args.latent_mem_mode in {"recurrent", "segment"}:
+            latent_memory = compiled_next_memory(x, latent_memory)
         prev_ids = x_np.reshape(-1)
         tgt_ids = y_np.reshape(-1)
         bytes_np = base_bytes_lut[tgt_ids].astype(np.int16, copy=True)
@@ -830,6 +1161,10 @@ def main() -> None:
     out_dir.mkdir(parents=True, exist_ok=True)
     logfile = out_dir / f"{args.run_id}.txt"
     print(logfile)
+    if min(args.train_seq_len, args.val_seq_len, args.seq_len_min) <= 0:
+        raise ValueError("TRAIN_SEQ_LEN, VAL_SEQ_LEN, and SEQ_LEN_MIN must be positive")
+    if args.seq_len_min > args.train_seq_len:
+        raise ValueError(f"SEQ_LEN_MIN={args.seq_len_min} must be <= TRAIN_SEQ_LEN={args.train_seq_len}")
 
     def log(msg: str, console: bool = True) -> None:
         if console:
@@ -857,7 +1192,8 @@ def main() -> None:
         args.data_path,
         args.tokenizer_path,
     )
-    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, args.val_seq_len)
+    val_tokens = maybe_limit_validation_tokens(val_tokens, args.val_seq_len, args.val_max_tokens)
 
     base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
         sp, args.vocab_size
@@ -885,7 +1221,24 @@ def main() -> None:
         rope_base=args.rope_base,
         tied_embed_init_std=args.tied_embed_init_std,
         qk_gain_init=args.qk_gain_init,
+        depth_share_mode=args.depth_share_mode,
+        depth_unique_layers=args.depth_unique_layers,
+        depth_step_scale=args.depth_step_scale,
+        depth_share_heavy_only=args.depth_share_heavy_only,
+        attnres_mode=args.attnres_mode,
+        attnres_block_size=args.attnres_block_size,
+        attnres_local_blend=args.attnres_local_blend,
+        attnres_sublayers=args.attnres_sublayers,
+        attnres_decoder_last_n=args.attnres_decoder_last_n,
+        latent_mem_mode=args.latent_mem_mode,
+        latent_mem_slots=args.latent_mem_slots,
+        latent_mem_layers=args.latent_mem_layers,
     )
+    if args.load_model_path:
+        load_path = Path(args.load_model_path)
+        if not load_path.exists():
+            raise FileNotFoundError(f"LOAD_MODEL_PATH does not exist: {load_path}")
+        model.update(tree_unflatten(list(load_flat_state_npz(load_path).items())))
     opt = SplitOptimizers(model, args)
 
     # ==============================================================================
@@ -895,19 +1248,24 @@ def main() -> None:
     # inside RoPE modules), so compiling only against trainable parameters throws "uncaptured inputs".
     # Compiling the model-bound functions and capturing the full model state fixes that while still
     # returning gradients only for trainable parameters via nn.value_and_grad(...).
-    compiled_loss = mx.compile(lambda x, y: model.loss(x, y), inputs=model.state, outputs=model.state)
+    compiled_loss = mx.compile(lambda x, y, m: model.loss(x, y, m), inputs=model.state, outputs=model.state)
     compiled_loss_and_grad = mx.compile(
-        nn.value_and_grad(model, lambda x, y: model.loss(x, y)),
+        nn.value_and_grad(model, lambda x, y, m: model.loss(x, y, m)),
         inputs=model.state,
         outputs=model.state,
     )
+    compiled_next_memory = mx.compile(lambda x, m: model.next_memory(x, m), inputs=model.state, outputs=model.state)
 
     # Print config once so logs are self-describing.
     n_params = sum(int(np.prod(p.shape)) for _, p in tree_flatten(model.parameters()))
     log(f"run_id:{args.run_id}")
     log(f"mlx_version:{mx.__version__}")
+    if args.load_model_path:
+        log(f"load_model_path:{args.load_model_path}")
     log(f"train_loader:shards pattern={args.train_files}")
     log(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.size - 1}")
+    if args.val_max_tokens > 0:
+        log(f"val_loader:limited_tokens:{val_tokens.size - 1}")
     if expected_train_files is None:
         log(f"train_loader:dataset:{dataset_name} train_shards:{actual_train_files}")
     elif actual_train_files < expected_train_files:
@@ -922,7 +1280,7 @@ def main() -> None:
     log(
         f"model_params:{n_params} vocab_size:{args.vocab_size} layers:{args.num_layers} "
         f"dim:{args.model_dim} heads:{args.num_heads} kv_heads:{args.num_kv_heads} "
-        f"seq_len:{args.train_seq_len} tie_embeddings:{args.tie_embeddings}"
+        f"train_seq_len:{args.train_seq_len} val_seq_len:{args.val_seq_len} tie_embeddings:{args.tie_embeddings}"
     )
     log(
         f"iterations:{args.iterations} train_batch_tokens:{args.train_batch_tokens} grad_accum_steps:{args.grad_accum_steps} "
@@ -930,18 +1288,47 @@ def main() -> None:
         f"val_batch_size:{args.val_batch_size} "
         f"warmup_steps:{args.warmup_steps} max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
     )
+    log(
+        f"seq_len_schedule:{args.seq_len_schedule} "
+        f"seq_len_min:{args.seq_len_min} "
+        f"seq_len_ramp_steps:{args.seq_len_ramp_steps}"
+    )
     log(f"mlx_max_microbatch_tokens:{args.mlx_max_microbatch_tokens}")
+    log(
+        f"depth_share_mode:{args.depth_share_mode} "
+        f"depth_unique_layers:{args.depth_unique_layers} "
+        f"depth_step_scale:{int(args.depth_step_scale)} "
+        f"depth_share_heavy_only:{int(args.depth_share_heavy_only)} "
+        f"block_wrappers:{len(model.blocks)} unique_cores:{len(model.block_cores) if model.block_cores is not None else len(model.blocks)}"
+    )
+    log(
+        f"attnres_mode:{args.attnres_mode} "
+        f"attnres_block_size:{args.attnres_block_size} "
+        f"attnres_local_blend:{args.attnres_local_blend:.3f} "
+        f"attnres_sublayers:{args.attnres_sublayers} "
+        f"attnres_decoder_last_n:{args.attnres_decoder_last_n}"
+    )
+    log(
+        f"latent_mem_mode:{args.latent_mem_mode} "
+        f"latent_mem_slots:{args.latent_mem_slots} "
+        f"latent_mem_layers:{args.latent_mem_layers}"
+    )
     log(
         f"optimizer:muon+adam muon_matrix_params:{len(opt.matrix_keys)} scalar_params:{len(opt.scalar_keys)} "
         f"embed_lr:{args.tied_embed_lr} "
         f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr} "
         f"muon_momentum:{args.muon_momentum} muon_steps:{args.muon_backend_steps}"
     )
+    log(
+        f"quantization:label:{quant_label()} matrix_bits:{QUANT_MATRIX_BITS} "
+        f"keep_float_max_numel:{INT8_KEEP_FLOAT_MAX_NUMEL} clip_percentile:{INT8_CLIP_PERCENTILE}"
+    )
     log(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
     log(f"compute_dtype:{COMPUTE_DTYPE} compile:True")
+    sample_core = model.block_cores[0] if model.block_cores is not None else model.blocks[0].core
     log(
         f"dtypes tok_emb:{model.tok_emb.weight.dtype} "
-        f"linear_weight:{model.blocks[0].attn.c_q.weight.dtype} "
+        f"linear_weight:{sample_core.attn.c_q.weight.dtype} "
         f"skip_weights:{model.skip_weights.dtype}"
     )
 
@@ -957,28 +1344,34 @@ def main() -> None:
             accum: dict[str, mx.array] | None = None
             warmup_loss = mx.array(0.0, dtype=mx.float32)
             grad_scale = 1.0 / args.grad_accum_steps
+            warm_memory = init_latent_memory(args)
+            warm_seq_len = args.train_seq_len_for_step(warmup_step)
             for _ in range(args.grad_accum_steps):
-                warmup_loss, grads = loss_and_grad_chunked(args, train_loader, compiled_loss_and_grad)
+                warmup_loss, grads, warm_memory = loss_and_grad_chunked(
+                    args, train_loader, compiled_loss_and_grad, compiled_next_memory, warm_memory, warm_seq_len
+                )
                 accum = accumulate_flat_grads(accum, grads, grad_scale)
-            mx.eval(warmup_loss, accum)
+            mx.eval(warmup_loss, accum, warm_memory)
             mx.synchronize()
             if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
                 log(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
 
         # Prime the standalone eval graph once too. It is compiled separately from value_and_grad.
         val_batch_tokens = args.val_batch_size // args.grad_accum_steps
-        if val_batch_tokens < args.train_seq_len:
+        if val_batch_tokens < args.val_seq_len:
             raise ValueError(
                 "VAL_BATCH_SIZE must provide at least one sequence; "
                 f"got VAL_BATCH_SIZE={args.val_batch_size}, GRAD_ACCUM_STEPS={args.grad_accum_steps}, "
-                f"TRAIN_SEQ_LEN={args.train_seq_len}"
+                f"VAL_SEQ_LEN={args.val_seq_len}"
             )
-        warm_val_seqs = min(val_batch_tokens // args.train_seq_len, (val_tokens.size - 1) // args.train_seq_len)
-        warm_chunk = val_tokens[: warm_val_seqs * args.train_seq_len + 1]
-        x_val = mx.array(warm_chunk[:-1].reshape(-1, args.train_seq_len), dtype=mx.int32)
-        y_val = mx.array(warm_chunk[1:].reshape(-1, args.train_seq_len), dtype=mx.int32)
-        warm_val_loss = compiled_loss(x_val, y_val)
-        mx.eval(warm_val_loss)
+        warm_val_seqs = min(val_batch_tokens // args.val_seq_len, (val_tokens.size - 1) // args.val_seq_len)
+        warm_chunk = val_tokens[: warm_val_seqs * args.val_seq_len + 1]
+        x_val = mx.array(warm_chunk[:-1].reshape(-1, args.val_seq_len), dtype=mx.int32)
+        y_val = mx.array(warm_chunk[1:].reshape(-1, args.val_seq_len), dtype=mx.int32)
+        warm_memory = init_latent_memory(args)
+        warm_val_loss = compiled_loss(x_val, y_val, warm_memory)
+        warm_next_memory = compiled_next_memory(x_val, warm_memory)
+        mx.eval(warm_val_loss, warm_next_memory)
         mx.synchronize()
 
         train_loader = TokenLoader(args.train_files, log_fn=log, dataset_name=dataset_name)
@@ -986,6 +1379,7 @@ def main() -> None:
     train_time_ms = 0.0
     max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
     stop_after_step: int | None = None
+    latent_memory = init_latent_memory(args)
     t0 = time.perf_counter()
     step = 0
     while True:
@@ -995,6 +1389,7 @@ def main() -> None:
             val_loss, val_bpb = eval_val(
                 args,
                 compiled_loss,
+                compiled_next_memory,
                 val_tokens,
                 base_bytes_lut,
                 has_leading_space_lut,
@@ -1018,8 +1413,11 @@ def main() -> None:
         accum: dict[str, mx.array] | None = None
         train_loss = mx.array(0.0, dtype=mx.float32)
         grad_scale = 1.0 / args.grad_accum_steps
+        step_seq_len = args.train_seq_len_for_step(step)
         for _ in range(args.grad_accum_steps):
-            loss, grads = loss_and_grad_chunked(args, train_loader, compiled_loss_and_grad)
+            loss, grads, latent_memory = loss_and_grad_chunked(
+                args, train_loader, compiled_loss_and_grad, compiled_next_memory, latent_memory, step_seq_len
+            )
             accum = accumulate_flat_grads(accum, grads, grad_scale)
             train_loss = train_loss + loss.astype(mx.float32) * grad_scale
 
@@ -1036,7 +1434,8 @@ def main() -> None:
         if args.train_log_every > 0 and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None):
             log(
                 f"step:{step}/{args.iterations} train_loss:{train_loss_value:.4f} "
-                f"train_time:{approx_train_time_ms:.0f}ms step_avg:{approx_train_time_ms / step:.2f}ms tok_s:{tok_s:.0f}"
+                f"train_time:{approx_train_time_ms:.0f}ms step_avg:{approx_train_time_ms / step:.2f}ms tok_s:{tok_s:.0f} "
+                f"seq_len:{step_seq_len}"
             )
         if max_wallclock_ms is not None and stop_after_step is None and approx_train_time_ms >= max_wallclock_ms:
             stop_after_step = step
@@ -1048,7 +1447,11 @@ def main() -> None:
     # quantized roundtrip directly by loading the dequantized tensors back into the
     # model and running one final validation pass.
     out_path = out_dir / f"{args.run_id}_mlx_model.npz"
-    flat_state = {k: v for k, v in tree_flatten(model.state)}
+    raw_state_items = list(tree_flatten(model.state))
+    flat_state = {k: v for k, v in raw_state_items if is_state_array_leaf(v)}
+    dropped_state_keys = [k for k, v in raw_state_items if not is_state_array_leaf(v)]
+    if dropped_state_keys:
+        log(f"state_export:dropped_nonarray_keys:{','.join(dropped_state_keys)}")
     mx.savez(str(out_path), **flat_state)
     log(f"saved_model:{out_path} bytes:{out_path.stat().st_size}")
 
@@ -1056,13 +1459,13 @@ def main() -> None:
     quant_raw = pickle.dumps(quant_obj, protocol=pickle.HIGHEST_PROTOCOL)
     quant_blob = zlib.compress(quant_raw, level=9)
     quant_serialized_bytes = len(quant_raw)
-    quant_path = out_dir / f"{args.run_id}_mlx_model.int8.ptz"
+    quant_path = out_dir / f"{args.run_id}_mlx_model.{quant_label()}.ptz"
     with quant_path.open("wb") as f:
         f.write(quant_blob)
     quant_file_bytes = quant_path.stat().st_size
     ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
     log(
-        f"serialized_model_int8_zlib:{quant_file_bytes} bytes "
+        f"serialized_model_{quant_label()}_zlib:{quant_file_bytes} bytes "
         f"(payload:{quant_stats['int8_payload_bytes']} raw_pickle:{quant_serialized_bytes} payload_ratio:{ratio:.2f}x)"
     )
 
@@ -1074,14 +1477,15 @@ def main() -> None:
     q_val_loss, q_val_bpb = eval_val(
         args,
         compiled_loss,
+        compiled_next_memory,
         val_tokens,
         base_bytes_lut,
         has_leading_space_lut,
         is_boundary_token_lut,
     )
     q_eval_ms = 1000.0 * (time.perf_counter() - q_t0)
-    log(f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} eval_time:{q_eval_ms:.0f}ms")
-    log(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+    log(f"final_{quant_label()}_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} eval_time:{q_eval_ms:.0f}ms")
+    log(f"final_{quant_label()}_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
 
 
 if __name__ == "__main__":

--- a/train_gpt_mlx.py
+++ b/train_gpt_mlx.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
-"""
-The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
-
-Hard stop: `train_gpt.py` and `train_gpt_mlx.py` must never be longer than 1500 lines.
-"""
+"""Starter script for local Parameter Golf research. Keep under 1500 lines."""
 from __future__ import annotations
 
 import glob
@@ -58,6 +54,7 @@ class Hyperparameters:
     grad_accum_steps: int = int(os.environ.get("GRAD_ACCUM_STEPS", 8))
     train_seq_len: int = int(os.environ.get("TRAIN_SEQ_LEN", os.environ.get("TRAIN_MAX_SEQ_LEN", 1024)))
     val_seq_len: int = int(os.environ.get("VAL_SEQ_LEN", os.environ.get("TRAIN_SEQ_LEN", os.environ.get("TRAIN_MAX_SEQ_LEN", 1024))))
+    val_stride: int = int(os.environ.get("VAL_STRIDE", "0"))
     seq_len_schedule: str = os.environ.get("SEQ_LEN_SCHEDULE", "none")
     seq_len_min: int = int(os.environ.get("SEQ_LEN_MIN", os.environ.get("TRAIN_SEQ_LEN", os.environ.get("TRAIN_MAX_SEQ_LEN", 1024))))
     seq_len_ramp_steps: int = int(os.environ.get("SEQ_LEN_RAMP_STEPS", 0))
@@ -93,6 +90,10 @@ class Hyperparameters:
     latent_mem_mode: str = os.environ.get("LATENT_MEM_MODE", "none")
     latent_mem_slots: int = int(os.environ.get("LATENT_MEM_SLOTS", 8))
     latent_mem_layers: int = int(os.environ.get("LATENT_MEM_LAYERS", 2))
+    mod_keep: float = float(os.environ.get("MOD_KEEP", "1.0"))
+    mod_core: int = int(os.environ.get("MOD_CORE", "1"))
+    smeargate: bool = bool(int(os.environ.get("SMEARGATE", "0")))
+    smeargate_init: float = float(os.environ.get("SMEARGATE_INIT", "-2.0"))
 
     # Optimizer. We keep the same per-group defaults as train_gpt.py.
     beta1: float = float(os.environ.get("BETA1", 0.9))
@@ -101,7 +102,9 @@ class Hyperparameters:
     tied_embed_lr: float = float(os.environ.get("TIED_EMBED_LR", 0.05))
     matrix_lr: float = float(os.environ.get("MATRIX_LR", 0.04))
     scalar_lr: float = float(os.environ.get("SCALAR_LR", 0.04))
+    mlp_lora_rank: int = int(os.environ.get("MLP_LORA_RANK", "0"))
     muon_momentum: float = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_weight_decay: float = float(os.environ.get("MUON_WEIGHT_DECAY", 0.0))
     muon_backend_steps: int = int(os.environ.get("MUON_BACKEND_STEPS", 5))
     muon_momentum_warmup_start: float = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
     muon_momentum_warmup_steps: int = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
@@ -146,7 +149,7 @@ CONTROL_TENSOR_NAME_PATTERNS = tuple(
     pattern
     for pattern in os.environ.get(
         "CONTROL_TENSOR_NAME_PATTERNS",
-        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,attn_res_query,mlp_res_query,step_scale,step_scales,latent_mem",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,attn_res_query,mlp_res_query,step_scale,step_scales,latent_mem,mlp_lora",
     ).split(",")
     if pattern
 )
@@ -309,16 +312,11 @@ class CastedLinear(nn.Module):
 
 
 class RMSNormNoWeight(nn.Module):
-    # MLX module wrapper around the functional RMSNorm helper so it composes nicely in blocks.
     def __call__(self, x: mx.array) -> mx.array:
         return rms_norm(x)
 
 
 class CausalSelfAttention(nn.Module):
-    # - separate q/k/v projections
-    # - RMSNorm on q and k before attention
-    # - RoPE on q and k
-    # - causal masked SDPA
     def __init__(
         self,
         dim: int,
@@ -361,7 +359,6 @@ class CausalSelfAttention(nn.Module):
 
 
 class MLP(nn.Module):
-    # Baseline MLP uses relu^2 instead of GELU/SiLU. It is cheap and works well in this setup.
     def __init__(self, dim: int, mlp_mult: int):
         super().__init__()
         hidden = dim * mlp_mult
@@ -421,6 +418,10 @@ class Block(nn.Module):
         self.attn_scale = mx.ones((dim,), dtype=mx.float32)
         self.mlp_scale = mx.ones((dim,), dtype=mx.float32)
         self.resid_mix = mx.array(np.stack((np.ones((dim,), dtype=np.float32), np.zeros((dim,), dtype=np.float32))))
+        r = Hyperparameters.mlp_lora_rank
+        self.mlp_lora_a = mx.random.normal((r, dim), dtype=mx.float32) * (1.0 / math.sqrt(max(dim, 1))) if r > 0 else None
+        self.mlp_lora_b = mx.zeros((dim, r), dtype=mx.float32) if r > 0 else None
+        self.mlp_lora_scale = 1.0 / max(r, 1)
         self.attn_res_query = mx.zeros((dim,), dtype=mx.float32)
         self.mlp_res_query = mx.zeros((dim,), dtype=mx.float32)
         self.attn_res_norm = RMSNormNoWeight()
@@ -453,6 +454,7 @@ class Block(nn.Module):
         use_attnres_mlp: bool = True,
         step_scales: mx.array | None = None,
         core: BlockCore | None = None,
+        mod_keep: float = 1.0,
     ) -> mx.array:
         core = self.core if core is None else core
         x = history_outputs[-1]  # standard residual base (previous layer output)
@@ -472,21 +474,25 @@ class Block(nn.Module):
         if attnres_mode != "none" and use_attnres_mlp:
             mlp_in = self._depth_mix(history_outputs + [x], self.mlp_res_query, self.mlp_res_norm)
             mlp_in = self._blend_local(x, mlp_in, local_blend)
-        x = x + (mlp_gate * self.mlp_scale.astype(x.dtype))[None, None, :] * core.mlp(self.mlp_norm(mlp_in))
+        mlp_x = self.mlp_norm(mlp_in)
+        if mod_keep < 1.0:
+            flat = mlp_x.reshape(-1, mlp_x.shape[-1]); k = max(1, int(round(mod_keep * float(flat.shape[0])))); idx = mx.stop_gradient(mx.argsort(mx.mean(mx.abs(flat.astype(mx.float32)), axis=-1))[-k:])
+            sel = core.mlp(flat[idx]); mlp_out = mx.put_along_axis(mx.zeros_like(flat), mx.broadcast_to(idx[:, None], sel.shape), sel, axis=0).reshape(mlp_x.shape)
+        else: mlp_out = core.mlp(mlp_x)
+        if self.mlp_lora_a is not None:
+            mlp_out = mlp_out + self.mlp_lora_scale * ((mlp_x @ self.mlp_lora_a.astype(x.dtype).T) @ self.mlp_lora_b.astype(x.dtype).T)
+        x = x + (mlp_gate * self.mlp_scale.astype(x.dtype))[None, None, :] * mlp_out
         return x
 
 
 class GPT(nn.Module):
-    # - token embedding + RMSNorm
-    # - encoder half accumulates skip tensors
-    # - decoder half consumes reversed skips with learned skip_weights
-    # - tied embeddings for the LM head (the baseline default setup)
     def __init__(self, vocab_size: int, num_layers: int, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int,
                  logit_chunk_tokens: int, logit_softcap: float, rope_base: float, tied_embed_init_std: float,
                  qk_gain_init: float, depth_share_mode: str, depth_unique_layers: int, depth_step_scale: bool, depth_share_heavy_only: bool,
                  attnres_mode: str, attnres_block_size: int, attnres_local_blend: float,
                  attnres_sublayers: str, attnres_decoder_last_n: int,
-                 latent_mem_mode: str, latent_mem_slots: int, latent_mem_layers: int):
+                 latent_mem_mode: str, latent_mem_slots: int, latent_mem_layers: int, mod_keep: float, mod_core: int,
+                 smeargate: bool, smeargate_init: float):
         super().__init__()
         if logit_softcap <= 0.0:
             raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
@@ -524,6 +530,9 @@ class GPT(nn.Module):
         self.latent_mem_mode = latent_mem_mode
         self.latent_mem_slots = latent_mem_slots
         self.latent_mem_layers = latent_mem_layers
+        self.mod_keep = mod_keep
+        self.mod_core = mod_core
+        self.smeargate_gate = mx.ones((dim,), dtype=mx.float32) * smeargate_init if smeargate else None
 
         self.tok_emb = nn.Embedding(vocab_size, dim)
         self.num_layers_total = num_layers
@@ -532,12 +541,16 @@ class GPT(nn.Module):
         self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
         self.skip_weights = mx.ones((self.num_skip_weights, dim), dtype=mx.float32)
         self.layer_block_indices, num_unique_blocks = self._build_layer_block_indices()
+        heads = (HEAD_SCHEDULE or [num_heads]) * num_unique_blocks if len(HEAD_SCHEDULE) <= 1 else HEAD_SCHEDULE
+        kv_heads = (KV_HEAD_SCHEDULE or [num_kv_heads]) * num_unique_blocks if len(KV_HEAD_SCHEDULE) <= 1 else KV_HEAD_SCHEDULE
+        if len(heads) != num_unique_blocks or len(kv_heads) != num_unique_blocks:
+            raise ValueError(f"HEAD_SCHEDULE/KV_HEAD_SCHEDULE must have length 1 or {num_unique_blocks}")
         self.block_cores = (
-            [BlockCore(dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init) for _ in range(num_unique_blocks)]
+            [BlockCore(dim, heads[i], kv_heads[i], mlp_mult, rope_base, qk_gain_init) for i in range(num_unique_blocks)]
             if self.depth_share_heavy_only else None
         )
-        self.blocks = [Block(dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init, share_heavy_only=self.depth_share_heavy_only)
-                       for _ in range(self.num_layers_total if self.depth_share_heavy_only else num_unique_blocks)]
+        self.blocks = [Block(dim, num_heads if self.depth_share_heavy_only else heads[i], num_kv_heads if self.depth_share_heavy_only else kv_heads[i], mlp_mult, rope_base, qk_gain_init, share_heavy_only=self.depth_share_heavy_only)
+                       for i in range(self.num_layers_total if self.depth_share_heavy_only else num_unique_blocks)]
         self.step_scales = (
             mx.ones((num_layers, 2), dtype=mx.float32)
             if self.depth_step_scale
@@ -574,7 +587,12 @@ class GPT(nn.Module):
         return c * mx.tanh(logits / c)
 
     def __call__(self, input_ids: mx.array, latent_memory: mx.array | None = None) -> mx.array:
-        x = rms_norm(self.tok_emb(input_ids).astype(COMPUTE_DTYPE))
+        x = self.tok_emb(input_ids).astype(COMPUTE_DTYPE)
+        if self.smeargate_gate is not None:
+            prev = mx.concatenate([x[:, :1, :], x[:, :-1, :]], axis=1)
+            gate = mx.sigmoid(self.smeargate_gate.astype(x.dtype))[None, None, :]
+            x = x + gate * (prev - x)
+        x = rms_norm(x)
         layer_outputs = [x]  # x0 is entry 0
         block_outputs = [x]
         latent_read = None
@@ -589,6 +607,8 @@ class GPT(nn.Module):
 
         def core_for(layer_idx: int) -> BlockCore | None:
             return self.block_cores[self.layer_block_indices[layer_idx]] if self.block_cores is not None else None
+        def mod_keep_for(layer_idx: int) -> float:
+            return self.mod_keep if self.layer_block_indices[layer_idx] == self.mod_core else 1.0
 
         def history_for_mode() -> list[mx.array]:
             if self.attnres_mode == "block":
@@ -624,6 +644,7 @@ class GPT(nn.Module):
                 use_attnres_mlp=use_attnres_mlp_for(i),
                 step_scales=step_scales_for(i),
                 core=core_for(i),
+                mod_keep=mod_keep_for(i),
             )
             layer_outputs.append(x)
             if self.attnres_mode == "block" and (
@@ -655,6 +676,7 @@ class GPT(nn.Module):
                 use_attnres_mlp=use_attnres_mlp_for(absolute_layer_idx),
                 step_scales=step_scales_for(absolute_layer_idx),
                 core=core_for(absolute_layer_idx),
+                mod_keep=mod_keep_for(absolute_layer_idx),
             )
             layer_outputs.append(x)
             if self.attnres_mode == "block" and (
@@ -683,31 +705,22 @@ class GPT(nn.Module):
             return summary
         return 0.5 * latent_memory.astype(summary.dtype) + 0.5 * summary
 
-    def loss(self, input_ids: mx.array, target_ids: mx.array, latent_memory: mx.array | None = None) -> mx.array:
-        # Cross-entropy over flattened tokens. We keep optional logit chunking because it is a useful
-        # memory knob on Macs, but the common path is chunk_tokens=0 (single matmul + CE).
+    def loss(self, input_ids: mx.array, target_ids: mx.array, latent_memory: mx.array | None = None, reduction: str = "mean") -> mx.array:
         x = self(input_ids, latent_memory=latent_memory).reshape(-1, self.tok_emb.weight.shape[1])
         y = target_ids.reshape(-1)
-        if self.logit_chunk_tokens <= 0 or x.shape[0] <= self.logit_chunk_tokens:
-            logits_proj = x @ self.tok_emb.weight.astype(x.dtype).T
-            logits = self.softcap(logits_proj)
-            return nn.losses.cross_entropy(logits.astype(mx.float32), y, reduction="mean")
+        if self.logit_chunk_tokens > 0 and x.shape[0] > self.logit_chunk_tokens:
+            loss_sum = mx.array(0.0, dtype=mx.float32); n = int(x.shape[0]); chunks = [] if reduction == "none" else None
+            for s in range(0, n, self.logit_chunk_tokens):
+                e = min(s + self.logit_chunk_tokens, n)
+                ce = nn.losses.cross_entropy(self.softcap(x[s:e] @ self.tok_emb.weight.astype(x.dtype).T).astype(mx.float32), y[s:e], reduction="none")
+                if chunks is not None: chunks.append(ce)
+                else: loss_sum = loss_sum + mx.sum(ce)
+            return mx.concatenate(chunks, axis=0) if chunks is not None else loss_sum / float(n)
+        logits = self.softcap(x @ self.tok_emb.weight.astype(x.dtype).T).astype(mx.float32)
+        ce = nn.losses.cross_entropy(logits, y, reduction="none")
+        return ce if reduction == "none" else mx.mean(ce)
 
-        loss_sum = mx.array(0.0, dtype=mx.float32)
-        n = int(x.shape[0])
-        for s in range(0, n, self.logit_chunk_tokens):
-            e = min(s + self.logit_chunk_tokens, n)
-            logits_proj = x[s:e] @ self.tok_emb.weight.astype(x.dtype).T
-            logits = self.softcap(logits_proj)
-            loss_sum = loss_sum + nn.losses.cross_entropy(logits.astype(mx.float32), y[s:e], reduction="sum")
-        return loss_sum / float(n)
-
-# ==============================================================================
-# OPTIMIZERS (MUON + ADAM SPLIT)
-# ==============================================================================
 class Muon:
-    # Muon applies SGD-momentum to matrix gradients, then orthogonalizes the result before the
-    # parameter update.
     def __init__(self, keys: list[str], params: dict[str, mx.array], args: Hyperparameters):
         self.keys = keys
         self.args = args
@@ -729,15 +742,13 @@ class Muon:
             g_eff = g + momentum * buf
             g_ortho = zeropower_newtonschulz5(g_eff, self.args.muon_backend_steps)
             scale = math.sqrt(max(1.0, float(p.shape[0]) / float(p.shape[1])))
-            out[k] = p - lr * (g_ortho * scale).astype(p.dtype)
+            p_decay = p * (1.0 - lr * self.args.muon_weight_decay) if self.args.muon_weight_decay > 0 else p
+            out[k] = p_decay - lr * (g_ortho * scale).astype(p.dtype)
         return out
 
 
 class SplitOptimizers:
-    # - embeddings: Adam with the tied-embedding LR
-    # - block matrices (2D): Muon
-    # - block scalars + skip weights: Adam
-    # This preserves the high-level optimization behavior even though MLX internals differ.
+    # embeddings: Adam, 2D blocks: Muon, small/control tensors: Adam
     def __init__(self, model: GPT, args: Hyperparameters):
         self.args = args
         params = dict(tree_flatten(model.parameters()))
@@ -808,17 +819,21 @@ MX_DTYPE_FROM_NAME = {
 }
 
 QUANT_MATRIX_BITS = int(os.environ.get("QUANT_MATRIX_BITS", "8"))
-if QUANT_MATRIX_BITS not in {8, 4}:
-    raise ValueError(f"QUANT_MATRIX_BITS must be 8 or 4, got {QUANT_MATRIX_BITS}")
+if QUANT_MATRIX_BITS not in {8, 6, 4}:
+    raise ValueError(f"QUANT_MATRIX_BITS must be 8, 6, or 4, got {QUANT_MATRIX_BITS}")
+QUANT_MATRIX_BITS_OVERRIDES = tuple((pat, int(bits)) for spec in os.environ.get("QUANT_MATRIX_BITS_OVERRIDES", "").split(",") if ":" in spec for pat, bits in [spec.rsplit(":", 1)])
 INT8_KEEP_FLOAT_MAX_NUMEL = int(os.environ.get("INT8_KEEP_FLOAT_MAX_NUMEL", "65536"))
 INT8_KEEP_FLOAT_STORE_DTYPE = np.float16
 INT8_PER_ROW_SCALE_DTYPE = np.float16
 INT8_CLIP_PERCENTILE = float(os.environ.get("INT8_CLIP_PERCENTILE", "99.99984"))
 INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+HEAD_SCHEDULE = [int(x) for x in os.environ.get("HEAD_SCHEDULE", "").split(",") if x]
+KV_HEAD_SCHEDULE = [int(x) for x in os.environ.get("KV_HEAD_SCHEDULE", "").split(",") if x]
 
 
 def quant_label() -> str:
-    return "int8" if QUANT_MATRIX_BITS == 8 else f"m{QUANT_MATRIX_BITS}"
+    base = "int8" if QUANT_MATRIX_BITS == 8 else f"m{QUANT_MATRIX_BITS}"
+    return f"{base}mix" if QUANT_MATRIX_BITS_OVERRIDES else base
 
 
 def _np_float32(arr: mx.array) -> np.ndarray:
@@ -832,40 +847,31 @@ def keep_float_array(name: str, arr: mx.array, passthrough_orig_dtypes: dict[str
         passthrough_orig_dtypes[name] = str(arr.dtype).split(".")[-1]
         return np.ascontiguousarray(np.array(arr.astype(mx.float16), dtype=INT8_KEEP_FLOAT_STORE_DTYPE, copy=False))
     return np.ascontiguousarray(np.array(arr, copy=True))
-
-
-def pack_int4(values: np.ndarray) -> tuple[np.ndarray, tuple[int, ...]]:
+def pack_nbits(values: np.ndarray, bits: int) -> tuple[np.ndarray, tuple[int, ...]]:
     q = np.asarray(values, dtype=np.int8, order="C")
-    orig_shape = q.shape
-    flat = q.reshape(-1).astype(np.int16, copy=False) + 8
-    if flat.size % 2:
-        flat = np.pad(flat, (0, 1))
-    packed = ((flat[1::2] << 4) | flat[0::2]).astype(np.uint8, copy=False)
-    return np.ascontiguousarray(packed), orig_shape
-
-
-def unpack_int4(packed: np.ndarray, orig_shape: tuple[int, ...]) -> np.ndarray:
-    packed_u8 = np.asarray(packed, dtype=np.uint8)
-    flat = np.empty((packed_u8.size * 2,), dtype=np.int8)
-    flat[0::2] = (packed_u8 & 0x0F).astype(np.int8, copy=False) - 8
-    flat[1::2] = ((packed_u8 >> 4) & 0x0F).astype(np.int8, copy=False) - 8
+    flat = q.reshape(-1).astype(np.uint8, copy=False) + (1 << (bits - 1))
+    bits_u8 = ((flat[:, None] >> np.arange(bits, dtype=np.uint8)) & 1).reshape(-1)
+    return np.ascontiguousarray(np.packbits(bits_u8, bitorder="little")), q.shape
+def unpack_nbits(packed: np.ndarray, orig_shape: tuple[int, ...], bits: int) -> np.ndarray:
     needed = int(np.prod(orig_shape))
-    return np.ascontiguousarray(flat[:needed].reshape(orig_shape))
-
-
-def quantize_float_array(arr: mx.array) -> tuple[np.ndarray, np.ndarray, dict[str, object]]:
+    bits_u8 = np.unpackbits(np.asarray(packed, dtype=np.uint8), bitorder="little")[: needed * bits].reshape(needed, bits)
+    flat = (bits_u8.astype(np.uint8) * (1 << np.arange(bits, dtype=np.uint8))).sum(axis=1, dtype=np.uint16)
+    return np.ascontiguousarray((flat.astype(np.int16) - (1 << (bits - 1))).astype(np.int8).reshape(orig_shape))
+def matrix_bits_for_name(name: str) -> int:
+    return next((bits for pattern, bits in QUANT_MATRIX_BITS_OVERRIDES if pattern in name), QUANT_MATRIX_BITS)
+def quantize_float_array(arr: mx.array, bits: int) -> tuple[np.ndarray, np.ndarray, dict[str, object]]:
     f32 = _np_float32(arr)
     if f32.ndim == 2:
         # Matrices get one scale per row, which usually tracks output-channel
         # ranges much better than a single tensor-wide scale.
         clip_abs = np.quantile(np.abs(f32), INT8_CLIP_Q, axis=1) if f32.size else np.empty((f32.shape[0],), dtype=np.float32)
         clipped = np.clip(f32, -clip_abs[:, None], clip_abs[:, None])
-        qmax = 127 if QUANT_MATRIX_BITS == 8 else 7
+        qmax = 127 if bits == 8 else (1 << (bits - 1)) - 1
         scale = np.maximum(clip_abs / qmax, 1.0 / qmax).astype(np.float32, copy=False)
         q = np.clip(np.round(clipped / scale[:, None]), -qmax, qmax).astype(np.int8, copy=False)
-        meta: dict[str, object] = {"scheme": "per_row", "axis": 0, "bits": QUANT_MATRIX_BITS}
-        if QUANT_MATRIX_BITS == 4:
-            packed, orig_shape = pack_int4(q)
+        meta: dict[str, object] = {"scheme": "per_row", "axis": 0, "bits": bits}
+        if bits < 8:
+            packed, orig_shape = pack_nbits(q, bits)
             meta["packed"] = True
             meta["orig_shape"] = orig_shape
             return packed, np.ascontiguousarray(scale.astype(INT8_PER_ROW_SCALE_DTYPE, copy=False)), meta
@@ -908,7 +914,7 @@ def quantize_state_dict_int8(flat_state: dict[str, mx.array]) -> tuple[dict[str,
             continue
 
         stats["num_float_tensors"] += 1
-        q, s, meta = quantize_float_array(arr)
+        q, s, meta = quantize_float_array(arr, matrix_bits_for_name(name))
         if meta:
             qmeta[name] = meta
         quantized[name] = q
@@ -935,8 +941,8 @@ def dequantize_state_dict_int8(quant_obj: dict[str, object]) -> dict[str, mx.arr
     passthrough_orig_dtypes = quant_obj.get("passthrough_orig_dtypes", {})
     for name, q in quant_obj["quantized"].items():
         meta = qmeta.get(name, {})
-        if meta.get("bits") == 4 and meta.get("packed"):
-            q_np = unpack_int4(q, tuple(meta["orig_shape"]))
+        if meta.get("packed"):
+            q_np = unpack_nbits(q, tuple(meta["orig_shape"]), int(meta["bits"]))
         else:
             q_np = np.asarray(q, dtype=np.int8)
         dtype_name = quant_obj["dtypes"][name]
@@ -1078,19 +1084,17 @@ def load_flat_state_npz(path: Path) -> dict[str, mx.array]:
 def init_latent_memory(args: Hyperparameters) -> mx.array:
     return mx.zeros((1, max(args.latent_mem_slots, 1), args.model_dim), dtype=COMPUTE_DTYPE)
 
-
 def eval_val(
     args: Hyperparameters,
     compiled_loss,
+    compiled_loss_tokens,
     compiled_next_memory,
     val_tokens: np.ndarray,
     base_bytes_lut: np.ndarray,
     has_leading_space_lut: np.ndarray,
     is_boundary_token_lut: np.ndarray,
 ) -> tuple[float, float]:
-    # Validation computes two metrics:
-    # - val_loss: token cross-entropy (natural log)
-    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    # Validation reports cross-entropy and tokenizer-agnostic val_bpb.
     val_batch_tokens = args.val_batch_size // args.grad_accum_steps
     if val_batch_tokens < args.val_seq_len:
         raise ValueError(
@@ -1098,6 +1102,19 @@ def eval_val(
             f"got VAL_BATCH_SIZE={args.val_batch_size}, GRAD_ACCUM_STEPS={args.grad_accum_steps}, "
             f"VAL_SEQ_LEN={args.val_seq_len}"
         )
+    if 0 < args.val_stride < args.val_seq_len:
+        if args.latent_mem_mode != "none": raise ValueError("Sliding-window eval does not support latent memory modes yet")
+        total_loss = total_tokens = total_bytes = 0.0; last_scored = -1; last_start = max(val_tokens.size - 1 - args.val_seq_len, 0)
+        starts = list(range(0, last_start + 1, args.val_stride))
+        if starts[-1] != last_start: starts.append(last_start)
+        for start in starts:
+            chunk = val_tokens[start : start + args.val_seq_len + 1]; x_np = chunk[:-1][None, :]; y_np = chunk[1:][None, :]
+            losses = np.array(compiled_loss_tokens(mx.array(x_np, dtype=mx.int32), mx.array(y_np, dtype=mx.int32), init_latent_memory(args)), dtype=np.float32)
+            score_from = max(last_scored + 1 - start, 0); last_scored = start + args.val_seq_len - 1
+            prev_ids = x_np.reshape(-1)[score_from:]; tgt_ids = y_np.reshape(-1)[score_from:]; loss_np = losses[score_from:]
+            bytes_np = base_bytes_lut[tgt_ids].astype(np.int16, copy=True); bytes_np += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).astype(np.int16, copy=False)
+            total_loss += float(loss_np.astype(np.float64).sum()); total_tokens += float(loss_np.size); total_bytes += float(bytes_np.astype(np.float64).sum())
+        val_loss = total_loss / total_tokens; bits_per_token = val_loss / math.log(2.0); return val_loss, bits_per_token * (total_tokens / total_bytes)
     val_batch_seqs = val_batch_tokens // args.val_seq_len
     total_seqs = (val_tokens.size - 1) // args.val_seq_len
     total_loss = mx.array(0.0, dtype=mx.float32)
@@ -1153,9 +1170,6 @@ def clip_grad_tree(grads_tree: dict, max_norm: float) -> dict:
 
 
 def main() -> None:
-    # ==============================================================================
-    # TOKENIZER + VALIDATION METRIC SETUP
-    # ==============================================================================
     args = Hyperparameters()
     out_dir = Path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -1199,16 +1213,10 @@ def main() -> None:
         sp, args.vocab_size
     )
 
-    # ==============================================================================
-    # TRAINING SETUP
-    # ==============================================================================
     mx.random.seed(args.seed)
 
     train_loader = TokenLoader(args.train_files, log_fn=log, dataset_name=dataset_name)
 
-    # ==============================================================================
-    # MODEL + OPTIMIZER SETUP
-    # ==============================================================================
     model = GPT(
         vocab_size=args.vocab_size,
         num_layers=args.num_layers,
@@ -1233,6 +1241,10 @@ def main() -> None:
         latent_mem_mode=args.latent_mem_mode,
         latent_mem_slots=args.latent_mem_slots,
         latent_mem_layers=args.latent_mem_layers,
+        mod_keep=args.mod_keep,
+        mod_core=args.mod_core,
+        smeargate=args.smeargate,
+        smeargate_init=args.smeargate_init,
     )
     if args.load_model_path:
         load_path = Path(args.load_model_path)
@@ -1241,14 +1253,8 @@ def main() -> None:
         model.update(tree_unflatten(list(load_flat_state_npz(load_path).items())))
     opt = SplitOptimizers(model, args)
 
-    # ==============================================================================
-    # COMPILED TRAIN / EVAL FUNCTIONS (MLX)
-    # ==============================================================================
-    # The crucial MLX detail is capture scope: this model contains non-trainable arrays too (for example
-    # inside RoPE modules), so compiling only against trainable parameters throws "uncaptured inputs".
-    # Compiling the model-bound functions and capturing the full model state fixes that while still
-    # returning gradients only for trainable parameters via nn.value_and_grad(...).
     compiled_loss = mx.compile(lambda x, y, m: model.loss(x, y, m), inputs=model.state, outputs=model.state)
+    compiled_loss_tokens = mx.compile(lambda x, y, m: model.loss(x, y, m, reduction="none"), inputs=model.state, outputs=model.state)
     compiled_loss_and_grad = mx.compile(
         nn.value_and_grad(model, lambda x, y, m: model.loss(x, y, m)),
         inputs=model.state,
@@ -1280,7 +1286,7 @@ def main() -> None:
     log(
         f"model_params:{n_params} vocab_size:{args.vocab_size} layers:{args.num_layers} "
         f"dim:{args.model_dim} heads:{args.num_heads} kv_heads:{args.num_kv_heads} "
-        f"train_seq_len:{args.train_seq_len} val_seq_len:{args.val_seq_len} tie_embeddings:{args.tie_embeddings}"
+        f"train_seq_len:{args.train_seq_len} val_seq_len:{args.val_seq_len} val_stride:{args.val_stride} tie_embeddings:{args.tie_embeddings}"
     )
     log(
         f"iterations:{args.iterations} train_batch_tokens:{args.train_batch_tokens} grad_accum_steps:{args.grad_accum_steps} "
@@ -1301,6 +1307,7 @@ def main() -> None:
         f"depth_share_heavy_only:{int(args.depth_share_heavy_only)} "
         f"block_wrappers:{len(model.blocks)} unique_cores:{len(model.block_cores) if model.block_cores is not None else len(model.blocks)}"
     )
+    if HEAD_SCHEDULE or KV_HEAD_SCHEDULE: log(f"head_schedule:{HEAD_SCHEDULE or [args.num_heads]} kv_head_schedule:{KV_HEAD_SCHEDULE or [args.num_kv_heads]}")
     log(
         f"attnres_mode:{args.attnres_mode} "
         f"attnres_block_size:{args.attnres_block_size} "
@@ -1311,7 +1318,9 @@ def main() -> None:
     log(
         f"latent_mem_mode:{args.latent_mem_mode} "
         f"latent_mem_slots:{args.latent_mem_slots} "
-        f"latent_mem_layers:{args.latent_mem_layers}"
+        f"latent_mem_layers:{args.latent_mem_layers} "
+        f"mod_keep:{args.mod_keep} mod_core:{args.mod_core} "
+        f"smeargate:{int(args.smeargate)} smeargate_init:{args.smeargate_init}"
     )
     log(
         f"optimizer:muon+adam muon_matrix_params:{len(opt.matrix_keys)} scalar_params:{len(opt.scalar_keys)} "
@@ -1332,14 +1341,7 @@ def main() -> None:
         f"skip_weights:{model.skip_weights.dtype}"
     )
 
-    # ==============================================================================
-    # TRAINING LOOP
-    # ==============================================================================
     if args.warmup_steps > 0:
-        # Warmup should only prime MLX compile/allocation paths. Updating parameters here forces us
-        # to snapshot and restore model/optimizer state, which is expensive on unified-memory Macs.
-        # Instead we run the real train shapes, force the loss/grads to materialize, and then reset
-        # the loader so measured training still starts from the true init and token window.
         for warmup_step in range(args.warmup_steps):
             accum: dict[str, mx.array] | None = None
             warmup_loss = mx.array(0.0, dtype=mx.float32)
@@ -1389,6 +1391,7 @@ def main() -> None:
             val_loss, val_bpb = eval_val(
                 args,
                 compiled_loss,
+                compiled_loss_tokens,
                 compiled_next_memory,
                 val_tokens,
                 base_bytes_lut,
@@ -1440,12 +1443,7 @@ def main() -> None:
         if max_wallclock_ms is not None and stop_after_step is None and approx_train_time_ms >= max_wallclock_ms:
             stop_after_step = step
 
-    # ==============================================================================
-    # FINAL SERIALIZATION + QUANTIZED ROUNDTRIP EVAL
-    # ==============================================================================
-    # We always write a raw artifact and a quantized artifact, then validate the
-    # quantized roundtrip directly by loading the dequantized tensors back into the
-    # model and running one final validation pass.
+    # Final serialization plus quantized roundtrip validation.
     out_path = out_dir / f"{args.run_id}_mlx_model.npz"
     raw_state_items = list(tree_flatten(model.state))
     flat_state = {k: v for k, v in raw_state_items if is_state_array_leaf(v)}
@@ -1477,6 +1475,7 @@ def main() -> None:
     q_val_loss, q_val_bpb = eval_val(
         args,
         compiled_loss,
+        compiled_loss_tokens,
         compiled_next_memory,
         val_tokens,
         base_bytes_lut,


### PR DESCRIPTION
## Summary
This draft PR packages the current local MLX research harness and the leading research direction for the Parameter Golf challenge.

The working objective is the challenge’s real target: best post-quantized `val_bpb` under a fixed training-time budget and a strict artifact-byte cap. The current research direction is a shared-heavy / unique-light transformer family that reuses the expensive core weights across depth while keeping small per-layer controls unique.

## What’s in this PR
- Local fixed-wallclock MLX screening support
- Faster local validation / export iteration support
- Shared-heavy / unique-light depth tying experiments
- Additional research toggles for curriculum, residual routing, memory, and export experiments

## Current status
- Draft PR
- Non-record research code, not an H100-validated submission
- Intended to support compute grant application and remote validation

## Current lead
Local matched-wallclock experiments currently point to the shared-heavy / unique-light cycle-3 backbone as the strongest direction in this branch. It is the first local architecture family in this repo exploration to consistently outperform the current baseline under equal local wallclock while also compressing very well.

## Why this direction
The main hypothesis is that this challenge rewards useful model behavior per second and per stored byte, not naive parameter scaling. This branch therefore focuses on:
- fast parameter-efficient backbones
- compression-aware model/export design
- a small number of controlled alternate architecture explorations

## Next steps
- Port the leading shared-heavy branch into `train_gpt.py`
- Run CUDA / H100 pilot experiments
- Explore compression-aware export and low-bit robustness on top of the shared-heavy backbone
- Keep one higher-risk alternate backbone branch in parallel
