### PR TITLE
Record: Int6 QAT + SmearGate + Muon WD (val_bpb=1.1669)

### DIFF
--- a/records/track_10min_16mb/2026-03-20_11L_QAT_SmearGate_WD038/README.md
+++ b/records/track_10min_16mb/2026-03-20_11L_QAT_SmearGate_WD038/README.md
@@ -1,0 +1,69 @@
+# 11L Int6 QAT + SmearGate + Decoupled WD 0.038
+
+**val_bpb: 1.1502** | **Artifact: 15.50 MB**
+
+## Key Techniques
+
+1. **11 layers** — More depth for better representation capacity. Enabled by int6 compression fitting under 16MB.
+
+2. **Int6 Quantization-Aware Training (QAT)**: Straight-through estimator (STE) fake int6 quantization during the forward pass. Per-row symmetric quantization with 6-bit clipping.
+
+3. **Int6-in-Int8 compression**: Int6 values (-32 to 31) stored in int8 containers. zstd-22 compresses the restricted value range ~35%.
+
+4. **SmearGate**: Learned gate (~513 params) blending current and previous token embeddings, zero-initialized.
+
+5. **Decoupled Muon weight decay (0.038)**: High WD keeps weights small for better int6 quantization and generalization.
+
+6. **Sliding window evaluation** (stride=64, batch=32 sequences): Full-context scoring for every token position.
+
+7. **FP16 tied embedding passthrough**: Embedding weights kept in fp16.
+
+## Architecture
+
+- 11 layers, 512 dim, 8 heads, 4 KV heads, MLP mult 3x
+- 26.5M parameters, tied embeddings
+- Vocab size 1024 (sp1024 tokenizer)
+- Training sequence length 2048, batch 524288 tokens
+
+## Training Config
+
+| Parameter | Value |
+|-----------|-------|
+| Matrix LR | 0.02 |
+| Scalar LR | 0.02 |
+| Tied Embed LR | 0.03 |
+| Muon Momentum | 0.99 |
+| Muon Weight Decay | 0.038 |
+| Warmdown Steps | 3000 |
+| QAT Bits | 6 |
+
+## Results
+
+| Seed | val_loss | val_bpb | Steps | ms/step |
+|------|----------|---------|-------|---------|
+| 1337 | 1.9421 | 1.1502 | 7723 | 77.25 |
+
+Serialized model int6+zstd22: 15,411,175 bytes
+Code size: ~72,000 bytes
+Total artifact: 15,495,792 bytes (under 16MB cap)
+
+## Command
+
+```bash
+NCCL_NVLS_ENABLE=0 \
+RUN_ID=v3c_11L_match179 \
+DATA_PATH=/workspace/parameter-golf/data/datasets/fineweb10B_sp1024 \
+TOKENIZER_PATH=/workspace/parameter-golf/data/tokenizers/fineweb_1024_bpe.model \
+VOCAB_SIZE=1024 NUM_HEADS=8 NUM_KV_HEADS=4 MODEL_DIM=512 \
+NUM_LAYERS=11 MLP_MULT=3 \
+QAT=1 QUANT_BITS=6 FP16_EMBED=1 LATE_K_LAYERS=0 \
+EVAL_STRIDE=64 EVAL_BATCH_SEQS=32 \
+MATRIX_LR=0.02 SCALAR_LR=0.02 TIED_EMBED_LR=0.03 \
+MUON_MOMENTUM=0.99 MUON_WEIGHT_DECAY=0.038 \
+SMEAR_GATE=1 BIGRAM_HASH=0 \
+TRAIN_SEQ_LEN=2048 TRAIN_BATCH_TOKENS=524288 \
+WARMDOWN_STEPS=3000 \
+MAX_WALLCLOCK_SECONDS=600 \
+TRAIN_LOG_EVERY=50 VAL_LOSS_EVERY=200 \
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```

--- a/records/track_10min_16mb/2026-03-20_11L_QAT_SmearGate_WD038/submission.json
+++ b/records/track_10min_16mb/2026-03-20_11L_QAT_SmearGate_WD038/submission.json
@@ -1,0 +1,13 @@
+{
+  "track": "10min_16mb",
+  "date": "2026-03-20",
+  "name": "11L Int6 QAT + SmearGate + Decoupled WD 0.038",
+  "author": "baudrillardsgh0st",
+  "seed_results": {
+    "1337": {"val_loss": 1.94212606, "val_bpb": 1.15023949, "steps": 7723, "ms_per_step": 77.25}
+  },
+  "mean_val_loss": 1.94212606,
+  "mean_val_bpb": 1.15023949,
+  "artifact_bytes": 15495792,
+  "code_bytes": 71909
+}

--- a/records/track_10min_16mb/2026-03-20_11L_QAT_SmearGate_WD038/train.log
+++ b/records/track_10min_16mb/2026-03-20_11L_QAT_SmearGate_WD038/train.log
@@ -1,0 +1,344 @@
+W0320 07:29:31.152000 134616321872512 torch/distributed/run.py:779] 
+W0320 07:29:31.152000 134616321872512 torch/distributed/run.py:779] *****************************************
+W0320 07:29:31.152000 134616321872512 torch/distributed/run.py:779] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0320 07:29:31.152000 134616321872512 torch/distributed/run.py:779] *****************************************
+logs/v3c_11L_match179.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/workspace/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=/workspace/parameter-golf/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+qat:True quant_bits:6
+smear_gate:enabled lr:0.0002
+model_params:26502233 (unique_layers:11 loops:1 effective_depth:11 lora_rank:0 lora_params:0)
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.03 head_lr:0.0 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:524288 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9365 val_bpb:4.1082 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9365 train_time:124ms step_avg:124.35ms
+step:2/20000 train_loss:12.1144 train_time:188ms step_avg:93.99ms
+step:3/20000 train_loss:11.2272 train_time:268ms step_avg:89.30ms
+step:4/20000 train_loss:9.6608 train_time:347ms step_avg:86.84ms
+step:5/20000 train_loss:8.0533 train_time:427ms step_avg:85.33ms
+step:6/20000 train_loss:7.7468 train_time:506ms step_avg:84.30ms
+step:7/20000 train_loss:6.3594 train_time:585ms step_avg:83.62ms
+step:8/20000 train_loss:6.0738 train_time:665ms step_avg:83.11ms
+step:9/20000 train_loss:5.9082 train_time:744ms step_avg:82.69ms
+step:10/20000 train_loss:5.7609 train_time:823ms step_avg:82.34ms
+step:50/20000 train_loss:4.4502 train_time:3790ms step_avg:75.79ms
+step:100/20000 train_loss:3.6634 train_time:7499ms step_avg:74.99ms
+step:150/20000 train_loss:3.1827 train_time:11209ms step_avg:74.73ms
+step:200/20000 train_loss:2.8833 train_time:15006ms step_avg:75.03ms
+step:200/20000 val_loss:2.8640 val_bpb:1.6962 train_time:15028ms step_avg:75.14ms
+step:250/20000 train_loss:2.7520 train_time:18722ms step_avg:74.89ms
+step:300/20000 train_loss:2.4553 train_time:22436ms step_avg:74.79ms
+step:350/20000 train_loss:2.6541 train_time:26145ms step_avg:74.70ms
+step:400/20000 train_loss:2.3278 train_time:29937ms step_avg:74.84ms
+step:400/20000 val_loss:2.5175 val_bpb:1.4910 train_time:29960ms step_avg:74.90ms
+step:450/20000 train_loss:2.4722 train_time:33649ms step_avg:74.77ms
+step:500/20000 train_loss:2.4657 train_time:37356ms step_avg:74.71ms
+step:550/20000 train_loss:2.3565 train_time:41066ms step_avg:74.67ms
+step:600/20000 train_loss:2.5071 train_time:44859ms step_avg:74.77ms
+step:600/20000 val_loss:2.3994 val_bpb:1.4211 train_time:44881ms step_avg:74.80ms
+step:650/20000 train_loss:2.3533 train_time:48571ms step_avg:74.72ms
+step:700/20000 train_loss:2.4049 train_time:52284ms step_avg:74.69ms
+step:750/20000 train_loss:2.2376 train_time:55998ms step_avg:74.66ms
+step:800/20000 train_loss:2.2579 train_time:59801ms step_avg:74.75ms
+step:800/20000 val_loss:2.3339 val_bpb:1.3823 train_time:59823ms step_avg:74.78ms
+step:850/20000 train_loss:2.6777 train_time:63515ms step_avg:74.72ms
+step:900/20000 train_loss:2.3047 train_time:67225ms step_avg:74.69ms
+step:950/20000 train_loss:2.3521 train_time:70937ms step_avg:74.67ms
+step:1000/20000 train_loss:2.3458 train_time:74736ms step_avg:74.74ms
+step:1000/20000 val_loss:2.2899 val_bpb:1.3562 train_time:74758ms step_avg:74.76ms
+step:1050/20000 train_loss:2.4559 train_time:78448ms step_avg:74.71ms
+step:1100/20000 train_loss:2.2156 train_time:82165ms step_avg:74.70ms
+step:1150/20000 train_loss:2.2176 train_time:85985ms step_avg:74.77ms
+step:1200/20000 train_loss:2.3616 train_time:89703ms step_avg:74.75ms
+step:1200/20000 val_loss:2.2640 val_bpb:1.3408 train_time:89725ms step_avg:74.77ms
+step:1250/20000 train_loss:2.1790 train_time:93422ms step_avg:74.74ms
+step:1300/20000 train_loss:2.3413 train_time:97137ms step_avg:74.72ms
+step:1350/20000 train_loss:2.2366 train_time:100939ms step_avg:74.77ms
+step:1400/20000 train_loss:2.3915 train_time:104651ms step_avg:74.75ms
+step:1400/20000 val_loss:2.2467 val_bpb:1.3306 train_time:104672ms step_avg:74.77ms
+step:1450/20000 train_loss:2.2158 train_time:108366ms step_avg:74.74ms
+step:1500/20000 train_loss:2.2037 train_time:112080ms step_avg:74.72ms
+step:1550/20000 train_loss:2.1290 train_time:115880ms step_avg:74.76ms
+step:1600/20000 train_loss:2.0606 train_time:119595ms step_avg:74.75ms
+step:1600/20000 val_loss:2.2352 val_bpb:1.3238 train_time:119616ms step_avg:74.76ms
+step:1650/20000 train_loss:2.2042 train_time:123311ms step_avg:74.73ms
+step:1700/20000 train_loss:2.1348 train_time:127027ms step_avg:74.72ms
+step:1750/20000 train_loss:2.2092 train_time:130825ms step_avg:74.76ms
+step:1800/20000 train_loss:2.1663 train_time:134538ms step_avg:74.74ms
+step:1800/20000 val_loss:2.2077 val_bpb:1.3075 train_time:134560ms step_avg:74.76ms
+step:1850/20000 train_loss:2.2706 train_time:138253ms step_avg:74.73ms
+step:1900/20000 train_loss:2.1509 train_time:141966ms step_avg:74.72ms
+step:1950/20000 train_loss:2.1637 train_time:145774ms step_avg:74.76ms
+step:2000/20000 train_loss:2.2021 train_time:149489ms step_avg:74.74ms
+step:2000/20000 val_loss:2.1836 val_bpb:1.2932 train_time:149510ms step_avg:74.76ms
+step:2050/20000 train_loss:2.2020 train_time:153203ms step_avg:74.73ms
+step:2100/20000 train_loss:2.2196 train_time:157012ms step_avg:74.77ms
+step:2150/20000 train_loss:2.1311 train_time:160726ms step_avg:74.76ms
+step:2200/20000 train_loss:2.0213 train_time:164440ms step_avg:74.75ms
+step:2200/20000 val_loss:2.1700 val_bpb:1.2852 train_time:164464ms step_avg:74.76ms
+step:2250/20000 train_loss:2.1100 train_time:168159ms step_avg:74.74ms
+step:2300/20000 train_loss:2.3148 train_time:171953ms step_avg:74.76ms
+step:2350/20000 train_loss:2.1403 train_time:175671ms step_avg:74.75ms
+step:2400/20000 train_loss:2.1439 train_time:179385ms step_avg:74.74ms
+step:2400/20000 val_loss:2.1555 val_bpb:1.2766 train_time:179408ms step_avg:74.75ms
+step:2450/20000 train_loss:2.1511 train_time:183098ms step_avg:74.73ms
+step:2500/20000 train_loss:2.0747 train_time:186898ms step_avg:74.76ms
+step:2550/20000 train_loss:2.0748 train_time:190611ms step_avg:74.75ms
+step:2600/20000 train_loss:2.3663 train_time:194327ms step_avg:74.74ms
+step:2600/20000 val_loss:2.1539 val_bpb:1.2757 train_time:194349ms step_avg:74.75ms
+step:2650/20000 train_loss:2.1740 train_time:198041ms step_avg:74.73ms
+step:2700/20000 train_loss:2.0936 train_time:201842ms step_avg:74.76ms
+step:2750/20000 train_loss:2.3045 train_time:205555ms step_avg:74.75ms
+step:2800/20000 train_loss:2.1780 train_time:209267ms step_avg:74.74ms
+step:2800/20000 val_loss:2.1415 val_bpb:1.2683 train_time:209289ms step_avg:74.75ms
+step:2850/20000 train_loss:2.1274 train_time:212982ms step_avg:74.73ms
+step:2900/20000 train_loss:2.1270 train_time:216773ms step_avg:74.75ms
+step:2950/20000 train_loss:2.1740 train_time:220491ms step_avg:74.74ms
+step:3000/20000 train_loss:2.1736 train_time:224205ms step_avg:74.73ms
+step:3000/20000 val_loss:2.1327 val_bpb:1.2631 train_time:224226ms step_avg:74.74ms
+step:3050/20000 train_loss:2.1009 train_time:227918ms step_avg:74.73ms
+step:3100/20000 train_loss:2.1446 train_time:231720ms step_avg:74.75ms
+step:3150/20000 train_loss:2.1096 train_time:235433ms step_avg:74.74ms
+step:3200/20000 train_loss:2.1356 train_time:239143ms step_avg:74.73ms
+step:3200/20000 val_loss:2.1284 val_bpb:1.2605 train_time:239165ms step_avg:74.74ms
+step:3250/20000 train_loss:2.0313 train_time:242943ms step_avg:74.75ms
+step:3300/20000 train_loss:2.1788 train_time:246656ms step_avg:74.74ms
+step:3350/20000 train_loss:2.0311 train_time:250369ms step_avg:74.74ms
+step:3400/20000 train_loss:2.1039 train_time:254082ms step_avg:74.73ms
+step:3400/20000 val_loss:2.1254 val_bpb:1.2588 train_time:254104ms step_avg:74.74ms
+step:3450/20000 train_loss:2.0390 train_time:257880ms step_avg:74.75ms
+step:3500/20000 train_loss:2.1955 train_time:261596ms step_avg:74.74ms
+step:3550/20000 train_loss:2.3333 train_time:265307ms step_avg:74.73ms
+step:3600/20000 train_loss:2.0480 train_time:269021ms step_avg:74.73ms
+step:3600/20000 val_loss:2.1175 val_bpb:1.2541 train_time:269043ms step_avg:74.73ms
+step:3650/20000 train_loss:2.1495 train_time:272823ms step_avg:74.75ms
+step:3700/20000 train_loss:2.0818 train_time:276537ms step_avg:74.74ms
+step:3750/20000 train_loss:2.0885 train_time:280250ms step_avg:74.73ms
+step:3800/20000 train_loss:2.1524 train_time:283962ms step_avg:74.73ms
+step:3800/20000 val_loss:2.1131 val_bpb:1.2515 train_time:283984ms step_avg:74.73ms
+step:3850/20000 train_loss:2.1129 train_time:287765ms step_avg:74.74ms
+step:3900/20000 train_loss:1.9343 train_time:291477ms step_avg:74.74ms
+step:3950/20000 train_loss:2.0707 train_time:295188ms step_avg:74.73ms
+step:4000/20000 train_loss:2.1193 train_time:298903ms step_avg:74.73ms
+step:4000/20000 val_loss:2.1108 val_bpb:1.2501 train_time:298925ms step_avg:74.73ms
+step:4050/20000 train_loss:2.0486 train_time:302708ms step_avg:74.74ms
+step:4100/20000 train_loss:2.1321 train_time:306418ms step_avg:74.74ms
+step:4150/20000 train_loss:2.2689 train_time:310129ms step_avg:74.73ms
+step:4200/20000 train_loss:2.1131 train_time:313928ms step_avg:74.74ms
+step:4200/20000 val_loss:2.1069 val_bpb:1.2479 train_time:313950ms step_avg:74.75ms
+step:4250/20000 train_loss:2.0689 train_time:317639ms step_avg:74.74ms
+step:4300/20000 train_loss:1.9586 train_time:321350ms step_avg:74.73ms
+step:4350/20000 train_loss:2.1566 train_time:325065ms step_avg:74.73ms
+step:4400/20000 train_loss:2.0558 train_time:328863ms step_avg:74.74ms
+step:4400/20000 val_loss:2.1079 val_bpb:1.2484 train_time:328885ms step_avg:74.75ms
+step:4450/20000 train_loss:2.0056 train_time:332578ms step_avg:74.74ms
+step:4500/20000 train_loss:2.2035 train_time:336288ms step_avg:74.73ms
+step:4550/20000 train_loss:1.9969 train_time:339998ms step_avg:74.72ms
+step:4600/20000 train_loss:1.9184 train_time:343792ms step_avg:74.74ms
+step:4600/20000 val_loss:2.1049 val_bpb:1.2467 train_time:343814ms step_avg:74.74ms
+step:4650/20000 train_loss:2.0144 train_time:347503ms step_avg:74.73ms
+step:4700/20000 train_loss:2.2171 train_time:351214ms step_avg:74.73ms
+step:4750/20000 train_loss:1.9114 train_time:354931ms step_avg:74.72ms
+step:4800/20000 train_loss:2.2045 train_time:358725ms step_avg:74.73ms
+step:4800/20000 val_loss:2.1025 val_bpb:1.2452 train_time:358747ms step_avg:74.74ms
+step:4850/20000 train_loss:2.1029 train_time:362437ms step_avg:74.73ms
+step:4900/20000 train_loss:2.1189 train_time:366147ms step_avg:74.72ms
+step:4950/20000 train_loss:2.2943 train_time:369862ms step_avg:74.72ms
+step:5000/20000 train_loss:1.9707 train_time:375197ms step_avg:75.04ms
+step:5000/20000 val_loss:2.0980 val_bpb:1.2426 train_time:375218ms step_avg:75.04ms
+step:5050/20000 train_loss:2.1591 train_time:378916ms step_avg:75.03ms
+step:5100/20000 train_loss:1.9706 train_time:382646ms step_avg:75.03ms
+step:5150/20000 train_loss:2.2332 train_time:387980ms step_avg:75.34ms
+step:5200/20000 train_loss:2.1171 train_time:391698ms step_avg:75.33ms
+step:5200/20000 val_loss:2.0932 val_bpb:1.2397 train_time:391721ms step_avg:75.33ms
+step:5250/20000 train_loss:2.0679 train_time:395420ms step_avg:75.32ms
+step:5300/20000 train_loss:2.1480 train_time:399141ms step_avg:75.31ms
+step:5350/20000 train_loss:2.0866 train_time:404482ms step_avg:75.60ms
+step:5400/20000 train_loss:2.1327 train_time:408193ms step_avg:75.59ms
+step:5400/20000 val_loss:2.0842 val_bpb:1.2344 train_time:408216ms step_avg:75.60ms
+step:5450/20000 train_loss:2.1401 train_time:411909ms step_avg:75.58ms
+step:5500/20000 train_loss:2.0814 train_time:415625ms step_avg:75.57ms
+step:5550/20000 train_loss:2.0407 train_time:420969ms step_avg:75.85ms
+step:5600/20000 train_loss:2.1070 train_time:424685ms step_avg:75.84ms
+step:5600/20000 val_loss:2.0765 val_bpb:1.2298 train_time:424707ms step_avg:75.84ms
+step:5650/20000 train_loss:1.9851 train_time:428403ms step_avg:75.82ms
+step:5700/20000 train_loss:2.1010 train_time:432119ms step_avg:75.81ms
+step:5750/20000 train_loss:2.1450 train_time:437465ms step_avg:76.08ms
+step:5800/20000 train_loss:2.0596 train_time:441178ms step_avg:76.07ms
+step:5800/20000 val_loss:2.0675 val_bpb:1.2245 train_time:441200ms step_avg:76.07ms
+step:5850/20000 train_loss:2.1113 train_time:444892ms step_avg:76.05ms
+step:5900/20000 train_loss:2.0176 train_time:448606ms step_avg:76.03ms
+step:5950/20000 train_loss:2.0593 train_time:453901ms step_avg:76.29ms
+step:6000/20000 train_loss:2.1398 train_time:457613ms step_avg:76.27ms
+step:6000/20000 val_loss:2.0595 val_bpb:1.2197 train_time:457635ms step_avg:76.27ms
+step:6050/20000 train_loss:2.0494 train_time:461328ms step_avg:76.25ms
+step:6100/20000 train_loss:2.0366 train_time:465039ms step_avg:76.24ms
+step:6150/20000 train_loss:2.0115 train_time:470258ms step_avg:76.46ms
+step:6200/20000 train_loss:2.0005 train_time:473973ms step_avg:76.45ms
+step:6200/20000 val_loss:2.0505 val_bpb:1.2144 train_time:473994ms step_avg:76.45ms
+step:6250/20000 train_loss:2.0624 train_time:477694ms step_avg:76.43ms
+step:6300/20000 train_loss:1.9445 train_time:482975ms step_avg:76.66ms
+step:6350/20000 train_loss:1.9192 train_time:486689ms step_avg:76.64ms
+step:6400/20000 train_loss:2.0744 train_time:490399ms step_avg:76.62ms
+step:6400/20000 val_loss:2.0416 val_bpb:1.2092 train_time:490421ms step_avg:76.63ms
+step:6450/20000 train_loss:1.9891 train_time:494114ms step_avg:76.61ms
+step:6500/20000 train_loss:1.9823 train_time:499475ms step_avg:76.84ms
+step:6550/20000 train_loss:2.1105 train_time:503186ms step_avg:76.82ms
+step:6600/20000 train_loss:2.0196 train_time:506899ms step_avg:76.80ms
+step:6600/20000 val_loss:2.0307 val_bpb:1.2027 train_time:506921ms step_avg:76.81ms
+step:6650/20000 train_loss:2.1933 train_time:510616ms step_avg:76.78ms
+step:6700/20000 train_loss:2.0555 train_time:515936ms step_avg:77.01ms
+step:6750/20000 train_loss:2.2093 train_time:519650ms step_avg:76.99ms
+step:6800/20000 train_loss:2.0780 train_time:523364ms step_avg:76.97ms
+step:6800/20000 val_loss:2.0211 val_bpb:1.1970 train_time:523387ms step_avg:76.97ms
+step:6850/20000 train_loss:1.9186 train_time:527078ms step_avg:76.95ms
+step:6900/20000 train_loss:1.9865 train_time:532265ms step_avg:77.14ms
+step:6950/20000 train_loss:2.0548 train_time:535981ms step_avg:77.12ms
+step:7000/20000 train_loss:2.1108 train_time:539697ms step_avg:77.10ms
+step:7000/20000 val_loss:2.0114 val_bpb:1.1912 train_time:539719ms step_avg:77.10ms
+step:7050/20000 train_loss:2.1383 train_time:543416ms step_avg:77.08ms
+step:7100/20000 train_loss:1.9442 train_time:548717ms step_avg:77.28ms
+step:7150/20000 train_loss:2.0305 train_time:552438ms step_avg:77.26ms
+step:7200/20000 train_loss:2.0692 train_time:556158ms step_avg:77.24ms
+step:7200/20000 val_loss:1.9998 val_bpb:1.1844 train_time:556181ms step_avg:77.25ms
+step:7250/20000 train_loss:1.9727 train_time:561467ms step_avg:77.44ms
+step:7300/20000 train_loss:1.9562 train_time:565178ms step_avg:77.42ms
+step:7350/20000 train_loss:2.0631 train_time:568889ms step_avg:77.40ms
+step:7400/20000 train_loss:1.9926 train_time:572605ms step_avg:77.38ms
+step:7400/20000 val_loss:1.9901 val_bpb:1.1786 train_time:572627ms step_avg:77.38ms
+step:7450/20000 train_loss:1.9771 train_time:577921ms step_avg:77.57ms
+step:7500/20000 train_loss:1.9805 train_time:581634ms step_avg:77.55ms
+step:7550/20000 train_loss:2.0319 train_time:585346ms step_avg:77.53ms
+step:7600/20000 train_loss:1.8618 train_time:589061ms step_avg:77.51ms
+step:7600/20000 val_loss:1.9812 val_bpb:1.1733 train_time:589083ms step_avg:77.51ms
+step:7650/20000 train_loss:2.1477 train_time:594384ms step_avg:77.70ms
+step:7700/20000 train_loss:1.9391 train_time:598095ms step_avg:77.67ms
+step:7723/20000 val_loss:1.9781 val_bpb:1.1715 train_time:599822ms step_avg:77.67ms
+stopping_early: wallclock_cap train_time:599822ms step:7723/20000
+peak memory allocated: 17524 MiB reserved: 17584 MiB
+Serialized model: 105000806 bytes
+Code size: 84617 bytes
+Total submission size: 105085423 bytes
+fp16_passthrough: tok_emb.weight
+Serialized model int6+zstd22: 15411175 bytes (payload:27181410 raw_torch:27236362 payload_ratio:3.86x)
+Total submission size int6+zstd22: 15495792 bytes
+/workspace/train_gpt_v2.py:1885: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+  quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+/workspace/train_gpt_v2.py:1885: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+  quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+/workspace/train_gpt_v2.py:1885: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+  quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+/workspace/train_gpt_v2.py:1885: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+  quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+/workspace/train_gpt_v2.py:1885: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+  quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+/workspace/train_gpt_v2.py:1885: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+  quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+/workspace/train_gpt_v2.py:1885: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+  quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+/workspace/train_gpt_v2.py:1885: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+  quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+final_eval_mode:sliding_window stride:64 batch_seqs:32
+  sliding_eval [  0.0%] 32/121136 windows running_bpb=1.215597
+  sliding_eval [  1.3%] 1632/121136 windows running_bpb=1.143890
+  sliding_eval [  2.7%] 3232/121136 windows running_bpb=1.145316
+  sliding_eval [  4.0%] 4832/121136 windows running_bpb=1.139611
+  sliding_eval [  5.3%] 6432/121136 windows running_bpb=1.151692
+  sliding_eval [  6.6%] 8032/121136 windows running_bpb=1.152806
+  sliding_eval [  8.0%] 9632/121136 windows running_bpb=1.154478
+  sliding_eval [  9.3%] 11232/121136 windows running_bpb=1.149847
+  sliding_eval [ 10.6%] 12832/121136 windows running_bpb=1.147504
+  sliding_eval [ 11.9%] 14432/121136 windows running_bpb=1.149244
+  sliding_eval [ 13.2%] 16032/121136 windows running_bpb=1.157842
+  sliding_eval [ 14.6%] 17632/121136 windows running_bpb=1.156779
+  sliding_eval [ 15.9%] 19232/121136 windows running_bpb=1.158085
+  sliding_eval [ 17.2%] 20832/121136 windows running_bpb=1.156262
+  sliding_eval [ 18.5%] 22432/121136 windows running_bpb=1.154739
+  sliding_eval [ 19.8%] 24032/121136 windows running_bpb=1.154930
+  sliding_eval [ 21.2%] 25632/121136 windows running_bpb=1.156313
+  sliding_eval [ 22.5%] 27232/121136 windows running_bpb=1.156798
+  sliding_eval [ 23.8%] 28832/121136 windows running_bpb=1.162916
+  sliding_eval [ 25.1%] 30432/121136 windows running_bpb=1.160286
+  sliding_eval [ 26.4%] 32032/121136 windows running_bpb=1.161262
+  sliding_eval [ 27.8%] 33632/121136 windows running_bpb=1.159837
+  sliding_eval [ 29.1%] 35232/121136 windows running_bpb=1.159217
+  sliding_eval [ 30.4%] 36832/121136 windows running_bpb=1.158808
+  sliding_eval [ 31.7%] 38432/121136 windows running_bpb=1.159427
+  sliding_eval [ 33.0%] 40032/121136 windows running_bpb=1.157074
+  sliding_eval [ 34.4%] 41632/121136 windows running_bpb=1.156029
+  sliding_eval [ 35.7%] 43232/121136 windows running_bpb=1.156364
+  sliding_eval [ 37.0%] 44832/121136 windows running_bpb=1.155125
+  sliding_eval [ 38.3%] 46432/121136 windows running_bpb=1.155002
+  sliding_eval [ 39.7%] 48032/121136 windows running_bpb=1.154246
+  sliding_eval [ 41.0%] 49632/121136 windows running_bpb=1.155501
+  sliding_eval [ 42.3%] 51232/121136 windows running_bpb=1.156547
+  sliding_eval [ 43.6%] 52832/121136 windows running_bpb=1.157062
+  sliding_eval [ 44.9%] 54432/121136 windows running_bpb=1.156539
+  sliding_eval [ 46.3%] 56032/121136 windows running_bpb=1.156932
+  sliding_eval [ 47.6%] 57632/121136 windows running_bpb=1.156026
+  sliding_eval [ 48.9%] 59232/121136 windows running_bpb=1.152088
+  sliding_eval [ 50.2%] 60832/121136 windows running_bpb=1.152155
+  sliding_eval [ 51.5%] 62432/121136 windows running_bpb=1.153090
+  sliding_eval [ 52.9%] 64032/121136 windows running_bpb=1.153267
+  sliding_eval [ 54.2%] 65632/121136 windows running_bpb=1.153146
+  sliding_eval [ 55.5%] 67232/121136 windows running_bpb=1.151919
+  sliding_eval [ 56.8%] 68832/121136 windows running_bpb=1.151605
+  sliding_eval [ 58.1%] 70432/121136 windows running_bpb=1.150922
+  sliding_eval [ 59.5%] 72032/121136 windows running_bpb=1.150985
+  sliding_eval [ 60.8%] 73632/121136 windows running_bpb=1.150948
+  sliding_eval [ 62.1%] 75232/121136 windows running_bpb=1.151157
+  sliding_eval [ 63.4%] 76832/121136 windows running_bpb=1.150862
+  sliding_eval [ 64.7%] 78432/121136 windows running_bpb=1.151413
+  sliding_eval [ 66.1%] 80032/121136 windows running_bpb=1.151726
+  sliding_eval [ 67.4%] 81632/121136 windows running_bpb=1.151441
+  sliding_eval [ 68.7%] 83232/121136 windows running_bpb=1.152473
+  sliding_eval [ 70.0%] 84832/121136 windows running_bpb=1.154402
+  sliding_eval [ 71.4%] 86432/121136 windows running_bpb=1.153641
+  sliding_eval [ 72.7%] 88032/121136 windows running_bpb=1.154336
+  sliding_eval [ 74.0%] 89632/121136 windows running_bpb=1.154681
+  sliding_eval [ 75.3%] 91232/121136 windows running_bpb=1.154660
+  sliding_eval [ 76.6%] 92832/121136 windows running_bpb=1.154251
+  sliding_eval [ 78.0%] 94432/121136 windows running_bpb=1.154490
+  sliding_eval [ 79.3%] 96032/121136 windows running_bpb=1.153910
+  sliding_eval [ 80.6%] 97632/121136 windows running_bpb=1.156734
+  sliding_eval [ 81.9%] 99232/121136 windows running_bpb=1.156769
+  sliding_eval [ 83.2%] 100832/121136 windows running_bpb=1.156783
+  sliding_eval [ 84.6%] 102432/121136 windows running_bpb=1.156398
+  sliding_eval [ 85.9%] 104032/121136 windows running_bpb=1.155929
+  sliding_eval [ 87.2%] 105632/121136 windows running_bpb=1.155162
+  sliding_eval [ 88.5%] 107232/121136 windows running_bpb=1.155133
+  sliding_eval [ 89.8%] 108832/121136 windows running_bpb=1.155750
+  sliding_eval [ 91.2%] 110432/121136 windows running_bpb=1.155784
+  sliding_eval [ 92.5%] 112032/121136 windows running_bpb=1.155769
+  sliding_eval [ 93.8%] 113632/121136 windows running_bpb=1.156201
+  sliding_eval [ 95.1%] 115232/121136 windows running_bpb=1.155954
+  sliding_eval [ 96.4%] 116832/121136 windows running_bpb=1.155566
+  sliding_eval [ 97.8%] 118432/121136 windows running_bpb=1.155883
+  sliding_eval [ 99.1%] 120032/121136 windows running_bpb=1.155976
+final_int6_zstd22_roundtrip val_loss:1.9421 val_bpb:1.1502 eval_time:279884ms
+final_int6_zstd22_roundtrip_exact val_loss:1.94212606 val_bpb:1.15023949

--- a/records/track_10min_16mb/2026-03-20_11L_QAT_SmearGate_WD038/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-20_11L_QAT_SmearGate_WD038/train_gpt.py
@@ -1,0 +1,1949 @@
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: To keep readable for newcomers, let's make sure `train_gpt.py` and `train_gpt_mlx.py` never are longer than 1500 lines.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+import zstandard as zstd
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 8))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 3))
+    num_loops = int(os.environ.get("NUM_LOOPS", 1))
+    lora_rank = int(os.environ.get("LORA_RANK", 0))
+    qat = bool(int(os.environ.get("QAT", "1")))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    quant_bits = int(os.environ.get("QUANT_BITS", 6))
+    fp16_embed = bool(int(os.environ.get("FP16_EMBED", "1")))
+    late_k_layers = int(os.environ.get("LATE_K_LAYERS", 2))
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    smear_gate = bool(int(os.environ.get("SMEAR_GATE", "0")))
+    bigram_hash = bool(int(os.environ.get("BIGRAM_HASH", "0")))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 4096))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 0))  # 0 = use model_dim directly
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_weight_decay = float(os.environ.get("MUON_WEIGHT_DECAY", 0.0))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    lora_lr = float(os.environ.get("LORA_LR", 0.01))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    # SWA: average checkpoints during late warmdown
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "0")))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.5))
+    swa_every = int(os.environ.get("SWA_EVERY", 200))
+    # TTT: test-time training with LoRA during eval
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    ttt_lora_rank = int(os.environ.get("TTT_LORA_RANK", 8))
+    ttt_lora_lr = float(os.environ.get("TTT_LORA_LR", 0.01))
+    ttt_chunk_size = int(os.environ.get("TTT_CHUNK_SIZE", 64))
+    ttt_train_chunk_size = int(os.environ.get("TTT_TRAIN_CHUNK_SIZE", 256))
+    ttt_eval_seq_len = int(os.environ.get("TTT_EVAL_SEQ_LEN", 1024))
+    ttt_batch_size = int(os.environ.get("TTT_BATCH_SIZE", 64))
+
+# -----------------------------
+# MUON OPTIMIZER 
+# -----------------------------
+# 
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, weight_decay=weight_decay),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            weight_decay = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                if weight_decay > 0:
+                    p.mul_(1 - lr * weight_decay)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# ---- Int6 quantization (6-bit per-row symmetric, bit-packed) ----
+INT6_MAX = 31
+
+def quantize_float_tensor_int6(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / INT6_MAX).clamp_min(1.0 / INT6_MAX)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -INT6_MAX, INT6_MAX).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / INT6_MAX if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -INT6_MAX, INT6_MAX).to(torch.int8).contiguous()
+    return q, scale
+
+def pack_int6(q_int8: Tensor) -> bytes:
+    flat = q_int8.flatten().numpy().astype(np.int8)
+    u = (flat.astype(np.int16) + INT6_MAX).astype(np.uint8)
+    n = len(u)
+    pad = (4 - n % 4) % 4
+    if pad:
+        u = np.concatenate([u, np.zeros(pad, dtype=np.uint8)])
+    v0, v1, v2, v3 = u[0::4], u[1::4], u[2::4], u[3::4]
+    packed = np.empty(len(u) // 4 * 3, dtype=np.uint8)
+    packed[0::3] = (v0 << 2) | (v1 >> 4)
+    packed[1::3] = ((v1 & 0x0F) << 4) | (v2 >> 2)
+    packed[2::3] = ((v2 & 0x03) << 6) | v3
+    return bytes(packed)
+
+def unpack_int6(data: bytes, shape: tuple) -> Tensor:
+    numel = 1
+    for s in shape:
+        numel *= s
+    packed = np.frombuffer(data, dtype=np.uint8)
+    m = len(packed) // 3
+    b0, b1, b2 = packed[0::3], packed[1::3], packed[2::3]
+    flat = np.empty(m * 4, dtype=np.uint8)
+    flat[0::4] = (b0 >> 2) & 0x3F
+    flat[1::4] = ((b0 & 0x03) << 4) | (b1 >> 4)
+    flat[2::4] = ((b1 & 0x0F) << 2) | (b2 >> 6)
+    flat[3::4] = b2 & 0x3F
+    signed = flat[:numel].astype(np.int8) - INT6_MAX
+    return torch.from_numpy(signed.copy()).reshape(shape).to(torch.int8)
+
+def quantize_state_dict_int6(state_dict: dict[str, Tensor], fp16_names: set[str] | None = None):
+    """Int6 quantization: store int6 values in int8 containers (zstd compresses the unused bits)."""
+    fp16_names = fp16_names or set()
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "payload_bytes"), 0,
+    )
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["payload_bytes"] += tensor_nbytes(t)
+            continue
+        # FP16 passthrough for tied embeddings and small tensors
+        if name in fp16_names or t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["payload_bytes"] += tensor_nbytes(kept)
+            continue
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor_int6(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        # Store int6 values in int8 containers -- zstd compresses the restricted range
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+    obj: dict[str, object] = {
+        "__quant_format__": "int6_in_int8_per_row_v1",
+        "quantized": quantized,
+        "scales": scales, "dtypes": dtypes, "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int6(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    # Support both old packed format and new int8-container format
+    quantized = obj.get("quantized", obj.get("quantized_packed", {}))
+    is_packed = "quantized_packed" in obj and "quantized" not in obj
+    for name, q_data in quantized.items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if is_packed:
+            shape = tuple(obj["quantized_shapes"][name])
+            q = unpack_int6(q_data, shape)
+        else:
+            q = q_data
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            out[name] = (q.float() * float(s.item())).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING 
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+def fake_quantize_int8_per_row(w: Tensor) -> Tensor:
+    """Simulate per-row int8 quantization with straight-through estimator."""
+    scale = w.detach().abs().amax(dim=-1, keepdim=True).div_(127.0).clamp_(min=1.0 / 127.0)
+    w_deq = (w / scale).round().clamp_(-127, 127) * scale
+    return w + (w_deq - w).detach()
+
+def fake_quantize_int6_per_row(w: Tensor) -> Tensor:
+    """Simulate per-row int6 quantization with straight-through estimator."""
+    scale = w.detach().abs().amax(dim=-1, keepdim=True).div_(31.0).clamp_(min=1.0 / 31.0)
+    w_deq = (w / scale).round().clamp_(-31, 31) * scale
+    return w + (w_deq - w).detach()
+
+# Module-level setting controlled by args.quant_bits
+_QAT_QUANT_BITS: int = 8
+
+class CastedLinear(nn.Linear):
+    _qat: bool = False
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight
+        if self._qat and self.training:
+            if _QAT_QUANT_BITS == 6:
+                w = fake_quantize_int6_per_row(w)
+            else:
+                w = fake_quantize_int8_per_row(w)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w.to(x.dtype), bias)
+
+
+class AttentionLoRA(nn.Module):
+    """Per-iteration LoRA adapters for attention Q, K, V, and output projections.
+
+    Initialized so that the LoRA contribution is zero at the start of training
+    (B matrices are zeros). During training, the optimizer learns per-iteration
+    specialization while the base attention weights remain shared across loops.
+    """
+    def __init__(self, dim: int, kv_dim: int, rank: int):
+        super().__init__()
+        self.q_A = nn.Parameter(torch.empty(dim, rank))
+        self.q_B = nn.Parameter(torch.zeros(rank, dim))
+        self.k_A = nn.Parameter(torch.empty(dim, rank))
+        self.k_B = nn.Parameter(torch.zeros(rank, kv_dim))
+        self.v_A = nn.Parameter(torch.empty(dim, rank))
+        self.v_B = nn.Parameter(torch.zeros(rank, kv_dim))
+        self.proj_A = nn.Parameter(torch.empty(dim, rank))
+        self.proj_B = nn.Parameter(torch.zeros(rank, dim))
+        self._init_lora()
+
+    def _init_lora(self) -> None:
+        for name in ("q_A", "k_A", "v_A", "proj_A"):
+            nn.init.kaiming_uniform_(getattr(self, name), a=math.sqrt(5))
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor, lora: AttentionLoRA | None = None, q_delta=None, v_delta=None) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x)
+        k = self.c_k(x)
+        v = self.c_v(x)
+        if lora is not None:
+            q = q + (x @ lora.q_A) @ lora.q_B
+            k = k + (x @ lora.k_A) @ lora.k_B
+            v = v + (x @ lora.v_A) @ lora.v_B
+        if q_delta is not None:
+            q = q + q_delta
+        if v_delta is not None:
+            v = v + v_delta
+        q = q.reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        if self.num_kv_heads != self.num_heads:
+            # GQA: expand KV heads to match query heads
+            rep = self.num_heads // self.num_kv_heads
+            k = k.unsqueeze(2).expand(-1, -1, rep, -1, -1).reshape(bsz, self.num_heads, seqlen, self.head_dim)
+            v = v.unsqueeze(2).expand(-1, -1, rep, -1, -1).reshape(bsz, self.num_heads, seqlen, self.head_dim)
+        y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True)
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        out = self.proj(y)
+        if lora is not None:
+            out = out + (y @ lora.proj_A) @ lora.proj_B
+        return out
+
+
+class MLP(nn.Module):
+    # relu^2 MLP from the original modded-nanogpt setup
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor, lora: AttentionLoRA | None = None, q_delta_fn=None, v_delta_fn=None) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = self.attn_norm(x)
+        qd = q_delta_fn(n) if q_delta_fn is not None else None
+        vd = v_delta_fn(n) if v_delta_fn is not None else None
+        attn_out = self.attn(n, lora=lora, q_delta=qd, v_delta=vd)
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+def get_bigram_hash(x: Tensor, bigram_vocab_size: int) -> Tensor:
+    """Hash consecutive token pairs into bigram bucket indices."""
+    rand_int_1, rand_int_2 = 36313, 27191
+    mod = bigram_vocab_size - 1
+    x32 = x.to(torch.int32)
+    out = x32.clone()
+    out[..., 0] = mod  # position 0 → sentinel bucket
+    out[..., 1:] = torch.bitwise_xor(rand_int_1 * x32[..., 1:], rand_int_2 * x32[..., :-1]) % mod
+    return out.long()
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        num_loops: int = 1,
+        lora_rank: int = 0,
+        smear_gate: bool = False,
+        bigram_hash: bool = False,
+        bigram_vocab_size: int = 4096,
+        bigram_dim: int = 0,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.num_unique_layers = num_layers
+        self.num_loops = num_loops
+        effective_depth = num_layers * num_loops
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.num_encoder_layers = effective_depth // 2
+        self.num_decoder_layers = effective_depth - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        # Per-(loop, block) LoRA adapters for attention projections.
+        # Only created when num_loops > 1 and lora_rank > 0.
+        kv_dim = num_kv_heads * (model_dim // num_heads)
+        if lora_rank > 0 and num_loops > 1:
+            self.lora_adapters = nn.ModuleList(
+                [
+                    nn.ModuleList(
+                        [AttentionLoRA(model_dim, kv_dim, lora_rank) for _ in range(num_layers)]
+                    )
+                    for _ in range(num_loops)
+                ]
+            )
+        else:
+            self.lora_adapters = None
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+
+        # SmearGate: learned gate blending current + previous token embedding
+        self.use_smear_gate = smear_gate
+        if smear_gate:
+            self.smear_gate = nn.Linear(model_dim, 1, bias=False)
+            self.smear_gate._zero_init = True
+            self.smear_lambda = nn.Parameter(torch.zeros(1))
+
+        # BigramHash: hash-based bigram embedding injected at every layer
+        self.use_bigram_hash = bigram_hash
+        self.bigram_vocab_size = bigram_vocab_size
+        if bigram_hash:
+            bdim = bigram_dim if bigram_dim > 0 else model_dim
+            self.bigram_embed = nn.Embedding(bigram_vocab_size, bdim)
+            nn.init.zeros_(self.bigram_embed.weight)
+            if bdim != model_dim:
+                self.bigram_proj = nn.Linear(bdim, model_dim, bias=False)
+                self.bigram_proj._zero_init = True
+            else:
+                self.bigram_proj = None
+            self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(effective_depth))
+
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        effective_depth = self.num_unique_layers * self.num_loops
+        out_scale = 1.0 / math.sqrt(2 * effective_depth)
+        for module in self.modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                else:
+                    nn.init.orthogonal_(module.weight)
+            # Scale output projections by 1/sqrt(2*depth) for stable residual stream
+            if isinstance(module, (CausalSelfAttention, MLP)):
+                if hasattr(module, "proj") and module.proj.weight is not None:
+                    module.proj.weight.data.mul_(out_scale)
+
+    def _apply_smear_gate(self, x: Tensor) -> Tensor:
+        """Blend each token embedding with the previous token's embedding."""
+        gate = self.smear_lambda * torch.sigmoid(self.smear_gate(x[..., 1:, :]))
+        smeared = x[..., 1:, :] + gate * x[..., :-1, :]
+        return torch.cat([x[..., :1, :], smeared], dim=-2)
+
+    def _get_bigram_emb(self, input_ids: Tensor) -> Tensor:
+        """Compute bigram hash embedding for injection at each layer."""
+        bh = get_bigram_hash(input_ids, self.bigram_vocab_size)
+        emb = self.bigram_embed(bh)
+        if self.bigram_proj is not None:
+            emb = self.bigram_proj(emb)
+        return emb
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor, ttt_lora=None) -> Tensor:
+        x = self.tok_emb(input_ids)
+
+        # SmearGate: blend with previous token before normalization
+        if self.use_smear_gate:
+            x = self._apply_smear_gate(x)
+
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+
+        # BigramHash: precompute bigram embedding for per-layer injection
+        bigram_emb = self._get_bigram_emb(input_ids) if self.use_bigram_hash else None
+
+        skips: list[Tensor] = []
+
+        # Iterate through effective layers: each unique block is reused across loops.
+        # First half (encoder) stores skip connections; second half (decoder) pops them.
+        eff_idx = 0
+        for loop_idx in range(self.num_loops):
+            for block_idx in range(self.num_unique_layers):
+                lora = self.lora_adapters[loop_idx][block_idx] if self.lora_adapters is not None else None
+                qd_fn = ttt_lora.q_loras[block_idx] if ttt_lora is not None else None
+                vd_fn = ttt_lora.v_loras[block_idx] if ttt_lora is not None else None
+                # Inject bigram embedding at each layer
+                if bigram_emb is not None:
+                    x = x + bigram_emb * self.bigram_lambdas[eff_idx].to(dtype=x.dtype)
+                if eff_idx < self.num_encoder_layers:
+                    x = self.blocks[block_idx](x, x0, lora=lora, q_delta_fn=qd_fn, v_delta_fn=vd_fn)
+                    skips.append(x)
+                else:
+                    dec_idx = eff_idx - self.num_encoder_layers
+                    if dec_idx < self.num_skip_weights and skips:
+                        x = x + self.skip_weights[dec_idx].to(dtype=x.dtype)[None, None, :] * skips.pop()
+                    x = self.blocks[block_idx](x, x0, lora=lora, q_delta_fn=qd_fn, v_delta_fn=vd_fn)
+                eff_idx += 1
+
+        x = self.final_norm(x)
+
+        # TTT path: keep 3D shape, add lm_head LoRA, return per-token losses
+        if ttt_lora is not None:
+            if self.tie_embeddings:
+                logits_proj = F.linear(x, self.tok_emb.weight)
+            else:
+                logits_proj = self.lm_head(x)
+            logits_proj = logits_proj + ttt_lora.lm_head_lora(x)
+            logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+            bsz, sl, V = logits.shape
+            return F.cross_entropy(
+                logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none"
+            ).reshape(bsz, sl)
+
+        # Normal training path: scalar mean loss
+        x = x.reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Return logits (bsz, seq_len, vocab) without computing loss."""
+        x = self.tok_emb(input_ids)
+
+        if self.use_smear_gate:
+            x = self._apply_smear_gate(x)
+
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+
+        bigram_emb = self._get_bigram_emb(input_ids) if self.use_bigram_hash else None
+
+        skips: list[Tensor] = []
+        eff_idx = 0
+        for loop_idx in range(self.num_loops):
+            for block_idx in range(self.num_unique_layers):
+                lora = self.lora_adapters[loop_idx][block_idx] if self.lora_adapters is not None else None
+                if bigram_emb is not None:
+                    x = x + bigram_emb * self.bigram_lambdas[eff_idx].to(dtype=x.dtype)
+                if eff_idx < self.num_encoder_layers:
+                    x = self.blocks[block_idx](x, x0, lora=lora)
+                    skips.append(x)
+                else:
+                    dec_idx = eff_idx - self.num_encoder_layers
+                    if dec_idx < self.num_skip_weights and skips:
+                        x = x + self.skip_weights[dec_idx].to(dtype=x.dtype)[None, None, :] * skips.pop()
+                    x = self.blocks[block_idx](x, x0, lora=lora)
+                eff_idx += 1
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context.
+
+    Windows of train_seq_len advance by `stride`. Only the last `stride` tokens
+    per window contribute to the score (first window scores all). Windows are
+    batched and distributed across ranks.
+    """
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+
+    # Build windows; skip any too short to score a full stride
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride]
+    total_windows = len(window_starts)
+
+    # Distribute across ranks
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = base_model.forward_logits(x_batch)
+
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else wlen - stride
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+
+            # Progress (rank 0 only)
+            if rank == 0 and (bi // batch_seqs) % 50 == 0:
+                done = min(bi + batch_seqs, len(my_windows))
+                pct = done / len(my_windows) * 100
+                running_bpb = 0.0
+                if token_count.item() > 0:
+                    rl = (loss_sum / token_count).item()
+                    running_bpb = rl / math.log(2.0) * (token_count.item() / byte_count.item())
+                print(f"  sliding_eval [{pct:5.1f}%] {done}/{len(my_windows)} windows running_bpb={running_bpb:.6f}", flush=True)
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+BOS_ID = 1
+
+class BatchedLinearLoRA(nn.Module):
+    """LoRA for a linear layer, with independent weights per batch element.
+    Computes x @ A^T @ B^T = x @ (BA)^T, i.e. the LoRA delta is DW = BA."""
+    def __init__(self, bsz: int, in_features: int, out_features: int, rank: int):
+        super().__init__()
+        self.in_features = in_features
+        self.A = nn.Parameter(torch.empty(bsz, rank, in_features))
+        self.B = nn.Parameter(torch.zeros(bsz, out_features, rank))
+        self.reset()
+
+    def forward(self, x: Tensor) -> Tensor:
+        return (x @ self.A.transpose(1, 2)) @ self.B.transpose(1, 2)
+
+    def reset(self) -> None:
+        bound = 1.0 / math.sqrt(self.in_features)
+        with torch.no_grad():
+            self.A.uniform_(-bound, bound)
+            self.B.zero_()
+
+
+class BatchedTTTLoRA(nn.Module):
+    """All LoRA adapters for one batch: LM head and Q/V per block."""
+    def __init__(self, bsz: int, model: GPT, rank: int):
+        super().__init__()
+        dim = model.tok_emb.embedding_dim
+        vocab = model.tok_emb.num_embeddings
+        self.lm_head_lora = BatchedLinearLoRA(bsz, dim, vocab, rank)
+        self.q_loras = nn.ModuleList()
+        self.v_loras = nn.ModuleList()
+        for block in model.blocks:
+            self.q_loras.append(BatchedLinearLoRA(bsz, dim, block.attn.c_q.weight.shape[0], rank))
+            self.v_loras.append(BatchedLinearLoRA(bsz, dim, block.attn.c_v.weight.shape[0], rank))
+
+    def reset(self) -> None:
+        for m in self.modules():
+            if isinstance(m, BatchedLinearLoRA):
+                m.reset()
+
+
+def _reset_ttt_optimizer(opt):
+    for group in opt.param_groups:
+        for p in group['params']:
+            s = opt.state.get(p)
+            if not s:
+                continue
+            s['exp_avg'].zero_()
+            s['exp_avg_sq'].zero_()
+            s['step'].fill_(0)
+
+
+def _build_ttt_optimizer(lora, args: Hyperparameters):
+    return torch.optim.Adam(lora.parameters(), lr=args.ttt_lora_lr, betas=(args.beta1, args.beta2), eps=1e-10)
+
+
+def _find_docs(all_tokens: Tensor, include_next_bos: bool = True) -> list[tuple[int, int]]:
+    """Return (start_offset, length) for each document, identified by BOS boundaries."""
+    bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0].numpy()
+    docs = []
+    for i in range(len(bos_positions)):
+        start = int(bos_positions[i])
+        end = int(bos_positions[i + 1]) if i + 1 < len(bos_positions) else all_tokens.numel()
+        if include_next_bos and i + 1 < len(bos_positions):
+            end += 1
+        assert end - start >= 2
+        docs.append((start, end - start))
+    return docs
+
+
+def _compute_chunk_window(ci: int, pred_len: int, num_chunks: int, chunk_size: int, eval_seq_len: int):
+    """Return (win_start, win_len, chunk_offset, chunk_len) for chunk ci of a doc."""
+    chunk_start = ci * chunk_size
+    chunk_end = pred_len if ci == num_chunks - 1 else (ci + 1) * chunk_size
+    win_start = max(0, chunk_end - eval_seq_len)
+    win_len = chunk_end - win_start
+    chunk_offset = chunk_start - win_start
+    chunk_len = chunk_end - chunk_start
+    return win_start, win_len, chunk_offset, chunk_len
+
+
+def _accumulate_bpb(
+    ptl: Tensor, x: Tensor, y: Tensor,
+    batch_i: int, chunk_offset: int, chunk_len: int,
+    base_bytes_lut: Tensor, has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    loss_sum: Tensor, byte_sum: Tensor, token_count: Tensor,
+):
+    """Add one doc-chunk's contribution to the running BPB accumulators."""
+    lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+    prev = x[batch_i, chunk_offset:chunk_offset + chunk_len]
+    tgt = y[batch_i, chunk_offset:chunk_offset + chunk_len]
+    tok_bytes = base_bytes_lut[tgt].to(torch.float64)
+    tok_bytes += has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]
+    loss_sum += lbl.sum()
+    byte_sum += tok_bytes.sum()
+    token_count += chunk_len
+
+
+def eval_val_ttt_lora(
+    args: Hyperparameters,
+    base_model: GPT,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    """Evaluate with batched LoRA test-time training. Returns (val_loss, val_bpb)."""
+    files = sorted(glob.glob(args.val_files))
+    all_tokens = torch.cat([load_data_shard(Path(f)) for f in files])
+    docs = _find_docs(all_tokens)
+
+    rank_docs = docs[(len(docs) * rank) // world_size : (len(docs) * (rank + 1)) // world_size]
+    chunk_size = args.ttt_chunk_size
+    train_chunk_size = args.ttt_train_chunk_size
+    train_every = max(1, train_chunk_size // chunk_size)
+    eval_seq_len = args.ttt_eval_seq_len
+    batch_size = args.ttt_batch_size
+    lora_rank = args.ttt_lora_rank
+
+    rank_docs.sort(key=lambda d: (d[1] - 2) // chunk_size)
+
+    base_model.eval()
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+
+    lora = BatchedTTTLoRA(batch_size, base_model, lora_rank).to(device)
+    opt = _build_ttt_optimizer(lora, args)
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    for bi in range(0, len(rank_docs), batch_size):
+        batch = rank_docs[bi:bi + batch_size]
+        bsz = len(batch)
+
+        if bsz == batch_size:
+            cur_lora, cur_opt = lora, opt
+            cur_lora.reset()
+            _reset_ttt_optimizer(cur_opt)
+        else:
+            cur_lora = BatchedTTTLoRA(bsz, base_model, lora_rank).to(device)
+            cur_opt = _build_ttt_optimizer(cur_lora, args)
+
+        pred_lens = [doc_len - 1 for _, doc_len in batch]
+        num_chunks = [(pl + chunk_size - 1) // chunk_size for pl in pred_lens]
+        max_nc = max(num_chunks)
+
+        for ci in range(max_nc):
+            chunk_stats = _compute_chunk_window(ci, (ci + 1) * chunk_size, ci + 1, chunk_size, eval_seq_len)
+            context_size, chunk_offset = chunk_stats[1], chunk_stats[2]
+
+            active = [ci < nc for nc in num_chunks]
+            is_train_chunk = (ci + 1) % train_every == 0
+            needs_train = is_train_chunk and any(ci < nc - 1 for nc in num_chunks)
+
+            x = torch.zeros(bsz, context_size, dtype=torch.int64, device=device)
+            y = torch.zeros(bsz, context_size, dtype=torch.int64, device=device)
+            doc_info = []
+            for b in range(bsz):
+                if not active[b]:
+                    doc_info.append((0, 0))
+                    continue
+                ds, dl = batch[b]
+                ws, wl, co, cl = _compute_chunk_window(ci, pred_lens[b], num_chunks[b], chunk_size, eval_seq_len)
+                chunk = all_tokens[ds + ws: ds + ws + wl + 1]
+                toks = chunk.to(dtype=torch.int64, device=device)
+                x[b, :wl] = toks[:-1]
+                y[b, :wl] = toks[1:]
+                doc_info.append((co, cl))
+
+            if needs_train:
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    ptl = base_model(x, y, ttt_lora=cur_lora)
+            else:
+                with torch.no_grad(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    ptl = base_model(x, y, ttt_lora=cur_lora)
+
+            with torch.no_grad():
+                for b in range(bsz):
+                    if not active[b]:
+                        continue
+                    co, cl = doc_info[b]
+                    _accumulate_bpb(
+                        ptl, x, y, b, co, cl, base_bytes_lut, has_leading_space_lut,
+                        is_boundary_token_lut, loss_sum, byte_sum, token_count)
+
+            if needs_train:
+                mask = torch.tensor([float(ci < num_chunks[b] - 1) for b in range(bsz)], device=device)
+                train_start = max(0, chunk_offset + chunk_size - train_chunk_size)
+                train_end = chunk_offset + chunk_size
+                per_doc = ptl[:, train_start:train_end].mean(dim=-1)
+                cur_opt.zero_grad()
+                (per_doc * mask).sum().backward()
+                cur_opt.step()
+
+        if rank == 0 and bi % (batch_size * 10) == 0:
+            running_bpb = 0.0
+            if token_count.item() > 0:
+                running_bpb = float((loss_sum.item() / math.log(2.0)) / byte_sum.item()) if byte_sum.item() > 0 else 0.0
+            print(f"  ttt_eval batch:{bi}/{len(rank_docs)} running_bpb={running_bpb:.6f}", flush=True)
+
+    # Restore model to trainable state
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+
+    val_loss = float(loss_sum.item() / token_count.item())
+    val_bpb = float((loss_sum.item() / math.log(2.0)) / byte_sum.item())
+    return val_loss, val_bpb
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        num_loops=args.num_loops,
+        lora_rank=args.lora_rank,
+        smear_gate=args.smear_gate,
+        bigram_hash=args.bigram_hash,
+        bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, (CastedLinear, AttentionLoRA)):
+            module.float()
+        if isinstance(module, CastedLinear) and args.qat:
+            module._qat = True
+    # Set module-level quant bits for QAT
+    global _QAT_QUANT_BITS
+    _QAT_QUANT_BITS = args.quant_bits
+    restore_low_dim_params_to_fp32(base_model)
+    log0(f"qat:{args.qat} quant_bits:{args.quant_bits}")
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_weight_decay,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lora_adapters is not None:
+        lora_params = list(base_model.lora_adapters.parameters())
+        optimizer_lora = torch.optim.Adam(
+            [{"params": lora_params, "lr": args.lora_lr, "base_lr": args.lora_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.append(optimizer_lora)
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    # SmearGate optimizer: very low LR, no weight decay (per modded-nanogpt)
+    if base_model.use_smear_gate:
+        smear_lr = args.scalar_lr * 0.01  # 1% of scalar LR
+        smear_params = [base_model.smear_gate.weight, base_model.smear_lambda]
+        optimizer_smear = torch.optim.Adam(
+            [{"params": smear_params, "lr": smear_lr, "base_lr": smear_lr}],
+            betas=(0.9, 0.99),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.append(optimizer_smear)
+        log0(f"smear_gate:enabled lr:{smear_lr}")
+
+    # BigramHash optimizer: embedding + projection use scalar LR, lambdas use scalar LR
+    if base_model.use_bigram_hash:
+        bigram_params: list[Tensor] = [base_model.bigram_embed.weight, base_model.bigram_lambdas]
+        if base_model.bigram_proj is not None:
+            bigram_params.append(base_model.bigram_proj.weight)
+        optimizer_bigram = torch.optim.Adam(
+            [{"params": bigram_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.append(optimizer_bigram)
+        n_bigram = sum(p.numel() for p in bigram_params)
+        log0(f"bigram_hash:enabled vocab:{args.bigram_vocab_size} dim:{args.bigram_dim or args.model_dim} params:{n_bigram}")
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    n_lora = sum(p.numel() for p in base_model.lora_adapters.parameters()) if base_model.lora_adapters is not None else 0
+    effective_depth = args.num_layers * args.num_loops
+    log0(f"model_params:{n_params} (unique_layers:{args.num_layers} loops:{args.num_loops} effective_depth:{effective_depth} lora_rank:{args.lora_rank} lora_params:{n_lora})")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    # SWA state
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        # SWA: collect checkpoint when LR has decayed below threshold
+        if args.swa_enabled and scale < args.swa_start_frac and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                if master_process:
+                    print(f"swa:started step:{step} lr_scale:{scale:.4f}", flush=True)
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed int8+zlib artifact and validate the round-tripped weights.
+
+    # Apply SWA averaging if enabled
+    if args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"swa:averaging {swa_count} checkpoints")
+        avg_state = {name: (tensor / swa_count).to(dtype=base_model.state_dict()[name].dtype)
+                     for name, tensor in swa_state.items()}
+        base_model.load_state_dict(avg_state, strict=True)
+        del swa_state
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_tag = f"int{args.quant_bits}"
+    quant_file = f"final_model.{quant_tag}.ptz"
+
+    # Build FP16 passthrough set
+    fp16_names: set[str] = set()
+    if args.fp16_embed and args.tie_embeddings:
+        fp16_names.add("tok_emb.weight")
+        log0("fp16_passthrough: tok_emb.weight")
+    # For int6: skip LATE_K_LAYERS passthrough (QAT handles quantization quality)
+    # For int8: keep late-K passthrough
+    if args.quant_bits != 6 and args.late_k_layers > 0:
+        num_layers_total = max(
+            (int(k.split(".")[1]) for k in base_model.state_dict() if k.startswith("blocks.")),
+            default=0,
+        ) + 1
+        for li in range(max(0, num_layers_total - args.late_k_layers), num_layers_total):
+            kname = f"blocks.{li}.attn.c_k.weight"
+            if kname in base_model.state_dict():
+                fp16_names.add(kname)
+                log0(f"fp16_passthrough: {kname}")
+
+    if args.quant_bits == 6:
+        quant_obj, quant_stats = quantize_state_dict_int6(base_model.state_dict(), fp16_names=fp16_names)
+    else:
+        quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    # Use zstd level 22 for better compression (saves ~1-2MB vs zlib)
+    zstd_cctx = zstd.ZstdCompressor(level=22)
+    quant_blob = zstd_cctx.compress(quant_raw)
+    quant_raw_bytes = len(quant_raw)
+    payload_bytes = quant_stats.get("payload_bytes", quant_stats.get("int8_payload_bytes", 0))
+    if master_process:
+        with open(quant_file, "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize(quant_file)
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(payload_bytes, 1)
+        log0(
+            f"Serialized model {quant_tag}+zstd22: {quant_file_bytes} bytes "
+            f"(payload:{payload_bytes} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size {quant_tag}+zstd22: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open(quant_file, "rb") as f:
+        quant_blob_disk = f.read()
+    zstd_dctx = zstd.ZstdDecompressor()
+    quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+    if args.quant_bits == 6:
+        base_model.load_state_dict(dequantize_state_dict_int6(quant_state), strict=True)
+    else:
+        base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    if args.eval_stride > 0 and args.eval_stride < args.train_seq_len:
+        log0(f"final_eval_mode:sliding_window stride:{args.eval_stride} batch_seqs:{args.eval_batch_seqs}")
+        q_val_loss, q_val_bpb = eval_val_sliding(
+            args,
+            base_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            stride=args.eval_stride,
+            batch_seqs=args.eval_batch_seqs,
+        )
+    else:
+        log0("final_eval_mode:standard")
+        q_val_loss, q_val_bpb = eval_val(
+            args,
+            model,
+            rank,
+            world_size,
+            device,
+            grad_accum_steps,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+        )
+    torch.cuda.synchronize()
+    log0(
+        f"final_{quant_tag}_zstd22_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_{quant_tag}_zstd22_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    # TTT: test-time training with LoRA during eval
+    if args.ttt_enabled:
+        torch._dynamo.reset()
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_val_loss, ttt_val_bpb = eval_val_ttt_lora(
+            args, base_model, rank, world_size, device,
+            base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_{quant_tag}_ttt_lora val_loss:{ttt_val_loss:.4f} val_bpb:{ttt_val_bpb:.4f} "
+            f"eval_time:{1000.0 * (time.perf_counter() - t_ttt):.0f}ms"
+        )
+        log0(f"final_{quant_tag}_ttt_lora_exact val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-03-20_Int6QAT_SmearGate_MuonWD/README.md
+++ b/records/track_10min_16mb/2026-03-20_Int6QAT_SmearGate_MuonWD/README.md
@@ -1,0 +1,78 @@
+# Int6 QAT + SmearGate + Muon WD
+
+**val_bpb: 1.1669** | **Artifact: 14.77 MB**
+
+## Key Techniques
+
+1. **Int6 Quantization-Aware Training (QAT)**: Straight-through estimator (STE) fake int6 quantization during the forward pass. Per-row symmetric quantization with 6-bit clipping. Nearly eliminates post-quantization degradation — no need for fp16 late-K layer passthrough.
+
+2. **Int6-in-Int8 compression**: Int6 values (-32 to 31) stored in int8 containers rather than bit-packed. zstd-22 compresses the restricted value range ~35%, achieving 14.77MB from 21.8M parameters. Bit-packing destroys byte alignment and defeats compressors.
+
+3. **SmearGate**: Learned gate (~513 params) blending current and previous token embeddings, zero-initialized with very low learning rate (1% of scalar LR). Provides bigram-level context at the embedding layer.
+
+4. **Decoupled Muon weight decay** (0.01): Applied in the Muon optimizer step, improving generalization and quantization robustness.
+
+5. **Sliding window evaluation** (stride=64, batch=32 sequences): Full-context scoring for every token position.
+
+6. **FP16 tied embedding passthrough**: Embedding weights kept in fp16 to avoid compounding int6 errors through both input and output paths.
+
+## Architecture
+
+- 9 layers, 512 dim, 8 heads, 4 KV heads, MLP mult 3x
+- 21.8M parameters, tied embeddings
+- Vocab size 1024 (sp1024 tokenizer)
+- Training sequence length 2048, batch 524288 tokens
+
+## Training Config
+
+| Parameter | Value |
+|-----------|-------|
+| Matrix LR | 0.06 |
+| Scalar LR | 0.06 |
+| Tied Embed LR | 0.07 |
+| Muon Momentum | 0.99 |
+| Muon Weight Decay | 0.01 |
+| Warmdown Steps | 8000 |
+| QAT Bits | 6 |
+| Late K Layers | 0 |
+
+## Results
+
+| Seed | val_loss | val_bpb | Steps | ms/step |
+|------|----------|---------|-------|---------|
+| 1337 | 1.9703 | 1.1669 | 9706 | 61.80 |
+
+Serialized model int6+zstd22: 14,696,046 bytes
+Code size: 71,909 bytes
+Total artifact: 14,767,955 bytes (well under 16MB cap)
+
+## Comparison to Current SOTA
+
+| | This submission | Current SOTA (notapplica) |
+|--|-----------------|---------------------------|
+| val_bpb | **1.1669** | 1.1748 |
+| Improvement | **-0.0079** | — |
+| Artifact size | 14.77 MB | ~14.7 MB |
+| Layers | 9 | 10 |
+| Quantization | Int6 QAT | Int8 |
+
+## Command
+
+```bash
+NCCL_NVLS_ENABLE=0 \
+RUN_ID=int6_qat_smeargate_v5_wd8k \
+DATA_PATH=/workspace/parameter-golf/data/datasets/fineweb10B_sp1024 \
+TOKENIZER_PATH=/workspace/parameter-golf/data/tokenizers/fineweb_1024_bpe.model \
+VOCAB_SIZE=1024 NUM_HEADS=8 NUM_KV_HEADS=4 MODEL_DIM=512 \
+NUM_LAYERS=9 MLP_MULT=3 \
+QAT=1 QUANT_BITS=6 FP16_EMBED=1 LATE_K_LAYERS=0 \
+EVAL_STRIDE=64 EVAL_BATCH_SEQS=32 \
+MATRIX_LR=0.06 SCALAR_LR=0.06 TIED_EMBED_LR=0.07 \
+MUON_MOMENTUM=0.99 MUON_WEIGHT_DECAY=0.01 \
+SMEAR_GATE=1 BIGRAM_HASH=0 \
+TRAIN_SEQ_LEN=2048 TRAIN_BATCH_TOKENS=524288 \
+WARMDOWN_STEPS=8000 \
+MAX_WALLCLOCK_SECONDS=600 \
+TRAIN_LOG_EVERY=50 VAL_LOSS_EVERY=200 \
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```

--- a/records/track_10min_16mb/2026-03-20_Int6QAT_SmearGate_MuonWD/submission.json
+++ b/records/track_10min_16mb/2026-03-20_Int6QAT_SmearGate_MuonWD/submission.json
@@ -1,0 +1,13 @@
+{
+  "track": "10min_16mb",
+  "date": "2026-03-20",
+  "name": "Int6 QAT + SmearGate + Muon WD",
+  "author": "baudrillardsgh0st",
+  "seed_results": {
+    "1337": {"val_loss": 1.97025414, "val_bpb": 1.16689857, "steps": 9706, "ms_per_step": 61.80}
+  },
+  "mean_val_loss": 1.97025414,
+  "mean_val_bpb": 1.16689857,
+  "artifact_bytes": 14767955,
+  "code_bytes": 71909
+}

--- a/records/track_10min_16mb/2026-03-20_Int6QAT_SmearGate_MuonWD/train.log
+++ b/records/track_10min_16mb/2026-03-20_Int6QAT_SmearGate_MuonWD/train.log
@@ -1,0 +1,394 @@
+W0320 02:52:55.724000 126188612874880 torch/distributed/run.py:779] 
+W0320 02:52:55.724000 126188612874880 torch/distributed/run.py:779] *****************************************
+W0320 02:52:55.724000 126188612874880 torch/distributed/run.py:779] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0320 02:52:55.724000 126188612874880 torch/distributed/run.py:779] *****************************************
+logs/submit_9L_int6_v5_wd8k.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/workspace/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=/workspace/parameter-golf/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+qat:True quant_bits:6
+smear_gate:enabled lr:0.0006
+model_params:21779017 (unique_layers:9 loops:1 effective_depth:9 lora_rank:0 lora_params:0)
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.07 head_lr:0.0 matrix_lr:0.06 scalar_lr:0.06
+train_batch_tokens:524288 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9366 val_bpb:4.1082 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9354 train_time:108ms step_avg:107.79ms
+step:2/20000 train_loss:20.2610 train_time:150ms step_avg:75.02ms
+step:3/20000 train_loss:17.9191 train_time:216ms step_avg:72.04ms
+step:4/20000 train_loss:13.5995 train_time:283ms step_avg:70.65ms
+step:5/20000 train_loss:9.7365 train_time:348ms step_avg:69.70ms
+step:6/20000 train_loss:8.6023 train_time:414ms step_avg:69.07ms
+step:7/20000 train_loss:6.5554 train_time:481ms step_avg:68.66ms
+step:8/20000 train_loss:6.1798 train_time:548ms step_avg:68.51ms
+step:9/20000 train_loss:5.9933 train_time:614ms step_avg:68.21ms
+step:10/20000 train_loss:5.7634 train_time:684ms step_avg:68.36ms
+step:50/20000 train_loss:4.2296 train_time:3128ms step_avg:62.56ms
+step:100/20000 train_loss:3.4799 train_time:6187ms step_avg:61.87ms
+step:150/20000 train_loss:3.1128 train_time:9249ms step_avg:61.66ms
+step:200/20000 train_loss:2.8692 train_time:12403ms step_avg:62.02ms
+step:200/20000 val_loss:2.8436 val_bpb:1.6841 train_time:12435ms step_avg:62.17ms
+step:250/20000 train_loss:2.7355 train_time:15466ms step_avg:61.86ms
+step:300/20000 train_loss:2.4535 train_time:18528ms step_avg:61.76ms
+step:350/20000 train_loss:2.6433 train_time:21590ms step_avg:61.69ms
+step:400/20000 train_loss:2.3251 train_time:24744ms step_avg:61.86ms
+step:400/20000 val_loss:2.5288 val_bpb:1.4977 train_time:24776ms step_avg:61.94ms
+step:450/20000 train_loss:2.4699 train_time:27808ms step_avg:61.80ms
+step:500/20000 train_loss:2.4707 train_time:30875ms step_avg:61.75ms
+step:550/20000 train_loss:2.3813 train_time:33939ms step_avg:61.71ms
+step:600/20000 train_loss:2.5286 train_time:37095ms step_avg:61.83ms
+step:600/20000 val_loss:2.4220 val_bpb:1.4344 train_time:37126ms step_avg:61.88ms
+step:650/20000 train_loss:2.3688 train_time:40160ms step_avg:61.78ms
+step:700/20000 train_loss:2.4236 train_time:43227ms step_avg:61.75ms
+step:750/20000 train_loss:2.2563 train_time:46293ms step_avg:61.72ms
+step:800/20000 train_loss:2.2789 train_time:49450ms step_avg:61.81ms
+step:800/20000 val_loss:2.3639 val_bpb:1.4000 train_time:49481ms step_avg:61.85ms
+step:850/20000 train_loss:2.6990 train_time:52516ms step_avg:61.78ms
+step:900/20000 train_loss:2.3282 train_time:55582ms step_avg:61.76ms
+step:950/20000 train_loss:2.3863 train_time:58651ms step_avg:61.74ms
+step:1000/20000 train_loss:2.3732 train_time:61807ms step_avg:61.81ms
+step:1000/20000 val_loss:2.3233 val_bpb:1.3760 train_time:61839ms step_avg:61.84ms
+step:1050/20000 train_loss:2.4856 train_time:64873ms step_avg:61.78ms
+step:1100/20000 train_loss:2.2461 train_time:67942ms step_avg:61.77ms
+step:1150/20000 train_loss:2.2537 train_time:71107ms step_avg:61.83ms
+step:1200/20000 train_loss:2.3912 train_time:74175ms step_avg:61.81ms
+step:1200/20000 val_loss:2.2991 val_bpb:1.3617 train_time:74207ms step_avg:61.84ms
+step:1250/20000 train_loss:2.2135 train_time:77245ms step_avg:61.80ms
+step:1300/20000 train_loss:2.3664 train_time:80313ms step_avg:61.78ms
+step:1350/20000 train_loss:2.2707 train_time:83470ms step_avg:61.83ms
+step:1400/20000 train_loss:2.4243 train_time:86542ms step_avg:61.82ms
+step:1400/20000 val_loss:2.2800 val_bpb:1.3504 train_time:86574ms step_avg:61.84ms
+step:1450/20000 train_loss:2.2491 train_time:89615ms step_avg:61.80ms
+step:1500/20000 train_loss:2.2402 train_time:92686ms step_avg:61.79ms
+step:1550/20000 train_loss:2.1642 train_time:95849ms step_avg:61.84ms
+step:1600/20000 train_loss:2.1014 train_time:98919ms step_avg:61.82ms
+step:1600/20000 val_loss:2.2716 val_bpb:1.3454 train_time:98950ms step_avg:61.84ms
+step:1650/20000 train_loss:2.2386 train_time:101986ms step_avg:61.81ms
+step:1700/20000 train_loss:2.1731 train_time:105055ms step_avg:61.80ms
+step:1750/20000 train_loss:2.2455 train_time:108223ms step_avg:61.84ms
+step:1800/20000 train_loss:2.2047 train_time:111293ms step_avg:61.83ms
+step:1800/20000 val_loss:2.2444 val_bpb:1.3293 train_time:111325ms step_avg:61.85ms
+step:1850/20000 train_loss:2.3036 train_time:114363ms step_avg:61.82ms
+step:1900/20000 train_loss:2.1896 train_time:117432ms step_avg:61.81ms
+step:1950/20000 train_loss:2.2026 train_time:120593ms step_avg:61.84ms
+step:2000/20000 train_loss:2.2400 train_time:123662ms step_avg:61.83ms
+step:2000/20000 val_loss:2.2208 val_bpb:1.3153 train_time:123694ms step_avg:61.85ms
+step:2050/20000 train_loss:2.2396 train_time:126730ms step_avg:61.82ms
+step:2100/20000 train_loss:2.2562 train_time:129894ms step_avg:61.85ms
+step:2150/20000 train_loss:2.1668 train_time:132965ms step_avg:61.84ms
+step:2200/20000 train_loss:2.0612 train_time:136035ms step_avg:61.83ms
+step:2200/20000 val_loss:2.2052 val_bpb:1.3060 train_time:136066ms step_avg:61.85ms
+step:2250/20000 train_loss:2.1464 train_time:139102ms step_avg:61.82ms
+step:2300/20000 train_loss:2.3539 train_time:142257ms step_avg:61.85ms
+step:2350/20000 train_loss:2.1720 train_time:145324ms step_avg:61.84ms
+step:2400/20000 train_loss:2.1835 train_time:148391ms step_avg:61.83ms
+step:2400/20000 val_loss:2.1911 val_bpb:1.2977 train_time:148423ms step_avg:61.84ms
+step:2450/20000 train_loss:2.1814 train_time:151462ms step_avg:61.82ms
+step:2500/20000 train_loss:2.1078 train_time:154618ms step_avg:61.85ms
+step:2550/20000 train_loss:2.1059 train_time:157684ms step_avg:61.84ms
+step:2600/20000 train_loss:2.4039 train_time:160751ms step_avg:61.83ms
+step:2600/20000 val_loss:2.1985 val_bpb:1.3021 train_time:160783ms step_avg:61.84ms
+step:2650/20000 train_loss:2.2088 train_time:163815ms step_avg:61.82ms
+step:2700/20000 train_loss:2.1271 train_time:166976ms step_avg:61.84ms
+step:2750/20000 train_loss:2.3365 train_time:170042ms step_avg:61.83ms
+step:2800/20000 train_loss:2.2105 train_time:173108ms step_avg:61.82ms
+step:2800/20000 val_loss:2.1718 val_bpb:1.2863 train_time:173140ms step_avg:61.84ms
+step:2850/20000 train_loss:2.1581 train_time:176174ms step_avg:61.82ms
+step:2900/20000 train_loss:2.1530 train_time:179338ms step_avg:61.84ms
+step:2950/20000 train_loss:2.1995 train_time:182406ms step_avg:61.83ms
+step:3000/20000 train_loss:2.1981 train_time:185474ms step_avg:61.82ms
+step:3000/20000 val_loss:2.1615 val_bpb:1.2802 train_time:185505ms step_avg:61.83ms
+step:3050/20000 train_loss:2.1313 train_time:188542ms step_avg:61.82ms
+step:3100/20000 train_loss:2.1691 train_time:191705ms step_avg:61.84ms
+step:3150/20000 train_loss:2.1377 train_time:194775ms step_avg:61.83ms
+step:3200/20000 train_loss:2.1611 train_time:197841ms step_avg:61.83ms
+step:3200/20000 val_loss:2.1555 val_bpb:1.2766 train_time:197872ms step_avg:61.84ms
+step:3250/20000 train_loss:2.0601 train_time:200999ms step_avg:61.85ms
+step:3300/20000 train_loss:2.2079 train_time:204064ms step_avg:61.84ms
+step:3350/20000 train_loss:2.0611 train_time:207132ms step_avg:61.83ms
+step:3400/20000 train_loss:2.1295 train_time:210197ms step_avg:61.82ms
+step:3400/20000 val_loss:2.1509 val_bpb:1.2739 train_time:210229ms step_avg:61.83ms
+step:3450/20000 train_loss:2.0666 train_time:213359ms step_avg:61.84ms
+step:3500/20000 train_loss:2.2230 train_time:216424ms step_avg:61.84ms
+step:3550/20000 train_loss:2.3602 train_time:219489ms step_avg:61.83ms
+step:3600/20000 train_loss:2.0728 train_time:222560ms step_avg:61.82ms
+step:3600/20000 val_loss:2.1419 val_bpb:1.2685 train_time:222591ms step_avg:61.83ms
+step:3650/20000 train_loss:2.1748 train_time:225721ms step_avg:61.84ms
+step:3700/20000 train_loss:2.1049 train_time:228783ms step_avg:61.83ms
+step:3750/20000 train_loss:2.1112 train_time:231848ms step_avg:61.83ms
+step:3800/20000 train_loss:2.1763 train_time:234915ms step_avg:61.82ms
+step:3800/20000 val_loss:2.1359 val_bpb:1.2650 train_time:234946ms step_avg:61.83ms
+step:3850/20000 train_loss:2.1366 train_time:238077ms step_avg:61.84ms
+step:3900/20000 train_loss:1.9559 train_time:241145ms step_avg:61.83ms
+step:3950/20000 train_loss:2.0913 train_time:244206ms step_avg:61.82ms
+step:4000/20000 train_loss:2.1385 train_time:247272ms step_avg:61.82ms
+step:4000/20000 val_loss:2.1302 val_bpb:1.2616 train_time:247303ms step_avg:61.83ms
+step:4050/20000 train_loss:2.0642 train_time:250430ms step_avg:61.83ms
+step:4100/20000 train_loss:2.1486 train_time:253493ms step_avg:61.83ms
+step:4150/20000 train_loss:2.2876 train_time:256558ms step_avg:61.82ms
+step:4200/20000 train_loss:2.1335 train_time:259717ms step_avg:61.84ms
+step:4200/20000 val_loss:2.1247 val_bpb:1.2584 train_time:259748ms step_avg:61.84ms
+step:4250/20000 train_loss:2.0843 train_time:262782ms step_avg:61.83ms
+step:4300/20000 train_loss:1.9818 train_time:265847ms step_avg:61.82ms
+step:4350/20000 train_loss:2.1745 train_time:268911ms step_avg:61.82ms
+step:4400/20000 train_loss:2.0710 train_time:272067ms step_avg:61.83ms
+step:4400/20000 val_loss:2.1219 val_bpb:1.2567 train_time:272098ms step_avg:61.84ms
+step:4450/20000 train_loss:2.0195 train_time:275130ms step_avg:61.83ms
+step:4500/20000 train_loss:2.2191 train_time:278195ms step_avg:61.82ms
+step:4550/20000 train_loss:2.0168 train_time:281256ms step_avg:61.81ms
+step:4600/20000 train_loss:1.9330 train_time:284411ms step_avg:61.83ms
+step:4600/20000 val_loss:2.1172 val_bpb:1.2539 train_time:284442ms step_avg:61.84ms
+step:4650/20000 train_loss:2.0347 train_time:287477ms step_avg:61.82ms
+step:4700/20000 train_loss:2.2294 train_time:290544ms step_avg:61.82ms
+step:4750/20000 train_loss:1.9278 train_time:293609ms step_avg:61.81ms
+step:4800/20000 train_loss:2.2159 train_time:296762ms step_avg:61.83ms
+step:4800/20000 val_loss:2.1129 val_bpb:1.2514 train_time:296793ms step_avg:61.83ms
+step:4850/20000 train_loss:2.1167 train_time:299827ms step_avg:61.82ms
+step:4900/20000 train_loss:2.1267 train_time:302890ms step_avg:61.81ms
+step:4950/20000 train_loss:2.3079 train_time:305954ms step_avg:61.81ms
+step:5000/20000 train_loss:1.9737 train_time:309114ms step_avg:61.82ms
+step:5000/20000 val_loss:2.1072 val_bpb:1.2480 train_time:309145ms step_avg:61.83ms
+step:5050/20000 train_loss:2.1677 train_time:312180ms step_avg:61.82ms
+step:5100/20000 train_loss:1.9838 train_time:315244ms step_avg:61.81ms
+step:5150/20000 train_loss:2.2423 train_time:318404ms step_avg:61.83ms
+step:5200/20000 train_loss:2.1302 train_time:321467ms step_avg:61.82ms
+step:5200/20000 val_loss:2.1046 val_bpb:1.2465 train_time:321499ms step_avg:61.83ms
+step:5250/20000 train_loss:2.0827 train_time:324531ms step_avg:61.82ms
+step:5300/20000 train_loss:2.1642 train_time:327594ms step_avg:61.81ms
+step:5350/20000 train_loss:2.1034 train_time:330755ms step_avg:61.82ms
+step:5400/20000 train_loss:2.1451 train_time:333818ms step_avg:61.82ms
+step:5400/20000 val_loss:2.1004 val_bpb:1.2440 train_time:333849ms step_avg:61.82ms
+step:5450/20000 train_loss:2.1568 train_time:336882ms step_avg:61.81ms
+step:5500/20000 train_loss:2.0999 train_time:339942ms step_avg:61.81ms
+step:5550/20000 train_loss:2.0601 train_time:343104ms step_avg:61.82ms
+step:5600/20000 train_loss:2.1322 train_time:346166ms step_avg:61.82ms
+step:5600/20000 val_loss:2.0973 val_bpb:1.2421 train_time:346197ms step_avg:61.82ms
+step:5650/20000 train_loss:2.0099 train_time:349228ms step_avg:61.81ms
+step:5700/20000 train_loss:2.1269 train_time:352291ms step_avg:61.81ms
+step:5750/20000 train_loss:2.1705 train_time:355441ms step_avg:61.82ms
+step:5800/20000 train_loss:2.0835 train_time:358509ms step_avg:61.81ms
+step:5800/20000 val_loss:2.0928 val_bpb:1.2395 train_time:358541ms step_avg:61.82ms
+step:5850/20000 train_loss:2.1375 train_time:361572ms step_avg:61.81ms
+step:5900/20000 train_loss:2.0443 train_time:364634ms step_avg:61.80ms
+step:5950/20000 train_loss:2.0850 train_time:367796ms step_avg:61.81ms
+step:6000/20000 train_loss:2.1636 train_time:370861ms step_avg:61.81ms
+step:6000/20000 val_loss:2.0887 val_bpb:1.2371 train_time:370893ms step_avg:61.82ms
+step:6050/20000 train_loss:2.0740 train_time:373926ms step_avg:61.81ms
+step:6100/20000 train_loss:2.0691 train_time:376989ms step_avg:61.80ms
+step:6150/20000 train_loss:2.0457 train_time:380147ms step_avg:61.81ms
+step:6200/20000 train_loss:2.0320 train_time:383212ms step_avg:61.81ms
+step:6200/20000 val_loss:2.0841 val_bpb:1.2343 train_time:383243ms step_avg:61.81ms
+step:6250/20000 train_loss:2.0971 train_time:386275ms step_avg:61.80ms
+step:6300/20000 train_loss:1.9786 train_time:389436ms step_avg:61.82ms
+step:6350/20000 train_loss:1.9577 train_time:392500ms step_avg:61.81ms
+step:6400/20000 train_loss:2.1107 train_time:395564ms step_avg:61.81ms
+step:6400/20000 val_loss:2.0805 val_bpb:1.2322 train_time:395595ms step_avg:61.81ms
+step:6450/20000 train_loss:2.0274 train_time:398628ms step_avg:61.80ms
+step:6500/20000 train_loss:2.0252 train_time:401782ms step_avg:61.81ms
+step:6550/20000 train_loss:2.1505 train_time:404845ms step_avg:61.81ms
+step:6600/20000 train_loss:2.0661 train_time:407909ms step_avg:61.80ms
+step:6600/20000 val_loss:2.0752 val_bpb:1.2290 train_time:407941ms step_avg:61.81ms
+step:6650/20000 train_loss:2.2409 train_time:410973ms step_avg:61.80ms
+step:6700/20000 train_loss:2.1042 train_time:414127ms step_avg:61.81ms
+step:6750/20000 train_loss:2.2576 train_time:417189ms step_avg:61.81ms
+step:6800/20000 train_loss:2.1244 train_time:420252ms step_avg:61.80ms
+step:6800/20000 val_loss:2.0700 val_bpb:1.2260 train_time:420283ms step_avg:61.81ms
+step:6850/20000 train_loss:1.9654 train_time:423312ms step_avg:61.80ms
+step:6900/20000 train_loss:2.0385 train_time:426471ms step_avg:61.81ms
+step:6950/20000 train_loss:2.1082 train_time:429533ms step_avg:61.80ms
+step:7000/20000 train_loss:2.1687 train_time:432596ms step_avg:61.80ms
+step:7000/20000 val_loss:2.0661 val_bpb:1.2237 train_time:432628ms step_avg:61.80ms
+step:7050/20000 train_loss:2.1945 train_time:435662ms step_avg:61.80ms
+step:7100/20000 train_loss:2.0030 train_time:438825ms step_avg:61.81ms
+step:7150/20000 train_loss:2.0873 train_time:441888ms step_avg:61.80ms
+step:7200/20000 train_loss:2.1340 train_time:444953ms step_avg:61.80ms
+step:7200/20000 val_loss:2.0617 val_bpb:1.2211 train_time:444984ms step_avg:61.80ms
+step:7250/20000 train_loss:2.0282 train_time:448105ms step_avg:61.81ms
+step:7300/20000 train_loss:2.0208 train_time:451166ms step_avg:61.80ms
+step:7350/20000 train_loss:2.1261 train_time:454230ms step_avg:61.80ms
+step:7400/20000 train_loss:2.0555 train_time:457295ms step_avg:61.80ms
+step:7400/20000 val_loss:2.0569 val_bpb:1.2182 train_time:457327ms step_avg:61.80ms
+step:7450/20000 train_loss:2.0450 train_time:460453ms step_avg:61.81ms
+step:7500/20000 train_loss:2.0520 train_time:463517ms step_avg:61.80ms
+step:7550/20000 train_loss:2.1004 train_time:466584ms step_avg:61.80ms
+step:7600/20000 train_loss:1.9330 train_time:469646ms step_avg:61.80ms
+step:7600/20000 val_loss:2.0531 val_bpb:1.2160 train_time:469678ms step_avg:61.80ms
+step:7650/20000 train_loss:2.2266 train_time:472807ms step_avg:61.80ms
+step:7700/20000 train_loss:2.0115 train_time:475871ms step_avg:61.80ms
+step:7750/20000 train_loss:2.0388 train_time:478937ms step_avg:61.80ms
+step:7800/20000 train_loss:2.0735 train_time:482000ms step_avg:61.79ms
+step:7800/20000 val_loss:2.0474 val_bpb:1.2126 train_time:482032ms step_avg:61.80ms
+step:7850/20000 train_loss:1.9061 train_time:485147ms step_avg:61.80ms
+step:7900/20000 train_loss:2.0596 train_time:488210ms step_avg:61.80ms
+step:7950/20000 train_loss:2.0181 train_time:491272ms step_avg:61.80ms
+step:8000/20000 train_loss:2.0443 train_time:494338ms step_avg:61.79ms
+step:8000/20000 val_loss:2.0427 val_bpb:1.2098 train_time:494369ms step_avg:61.80ms
+step:8050/20000 train_loss:2.0032 train_time:497503ms step_avg:61.80ms
+step:8100/20000 train_loss:2.0749 train_time:500567ms step_avg:61.80ms
+step:8150/20000 train_loss:2.1804 train_time:503631ms step_avg:61.80ms
+step:8200/20000 train_loss:2.1132 train_time:506696ms step_avg:61.79ms
+step:8200/20000 val_loss:2.0383 val_bpb:1.2072 train_time:506727ms step_avg:61.80ms
+step:8250/20000 train_loss:2.0714 train_time:509860ms step_avg:61.80ms
+step:8300/20000 train_loss:2.0361 train_time:512925ms step_avg:61.80ms
+step:8350/20000 train_loss:2.1525 train_time:515987ms step_avg:61.79ms
+step:8400/20000 train_loss:2.0518 train_time:519149ms step_avg:61.80ms
+step:8400/20000 val_loss:2.0335 val_bpb:1.2043 train_time:519181ms step_avg:61.81ms
+step:8450/20000 train_loss:2.1384 train_time:522214ms step_avg:61.80ms
+step:8500/20000 train_loss:2.0307 train_time:525280ms step_avg:61.80ms
+step:8550/20000 train_loss:2.1062 train_time:528345ms step_avg:61.79ms
+step:8600/20000 train_loss:2.0621 train_time:531504ms step_avg:61.80ms
+step:8600/20000 val_loss:2.0285 val_bpb:1.2014 train_time:531535ms step_avg:61.81ms
+step:8650/20000 train_loss:2.0055 train_time:534568ms step_avg:61.80ms
+step:8700/20000 train_loss:1.9449 train_time:537632ms step_avg:61.80ms
+step:8750/20000 train_loss:2.1111 train_time:540694ms step_avg:61.79ms
+step:8800/20000 train_loss:2.0166 train_time:543854ms step_avg:61.80ms
+step:8800/20000 val_loss:2.0236 val_bpb:1.1985 train_time:543885ms step_avg:61.81ms
+step:8850/20000 train_loss:2.2019 train_time:546918ms step_avg:61.80ms
+step:8900/20000 train_loss:2.1138 train_time:549981ms step_avg:61.80ms
+step:8950/20000 train_loss:2.0759 train_time:553049ms step_avg:61.79ms
+step:9000/20000 train_loss:1.9315 train_time:556210ms step_avg:61.80ms
+step:9000/20000 val_loss:2.0191 val_bpb:1.1959 train_time:556242ms step_avg:61.80ms
+step:9050/20000 train_loss:1.9635 train_time:559277ms step_avg:61.80ms
+step:9100/20000 train_loss:2.1985 train_time:562342ms step_avg:61.80ms
+step:9150/20000 train_loss:1.8990 train_time:565406ms step_avg:61.79ms
+step:9200/20000 train_loss:1.9907 train_time:568566ms step_avg:61.80ms
+step:9200/20000 val_loss:2.0140 val_bpb:1.1928 train_time:568597ms step_avg:61.80ms
+step:9250/20000 train_loss:2.1036 train_time:571631ms step_avg:61.80ms
+step:9300/20000 train_loss:2.0345 train_time:574698ms step_avg:61.80ms
+step:9350/20000 train_loss:2.1241 train_time:577849ms step_avg:61.80ms
+step:9400/20000 train_loss:2.0290 train_time:580911ms step_avg:61.80ms
+step:9400/20000 val_loss:2.0095 val_bpb:1.1901 train_time:580942ms step_avg:61.80ms
+step:9450/20000 train_loss:2.0616 train_time:583976ms step_avg:61.80ms
+step:9500/20000 train_loss:2.1515 train_time:587040ms step_avg:61.79ms
+step:9550/20000 train_loss:2.0986 train_time:590198ms step_avg:61.80ms
+step:9600/20000 train_loss:2.0450 train_time:593262ms step_avg:61.80ms
+step:9600/20000 val_loss:2.0060 val_bpb:1.1881 train_time:593294ms step_avg:61.80ms
+step:9650/20000 train_loss:1.9787 train_time:596326ms step_avg:61.80ms
+step:9700/20000 train_loss:1.9967 train_time:599389ms step_avg:61.79ms
+step:9706/20000 val_loss:2.0051 val_bpb:1.1875 train_time:599787ms step_avg:61.80ms
+stopping_early: wallclock_cap train_time:599787ms step:9706/20000
+peak memory allocated: 14330 MiB reserved: 14396 MiB
+Serialized model: 86100612 bytes
+Code size: 71909 bytes
+Total submission size: 86172521 bytes
+fp16_passthrough: tok_emb.weight
+Serialized model int6+zstd22: 14696046 bytes (payload:22429986 raw_torch:22475018 payload_ratio:3.84x)
+Total submission size int6+zstd22: 14767955 bytes
+/workspace/parameter-golf/train_gpt_qat_int6.py:1608: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+  quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+/workspace/parameter-golf/train_gpt_qat_int6.py:1608: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+  quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+/workspace/parameter-golf/train_gpt_qat_int6.py:1608: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+  quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+/workspace/parameter-golf/train_gpt_qat_int6.py:1608: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+  quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+/workspace/parameter-golf/train_gpt_qat_int6.py:1608: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+  quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+/workspace/parameter-golf/train_gpt_qat_int6.py:1608: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+  quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+/workspace/parameter-golf/train_gpt_qat_int6.py:1608: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+  quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+/workspace/parameter-golf/train_gpt_qat_int6.py:1608: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+  quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+final_eval_mode:sliding_window stride:64 batch_seqs:32
+  sliding_eval [  0.0%] 32/121136 windows running_bpb=1.229418
+  sliding_eval [  1.3%] 1632/121136 windows running_bpb=1.160780
+  sliding_eval [  2.7%] 3232/121136 windows running_bpb=1.160463
+  sliding_eval [  4.0%] 4832/121136 windows running_bpb=1.154949
+  sliding_eval [  5.3%] 6432/121136 windows running_bpb=1.167860
+  sliding_eval [  6.6%] 8032/121136 windows running_bpb=1.169222
+  sliding_eval [  8.0%] 9632/121136 windows running_bpb=1.171224
+  sliding_eval [  9.3%] 11232/121136 windows running_bpb=1.166730
+  sliding_eval [ 10.6%] 12832/121136 windows running_bpb=1.164226
+  sliding_eval [ 11.9%] 14432/121136 windows running_bpb=1.166113
+  sliding_eval [ 13.2%] 16032/121136 windows running_bpb=1.174641
+  sliding_eval [ 14.6%] 17632/121136 windows running_bpb=1.172481
+  sliding_eval [ 15.9%] 19232/121136 windows running_bpb=1.173716
+  sliding_eval [ 17.2%] 20832/121136 windows running_bpb=1.172138
+  sliding_eval [ 18.5%] 22432/121136 windows running_bpb=1.170682
+  sliding_eval [ 19.8%] 24032/121136 windows running_bpb=1.171159
+  sliding_eval [ 21.2%] 25632/121136 windows running_bpb=1.172525
+  sliding_eval [ 22.5%] 27232/121136 windows running_bpb=1.173074
+  sliding_eval [ 23.8%] 28832/121136 windows running_bpb=1.179249
+  sliding_eval [ 25.1%] 30432/121136 windows running_bpb=1.176651
+  sliding_eval [ 26.4%] 32032/121136 windows running_bpb=1.177761
+  sliding_eval [ 27.8%] 33632/121136 windows running_bpb=1.176330
+  sliding_eval [ 29.1%] 35232/121136 windows running_bpb=1.175673
+  sliding_eval [ 30.4%] 36832/121136 windows running_bpb=1.175283
+  sliding_eval [ 31.7%] 38432/121136 windows running_bpb=1.175916
+  sliding_eval [ 33.0%] 40032/121136 windows running_bpb=1.173607
+  sliding_eval [ 34.4%] 41632/121136 windows running_bpb=1.172699
+  sliding_eval [ 35.7%] 43232/121136 windows running_bpb=1.173059
+  sliding_eval [ 37.0%] 44832/121136 windows running_bpb=1.171899
+  sliding_eval [ 38.3%] 46432/121136 windows running_bpb=1.171732
+  sliding_eval [ 39.7%] 48032/121136 windows running_bpb=1.171031
+  sliding_eval [ 41.0%] 49632/121136 windows running_bpb=1.172255
+  sliding_eval [ 42.3%] 51232/121136 windows running_bpb=1.173393
+  sliding_eval [ 43.6%] 52832/121136 windows running_bpb=1.173919
+  sliding_eval [ 44.9%] 54432/121136 windows running_bpb=1.173391
+  sliding_eval [ 46.3%] 56032/121136 windows running_bpb=1.173786
+  sliding_eval [ 47.6%] 57632/121136 windows running_bpb=1.172996
+  sliding_eval [ 48.9%] 59232/121136 windows running_bpb=1.169117
+  sliding_eval [ 50.2%] 60832/121136 windows running_bpb=1.169232
+  sliding_eval [ 51.5%] 62432/121136 windows running_bpb=1.170133
+  sliding_eval [ 52.9%] 64032/121136 windows running_bpb=1.170327
+  sliding_eval [ 54.2%] 65632/121136 windows running_bpb=1.170166
+  sliding_eval [ 55.5%] 67232/121136 windows running_bpb=1.168964
+  sliding_eval [ 56.8%] 68832/121136 windows running_bpb=1.168653
+  sliding_eval [ 58.1%] 70432/121136 windows running_bpb=1.167965
+  sliding_eval [ 59.5%] 72032/121136 windows running_bpb=1.168012
+  sliding_eval [ 60.8%] 73632/121136 windows running_bpb=1.168056
+  sliding_eval [ 62.1%] 75232/121136 windows running_bpb=1.168233
+  sliding_eval [ 63.4%] 76832/121136 windows running_bpb=1.167985
+  sliding_eval [ 64.7%] 78432/121136 windows running_bpb=1.168595
+  sliding_eval [ 66.1%] 80032/121136 windows running_bpb=1.168901
+  sliding_eval [ 67.4%] 81632/121136 windows running_bpb=1.168639
+  sliding_eval [ 68.7%] 83232/121136 windows running_bpb=1.169680
+  sliding_eval [ 70.0%] 84832/121136 windows running_bpb=1.171656
+  sliding_eval [ 71.4%] 86432/121136 windows running_bpb=1.170945
+  sliding_eval [ 72.7%] 88032/121136 windows running_bpb=1.171737
+  sliding_eval [ 74.0%] 89632/121136 windows running_bpb=1.172114
+  sliding_eval [ 75.3%] 91232/121136 windows running_bpb=1.172091
+  sliding_eval [ 76.6%] 92832/121136 windows running_bpb=1.171649
+  sliding_eval [ 78.0%] 94432/121136 windows running_bpb=1.171900
+  sliding_eval [ 79.3%] 96032/121136 windows running_bpb=1.171324
+  sliding_eval [ 80.6%] 97632/121136 windows running_bpb=1.174124
+  sliding_eval [ 81.9%] 99232/121136 windows running_bpb=1.174123
+  sliding_eval [ 83.2%] 100832/121136 windows running_bpb=1.174163
+  sliding_eval [ 84.6%] 102432/121136 windows running_bpb=1.173797
+  sliding_eval [ 85.9%] 104032/121136 windows running_bpb=1.173288
+  sliding_eval [ 87.2%] 105632/121136 windows running_bpb=1.172535
+  sliding_eval [ 88.5%] 107232/121136 windows running_bpb=1.172538
+  sliding_eval [ 89.8%] 108832/121136 windows running_bpb=1.173175
+  sliding_eval [ 91.2%] 110432/121136 windows running_bpb=1.173209
+  sliding_eval [ 92.5%] 112032/121136 windows running_bpb=1.173186
+  sliding_eval [ 93.8%] 113632/121136 windows running_bpb=1.173639
+  sliding_eval [ 95.1%] 115232/121136 windows running_bpb=1.173398
+  sliding_eval [ 96.4%] 116832/121136 windows running_bpb=1.172995
+  sliding_eval [ 97.8%] 118432/121136 windows running_bpb=1.173317
+  sliding_eval [ 99.1%] 120032/121136 windows running_bpb=1.173419
+final_int6_zstd22_roundtrip val_loss:1.9703 val_bpb:1.1669 eval_time:232075ms
+final_int6_zstd22_roundtrip_exact val_loss:1.97025414 val_bpb:1.16689857

--- a/records/track_10min_16mb/2026-03-20_Int6QAT_SmearGate_MuonWD/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-20_Int6QAT_SmearGate_MuonWD/train_gpt.py
@@ -1,0 +1,1656 @@
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: To keep readable for newcomers, let's make sure `train_gpt.py` and `train_gpt_mlx.py` never are longer than 1500 lines.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+import zstandard as zstd
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 8))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 3))
+    num_loops = int(os.environ.get("NUM_LOOPS", 1))
+    lora_rank = int(os.environ.get("LORA_RANK", 0))
+    qat = bool(int(os.environ.get("QAT", "1")))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    quant_bits = int(os.environ.get("QUANT_BITS", 6))
+    fp16_embed = bool(int(os.environ.get("FP16_EMBED", "1")))
+    late_k_layers = int(os.environ.get("LATE_K_LAYERS", 2))
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    smear_gate = bool(int(os.environ.get("SMEAR_GATE", "0")))
+    bigram_hash = bool(int(os.environ.get("BIGRAM_HASH", "0")))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 4096))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 0))  # 0 = use model_dim directly
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_weight_decay = float(os.environ.get("MUON_WEIGHT_DECAY", 0.0))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    lora_lr = float(os.environ.get("LORA_LR", 0.01))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+
+# -----------------------------
+# MUON OPTIMIZER 
+# -----------------------------
+# 
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, weight_decay=weight_decay),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            weight_decay = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                if weight_decay > 0:
+                    p.mul_(1 - lr * weight_decay)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# ---- Int6 quantization (6-bit per-row symmetric, bit-packed) ----
+INT6_MAX = 31
+
+def quantize_float_tensor_int6(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / INT6_MAX).clamp_min(1.0 / INT6_MAX)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -INT6_MAX, INT6_MAX).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / INT6_MAX if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -INT6_MAX, INT6_MAX).to(torch.int8).contiguous()
+    return q, scale
+
+def pack_int6(q_int8: Tensor) -> bytes:
+    flat = q_int8.flatten().numpy().astype(np.int8)
+    u = (flat.astype(np.int16) + INT6_MAX).astype(np.uint8)
+    n = len(u)
+    pad = (4 - n % 4) % 4
+    if pad:
+        u = np.concatenate([u, np.zeros(pad, dtype=np.uint8)])
+    v0, v1, v2, v3 = u[0::4], u[1::4], u[2::4], u[3::4]
+    packed = np.empty(len(u) // 4 * 3, dtype=np.uint8)
+    packed[0::3] = (v0 << 2) | (v1 >> 4)
+    packed[1::3] = ((v1 & 0x0F) << 4) | (v2 >> 2)
+    packed[2::3] = ((v2 & 0x03) << 6) | v3
+    return bytes(packed)
+
+def unpack_int6(data: bytes, shape: tuple) -> Tensor:
+    numel = 1
+    for s in shape:
+        numel *= s
+    packed = np.frombuffer(data, dtype=np.uint8)
+    m = len(packed) // 3
+    b0, b1, b2 = packed[0::3], packed[1::3], packed[2::3]
+    flat = np.empty(m * 4, dtype=np.uint8)
+    flat[0::4] = (b0 >> 2) & 0x3F
+    flat[1::4] = ((b0 & 0x03) << 4) | (b1 >> 4)
+    flat[2::4] = ((b1 & 0x0F) << 2) | (b2 >> 6)
+    flat[3::4] = b2 & 0x3F
+    signed = flat[:numel].astype(np.int8) - INT6_MAX
+    return torch.from_numpy(signed.copy()).reshape(shape).to(torch.int8)
+
+def quantize_state_dict_int6(state_dict: dict[str, Tensor], fp16_names: set[str] | None = None):
+    """Int6 quantization: store int6 values in int8 containers (zstd compresses the unused bits)."""
+    fp16_names = fp16_names or set()
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "payload_bytes"), 0,
+    )
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["payload_bytes"] += tensor_nbytes(t)
+            continue
+        # FP16 passthrough for tied embeddings and small tensors
+        if name in fp16_names or t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["payload_bytes"] += tensor_nbytes(kept)
+            continue
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor_int6(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        # Store int6 values in int8 containers -- zstd compresses the restricted range
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+    obj: dict[str, object] = {
+        "__quant_format__": "int6_in_int8_per_row_v1",
+        "quantized": quantized,
+        "scales": scales, "dtypes": dtypes, "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int6(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    # Support both old packed format and new int8-container format
+    quantized = obj.get("quantized", obj.get("quantized_packed", {}))
+    is_packed = "quantized_packed" in obj and "quantized" not in obj
+    for name, q_data in quantized.items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if is_packed:
+            shape = tuple(obj["quantized_shapes"][name])
+            q = unpack_int6(q_data, shape)
+        else:
+            q = q_data
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            out[name] = (q.float() * float(s.item())).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING 
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+def fake_quantize_int8_per_row(w: Tensor) -> Tensor:
+    """Simulate per-row int8 quantization with straight-through estimator."""
+    scale = w.detach().abs().amax(dim=-1, keepdim=True).div_(127.0).clamp_(min=1.0 / 127.0)
+    w_deq = (w / scale).round().clamp_(-127, 127) * scale
+    return w + (w_deq - w).detach()
+
+def fake_quantize_int6_per_row(w: Tensor) -> Tensor:
+    """Simulate per-row int6 quantization with straight-through estimator."""
+    scale = w.detach().abs().amax(dim=-1, keepdim=True).div_(31.0).clamp_(min=1.0 / 31.0)
+    w_deq = (w / scale).round().clamp_(-31, 31) * scale
+    return w + (w_deq - w).detach()
+
+# Module-level setting controlled by args.quant_bits
+_QAT_QUANT_BITS: int = 8
+
+class CastedLinear(nn.Linear):
+    _qat: bool = False
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight
+        if self._qat and self.training:
+            if _QAT_QUANT_BITS == 6:
+                w = fake_quantize_int6_per_row(w)
+            else:
+                w = fake_quantize_int8_per_row(w)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w.to(x.dtype), bias)
+
+
+class AttentionLoRA(nn.Module):
+    """Per-iteration LoRA adapters for attention Q, K, V, and output projections.
+
+    Initialized so that the LoRA contribution is zero at the start of training
+    (B matrices are zeros). During training, the optimizer learns per-iteration
+    specialization while the base attention weights remain shared across loops.
+    """
+    def __init__(self, dim: int, kv_dim: int, rank: int):
+        super().__init__()
+        self.q_A = nn.Parameter(torch.empty(dim, rank))
+        self.q_B = nn.Parameter(torch.zeros(rank, dim))
+        self.k_A = nn.Parameter(torch.empty(dim, rank))
+        self.k_B = nn.Parameter(torch.zeros(rank, kv_dim))
+        self.v_A = nn.Parameter(torch.empty(dim, rank))
+        self.v_B = nn.Parameter(torch.zeros(rank, kv_dim))
+        self.proj_A = nn.Parameter(torch.empty(dim, rank))
+        self.proj_B = nn.Parameter(torch.zeros(rank, dim))
+        self._init_lora()
+
+    def _init_lora(self) -> None:
+        for name in ("q_A", "k_A", "v_A", "proj_A"):
+            nn.init.kaiming_uniform_(getattr(self, name), a=math.sqrt(5))
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor, lora: AttentionLoRA | None = None) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x)
+        k = self.c_k(x)
+        v = self.c_v(x)
+        if lora is not None:
+            # LoRA delta: (bsz, seqlen, dim) @ (dim, rank) @ (rank, out_dim)
+            # autocast handles fp32->bf16 cast of LoRA params automatically
+            q = q + (x @ lora.q_A) @ lora.q_B
+            k = k + (x @ lora.k_A) @ lora.k_B
+            v = v + (x @ lora.v_A) @ lora.v_B
+        q = q.reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        if self.num_kv_heads != self.num_heads:
+            # GQA: expand KV heads to match query heads
+            rep = self.num_heads // self.num_kv_heads
+            k = k.unsqueeze(2).expand(-1, -1, rep, -1, -1).reshape(bsz, self.num_heads, seqlen, self.head_dim)
+            v = v.unsqueeze(2).expand(-1, -1, rep, -1, -1).reshape(bsz, self.num_heads, seqlen, self.head_dim)
+        y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True)
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        out = self.proj(y)
+        if lora is not None:
+            out = out + (y @ lora.proj_A) @ lora.proj_B
+        return out
+
+
+class MLP(nn.Module):
+    # relu^2 MLP from the original modded-nanogpt setup
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor, lora: AttentionLoRA | None = None) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x), lora=lora)
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+def get_bigram_hash(x: Tensor, bigram_vocab_size: int) -> Tensor:
+    """Hash consecutive token pairs into bigram bucket indices."""
+    rand_int_1, rand_int_2 = 36313, 27191
+    mod = bigram_vocab_size - 1
+    x32 = x.to(torch.int32)
+    out = x32.clone()
+    out[..., 0] = mod  # position 0 → sentinel bucket
+    out[..., 1:] = torch.bitwise_xor(rand_int_1 * x32[..., 1:], rand_int_2 * x32[..., :-1]) % mod
+    return out.long()
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        num_loops: int = 1,
+        lora_rank: int = 0,
+        smear_gate: bool = False,
+        bigram_hash: bool = False,
+        bigram_vocab_size: int = 4096,
+        bigram_dim: int = 0,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.num_unique_layers = num_layers
+        self.num_loops = num_loops
+        effective_depth = num_layers * num_loops
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.num_encoder_layers = effective_depth // 2
+        self.num_decoder_layers = effective_depth - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        # Per-(loop, block) LoRA adapters for attention projections.
+        # Only created when num_loops > 1 and lora_rank > 0.
+        kv_dim = num_kv_heads * (model_dim // num_heads)
+        if lora_rank > 0 and num_loops > 1:
+            self.lora_adapters = nn.ModuleList(
+                [
+                    nn.ModuleList(
+                        [AttentionLoRA(model_dim, kv_dim, lora_rank) for _ in range(num_layers)]
+                    )
+                    for _ in range(num_loops)
+                ]
+            )
+        else:
+            self.lora_adapters = None
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+
+        # SmearGate: learned gate blending current + previous token embedding
+        self.use_smear_gate = smear_gate
+        if smear_gate:
+            self.smear_gate = nn.Linear(model_dim, 1, bias=False)
+            self.smear_gate._zero_init = True
+            self.smear_lambda = nn.Parameter(torch.zeros(1))
+
+        # BigramHash: hash-based bigram embedding injected at every layer
+        self.use_bigram_hash = bigram_hash
+        self.bigram_vocab_size = bigram_vocab_size
+        if bigram_hash:
+            bdim = bigram_dim if bigram_dim > 0 else model_dim
+            self.bigram_embed = nn.Embedding(bigram_vocab_size, bdim)
+            nn.init.zeros_(self.bigram_embed.weight)
+            if bdim != model_dim:
+                self.bigram_proj = nn.Linear(bdim, model_dim, bias=False)
+                self.bigram_proj._zero_init = True
+            else:
+                self.bigram_proj = None
+            self.bigram_lambdas = nn.Parameter(0.05 * torch.ones(effective_depth))
+
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        effective_depth = self.num_unique_layers * self.num_loops
+        out_scale = 1.0 / math.sqrt(2 * effective_depth)
+        for module in self.modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                else:
+                    nn.init.orthogonal_(module.weight)
+            # Scale output projections by 1/sqrt(2*depth) for stable residual stream
+            if isinstance(module, (CausalSelfAttention, MLP)):
+                if hasattr(module, "proj") and module.proj.weight is not None:
+                    module.proj.weight.data.mul_(out_scale)
+
+    def _apply_smear_gate(self, x: Tensor) -> Tensor:
+        """Blend each token embedding with the previous token's embedding."""
+        gate = self.smear_lambda * torch.sigmoid(self.smear_gate(x[..., 1:, :]))
+        smeared = x[..., 1:, :] + gate * x[..., :-1, :]
+        return torch.cat([x[..., :1, :], smeared], dim=-2)
+
+    def _get_bigram_emb(self, input_ids: Tensor) -> Tensor:
+        """Compute bigram hash embedding for injection at each layer."""
+        bh = get_bigram_hash(input_ids, self.bigram_vocab_size)
+        emb = self.bigram_embed(bh)
+        if self.bigram_proj is not None:
+            emb = self.bigram_proj(emb)
+        return emb
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+
+        # SmearGate: blend with previous token before normalization
+        if self.use_smear_gate:
+            x = self._apply_smear_gate(x)
+
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+
+        # BigramHash: precompute bigram embedding for per-layer injection
+        bigram_emb = self._get_bigram_emb(input_ids) if self.use_bigram_hash else None
+
+        skips: list[Tensor] = []
+
+        # Iterate through effective layers: each unique block is reused across loops.
+        # First half (encoder) stores skip connections; second half (decoder) pops them.
+        eff_idx = 0
+        for loop_idx in range(self.num_loops):
+            for block_idx in range(self.num_unique_layers):
+                lora = self.lora_adapters[loop_idx][block_idx] if self.lora_adapters is not None else None
+                # Inject bigram embedding at each layer
+                if bigram_emb is not None:
+                    x = x + bigram_emb * self.bigram_lambdas[eff_idx].to(dtype=x.dtype)
+                if eff_idx < self.num_encoder_layers:
+                    x = self.blocks[block_idx](x, x0, lora=lora)
+                    skips.append(x)
+                else:
+                    dec_idx = eff_idx - self.num_encoder_layers
+                    if dec_idx < self.num_skip_weights and skips:
+                        x = x + self.skip_weights[dec_idx].to(dtype=x.dtype)[None, None, :] * skips.pop()
+                    x = self.blocks[block_idx](x, x0, lora=lora)
+                eff_idx += 1
+
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Return logits (bsz, seq_len, vocab) without computing loss."""
+        x = self.tok_emb(input_ids)
+
+        if self.use_smear_gate:
+            x = self._apply_smear_gate(x)
+
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+
+        bigram_emb = self._get_bigram_emb(input_ids) if self.use_bigram_hash else None
+
+        skips: list[Tensor] = []
+        eff_idx = 0
+        for loop_idx in range(self.num_loops):
+            for block_idx in range(self.num_unique_layers):
+                lora = self.lora_adapters[loop_idx][block_idx] if self.lora_adapters is not None else None
+                if bigram_emb is not None:
+                    x = x + bigram_emb * self.bigram_lambdas[eff_idx].to(dtype=x.dtype)
+                if eff_idx < self.num_encoder_layers:
+                    x = self.blocks[block_idx](x, x0, lora=lora)
+                    skips.append(x)
+                else:
+                    dec_idx = eff_idx - self.num_encoder_layers
+                    if dec_idx < self.num_skip_weights and skips:
+                        x = x + self.skip_weights[dec_idx].to(dtype=x.dtype)[None, None, :] * skips.pop()
+                    x = self.blocks[block_idx](x, x0, lora=lora)
+                eff_idx += 1
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context.
+
+    Windows of train_seq_len advance by `stride`. Only the last `stride` tokens
+    per window contribute to the score (first window scores all). Windows are
+    batched and distributed across ranks.
+    """
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+
+    # Build windows; skip any too short to score a full stride
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride]
+    total_windows = len(window_starts)
+
+    # Distribute across ranks
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = base_model.forward_logits(x_batch)
+
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else wlen - stride
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+
+            # Progress (rank 0 only)
+            if rank == 0 and (bi // batch_seqs) % 50 == 0:
+                done = min(bi + batch_seqs, len(my_windows))
+                pct = done / len(my_windows) * 100
+                running_bpb = 0.0
+                if token_count.item() > 0:
+                    rl = (loss_sum / token_count).item()
+                    running_bpb = rl / math.log(2.0) * (token_count.item() / byte_count.item())
+                print(f"  sliding_eval [{pct:5.1f}%] {done}/{len(my_windows)} windows running_bpb={running_bpb:.6f}", flush=True)
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        num_loops=args.num_loops,
+        lora_rank=args.lora_rank,
+        smear_gate=args.smear_gate,
+        bigram_hash=args.bigram_hash,
+        bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, (CastedLinear, AttentionLoRA)):
+            module.float()
+        if isinstance(module, CastedLinear) and args.qat:
+            module._qat = True
+    # Set module-level quant bits for QAT
+    global _QAT_QUANT_BITS
+    _QAT_QUANT_BITS = args.quant_bits
+    restore_low_dim_params_to_fp32(base_model)
+    log0(f"qat:{args.qat} quant_bits:{args.quant_bits}")
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_weight_decay,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lora_adapters is not None:
+        lora_params = list(base_model.lora_adapters.parameters())
+        optimizer_lora = torch.optim.Adam(
+            [{"params": lora_params, "lr": args.lora_lr, "base_lr": args.lora_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.append(optimizer_lora)
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    # SmearGate optimizer: very low LR, no weight decay (per modded-nanogpt)
+    if base_model.use_smear_gate:
+        smear_lr = args.scalar_lr * 0.01  # 1% of scalar LR
+        smear_params = [base_model.smear_gate.weight, base_model.smear_lambda]
+        optimizer_smear = torch.optim.Adam(
+            [{"params": smear_params, "lr": smear_lr, "base_lr": smear_lr}],
+            betas=(0.9, 0.99),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.append(optimizer_smear)
+        log0(f"smear_gate:enabled lr:{smear_lr}")
+
+    # BigramHash optimizer: embedding + projection use scalar LR, lambdas use scalar LR
+    if base_model.use_bigram_hash:
+        bigram_params: list[Tensor] = [base_model.bigram_embed.weight, base_model.bigram_lambdas]
+        if base_model.bigram_proj is not None:
+            bigram_params.append(base_model.bigram_proj.weight)
+        optimizer_bigram = torch.optim.Adam(
+            [{"params": bigram_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.append(optimizer_bigram)
+        n_bigram = sum(p.numel() for p in bigram_params)
+        log0(f"bigram_hash:enabled vocab:{args.bigram_vocab_size} dim:{args.bigram_dim or args.model_dim} params:{n_bigram}")
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    n_lora = sum(p.numel() for p in base_model.lora_adapters.parameters()) if base_model.lora_adapters is not None else 0
+    effective_depth = args.num_layers * args.num_loops
+    log0(f"model_params:{n_params} (unique_layers:{args.num_layers} loops:{args.num_loops} effective_depth:{effective_depth} lora_rank:{args.lora_rank} lora_params:{n_lora})")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed int8+zlib artifact and validate the round-tripped weights.
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_tag = f"int{args.quant_bits}"
+    quant_file = f"final_model.{quant_tag}.ptz"
+
+    # Build FP16 passthrough set
+    fp16_names: set[str] = set()
+    if args.fp16_embed and args.tie_embeddings:
+        fp16_names.add("tok_emb.weight")
+        log0("fp16_passthrough: tok_emb.weight")
+    # For int6: skip LATE_K_LAYERS passthrough (QAT handles quantization quality)
+    # For int8: keep late-K passthrough
+    if args.quant_bits != 6 and args.late_k_layers > 0:
+        num_layers_total = max(
+            (int(k.split(".")[1]) for k in base_model.state_dict() if k.startswith("blocks.")),
+            default=0,
+        ) + 1
+        for li in range(max(0, num_layers_total - args.late_k_layers), num_layers_total):
+            kname = f"blocks.{li}.attn.c_k.weight"
+            if kname in base_model.state_dict():
+                fp16_names.add(kname)
+                log0(f"fp16_passthrough: {kname}")
+
+    if args.quant_bits == 6:
+        quant_obj, quant_stats = quantize_state_dict_int6(base_model.state_dict(), fp16_names=fp16_names)
+    else:
+        quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    # Use zstd level 22 for better compression (saves ~1-2MB vs zlib)
+    zstd_cctx = zstd.ZstdCompressor(level=22)
+    quant_blob = zstd_cctx.compress(quant_raw)
+    quant_raw_bytes = len(quant_raw)
+    payload_bytes = quant_stats.get("payload_bytes", quant_stats.get("int8_payload_bytes", 0))
+    if master_process:
+        with open(quant_file, "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize(quant_file)
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(payload_bytes, 1)
+        log0(
+            f"Serialized model {quant_tag}+zstd22: {quant_file_bytes} bytes "
+            f"(payload:{payload_bytes} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size {quant_tag}+zstd22: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open(quant_file, "rb") as f:
+        quant_blob_disk = f.read()
+    zstd_dctx = zstd.ZstdDecompressor()
+    quant_state = torch.load(io.BytesIO(zstd_dctx.decompress(quant_blob_disk)), map_location="cpu")
+    if args.quant_bits == 6:
+        base_model.load_state_dict(dequantize_state_dict_int6(quant_state), strict=True)
+    else:
+        base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    if args.eval_stride > 0 and args.eval_stride < args.train_seq_len:
+        log0(f"final_eval_mode:sliding_window stride:{args.eval_stride} batch_seqs:{args.eval_batch_seqs}")
+        q_val_loss, q_val_bpb = eval_val_sliding(
+            args,
+            base_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            stride=args.eval_stride,
+            batch_seqs=args.eval_batch_seqs,
+        )
+    else:
+        log0("final_eval_mode:standard")
+        q_val_loss, q_val_bpb = eval_val(
+            args,
+            model,
+            rank,
+            world_size,
+            device,
+            grad_accum_steps,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+        )
+    torch.cuda.synchronize()
+    log0(
+        f"final_{quant_tag}_zstd22_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_{quant_tag}_zstd22_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **val_bpb: 1.1669** — beats current SOTA (1.1748) by 0.0079
- **Artifact: 14.77 MB** — well under 16MB cap
- 9L/512dim/8H/4KV, 21.8M params, trained 9706 steps @ 61.8ms/step on 8×H100 SXM

## Key Techniques

1. **Int6 QAT (Quantization-Aware Training)**: STE fake int6 quantization during forward pass with per-row symmetric scaling. Eliminates post-quant degradation without needing fp16 late-K layer passthrough.

2. **Int6-in-Int8 zstd22 compression**: Store int6 values (-32 to 31) in int8 containers — zstd-22 compresses the restricted value range ~35%. Achieves 14.77MB from 21.8M params. (Bit-packing int6 values destroys byte alignment and defeats compressors.)

3. **SmearGate**: ~513-param learned gate blending current + previous token embedding. Zero-initialized, very low LR. Provides cheap bigram context at the embedding layer.

4. **Decoupled Muon weight decay** (0.01): Applied in the Muon optimizer step for improved generalization and quantization robustness.

5. **Sliding window evaluation** (stride=64, batch=32 seqs): Full-context scoring at every token position.

6. **FP16 tied embedding passthrough**: Avoids compounding int6 errors through both input/output paths.

## Results

| Seed | val_loss | val_bpb | Steps | ms/step |
|------|----------|---------|-------|---------|
| 1337 | 1.9703 | 1.1669 | 9706 | 61.80 |

## Artifact Size

| Component | Bytes |
|-----------|-------|
| Model (int6+zstd22) | 14,696,046 |
| Code | 71,909 |
| **Total** | **14,767,955** |

## Test plan

- [x] Trained on 8×H100 SXM in under 10 minutes (600s wallclock)
- [x] Artifact under 16MB (14.77MB)
- [x] val_bpb improvement over SOTA exceeds 0.005 threshold (0.0079)
- [x] train.log included with full training output
- [x] train_gpt.py runs standalone within the records folder