### PR TITLE
Add strong-submission eval pipeline and ablation tooling

### DIFF
--- a/experiments/parameter_golf/PLAN.md
+++ b/experiments/parameter_golf/PLAN.md
@@ -1,0 +1,37 @@
+# Parameter Golf Strong Submission Plan
+
+## Objective
+Beat the current 10min/16MB SOTA by combining:
+- top training recipe (10L, Muon WD, fp16 tied-embedding export)
+- stronger evaluation (sliding and LoRA TTT)
+- statistically valid multi-seed comparisons.
+
+## Implemented in `train_gpt.py`
+- `FINAL_EVAL_MODE=standard|sliding|ttt`
+- `EVAL_SEQ_LEN`, `EVAL_STRIDE`, `EVAL_BATCH_SEQS`
+- `MUON_WEIGHT_DECAY` (decoupled in Muon optimizer)
+- `INT8_ALWAYS_KEEP_FLOAT_NAME_PATTERNS` (default keeps `tok_emb.weight` in fp16)
+
+## Execution Stages
+1. Reproduce top-like training quality (single seed smoke, then 3 seeds)
+2. Compare final eval modes on same checkpoint family:
+   - `standard`
+   - `sliding` with `EVAL_STRIDE=64`
+   - `ttt` with chunk sweep (`TTT_CHUNK_SIZE=256,128,64`)
+3. Promote best eval setup; run 3+ seeds with fixed config
+4. If mean improves >= 0.005 nats and p<0.01, package submission
+
+## Recommended Baseline Config
+- `NUM_LAYERS=10`
+- `MODEL_DIM=512`
+- `NUM_HEADS=8 NUM_KV_HEADS=4`
+- `MATRIX_LR=0.04`
+- `MUON_WEIGHT_DECAY=0.02`
+- `WARMDOWN_ITERS=2500`
+- `TIED_EMBED_LR=0.10`
+- `INT8_ALWAYS_KEEP_FLOAT_NAME_PATTERNS=tok_emb.weight`
+
+## Promotion Criteria
+- Primary: `final_*_exact val_loss`
+- Secondary: `val_bpb`, eval runtime
+- Hard constraints: code+artifact < 16,000,000 bytes and valid significance test vs prior best.

--- a/experiments/parameter_golf/run_ablation.sh
+++ b/experiments/parameter_golf/run_ablation.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DATA_PATH:=./data/datasets/fineweb10B_sp1024}"
+: "${TOKENIZER_PATH:=./data/tokenizers/fineweb_1024_bpe.model}"
+: "${NPROC:=8}"
+: "${SEED:=1337}"
+: "${RUN_ID_PREFIX:=sota_push}"
+
+COMMON_ENV=(
+  DATA_PATH="$DATA_PATH"
+  TOKENIZER_PATH="$TOKENIZER_PATH"
+  VOCAB_SIZE=1024
+  NUM_LAYERS=10
+  MODEL_DIM=512
+  NUM_HEADS=8
+  NUM_KV_HEADS=4
+  TRAIN_BATCH_TOKENS=524288
+  TRAIN_SEQ_LEN=1024
+  MAX_WALLCLOCK_SECONDS=600
+  MATRIX_LR=0.04
+  MUON_WEIGHT_DECAY=0.02
+  TIED_EMBED_LR=0.10
+  WARMDOWN_ITERS=2500
+  INT8_ALWAYS_KEEP_FLOAT_NAME_PATTERNS=tok_emb.weight
+  SEED="$SEED"
+)
+
+run_case () {
+  local case_name="$1"
+  shift
+  echo "=== Running case: ${case_name} ==="
+  env RUN_ID="${RUN_ID_PREFIX}_${case_name}_s${SEED}" "${COMMON_ENV[@]}" "$@" \
+    torchrun --standalone --nproc_per_node="$NPROC" train_gpt.py
+}
+
+# 1) Baseline final eval (non-overlap)
+run_case standard FINAL_EVAL_MODE=standard
+
+# 2) Sliding-window final eval
+run_case sliding FINAL_EVAL_MODE=sliding EVAL_SEQ_LEN=1024 EVAL_STRIDE=64 EVAL_BATCH_SEQS=256
+
+# 3) LoRA TTT final eval (default chunk=256)
+run_case ttt_256 FINAL_EVAL_MODE=ttt TTT_CHUNK_SIZE=256 TTT_EVAL_SEQ_LEN=1024 TTT_LORA_RANK=8 TTT_LORA_LR=0.01 TTT_BATCH_SIZE=64
+
+# 4) LoRA TTT finer chunks (more adaptation, higher eval cost)
+run_case ttt_128 FINAL_EVAL_MODE=ttt TTT_CHUNK_SIZE=128 TTT_EVAL_SEQ_LEN=1024 TTT_LORA_RANK=8 TTT_LORA_LR=0.01 TTT_BATCH_SIZE=64
+run_case ttt_64 FINAL_EVAL_MODE=ttt TTT_CHUNK_SIZE=64 TTT_EVAL_SEQ_LEN=1024 TTT_LORA_RANK=8 TTT_LORA_LR=0.01 TTT_BATCH_SIZE=64

--- a/experiments/parameter_golf/run_top3.sh
+++ b/experiments/parameter_golf/run_top3.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${NPROC:=8}"
+: "${DATA_PATH:=./data/datasets/fineweb10B_sp1024}"
+: "${TOKENIZER_PATH:=./data/tokenizers/fineweb_1024_bpe.model}"
+: "${FINAL_EVAL_MODE:=ttt}"  # standard|sliding|ttt
+
+for SEED in 1337 42 7; do
+  RUN_ID="strong_${FINAL_EVAL_MODE}_seed${SEED}"
+  echo "=== ${RUN_ID} ==="
+  env RUN_ID="$RUN_ID" SEED="$SEED" \
+    DATA_PATH="$DATA_PATH" TOKENIZER_PATH="$TOKENIZER_PATH" VOCAB_SIZE=1024 \
+    NUM_LAYERS=10 MODEL_DIM=512 NUM_HEADS=8 NUM_KV_HEADS=4 TRAIN_SEQ_LEN=1024 TRAIN_BATCH_TOKENS=524288 \
+    MAX_WALLCLOCK_SECONDS=600 MATRIX_LR=0.04 MUON_WEIGHT_DECAY=0.02 TIED_EMBED_LR=0.10 WARMDOWN_ITERS=2500 \
+    INT8_ALWAYS_KEEP_FLOAT_NAME_PATTERNS=tok_emb.weight \
+    FINAL_EVAL_MODE="$FINAL_EVAL_MODE" EVAL_SEQ_LEN=1024 EVAL_STRIDE=64 EVAL_BATCH_SEQS=256 \
+    TTT_CHUNK_SIZE=128 TTT_EVAL_SEQ_LEN=1024 TTT_LORA_RANK=8 TTT_LORA_LR=0.01 TTT_BATCH_SIZE=64 \
+    torchrun --standalone --nproc_per_node="$NPROC" train_gpt.py
+
+done

--- a/experiments/parameter_golf/summarize_runs.py
+++ b/experiments/parameter_golf/summarize_runs.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import argparse
+import math
+import re
+from pathlib import Path
+
+PAT = re.compile(r"(final_[^ ]+)_exact val_loss:([0-9.]+) val_bpb:([0-9.]+)")
+
+
+def parse_metric(path: Path):
+    tag = None
+    loss = None
+    bpb = None
+    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        m = PAT.search(line)
+        if m:
+            tag = m.group(1)
+            loss = float(m.group(2))
+            bpb = float(m.group(3))
+    if tag is None:
+        raise ValueError(f"No final exact metric found in {path}")
+    return tag, loss, bpb
+
+
+def mean(xs):
+    return sum(xs) / len(xs)
+
+
+def std(xs):
+    if len(xs) < 2:
+        return 0.0
+    m = mean(xs)
+    return math.sqrt(sum((x - m) ** 2 for x in xs) / (len(xs) - 1))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--glob", default="logs/*.txt", help="log file glob")
+    args = ap.parse_args()
+
+    paths = sorted(Path().glob(args.glob))
+    if not paths:
+        raise SystemExit(f"No files matched: {args.glob}")
+
+    rows = []
+    for p in paths:
+        tag, loss, bpb = parse_metric(p)
+        rows.append((p, tag, loss, bpb))
+
+    print("file\ttag\tval_loss\tval_bpb")
+    for p, tag, loss, bpb in rows:
+        print(f"{p}\t{tag}\t{loss:.8f}\t{bpb:.8f}")
+
+    losses = [r[2] for r in rows]
+    bpbs = [r[3] for r in rows]
+    print()
+    print(f"count={len(rows)}")
+    print(f"mean_val_loss={mean(losses):.8f} std={std(losses):.8f}")
+    print(f"mean_val_bpb={mean(bpbs):.8f} std={std(bpbs):.8f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -56,6 +56,10 @@ class Hyperparameters:
     warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
     train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
     train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 0))  # 0 = same as train_seq_len
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 0))  # 0 = non-overlapping; >0 = sliding window
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 256))
+    final_eval_mode = os.environ.get("FINAL_EVAL_MODE", "ttt").lower()  # standard|sliding|ttt
     max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
     qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
 
@@ -76,6 +80,7 @@ class Hyperparameters:
     tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
     tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
     matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    muon_weight_decay = float(os.environ.get("MUON_WEIGHT_DECAY", 0.0))
     scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
     muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
     muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
@@ -142,6 +147,7 @@ class Muon(torch.optim.Optimizer):
             momentum = group["momentum"]
             backend_steps = group["backend_steps"]
             nesterov = group["nesterov"]
+            weight_decay = group.get("weight_decay", 0.0)
 
             total_params = sum(int(p.numel()) for p in params)
             updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
@@ -170,6 +176,9 @@ class Muon(torch.optim.Optimizer):
             for p in params:
                 g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
                 p.add_(g, alpha=-lr)
+                if weight_decay > 0.0:
+                    # Decoupled weight decay for Muon matrix params.
+                    p.mul_(1.0 - lr * weight_decay)
                 curr += p.numel()
 
         return loss
@@ -234,19 +243,21 @@ def eval_val(
     base_bytes_lut: Tensor,
     has_leading_space_lut: Tensor,
     is_boundary_token_lut: Tensor,
+    seq_len_override: int = 0,
 ) -> tuple[float, float]:
     # Validation computes two metrics:
     # - val_loss: token cross-entropy (natural log)
     # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    seq_len = seq_len_override if seq_len_override > 0 else args.train_seq_len
     local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
-    if local_batch_tokens < args.train_seq_len:
+    if local_batch_tokens < seq_len:
         raise ValueError(
             "VAL_BATCH_SIZE must provide at least one sequence per rank; "
             f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
-            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
         )
-    local_batch_seqs = local_batch_tokens // args.train_seq_len
-    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
     seq_start = (total_seqs * rank) // world_size
     seq_end = (total_seqs * (rank + 1)) // world_size
     val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
@@ -257,11 +268,11 @@ def eval_val(
     with torch.inference_mode():
         for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
             batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
-            raw_start = batch_seq_start * args.train_seq_len
-            raw_end = batch_seq_end * args.train_seq_len + 1
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
             local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
-            x = local[:-1].reshape(-1, args.train_seq_len)
-            y = local[1:].reshape(-1, args.train_seq_len)
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
             with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
                 batch_loss = model(x, y).detach()
             batch_token_count = float(y.numel())
@@ -283,6 +294,69 @@ def eval_val(
     tokens_per_byte = val_token_count.item() / val_byte_count.item()
     model.train()
     return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+def eval_val_sliding(
+    logits_fn,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    seq_len: int,
+    stride: int,
+    eval_batch_seqs: int = 256,
+) -> tuple[float, float]:
+    """Sliding window eval where each token is scored once with near-max context."""
+    total = val_tokens.numel() - 1
+    windows: list[tuple[int, int]] = []
+    p = 0
+    while p + seq_len <= total:
+        score_offset = 0 if p == 0 else (seq_len - stride)
+        windows.append((p, score_offset))
+        p += stride
+    n = len(windows)
+    per_rank = (n + world_size - 1) // world_size
+    my_windows = windows[rank * per_rank : min((rank + 1) * per_rank, n)]
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    tok_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    with torch.inference_mode():
+        for i in range(0, len(my_windows), eval_batch_seqs):
+            batch = my_windows[i : i + eval_batch_seqs]
+            bs = len(batch)
+            x_list = [val_tokens[w : w + seq_len] for w, _ in batch]
+            y_list = [val_tokens[w + 1 : w + seq_len + 1] for w, _ in batch]
+            pad = eval_batch_seqs - bs
+            if pad > 0:
+                x_list.extend([x_list[-1]] * pad)
+                y_list.extend([y_list[-1]] * pad)
+            x = torch.stack(x_list).to(device=device, dtype=torch.int64)
+            y = torch.stack(y_list).to(device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = logits_fn(x)
+            for b in range(bs):
+                s = batch[b][1]
+                scored_logits = logits[b, s:]
+                scored_targets = y[b, s:]
+                loss_sum += F.cross_entropy(scored_logits.float(), scored_targets, reduction="sum").to(torch.float64)
+                ns = scored_targets.numel()
+                tok_count += ns
+                prev = x[b, s : s + ns]
+                tgt = scored_targets
+                tb = base_bytes_lut[tgt].to(torch.int16)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.int16)
+                byte_count += tb.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(tok_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / tok_count).item()
+    bpb = val_loss / math.log(2.0) * (tok_count.item() / byte_count.item())
+    return val_loss, bpb
 
 # -----------------------------
 # POST-TRAINING QUANTIZATION
@@ -313,6 +387,11 @@ INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
 INT8_PER_ROW_SCALE_DTYPE = torch.float16
 INT8_CLIP_PERCENTILE = 99.99984
 INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+INT8_ALWAYS_KEEP_FLOAT_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get("INT8_ALWAYS_KEEP_FLOAT_NAME_PATTERNS", "tok_emb.weight").split(",")
+    if pattern
+)
 
 def tensor_nbytes(t: Tensor) -> int:
     return int(t.numel()) * int(t.element_size())
@@ -373,6 +452,12 @@ def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
             stats["num_nonfloat_tensors"] += 1
             passthrough[name] = t
             stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        if any(pattern in name for pattern in INT8_ALWAYS_KEEP_FLOAT_NAME_PATTERNS):
+            kept = t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
             continue
 
         # Small float tensors are cheap enough to keep directly. We still downcast
@@ -742,6 +827,23 @@ class GPT(nn.Module):
                 logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none").reshape(bsz, sl)
         return F.cross_entropy(logits.float().reshape(-1, logits.size(-1)), target_ids.reshape(-1), reduction="mean")
 
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Forward pass returning logits [batch, seq_len, vocab] for sliding eval."""
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+        x = self.final_norm(x)
+        logits = F.linear(x, self.tok_emb.weight) if self.tie_embeddings else self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+
 
 # -----------------------------
 # TEST-TIME TRAINING (LoRA)
@@ -1101,7 +1203,7 @@ def main() -> None:
         fused=True,
     )
     optimizer_muon = Muon(
-        matrix_params,
+        [{"params": matrix_params, "weight_decay": args.muon_weight_decay}],
         lr=args.matrix_lr,
         momentum=args.muon_momentum,
         backend_steps=args.muon_backend_steps,
@@ -1132,7 +1234,7 @@ def main() -> None:
     log0(
         f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
         f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
-        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+        f"matrix_lr:{args.matrix_lr} muon_wd:{args.muon_weight_decay} scalar_lr:{args.scalar_lr}"
     )
     log0(
         f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
@@ -1329,40 +1431,64 @@ def main() -> None:
         quant_blob_disk = f.read()
     quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
     base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
-    torch.cuda.synchronize()
-    t_qeval = time.perf_counter()
-    q_val_loss, q_val_bpb = eval_val(
-        args,
-        model,
-        rank,
-        world_size,
-        device,
-        grad_accum_steps,
-        val_tokens,
-        base_bytes_lut,
-        has_leading_space_lut,
-        is_boundary_token_lut,
-    )
-    torch.cuda.synchronize()
-    log0(
-        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
-        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
-    )
-    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+    eval_sl = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    val_tokens_eval = load_validation_tokens(args.val_files, eval_sl) if eval_sl != args.train_seq_len else val_tokens
 
-    # LoRA test-time training evaluation (the competition score)
-    torch._dynamo.reset()
+    mode = args.final_eval_mode
+    if mode not in {"standard", "sliding", "ttt"}:
+        raise ValueError(f"FINAL_EVAL_MODE must be one of standard|sliding|ttt, got: {mode}")
+
     torch.cuda.synchronize()
-    t_ttt = time.perf_counter()
-    ttt_val_loss, ttt_val_bpb = eval_val_ttt_lora(
-        args, base_model, rank, world_size, device,
-        base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
-    )
+    t_eval = time.perf_counter()
+    if mode == "ttt":
+        torch._dynamo.reset()
+        q_val_loss, q_val_bpb = eval_val_ttt_lora(
+            args, base_model, rank, world_size, device,
+            base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        )
+        eval_tag = "final_int8_ttt_lora"
+    elif mode == "sliding":
+        if args.eval_stride <= 0:
+            raise ValueError("EVAL_STRIDE must be > 0 when FINAL_EVAL_MODE=sliding")
+        eval_batch_seqs = max(1, args.eval_batch_seqs)
+        log0(
+            f"Compiling forward_logits for sliding eval (stride={args.eval_stride}, "
+            f"seq_len={eval_sl}, batch={eval_batch_seqs})..."
+        )
+        compiled_logits = torch.compile(base_model.forward_logits, dynamic=False)
+        warmup_x = torch.zeros(eval_batch_seqs, eval_sl, dtype=torch.int64, device=device)
+        base_model.eval()
+        with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            _ = compiled_logits(warmup_x)
+        q_val_loss, q_val_bpb = eval_val_sliding(
+            compiled_logits, rank, world_size, device,
+            val_tokens_eval, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            eval_sl, args.eval_stride, eval_batch_seqs=eval_batch_seqs,
+        )
+        base_model.train()
+        eval_tag = "final_int8_sliding"
+    else:
+        q_val_loss, q_val_bpb = eval_val(
+            args,
+            model,
+            rank,
+            world_size,
+            device,
+            grad_accum_steps,
+            val_tokens_eval,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            seq_len_override=eval_sl if eval_sl != args.train_seq_len else 0,
+        )
+        eval_tag = "final_int8_zlib_roundtrip"
+
     torch.cuda.synchronize()
     log0(
-        f"final_int8_ttt_lora val_loss:{ttt_val_loss:.4f} val_bpb:{ttt_val_bpb:.4f} "
-        f"eval_time:{1000.0 * (time.perf_counter() - t_ttt):.0f}ms"
+        f"{eval_tag} val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_eval):.0f}ms"
     )
+    log0(f"{eval_tag}_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
 
     if distributed:
         dist.destroy_process_group()


### PR DESCRIPTION
## Summary
- add configurable final eval modes: `FINAL_EVAL_MODE=standard|sliding|ttt`
- add sliding-window eval path (`EVAL_SEQ_LEN`, `EVAL_STRIDE`, `EVAL_BATCH_SEQS`) with compiled `forward_logits`
- add decoupled Muon weight decay via `MUON_WEIGHT_DECAY`
- add export passthrough control `INT8_ALWAYS_KEEP_FLOAT_NAME_PATTERNS` (default keeps `tok_emb.weight` in fp16)
- add experiment runbook and scripts under `experiments/parameter_golf/`

## Why
This makes it possible to run controlled ablations and push for stronger 10min/16MB submissions by combining training-side robustness and evaluation-time improvements.

## Validation
- `python3 -m py_compile train_gpt.py`
- `bash -n experiments/parameter_golf/run_ablation.sh`
- `bash -n experiments/parameter_golf/run_top3.sh`
- `python3 experiments/parameter_golf/summarize_runs.py --help`

## Notes
GPU training/eval sweeps were not run in this local environment (no CUDA tooling present).