### PR TITLE
Record submission : Int6 + MLP 3x + Flash Attention 3 + NorMuon, val_bpb = 1.1532

### DIFF
--- a/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/README.md
+++ b/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/README.md
@@ -1,0 +1,67 @@
+# Int6 + MLP 3x + Sliding Window + NorMuon + FlashAttention 3
+
+## Score
+
+**best val_bpb = 1.1532** (seed 7, sliding window eval, stride=256)
+
+## Approach
+
+Int6 post-training quantization compresses weight matrices to 6-bit precision (±31 range with per-row scaling), freeing enough artifact space to triple the MLP hidden dimension from 1024 to 1536. The result: 21.8M effective parameters in a 15.98MB artifact. Use NorMuon optimizer instead of Muon and add Flash Attention 3.
+
+### Quantization Strategy
+
+- **Weight matrices**: int6 per-row quantization (6-bit range, stored as int8 bytes)
+- **Tied embedding** (`tok_emb.weight`): kept in fp16 — this tensor serves as both input lookup and output projection, making it disproportionately sensitive to quantization
+- **Late-K passthrough**: last 2 layers' `c_k.weight` kept in fp16 — late-layer key projections need precision for fine-grained token discrimination
+- **Control tensors** (scales, mixes, gains): fp16
+
+### Architecture
+
+- 9 layers, dim=512, 8 heads, 4 KV heads
+- **MLP hidden=1536** (3x expansion, up from default 1024)
+- ReLU-squared activation (unchanged)
+
+### Training
+
+- `TRAIN_SEQ_LEN=2048` with `TRAIN_BATCH_TOKENS=786432`
+- `MATRIX_LR=0.02`, `MUON_MOMENTUM=0.99`, `GRAD_CLIP_NORM=0.3`
+- `WARMDOWN_ITERS=3000`
+
+### Evaluation
+
+- Sliding window with `EVAL_STRIDE=256` at `EVAL_SEQ_LEN=2048`
+- Every scored token sees 1792 context tokens
+- Eval time: ~200-214 seconds on 8xH100
+
+### Results
+
+| Eval Method        | val_bpb    |
+| ------------------ | ---------- |
+| Non-overlapping    | 1.1746     |
+| Sliding stride=256 | **1.1532** |
+
+**15.96MB** artifact. **600s** training + ~**200-214s** eval on 8xH100 SXM.
+
+### Multi-Seed Validation
+
+| Seed     | val_bpb    | val_loss   |
+| -------- | ---------- | ---------- |
+| 1337     | 1.1563     | 1.9524     |
+| 7        | 1.1532     | 1.9471     |
+| 42       | 1.1542     | 1.9488     |
+| **Mean** | **1.1546** | **1.9495** |
+| Std      | 0.0013     | 0.0022     |
+
+## Reproduction
+
+```bash
+TRAIN_SEQ_LEN=2048 TRAIN_BATCH_TOKENS=786432 MATRIX_LR=0.02 SCALAR_LR=0.02 \
+TIED_EMBED_LR=0.03 MUON_MOMENTUM=0.99 MUON_MOMENTUM_WARMUP_START=0.92 \
+MUON_MOMENTUM_WARMUP_STEPS=1500 WARMDOWN_ITERS=3000 GRAD_CLIP_NORM=0.3 SEED=7 \
+MLP_HIDDEN=1536 EVAL_SEQ_LEN=2048 EVAL_STRIDE=256 \
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+8xH100 SXM (Modal, ~74-78ms/step with MLP 3x across seeds 1337, 7, and 42).
+
+Modal script used for training is also present in this directory.

--- a/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/modal_h100_train.py
+++ b/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/modal_h100_train.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import datetime as dt
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import modal
+
+APP_NAME = "parameter-golf-int6-normuon-fa3"
+LOCAL_FILE = Path(__file__).resolve()
+
+
+def _infer_local_repo_root(script_path: Path) -> Path:
+    parents = script_path.parents
+    return parents[3] if len(parents) > 3 else script_path.parent
+
+
+LOCAL_REPO_ROOT = _infer_local_repo_root(LOCAL_FILE)
+REMOTE_REPO_ROOT = Path("/root/parameter-golf")
+REMOTE_RECORD_DIR = REMOTE_REPO_ROOT / "records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3"
+REMOTE_TRAIN_FILE = REMOTE_RECORD_DIR / "train_gpt.py"
+REMOTE_DATA_MOUNT = Path("/mnt/parameter-golf-data")
+REMOTE_LOG_MOUNT = Path("/mnt/parameter-golf-logs")
+DEFAULT_DATA_PATH = REMOTE_REPO_ROOT / "data/datasets/fineweb10B_sp1024"
+DEFAULT_TOKENIZER_PATH = REMOTE_REPO_ROOT / "data/tokenizers/fineweb_1024_bpe.model"
+DEFAULT_TRAIN_ENV = {
+    "TRAIN_SEQ_LEN": "2048",
+    "TRAIN_BATCH_TOKENS": "786432",
+    "MATRIX_LR": "0.02",
+    "SCALAR_LR": "0.02",
+    "TIED_EMBED_LR": "0.03",
+    "MUON_MOMENTUM": "0.99",
+    "MUON_BETA2": "0.95",
+    "MUON_MOMENTUM_WARMUP_START": "0.92",
+    "MUON_MOMENTUM_WARMUP_STEPS": "1500",
+    "WARMDOWN_ITERS": "3000",
+    "GRAD_CLIP_NORM": "0.3",
+    "MLP_HIDDEN": "1536",
+    "EVAL_SEQ_LEN": "2048",
+    "EVAL_STRIDE": "256",
+    "SEED": "7",
+}
+FLASH_ATTN3_PREFETCH = (
+    "from kernels import get_kernel; "
+    "mod = get_kernel('kernels-community/flash-attn3', version=1); "
+    "print(getattr(mod, '__file__', 'flash-attn3-prefetched'))"
+)
+
+data_volume = modal.Volume.from_name("parameter-golf-data", create_if_missing=True)
+log_volume = modal.Volume.from_name("parameter-golf-logs", create_if_missing=True)
+
+image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .pip_install_from_requirements(str(LOCAL_REPO_ROOT / "requirements.txt"))
+    .add_local_dir(
+        str(LOCAL_REPO_ROOT),
+        remote_path=str(REMOTE_REPO_ROOT),
+        ignore=[
+            ".git",
+            ".git/**",
+            "**/__pycache__",
+            "**/__pycache__/**",
+            "**/*.pyc",
+            "**/*.log",
+            "data/datasets",
+            "data/datasets/**",
+            "data/tokenizers",
+            "data/tokenizers/**",
+        ],
+    )
+)
+
+app = modal.App(APP_NAME, image=image)
+
+
+def _ensure_symlink(link_path: Path, target_path: Path) -> None:
+    link_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.mkdir(parents=True, exist_ok=True)
+    if link_path.is_symlink():
+        if link_path.resolve() == target_path.resolve():
+            return
+        link_path.unlink()
+    elif link_path.exists():
+        if link_path.is_dir():
+            shutil.rmtree(link_path)
+        else:
+            link_path.unlink()
+    link_path.symlink_to(target_path, target_is_directory=True)
+
+
+def _stream_subprocess(command: list[str], *, cwd: Path, env: dict[str, str], log_path: Path) -> None:
+    with log_path.open("a", encoding="utf-8") as log_file:
+        process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        assert process.stdout is not None
+        for line in process.stdout:
+            sys.stdout.write(line)
+            sys.stdout.flush()
+            log_file.write(line)
+            log_file.flush()
+        return_code = process.wait()
+        if return_code != 0:
+            raise subprocess.CalledProcessError(return_code, command)
+
+
+@app.function(
+    gpu="H100:8",
+    cpu=16,
+    timeout=60 * 60 * 2,
+    volumes={
+        str(REMOTE_DATA_MOUNT): data_volume,
+        str(REMOTE_LOG_MOUNT): log_volume,
+    },
+)
+def run_training(
+    train_shards: int = 80,
+    run_id: str = "",
+    download_data: bool = True,
+) -> str:
+    _ensure_symlink(REMOTE_REPO_ROOT / "data/datasets", REMOTE_DATA_MOUNT / "datasets")
+    _ensure_symlink(REMOTE_REPO_ROOT / "data/tokenizers", REMOTE_DATA_MOUNT / "tokenizers")
+
+    effective_run_id = run_id or dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    log_dir = REMOTE_LOG_MOUNT / "int6_normuon_fa3"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"train_{effective_run_id}.log"
+
+    env = os.environ.copy()
+    env.update(DEFAULT_TRAIN_ENV)
+    env.update(
+        {
+            "PYTHONUNBUFFERED": "1",
+            "DATA_PATH": str(DEFAULT_DATA_PATH),
+            "TOKENIZER_PATH": str(DEFAULT_TOKENIZER_PATH),
+            "RUN_ID": effective_run_id,
+        }
+    )
+
+    with log_path.open("w", encoding="utf-8") as log_file:
+        log_file.write(f"run_id={effective_run_id}\n")
+        log_file.write(f"train_file={REMOTE_TRAIN_FILE}\n")
+        log_file.write(f"train_shards={train_shards}\n")
+        log_file.write(f"download_data={download_data}\n")
+        log_file.write(f"seed={env.get('SEED', '<unset>')}\n")
+
+    try:
+        if download_data:
+            _stream_subprocess(
+                [
+                    "python3",
+                    "data/cached_challenge_fineweb.py",
+                    "--variant",
+                    "sp1024",
+                    "--train-shards",
+                    str(train_shards),
+                ],
+                cwd=REMOTE_REPO_ROOT,
+                env=env,
+                log_path=log_path,
+            )
+            data_volume.commit()
+
+        _stream_subprocess(
+            ["python3", "-c", FLASH_ATTN3_PREFETCH],
+            cwd=REMOTE_REPO_ROOT,
+            env=env,
+            log_path=log_path,
+        )
+
+        _stream_subprocess(
+            [
+                "python3",
+                "-m",
+                "torch.distributed.run",
+                "--standalone",
+                "--nproc_per_node=8",
+                str(REMOTE_TRAIN_FILE),
+            ],
+            cwd=REMOTE_REPO_ROOT,
+            env=env,
+            log_path=log_path,
+        )
+    finally:
+        log_volume.commit()
+    return str(log_path)
+
+
+@app.function(volumes={str(REMOTE_LOG_MOUNT): log_volume})
+def fetch_log(log_path: str) -> bytes:
+    requested_path = Path(log_path)
+    resolved_path = requested_path if requested_path.is_absolute() else REMOTE_LOG_MOUNT / requested_path
+    return resolved_path.read_bytes()
+
+
+@app.local_entrypoint()
+def main(
+    train_shards: int = 80,
+    run_id: str = "",
+    skip_download: bool = False,
+) -> None:
+    log_path = run_training.remote(
+        train_shards=train_shards,
+        run_id=run_id,
+        download_data=not skip_download,
+    )
+    print(log_path)

--- a/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/submission.json
+++ b/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/submission.json
@@ -1,0 +1,11 @@
+{
+  "author": "Tamoghno Kandar",
+  "github_id": "tamoghnokandar",
+  "name": "Int6 MLP3x Sliding Window NorMuon Flash Attention 3",
+  "blurb": "Int6 post-training quantization enables 3x MLP expansion (21.8M params in 16MB). Sliding window eval stride=256 with train@2048. NorMuon optimizer and Flash Attention 3.",
+  "date": "2026-03-20",
+  "val_loss": 1.94714096,
+  "val_bpb": 1.15320656,
+  "bytes_total": 15959964,
+  "bytes_code": 55221
+}

--- a/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/train_1337.log
+++ b/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/train_1337.log
@@ -1,0 +1,137 @@
+run_id=myrun
+train_file=/root/parameter-golf/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/train_gpt.py
+train_shards=80
+download_data=True
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
+
+Fetching 7 files:  14%|█▍        | 1/7 [00:00<00:01,  3.52it/s]
+Fetching 7 files:  29%|██▊       | 2/7 [00:03<00:10,  2.13s/it]
+Fetching 7 files: 100%|██████████| 7/7 [00:03<00:00,  1.89it/s]
+/root/.cache/huggingface/hub/models--kernels-community--flash-attn3/snapshots/eae4c2ad2e0c6a1db24e2b7e8c0e8f03ed452702/build/torch210-cxx11-cu128-x86_64-linux/__init__.py
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 129912.07it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 41823.54it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 16710.37it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 18570.61it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 27160.16it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 20867.18it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 15600.49it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 14903.62it/s]
+logs/myrun.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/root/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=/root/parameter-golf/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:21778504
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.03 head_lr:0.0 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9378 val_bpb:4.1090 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9381 train_time:113ms step_avg:112.80ms
+step:2/20000 train_loss:12.1542 train_time:157ms step_avg:78.38ms
+step:3/20000 train_loss:10.5642 train_time:228ms step_avg:75.95ms
+step:4/20000 train_loss:8.3253 train_time:295ms step_avg:73.72ms
+step:5/20000 train_loss:6.7563 train_time:366ms step_avg:73.29ms
+step:6/20000 train_loss:6.1217 train_time:443ms step_avg:73.83ms
+step:7/20000 train_loss:5.9766 train_time:515ms step_avg:73.50ms
+step:8/20000 train_loss:5.9742 train_time:586ms step_avg:73.21ms
+step:9/20000 train_loss:5.8262 train_time:657ms step_avg:73.02ms
+step:10/20000 train_loss:5.7304 train_time:729ms step_avg:72.91ms
+step:200/20000 train_loss:2.3598 train_time:14745ms step_avg:73.72ms
+step:400/20000 train_loss:2.4037 train_time:29795ms step_avg:74.49ms
+step:600/20000 train_loss:2.3315 train_time:44549ms step_avg:74.25ms
+step:800/20000 train_loss:2.2368 train_time:59533ms step_avg:74.42ms
+step:1000/20000 train_loss:2.2731 train_time:74452ms step_avg:74.45ms
+step:1000/20000 val_loss:2.2263 val_bpb:1.3185 train_time:74480ms step_avg:74.48ms
+step:1200/20000 train_loss:2.3556 train_time:89436ms step_avg:74.53ms
+step:1400/20000 train_loss:2.1893 train_time:104423ms step_avg:74.59ms
+step:1600/20000 train_loss:2.0878 train_time:119184ms step_avg:74.49ms
+step:1800/20000 train_loss:2.1681 train_time:134311ms step_avg:74.62ms
+step:2000/20000 train_loss:2.0760 train_time:149105ms step_avg:74.55ms
+step:2000/20000 val_loss:2.1376 val_bpb:1.2660 train_time:149134ms step_avg:74.57ms
+step:2200/20000 train_loss:2.1514 train_time:164061ms step_avg:74.57ms
+step:2400/20000 train_loss:2.0697 train_time:178813ms step_avg:74.51ms
+step:2600/20000 train_loss:2.1054 train_time:193921ms step_avg:74.59ms
+step:2800/20000 train_loss:2.1487 train_time:208904ms step_avg:74.61ms
+step:3000/20000 train_loss:2.1549 train_time:223656ms step_avg:74.55ms
+step:3000/20000 val_loss:2.0858 val_bpb:1.2353 train_time:223689ms step_avg:74.56ms
+step:3200/20000 train_loss:2.1635 train_time:238700ms step_avg:74.59ms
+step:3400/20000 train_loss:2.0107 train_time:253444ms step_avg:74.54ms
+step:3600/20000 train_loss:2.0870 train_time:268321ms step_avg:74.53ms
+step:3800/20000 train_loss:2.0664 train_time:283052ms step_avg:74.49ms
+step:4000/20000 train_loss:1.9715 train_time:298013ms step_avg:74.50ms
+step:4000/20000 val_loss:2.0605 val_bpb:1.2203 train_time:298045ms step_avg:74.51ms
+step:4200/20000 train_loss:2.1473 train_time:313082ms step_avg:74.54ms
+step:4400/20000 train_loss:2.0332 train_time:327820ms step_avg:74.50ms
+step:4600/20000 train_loss:1.8500 train_time:342771ms step_avg:74.52ms
+step:4800/20000 train_loss:2.4520 train_time:357549ms step_avg:74.49ms
+step:5000/20000 train_loss:2.1227 train_time:372560ms step_avg:74.51ms
+step:5000/20000 val_loss:2.0419 val_bpb:1.2094 train_time:372588ms step_avg:74.52ms
+step:5200/20000 train_loss:2.0645 train_time:387295ms step_avg:74.48ms
+step:5400/20000 train_loss:2.0724 train_time:402244ms step_avg:74.49ms
+step:5600/20000 train_loss:1.9818 train_time:417232ms step_avg:74.51ms
+step:5800/20000 train_loss:2.0317 train_time:431988ms step_avg:74.48ms
+step:6000/20000 train_loss:1.9781 train_time:446881ms step_avg:74.48ms
+step:6000/20000 val_loss:2.0183 val_bpb:1.1953 train_time:446916ms step_avg:74.49ms
+step:6200/20000 train_loss:1.9908 train_time:461701ms step_avg:74.47ms
+step:6400/20000 train_loss:2.0466 train_time:476879ms step_avg:74.51ms
+step:6600/20000 train_loss:1.8988 train_time:491690ms step_avg:74.50ms
+step:6800/20000 train_loss:2.0893 train_time:506571ms step_avg:74.50ms
+step:7000/20000 train_loss:1.8583 train_time:521577ms step_avg:74.51ms
+step:7000/20000 val_loss:1.9961 val_bpb:1.1822 train_time:521605ms step_avg:74.51ms
+step:7200/20000 train_loss:1.9491 train_time:536317ms step_avg:74.49ms
+step:7400/20000 train_loss:1.9957 train_time:551331ms step_avg:74.50ms
+step:7600/20000 train_loss:1.8712 train_time:566095ms step_avg:74.49ms
+step:7800/20000 train_loss:1.9990 train_time:581154ms step_avg:74.51ms
+step:8000/20000 train_loss:1.9331 train_time:595991ms step_avg:74.50ms
+step:8000/20000 val_loss:1.9777 val_bpb:1.1713 train_time:596021ms step_avg:74.50ms
+step:8052/20000 val_loss:1.9775 val_bpb:1.1712 train_time:600062ms step_avg:74.52ms
+stopping_early: wallclock_cap train_time:600062ms step:8052/20000
+peak memory allocated: 16106 MiB reserved: 16468 MiB
+Serialized model: 86099351 bytes
+Code size: 55221 bytes
+Total submission size: 86154572 bytes
+Serialized model int8+zlib: 15902201 bytes (payload:22690080 raw_torch:22734303 payload_ratio:3.79x)
+Total submission size int8+zlib: 15957422 bytes
+final_int8_zlib_roundtrip val_loss:1.9882 val_bpb:1.1775 eval_time:1487ms eval_seq_len:2048
+final_int8_zlib_roundtrip_exact val_loss:1.98821203 val_bpb:1.17753115
+final_sliding_window val_loss:1.9524 val_bpb:1.1563 eval_time:200177ms stride:256 seq_len:2048
+final_sliding_window_exact val_loss:1.95235950 val_bpb:1.15629727

--- a/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/train_42.log
+++ b/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/train_42.log
@@ -1,0 +1,134 @@
+run_id=seed42
+train_file=/root/parameter-golf/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/train_gpt.py
+train_shards=80
+download_data=True
+seed=42
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
+
+Fetching 7 files:  29%|██▊       | 2/7 [00:04<00:11,  2.28s/it]
+Fetching 7 files: 100%|██████████| 7/7 [00:04<00:00,  1.54it/s]
+/root/.cache/huggingface/hub/models--kernels-community--flash-attn3/snapshots/eae4c2ad2e0c6a1db24e2b7e8c0e8f03ed452702/build/torch210-cxx11-cu128-x86_64-linux/__init__.py
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 116972.62it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 113359.57it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 20793.29it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 133455.13it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 61422.86it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 102657.79it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 99189.62it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 69905.07it/s]
+logs/seed42.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/root/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=/root/parameter-golf/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:21778504
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.03 head_lr:0.0 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:42
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9364 val_bpb:4.1081 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9372 train_time:124ms step_avg:123.52ms
+step:2/20000 train_loss:11.9567 train_time:172ms step_avg:86.24ms
+step:3/20000 train_loss:10.3454 train_time:247ms step_avg:82.43ms
+step:4/20000 train_loss:8.1856 train_time:326ms step_avg:81.62ms
+step:5/20000 train_loss:6.7106 train_time:403ms step_avg:80.61ms
+step:6/20000 train_loss:6.1046 train_time:478ms step_avg:79.67ms
+step:7/20000 train_loss:5.9878 train_time:554ms step_avg:79.13ms
+step:8/20000 train_loss:6.0029 train_time:637ms step_avg:79.64ms
+step:9/20000 train_loss:5.8400 train_time:721ms step_avg:80.12ms
+step:10/20000 train_loss:5.7015 train_time:797ms step_avg:79.67ms
+step:200/20000 train_loss:2.3610 train_time:15661ms step_avg:78.30ms
+step:400/20000 train_loss:2.4019 train_time:31431ms step_avg:78.58ms
+step:600/20000 train_loss:2.3243 train_time:47066ms step_avg:78.44ms
+step:800/20000 train_loss:2.2338 train_time:62862ms step_avg:78.58ms
+step:1000/20000 train_loss:2.2678 train_time:78679ms step_avg:78.68ms
+step:1000/20000 val_loss:2.2214 val_bpb:1.3156 train_time:78715ms step_avg:78.71ms
+step:1200/20000 train_loss:2.3480 train_time:94433ms step_avg:78.69ms
+step:1400/20000 train_loss:2.1826 train_time:110145ms step_avg:78.67ms
+step:1600/20000 train_loss:2.0803 train_time:125735ms step_avg:78.58ms
+step:1800/20000 train_loss:2.1642 train_time:141539ms step_avg:78.63ms
+step:2000/20000 train_loss:2.0656 train_time:157116ms step_avg:78.56ms
+step:2000/20000 val_loss:2.1312 val_bpb:1.2622 train_time:157147ms step_avg:78.57ms
+step:2200/20000 train_loss:2.1439 train_time:172917ms step_avg:78.60ms
+step:2400/20000 train_loss:2.0612 train_time:188444ms step_avg:78.52ms
+step:2600/20000 train_loss:2.0948 train_time:204158ms step_avg:78.52ms
+step:2800/20000 train_loss:2.1458 train_time:219894ms step_avg:78.53ms
+step:3000/20000 train_loss:2.1510 train_time:235518ms step_avg:78.51ms
+step:3000/20000 val_loss:2.0804 val_bpb:1.2321 train_time:235553ms step_avg:78.52ms
+step:3200/20000 train_loss:2.1576 train_time:251271ms step_avg:78.52ms
+step:3400/20000 train_loss:2.0055 train_time:266840ms step_avg:78.48ms
+step:3600/20000 train_loss:2.0810 train_time:282504ms step_avg:78.47ms
+step:3800/20000 train_loss:2.0609 train_time:298086ms step_avg:78.44ms
+step:4000/20000 train_loss:1.9641 train_time:313846ms step_avg:78.46ms
+step:4000/20000 val_loss:2.0552 val_bpb:1.2172 train_time:313881ms step_avg:78.47ms
+step:4200/20000 train_loss:2.1487 train_time:329516ms step_avg:78.46ms
+step:4400/20000 train_loss:2.0319 train_time:345054ms step_avg:78.42ms
+step:4600/20000 train_loss:1.8453 train_time:360772ms step_avg:78.43ms
+step:4800/20000 train_loss:2.4374 train_time:376307ms step_avg:78.40ms
+step:5000/20000 train_loss:2.1141 train_time:391986ms step_avg:78.40ms
+step:5000/20000 val_loss:2.0323 val_bpb:1.2036 train_time:392021ms step_avg:78.40ms
+step:5200/20000 train_loss:2.0536 train_time:407563ms step_avg:78.38ms
+step:5400/20000 train_loss:2.0643 train_time:423230ms step_avg:78.38ms
+step:5600/20000 train_loss:1.9730 train_time:438915ms step_avg:78.38ms
+step:5800/20000 train_loss:2.0207 train_time:454489ms step_avg:78.36ms
+step:6000/20000 train_loss:1.9670 train_time:470171ms step_avg:78.36ms
+step:6000/20000 val_loss:2.0069 val_bpb:1.1886 train_time:470203ms step_avg:78.37ms
+step:6200/20000 train_loss:1.9819 train_time:485736ms step_avg:78.34ms
+step:6400/20000 train_loss:2.0389 train_time:501417ms step_avg:78.35ms
+step:6600/20000 train_loss:1.8889 train_time:516905ms step_avg:78.32ms
+step:6800/20000 train_loss:2.0760 train_time:532671ms step_avg:78.33ms
+step:7000/20000 train_loss:1.8481 train_time:548428ms step_avg:78.35ms
+step:7000/20000 val_loss:1.9856 val_bpb:1.1760 train_time:548464ms step_avg:78.35ms
+step:7200/20000 train_loss:1.9382 train_time:564065ms step_avg:78.34ms
+step:7400/20000 train_loss:1.9853 train_time:579854ms step_avg:78.36ms
+step:7600/20000 train_loss:1.8636 train_time:595499ms step_avg:78.36ms
+step:7657/20000 val_loss:1.9748 val_bpb:1.1696 train_time:600104ms step_avg:78.37ms
+stopping_early: wallclock_cap train_time:600104ms step:7657/20000
+peak memory allocated: 16106 MiB reserved: 16468 MiB
+Serialized model: 86099351 bytes
+Code size: 55221 bytes
+Total submission size: 86154572 bytes
+Serialized model int8+zlib: 15904463 bytes (payload:22690080 raw_torch:22734303 payload_ratio:3.79x)
+Total submission size int8+zlib: 15959684 bytes
+final_int8_zlib_roundtrip val_loss:1.9851 val_bpb:1.1757 eval_time:1505ms eval_seq_len:2048
+final_int8_zlib_roundtrip_exact val_loss:1.98506920 val_bpb:1.17566980
+final_sliding_window val_loss:1.9488 val_bpb:1.1542 eval_time:207452ms stride:256 seq_len:2048
+final_sliding_window_exact val_loss:1.94884977 val_bpb:1.15421861

--- a/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/train_7.log
+++ b/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/train_7.log
@@ -1,0 +1,138 @@
+run_id=seed7
+train_file=/root/parameter-golf/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/train_gpt.py
+train_shards=80
+download_data=True
+seed=7
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
+
+Fetching 7 files:  14%|█▍        | 1/7 [00:00<00:00,  7.50it/s]
+Fetching 7 files:  29%|██▊       | 2/7 [00:03<00:10,  2.17s/it]
+Fetching 7 files: 100%|██████████| 7/7 [00:03<00:00,  1.88it/s]
+/root/.cache/huggingface/hub/models--kernels-community--flash-attn3/snapshots/eae4c2ad2e0c6a1db24e2b7e8c0e8f03ed452702/build/torch210-cxx11-cu128-x86_64-linux/__init__.py
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 125470.63it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 16338.41it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 118387.61it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 117440.51it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 19456.68it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 36654.34it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 15477.14it/s]
+
+Fetching 7 files:   0%|          | 0/7 [00:00<?, ?it/s]
+Fetching 7 files: 100%|██████████| 7/7 [00:00<00:00, 38379.25it/s]
+logs/seed7.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/root/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=/root/parameter-golf/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:21778504
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.03 head_lr:0.0 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:7
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9354 val_bpb:4.1076 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9348 train_time:113ms step_avg:113.40ms
+step:2/20000 train_loss:11.9491 train_time:160ms step_avg:79.80ms
+step:3/20000 train_loss:10.3202 train_time:232ms step_avg:77.44ms
+step:4/20000 train_loss:8.1368 train_time:307ms step_avg:76.80ms
+step:5/20000 train_loss:6.6650 train_time:378ms step_avg:75.67ms
+step:6/20000 train_loss:6.0862 train_time:450ms step_avg:75.00ms
+step:7/20000 train_loss:5.9919 train_time:521ms step_avg:74.45ms
+step:8/20000 train_loss:6.0150 train_time:594ms step_avg:74.25ms
+step:9/20000 train_loss:5.8492 train_time:666ms step_avg:74.02ms
+step:10/20000 train_loss:5.6866 train_time:739ms step_avg:73.95ms
+step:200/20000 train_loss:2.3726 train_time:14608ms step_avg:73.04ms
+step:400/20000 train_loss:2.3983 train_time:29310ms step_avg:73.28ms
+step:600/20000 train_loss:2.3206 train_time:43872ms step_avg:73.12ms
+step:800/20000 train_loss:2.2256 train_time:58566ms step_avg:73.21ms
+step:1000/20000 train_loss:2.2634 train_time:73547ms step_avg:73.55ms
+step:1000/20000 val_loss:2.2200 val_bpb:1.3148 train_time:73581ms step_avg:73.58ms
+step:1200/20000 train_loss:2.3463 train_time:88312ms step_avg:73.59ms
+step:1400/20000 train_loss:2.1786 train_time:103109ms step_avg:73.65ms
+step:1600/20000 train_loss:2.0806 train_time:117813ms step_avg:73.63ms
+step:1800/20000 train_loss:2.1604 train_time:132573ms step_avg:73.65ms
+step:2000/20000 train_loss:2.0678 train_time:147285ms step_avg:73.64ms
+step:2000/20000 val_loss:2.1311 val_bpb:1.2622 train_time:147313ms step_avg:73.66ms
+step:2200/20000 train_loss:2.1427 train_time:162058ms step_avg:73.66ms
+step:2400/20000 train_loss:2.0641 train_time:176717ms step_avg:73.63ms
+step:2600/20000 train_loss:2.1011 train_time:191555ms step_avg:73.67ms
+step:2800/20000 train_loss:2.1449 train_time:206395ms step_avg:73.71ms
+step:3000/20000 train_loss:2.1511 train_time:221078ms step_avg:73.69ms
+step:3000/20000 val_loss:2.0797 val_bpb:1.2317 train_time:221112ms step_avg:73.70ms
+step:3200/20000 train_loss:2.1577 train_time:235903ms step_avg:73.72ms
+step:3400/20000 train_loss:2.0080 train_time:250633ms step_avg:73.72ms
+step:3600/20000 train_loss:2.0816 train_time:265515ms step_avg:73.75ms
+step:3800/20000 train_loss:2.0594 train_time:280206ms step_avg:73.74ms
+step:4000/20000 train_loss:1.9626 train_time:295039ms step_avg:73.76ms
+step:4000/20000 val_loss:2.0546 val_bpb:1.2169 train_time:295070ms step_avg:73.77ms
+step:4200/20000 train_loss:2.1457 train_time:309849ms step_avg:73.77ms
+step:4400/20000 train_loss:2.0311 train_time:324614ms step_avg:73.78ms
+step:4600/20000 train_loss:1.8416 train_time:339446ms step_avg:73.79ms
+step:4800/20000 train_loss:2.4355 train_time:354163ms step_avg:73.78ms
+step:5000/20000 train_loss:2.1157 train_time:369039ms step_avg:73.81ms
+step:5000/20000 val_loss:2.0355 val_bpb:1.2056 train_time:369067ms step_avg:73.81ms
+step:5200/20000 train_loss:2.0585 train_time:383735ms step_avg:73.80ms
+step:5400/20000 train_loss:2.0699 train_time:398521ms step_avg:73.80ms
+step:5600/20000 train_loss:1.9817 train_time:413358ms step_avg:73.81ms
+step:5800/20000 train_loss:2.0286 train_time:428051ms step_avg:73.80ms
+step:6000/20000 train_loss:1.9741 train_time:442848ms step_avg:73.81ms
+step:6000/20000 val_loss:2.0130 val_bpb:1.1922 train_time:442886ms step_avg:73.81ms
+step:6200/20000 train_loss:1.9853 train_time:457555ms step_avg:73.80ms
+step:6400/20000 train_loss:2.0439 train_time:472390ms step_avg:73.81ms
+step:6600/20000 train_loss:1.8950 train_time:487051ms step_avg:73.80ms
+step:6800/20000 train_loss:2.0783 train_time:501842ms step_avg:73.80ms
+step:7000/20000 train_loss:1.8555 train_time:516651ms step_avg:73.81ms
+step:7000/20000 val_loss:1.9907 val_bpb:1.1790 train_time:516681ms step_avg:73.81ms
+step:7200/20000 train_loss:1.9421 train_time:531336ms step_avg:73.80ms
+step:7400/20000 train_loss:1.9926 train_time:546162ms step_avg:73.81ms
+step:7600/20000 train_loss:1.8668 train_time:560865ms step_avg:73.80ms
+step:7800/20000 train_loss:1.9976 train_time:575806ms step_avg:73.82ms
+step:8000/20000 train_loss:1.9281 train_time:590572ms step_avg:73.82ms
+step:8000/20000 val_loss:1.9715 val_bpb:1.1676 train_time:590600ms step_avg:73.83ms
+step:8126/20000 val_loss:1.9706 val_bpb:1.1671 train_time:600062ms step_avg:73.84ms
+stopping_early: wallclock_cap train_time:600062ms step:8126/20000
+peak memory allocated: 16106 MiB reserved: 16468 MiB
+Serialized model: 86099351 bytes
+Code size: 55221 bytes
+Total submission size: 86154572 bytes
+Serialized model int8+zlib: 15904743 bytes (payload:22690080 raw_torch:22734303 payload_ratio:3.79x)
+Total submission size int8+zlib: 15959964 bytes
+final_int8_zlib_roundtrip val_loss:1.9832 val_bpb:1.1746 eval_time:1480ms eval_seq_len:2048
+final_int8_zlib_roundtrip_exact val_loss:1.98323664 val_bpb:1.17458445
+final_sliding_window val_loss:1.9471 val_bpb:1.1532 eval_time:213896ms stride:256 seq_len:2048
+final_sliding_window_exact val_loss:1.94714096 val_bpb:1.15320656

--- a/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-20_Int6MLP3x_NorMuon_FA3/train_gpt.py
@@ -1,0 +1,1291 @@
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: `train_gpt.py` and `train_gpt_mlx.py` must never be longer than 1500 lines.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from kernels import get_kernel
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# Flash Attention 3
+fa3_module = get_kernel("kernels-community/flash-attn3", version=1)
+flash_attn_func = fa3_module.flash_attn_func
+
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 0))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 2))
+    mlp_hidden = int(os.environ.get("MLP_HIDDEN", 0))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+
+# -----------------------------
+# MUON OPTIMIZER 
+# -----------------------------
+# 
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+def normuon_update(
+    grad: Tensor,
+    momentum: Tensor,
+    second_momentum: Tensor,
+    beta: float = 0.95,
+    beta2: float = 0.95,
+    ns_steps: int = 5,
+    nesterov: bool = True,
+) -> Tensor:
+    momentum.lerp_(grad, 1 - beta)
+    update = grad.lerp_(momentum, beta) if nesterov else momentum
+    original_shape = None
+    if update.ndim == 4:
+        original_shape = update.shape
+        update = update.reshape(update.size(0), -1)
+    update = zeropower_via_newtonschulz5(update, steps=ns_steps)
+    update = update.to(grad.dtype)
+
+    if original_shape is not None:
+        update = update.reshape(original_shape)
+    vnorm = update.norm(dim=(-2, -1), keepdim=True)
+    v_mean = torch.mean(update * update, dim=-1, keepdim=True)
+    second_momentum.lerp_(v_mean, 1 - beta2)
+    step_size = 1 / second_momentum.sqrt().add_(1e-10)
+    update.mul_(step_size)
+    vnorm_new = update.norm(dim=(-2, -1), keepdim=True)
+    update.mul_(vnorm / (vnorm_new.add_(1e-10)))
+    update *= max(1, grad.size(-2) / grad.size(-1)) ** 0.5
+    return update
+
+# NorMuon implementation from the original paper, https://github.com/zichongli5/NorMuon, popularized by `modded-nanogpt`
+class NorMuon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr: float = 0.02,
+        weight_decay: float = 0.0,
+        momentum: float = 0.95,
+        beta2: float = 0.95,
+        backend_steps: int = 5,
+    ):
+        defaults = dict(
+            lr=lr,
+            weight_decay=weight_decay,
+            momentum=momentum,
+            beta2=beta2,
+            backend_steps=backend_steps,
+        )
+        assert isinstance(params, list) and len(params) >= 1 and isinstance(params[0], torch.nn.Parameter)
+        params = sorted(params, key=lambda x: x.size(), reverse=True)
+        super().__init__(params, defaults)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            pad_count = (-len(params)) % world_size
+            params_pad = params + [torch.empty_like(params[-1]) for _ in range(pad_count)]
+            for base_i in range(0, len(params_pad), world_size):
+                if base_i + rank < len(params):
+                    p = params[base_i + rank]
+                    had_grad = p.grad is not None
+                    if not had_grad:
+                        p.grad = torch.zeros_like(p)
+                    state = self.state[p]
+                    if len(state) == 0:
+                        state["momentum_buffer"] = torch.zeros_like(p)
+                        state["second_momentum_buffer"] = torch.zeros_like(p[..., 0:1])
+                    update = normuon_update(
+                        p.grad,
+                        state["momentum_buffer"],
+                        state["second_momentum_buffer"],
+                        beta=group["momentum"],
+                        beta2=group["beta2"],
+                        ns_steps=group["backend_steps"],
+                    )
+                    if group["weight_decay"] and had_grad:
+                        p.mul_(1 - group["lr"] * group["weight_decay"])
+                    p.add_(update.reshape(p.shape), alpha=-group["lr"])
+                if distributed:
+                    dist.all_gather(params_pad[base_i : base_i + world_size], params_pad[base_i + rank])
+
+        return loss
+
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    seq_len = eval_seq_len or args.train_seq_len
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor, bits: int = 8) -> tuple[Tensor, Tensor]:
+    max_val = 127 if bits == 8 else (2 ** (bits - 1)) - 1  # int6: 31, int8: 127
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / float(max_val)).clamp_min(1.0 / float(max_val))
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -max_val, max_val).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / float(max_val) if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -max_val, max_val).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # FP16 passthrough for tied embedding (our trick)
+        if name == "tok_emb.weight":
+            kept = t.to(dtype=torch.float16).contiguous()
+            passthrough[name] = kept
+            passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        # Late-K passthrough: keep last 2 layers' key weights in fp16 (PR #99's trick)
+        num_layers_total = max((int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")), default=0) + 1
+        if name.endswith("c_k.weight") and any(f"blocks.{i}." in name for i in range(num_layers_total - 2, num_layers_total)):
+            kept = t.to(dtype=torch.float16).contiguous()
+            passthrough[name] = kept
+            passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        # Small float tensors are cheap enough to keep directly.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        # Everything else: int6 quantization (saves ~25% vs int8)
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t, bits=6)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING 
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, self.weight.to(x.dtype), bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    # NTK-aware RoPE scaling for sequence length extrapolation at eval time.
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (self.dim / (self.dim - 2)))
+                inv_freq = 1.0 / (new_base ** (torch.arange(0, self.dim, 2, dtype=torch.float32, device=device) / self.dim))
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = flash_attn_func(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), causal=True).transpose(1, 2)
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int, mlp_hidden: int = 0):
+        super().__init__()
+        hidden = mlp_hidden if mlp_hidden > 0 else mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        mlp_hidden: int = 0,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult, mlp_hidden)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        mlp_hidden: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                    mlp_hidden=mlp_hidden,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+
+        # First half stores skips; second half reuses them in reverse order.
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    @torch.no_grad()
+    def get_logits(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+
+def eval_val_sliding(
+    args, base_model: nn.Module, rank: int, world_size: int, device: torch.device,
+    val_tokens: Tensor, base_bytes_lut: Tensor, has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor, eval_seq_len: int, eval_stride: int,
+) -> tuple[float, float]:
+    total_tokens = val_tokens.numel() - 1
+    all_starts = list(range(0, total_tokens - eval_seq_len + 1, eval_stride))
+    my_starts = all_starts[rank::world_size]
+
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    with torch.inference_mode():
+        for start in my_starts:
+            end = start + eval_seq_len
+            x = val_tokens[start:end].to(device=device, dtype=torch.int64).unsqueeze(0)
+            y = val_tokens[start + 1:end + 1].to(device=device, dtype=torch.int64).unsqueeze(0)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = base_model.get_logits(x)
+            score_from = eval_seq_len - eval_stride
+            if start == 0:
+                score_from = 0
+            suffix_logits = logits[0, score_from:].float()
+            suffix_targets = y[0, score_from:]
+            per_pos_loss = F.cross_entropy(suffix_logits, suffix_targets, reduction="none")
+            val_loss_sum += per_pos_loss.to(torch.float64).sum()
+            val_token_count += per_pos_loss.numel()
+            prev_ids = x[0, score_from:]
+            tgt_ids = y[0, score_from:]
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    base_model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    effective_eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        mlp_hidden=args.mlp_hidden,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizer_muon = NorMuon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        beta2=args.muon_beta2,
+        backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed int8+zlib artifact and validate the round-tripped weights.
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+        eval_seq_len=effective_eval_seq_len,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms "
+        f"eval_seq_len:{effective_eval_seq_len}"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if args.eval_stride > 0:
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        s_val_loss, s_val_bpb = eval_val_sliding(
+            args, base_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            eval_seq_len=effective_eval_seq_len, eval_stride=args.eval_stride,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_sliding_window val_loss:{s_val_loss:.4f} val_bpb:{s_val_bpb:.4f} "
+            f"eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms "
+            f"stride:{args.eval_stride} seq_len:{effective_eval_seq_len}"
+        )
+        log0(f"final_sliding_window_exact val_loss:{s_val_loss:.8f} val_bpb:{s_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR builds directly on the prior PR #114  and improves it further by replacing Muon with NorMuon and switching the attention path to FlashAttention 3.


**val_bpb = 1.1532 (best seed), 1.1546 mean over 3 seeds.**

On the three completed seeds in this PR:
- Seed 7: `val_bpb = 1.1532`, `val_loss = 1.9471`
- Seed 42: `val_bpb = 1.1542`, `val_loss = 1.9488`
- Seed 1337: `val_bpb = 1.1563`, `val_loss = 1.9524`

Mean over seeds 7 / 42 / 1337:
- `val_bpb = 1.1546`
- `val_loss = 1.9495`

Artifact size remains within budget at about `15.96MB`. Training still uses the 10-minute wallclock cap on `8x H100`, with sliding-window evaluation at stride 256.

## What's New

1. **NorMuon replaces Muon**  
   This keeps the same overall optimizer split but swaps the optimizer to NorMuon. In this setup, NorMuon gave a modest but repeatable improvement over the previous Muon-based version.

2. **FlashAttention 3 replaces the prior attention path**  
   The model now uses the FA3 kernel directly for the attention mechanism. This keeps the same architecture and evaluation setup, but improves the training/runtime path on H100s.

3. **Multi-seed validation**  
   The previous README highlighted a single best result plus older seed runs. This PR updates the result summary to the actual new 3-seed set for this NorMuon + FA3 variant: seeds `7`, `42`, and `1337`.

## Approach

This submission keeps the main structure from the previous PR:
- Int6 post-training quantization with per-row scaling
- MLP hidden size increased from `1024 -> 1536`
- tied embedding kept in fp16
- final-layer `c_k.weight` passthrough retained in fp16
- train at `seq_len=2048`
- sliding-window eval at `eval_seq_len=2048`, `stride=256`
- GRAD_CLIP_NORM=0.3 stabilizes long-sequence training

The key change here is not a new quantization scheme or architecture jump, but a cleaner training/runtime stack:
- **NorMuon** for optimizer updates
- **FlashAttention 3** for the attention kernel

## Training
Training was done on 8 H100 GPUs using Modal. The script for training on Modal is also attached.