### PR TITLE
Add CTM tail-QAT proxy non-record snapshot

### DIFF
--- a/records/track_non_record_16mb/2026-03-20_CTMTailQAT_Proxy1xH100_KHUCHAN/README.md
+++ b/records/track_non_record_16mb/2026-03-20_CTMTailQAT_Proxy1xH100_KHUCHAN/README.md
@@ -1,0 +1,60 @@
+This non-record snapshot captures the strongest `1xH100` proxy run we obtained for a cognitively motivated CTM recipe.
+
+It is not intended as a main-leaderboard claim. The run used the published `fineweb10B_sp1024` export and the standard exact int8+zlib evaluation path, but only `1xH100`, `10` training shards, and a `20 minute` wallclock cap. The purpose of this folder is to package the current best proxy recipe as a reproducible standalone record for review and follow-up.
+
+Approach:
+- Start from the public `9x512` GPT baseline with tied embeddings and `4` KV heads.
+- Add a small causal CTM workspace bridge with `4` slots x `64` dims.
+- Route workspace writes with `novelty + salience` (`CTM_NOVELTY_GAIN=1.0`, `CTM_SALIENCE_GAIN=0.5`).
+- Add prediction-error-gated skip connections with `SKIP_GATE_MODE=error`.
+- Add export-matched tail QAT (`QAT_MODE=export_int8`, `QAT_START_FRAC=0.70`) so the model trains against the same large-matrix int8 clipping/dequantization used by the final artifact path.
+
+Configuration:
+- Track: `non-record`, proxy run, not an `8xH100 / 10 minute` leaderboard submission
+- Data: published `fineweb10B_sp1024` shards and published SP-1024 tokenizer
+- Layout: `VOCAB_SIZE=1024 NUM_LAYERS=9 MODEL_DIM=512 NUM_HEADS=8 NUM_KV_HEADS=4 MLP_MULT=2`
+- CTM: `CTM_SLOTS=4 CTM_DIM=64 CTM_NOVELTY_GAIN=1.0 CTM_SALIENCE_GAIN=0.5 CTM_SHARE_READ=0`
+- Extra routing: `SKIP_GATE_MODE=error`
+- Quantization-aware training: `QAT_MODE=export_int8 QAT_START_FRAC=0.70`
+- Batching: `TRAIN_BATCH_TOKENS=131072 TRAIN_SEQ_LEN=1024`
+
+Command (track-relevant params):
+```bash
+RUN_ID=ctm_causal_salience_error_skip_tailqat_sp1024_1xh100 \
+DATA_PATH=/workspace/parameter-golf/data/datasets/fineweb10B_sp1024 \
+TOKENIZER_PATH=/workspace/parameter-golf/data/tokenizers/fineweb_1024_bpe.model \
+VOCAB_SIZE=1024 \
+CTM_SLOTS=4 \
+CTM_DIM=64 \
+CTM_NOVELTY_GAIN=1.0 \
+CTM_SALIENCE_GAIN=0.5 \
+CTM_SHARE_READ=0 \
+SKIP_GATE_MODE=error \
+QAT_MODE=export_int8 \
+QAT_START_FRAC=0.70 \
+TRAIN_BATCH_TOKENS=131072 \
+TRAIN_SEQ_LEN=1024 \
+MAX_WALLCLOCK_SECONDS=1200 \
+TRAIN_LOG_EVERY=50 \
+VAL_LOSS_EVERY=200 \
+torchrun --standalone --nproc_per_node=1 /workspace/parameter-golf/train_gpt.py
+```
+
+Key metrics (from `train.log`):
+- Timed training stopped at `6759/20000` steps due to the wallclock cap.
+- Pre-quant eval at stop: `val_loss:2.1809`, `val_bpb:1.2917`
+- Exact printed metric: `final_int8_zlib_roundtrip_exact val_bpb:1.29167890`
+- Train time: `1200062ms` (`step_avg:177.55ms`)
+- Peak memory: `3508 MiB allocated`, `4614 MiB reserved`
+- Serialized model int8+zlib: `15941743 bytes`
+- Code size at the time of the logged run: `67788 bytes`
+- Total submission size int8+zlib at the time of the logged run: `16009531 bytes`
+
+Important note:
+- This logged proxy run missed the decimal `16,000,000` byte artifact cap by `9531` bytes, so it is not a valid record submission as-is.
+- After this run, the root `train_gpt.py` was code-trimmed without changing the active CTM + error-skip + tail-QAT path, reducing the current script size to `49644` bytes and bringing the projected total below the cap. That exact rerun is not included in this folder, so this record should be read as an honest in-progress non-record snapshot rather than a leaderboard claim.
+
+Included files:
+- `train_gpt.py` (standalone code snapshot used for the logged proxy run)
+- `train.log` (exact `1xH100` proxy training log)
+- `submission.json` (metadata for this non-record snapshot)

--- a/records/track_non_record_16mb/2026-03-20_CTMTailQAT_Proxy1xH100_KHUCHAN/submission.json
+++ b/records/track_non_record_16mb/2026-03-20_CTMTailQAT_Proxy1xH100_KHUCHAN/submission.json
@@ -1,0 +1,11 @@
+{
+  "author": "Chanyoung Kim",
+  "github_id": "KHUCHAN",
+  "name": "CTM Tail QAT Proxy",
+  "blurb": "1xH100 proxy run for a causal CTM workspace + error-gated skip + export-matched tail QAT recipe on the published fineweb10B_sp1024 export. The exact logged run improves the local proxy winner to val_bpb 1.29167890, but the logged standalone artifact is 9,531 bytes over the 16,000,000-byte cap, so this folder is submitted as a non-record, in-progress snapshot.",
+  "date": "2026-03-20T00:00:00Z",
+  "val_loss": 2.18094572,
+  "val_bpb": 1.2916789,
+  "bytes_total": 16009531,
+  "bytes_code": 67788
+}

--- a/records/track_non_record_16mb/2026-03-20_CTMTailQAT_Proxy1xH100_KHUCHAN/train.log
+++ b/records/track_non_record_16mb/2026-03-20_CTMTailQAT_Proxy1xH100_KHUCHAN/train.log
@@ -1,0 +1,235 @@
+logs/ctm_causal_salience_error_skip_tailqat_sp1024_1xh100.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:10
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+data_strategy raw_prep_mode:off curriculum_mode:none curriculum_progress_mode:step curriculum_seq_lens:[128, 256, 512, 1024] doc_aware_probs:[1.0, 0.75, 0.5, 0.0] kd_mode:none kd_alpha:0.000 kd_hard_fraction:0.050
+model_params:17132636
+world_size:1 grad_accum_steps:8
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4 unique_layers:9
+ctm_bridge slots:4 dim:64 novelty_gain:1.00 salience_gain:0.50 share_read:0
+skip_gate_mode:error
+block_gate_mode:none
+ctm_decoder_refresh_every:0
+late_group_gate_mode:none late_group_size:0
+qat_mode:export_int8 qat_start_frac:0.70
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:131072 train_seq_len:1024 iterations:20000 warmup_steps:20 max_wallclock_seconds:1200.000
+seed:1337
+/usr/local/lib/python3.12/dist-packages/torch/_inductor/lowering.py:7242: UserWarning: 
+Online softmax is disabled on the fly since Inductor decides to
+split the reduction. Cut an issue to PyTorch if this is an
+important use case and you want to speed it up with online
+softmax.
+
+  warnings.warn(
+/usr/local/lib/python3.12/dist-packages/torch/_inductor/lowering.py:7242: UserWarning: 
+Online softmax is disabled on the fly since Inductor decides to
+split the reduction. Cut an issue to PyTorch if this is an
+important use case and you want to speed it up with online
+softmax.
+
+  warnings.warn(
+/usr/local/lib/python3.12/dist-packages/torch/_inductor/lowering.py:7242: UserWarning: 
+Online softmax is disabled on the fly since Inductor decides to
+split the reduction. Cut an issue to PyTorch if this is an
+important use case and you want to speed it up with online
+softmax.
+
+  warnings.warn(
+/usr/local/lib/python3.12/dist-packages/torch/_inductor/lowering.py:7242: UserWarning: 
+Online softmax is disabled on the fly since Inductor decides to
+split the reduction. Cut an issue to PyTorch if this is an
+important use case and you want to speed it up with online
+softmax.
+
+  warnings.warn(
+warmup_step:1/20 seq_len:1024
+warmup_step:2/20 seq_len:1024
+warmup_step:3/20 seq_len:1024
+warmup_step:4/20 seq_len:1024
+warmup_step:5/20 seq_len:1024
+warmup_step:6/20 seq_len:1024
+warmup_step:7/20 seq_len:1024
+warmup_step:8/20 seq_len:1024
+warmup_step:9/20 seq_len:1024
+warmup_step:10/20 seq_len:1024
+warmup_step:11/20 seq_len:1024
+warmup_step:12/20 seq_len:1024
+warmup_step:13/20 seq_len:1024
+warmup_step:14/20 seq_len:1024
+warmup_step:15/20 seq_len:1024
+warmup_step:16/20 seq_len:1024
+warmup_step:17/20 seq_len:1024
+warmup_step:18/20 seq_len:1024
+warmup_step:19/20 seq_len:1024
+warmup_step:20/20 seq_len:1024
+step:1/20000 train_loss:6.9366 train_time:192ms step_avg:191.97ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2/20000 train_loss:16.8294 train_time:415ms step_avg:207.72ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3/20000 train_loss:8.3657 train_time:673ms step_avg:224.25ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4/20000 train_loss:6.6647 train_time:961ms step_avg:240.29ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:5/20000 train_loss:6.9279 train_time:1260ms step_avg:251.92ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:6/20000 train_loss:6.8718 train_time:1563ms step_avg:260.54ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:7/20000 train_loss:6.5825 train_time:1857ms step_avg:265.29ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:8/20000 train_loss:6.3723 train_time:2195ms step_avg:274.41ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:9/20000 train_loss:6.1554 train_time:2528ms step_avg:280.84ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:10/20000 train_loss:5.9909 train_time:2730ms step_avg:273.03ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:50/20000 train_loss:4.0777 train_time:9107ms step_avg:182.14ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:100/20000 train_loss:3.7263 train_time:17494ms step_avg:174.94ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:150/20000 train_loss:3.3468 train_time:26006ms step_avg:173.37ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:200/20000 train_loss:3.1062 train_time:34311ms step_avg:171.55ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:250/20000 train_loss:2.9092 train_time:42620ms step_avg:170.48ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:300/20000 train_loss:2.8732 train_time:50915ms step_avg:169.72ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:350/20000 train_loss:2.7326 train_time:59273ms step_avg:169.35ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:400/20000 train_loss:2.8142 train_time:67478ms step_avg:168.70ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:450/20000 train_loss:2.6392 train_time:75516ms step_avg:167.81ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:500/20000 train_loss:2.7339 train_time:83457ms step_avg:166.91ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:550/20000 train_loss:2.6560 train_time:91267ms step_avg:165.94ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:600/20000 train_loss:2.6804 train_time:100116ms step_avg:166.86ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:650/20000 train_loss:2.5932 train_time:109052ms step_avg:167.77ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:700/20000 train_loss:2.4375 train_time:117454ms step_avg:167.79ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:750/20000 train_loss:2.5769 train_time:125615ms step_avg:167.49ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:800/20000 train_loss:2.5642 train_time:134427ms step_avg:168.03ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:850/20000 train_loss:2.6110 train_time:143625ms step_avg:168.97ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:900/20000 train_loss:2.5536 train_time:152568ms step_avg:169.52ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:950/20000 train_loss:2.5305 train_time:161483ms step_avg:169.98ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1000/20000 train_loss:2.4885 train_time:170332ms step_avg:170.33ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1050/20000 train_loss:2.5276 train_time:179254ms step_avg:170.72ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1100/20000 train_loss:2.4885 train_time:187406ms step_avg:170.37ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1150/20000 train_loss:2.3901 train_time:196553ms step_avg:170.92ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1200/20000 train_loss:2.4379 train_time:205718ms step_avg:171.43ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1250/20000 train_loss:2.4394 train_time:214932ms step_avg:171.95ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1300/20000 train_loss:2.4656 train_time:223898ms step_avg:172.23ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1350/20000 train_loss:2.4981 train_time:233245ms step_avg:172.77ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1400/20000 train_loss:2.4209 train_time:242461ms step_avg:173.19ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1450/20000 train_loss:2.4072 train_time:251669ms step_avg:173.57ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1500/20000 train_loss:2.4234 train_time:260758ms step_avg:173.84ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1550/20000 train_loss:2.4209 train_time:275551ms step_avg:177.77ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1600/20000 train_loss:2.2501 train_time:284824ms step_avg:178.01ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1650/20000 train_loss:2.4109 train_time:294234ms step_avg:178.32ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1700/20000 train_loss:2.3884 train_time:302934ms step_avg:178.20ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1750/20000 train_loss:2.3236 train_time:311585ms step_avg:178.05ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1800/20000 train_loss:2.4385 train_time:320335ms step_avg:177.96ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1850/20000 train_loss:2.3802 train_time:329171ms step_avg:177.93ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1900/20000 train_loss:2.3643 train_time:338002ms step_avg:177.90ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:1950/20000 train_loss:2.4095 train_time:346668ms step_avg:177.78ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2000/20000 train_loss:2.4445 train_time:355343ms step_avg:177.67ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2050/20000 train_loss:2.2657 train_time:363794ms step_avg:177.46ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2100/20000 train_loss:2.4909 train_time:371935ms step_avg:177.11ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2150/20000 train_loss:2.2814 train_time:380870ms step_avg:177.15ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2200/20000 train_loss:2.1995 train_time:389782ms step_avg:177.17ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2250/20000 train_loss:2.3781 train_time:398616ms step_avg:177.16ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2300/20000 train_loss:2.3260 train_time:410550ms step_avg:178.50ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2350/20000 train_loss:2.2888 train_time:419278ms step_avg:178.42ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2400/20000 train_loss:2.4273 train_time:427471ms step_avg:178.11ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2450/20000 train_loss:2.3943 train_time:435577ms step_avg:177.79ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2500/20000 train_loss:2.4086 train_time:444268ms step_avg:177.71ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2550/20000 train_loss:2.3986 train_time:452871ms step_avg:177.60ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2600/20000 train_loss:2.1956 train_time:461547ms step_avg:177.52ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2650/20000 train_loss:2.3018 train_time:470180ms step_avg:177.43ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2700/20000 train_loss:2.1957 train_time:478665ms step_avg:177.28ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2750/20000 train_loss:2.3082 train_time:486610ms step_avg:176.95ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2800/20000 train_loss:2.4474 train_time:495166ms step_avg:176.85ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2850/20000 train_loss:2.3062 train_time:503750ms step_avg:176.75ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2900/20000 train_loss:2.4484 train_time:512684ms step_avg:176.79ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:2950/20000 train_loss:2.2982 train_time:521455ms step_avg:176.76ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3000/20000 train_loss:2.2321 train_time:530183ms step_avg:176.73ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3050/20000 train_loss:2.2387 train_time:538654ms step_avg:176.61ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3100/20000 train_loss:2.5151 train_time:549440ms step_avg:177.24ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3150/20000 train_loss:2.3287 train_time:558439ms step_avg:177.28ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3200/20000 train_loss:2.3021 train_time:567327ms step_avg:177.29ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3250/20000 train_loss:2.2256 train_time:576266ms step_avg:177.31ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3300/20000 train_loss:2.3789 train_time:585041ms step_avg:177.29ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3350/20000 train_loss:2.3297 train_time:593309ms step_avg:177.11ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3400/20000 train_loss:2.3747 train_time:601620ms step_avg:176.95ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3450/20000 train_loss:2.2809 train_time:609749ms step_avg:176.74ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3500/20000 train_loss:2.2733 train_time:618376ms step_avg:176.68ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3550/20000 train_loss:2.2081 train_time:627155ms step_avg:176.66ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3600/20000 train_loss:2.3553 train_time:635684ms step_avg:176.58ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3650/20000 train_loss:2.2022 train_time:644338ms step_avg:176.53ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3700/20000 train_loss:2.3367 train_time:652935ms step_avg:176.47ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3750/20000 train_loss:2.2804 train_time:661455ms step_avg:176.39ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3800/20000 train_loss:2.3107 train_time:669864ms step_avg:176.28ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3850/20000 train_loss:2.2844 train_time:680372ms step_avg:176.72ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3900/20000 train_loss:2.2973 train_time:688860ms step_avg:176.63ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:3950/20000 train_loss:2.3581 train_time:697434ms step_avg:176.57ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4000/20000 train_loss:2.2824 train_time:706057ms step_avg:176.51ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4050/20000 train_loss:2.3053 train_time:714637ms step_avg:176.45ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4100/20000 train_loss:2.4667 train_time:722675ms step_avg:176.26ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4150/20000 train_loss:2.3270 train_time:730722ms step_avg:176.08ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4200/20000 train_loss:2.3274 train_time:739035ms step_avg:175.96ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4250/20000 train_loss:2.2499 train_time:747545ms step_avg:175.89ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4300/20000 train_loss:2.3078 train_time:756174ms step_avg:175.85ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4350/20000 train_loss:2.2802 train_time:764973ms step_avg:175.86ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4400/20000 train_loss:2.2095 train_time:773538ms step_avg:175.80ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4450/20000 train_loss:2.3742 train_time:782084ms step_avg:175.75ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4500/20000 train_loss:2.2813 train_time:790269ms step_avg:175.62ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4550/20000 train_loss:2.3864 train_time:798818ms step_avg:175.56ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4600/20000 train_loss:2.2225 train_time:807093ms step_avg:175.46ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4650/20000 train_loss:2.3511 train_time:816112ms step_avg:175.51ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4700/20000 train_loss:2.2475 train_time:824504ms step_avg:175.43ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4750/20000 train_loss:2.3285 train_time:832866ms step_avg:175.34ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4800/20000 train_loss:2.2674 train_time:841021ms step_avg:175.21ms seq_len:1024 doc_prob:0.00 qat_mix:0.00
+step:4850/20000 train_loss:2.1734 train_time:850038ms step_avg:175.27ms seq_len:1024 doc_prob:0.00 qat_mix:0.03
+step:4900/20000 train_loss:2.2418 train_time:859246ms step_avg:175.36ms seq_len:1024 doc_prob:0.00 qat_mix:0.05
+step:4950/20000 train_loss:2.2371 train_time:868491ms step_avg:175.45ms seq_len:1024 doc_prob:0.00 qat_mix:0.08
+step:5000/20000 train_loss:2.1939 train_time:877635ms step_avg:175.53ms seq_len:1024 doc_prob:0.00 qat_mix:0.10
+step:5050/20000 train_loss:2.3473 train_time:886905ms step_avg:175.62ms seq_len:1024 doc_prob:0.00 qat_mix:0.13
+step:5100/20000 train_loss:2.1337 train_time:896382ms step_avg:175.76ms seq_len:1024 doc_prob:0.00 qat_mix:0.16
+step:5150/20000 train_loss:2.3184 train_time:905321ms step_avg:175.79ms seq_len:1024 doc_prob:0.00 qat_mix:0.18
+step:5200/20000 train_loss:2.1974 train_time:914153ms step_avg:175.80ms seq_len:1024 doc_prob:0.00 qat_mix:0.21
+step:5250/20000 train_loss:2.2857 train_time:923358ms step_avg:175.88ms seq_len:1024 doc_prob:0.00 qat_mix:0.23
+step:5300/20000 train_loss:2.2721 train_time:932561ms step_avg:175.95ms seq_len:1024 doc_prob:0.00 qat_mix:0.26
+step:5350/20000 train_loss:2.1553 train_time:941780ms step_avg:176.03ms seq_len:1024 doc_prob:0.00 qat_mix:0.28
+step:5400/20000 train_loss:2.1902 train_time:950857ms step_avg:176.08ms seq_len:1024 doc_prob:0.00 qat_mix:0.31
+step:5450/20000 train_loss:2.3044 train_time:959896ms step_avg:176.13ms seq_len:1024 doc_prob:0.00 qat_mix:0.33
+step:5500/20000 train_loss:2.2154 train_time:968662ms step_avg:176.12ms seq_len:1024 doc_prob:0.00 qat_mix:0.36
+step:5550/20000 train_loss:2.2577 train_time:977636ms step_avg:176.15ms seq_len:1024 doc_prob:0.00 qat_mix:0.38
+step:5600/20000 train_loss:2.2500 train_time:986765ms step_avg:176.21ms seq_len:1024 doc_prob:0.00 qat_mix:0.41
+step:5650/20000 train_loss:2.1308 train_time:996129ms step_avg:176.31ms seq_len:1024 doc_prob:0.00 qat_mix:0.43
+step:5700/20000 train_loss:2.3728 train_time:1005416ms step_avg:176.39ms seq_len:1024 doc_prob:0.00 qat_mix:0.46
+step:5750/20000 train_loss:2.2456 train_time:1014446ms step_avg:176.43ms seq_len:1024 doc_prob:0.00 qat_mix:0.48
+step:5800/20000 train_loss:2.2458 train_time:1023300ms step_avg:176.43ms seq_len:1024 doc_prob:0.00 qat_mix:0.51
+step:5850/20000 train_loss:2.2374 train_time:1032192ms step_avg:176.44ms seq_len:1024 doc_prob:0.00 qat_mix:0.53
+step:5900/20000 train_loss:2.1014 train_time:1041358ms step_avg:176.50ms seq_len:1024 doc_prob:0.00 qat_mix:0.56
+step:5950/20000 train_loss:2.2712 train_time:1050476ms step_avg:176.55ms seq_len:1024 doc_prob:0.00 qat_mix:0.58
+step:6000/20000 train_loss:2.1966 train_time:1059671ms step_avg:176.61ms seq_len:1024 doc_prob:0.00 qat_mix:0.61
+step:6050/20000 train_loss:2.2223 train_time:1068953ms step_avg:176.69ms seq_len:1024 doc_prob:0.00 qat_mix:0.64
+step:6100/20000 train_loss:2.2176 train_time:1077999ms step_avg:176.72ms seq_len:1024 doc_prob:0.00 qat_mix:0.66
+step:6150/20000 train_loss:2.1319 train_time:1087741ms step_avg:176.87ms seq_len:1024 doc_prob:0.00 qat_mix:0.69
+step:6200/20000 train_loss:3.3724 train_time:1096959ms step_avg:176.93ms seq_len:1024 doc_prob:0.00 qat_mix:0.71
+step:6250/20000 train_loss:2.2000 train_time:1106227ms step_avg:177.00ms seq_len:1024 doc_prob:0.00 qat_mix:0.74
+step:6300/20000 train_loss:2.1789 train_time:1115399ms step_avg:177.05ms seq_len:1024 doc_prob:0.00 qat_mix:0.76
+step:6350/20000 train_loss:2.2803 train_time:1124690ms step_avg:177.12ms seq_len:1024 doc_prob:0.00 qat_mix:0.79
+step:6400/20000 train_loss:2.2232 train_time:1134026ms step_avg:177.19ms seq_len:1024 doc_prob:0.00 qat_mix:0.82
+step:6450/20000 train_loss:2.1218 train_time:1143165ms step_avg:177.23ms seq_len:1024 doc_prob:0.00 qat_mix:0.84
+step:6500/20000 train_loss:2.1530 train_time:1152088ms step_avg:177.24ms seq_len:1024 doc_prob:0.00 qat_mix:0.87
+step:6550/20000 train_loss:2.2164 train_time:1161440ms step_avg:177.32ms seq_len:1024 doc_prob:0.00 qat_mix:0.89
+step:6600/20000 train_loss:2.2324 train_time:1170659ms step_avg:177.37ms seq_len:1024 doc_prob:0.00 qat_mix:0.92
+step:6650/20000 train_loss:2.1947 train_time:1179975ms step_avg:177.44ms seq_len:1024 doc_prob:0.00 qat_mix:0.94
+step:6700/20000 train_loss:2.1571 train_time:1189048ms step_avg:177.47ms seq_len:1024 doc_prob:0.00 qat_mix:0.97
+step:6750/20000 train_loss:2.1704 train_time:1198348ms step_avg:177.53ms seq_len:1024 doc_prob:0.00 qat_mix:0.99
+/usr/local/lib/python3.12/dist-packages/torch/_inductor/lowering.py:7242: UserWarning: 
+Online softmax is disabled on the fly since Inductor decides to
+split the reduction. Cut an issue to PyTorch if this is an
+important use case and you want to speed it up with online
+softmax.
+
+  warnings.warn(
+/usr/local/lib/python3.12/dist-packages/torch/_inductor/lowering.py:7242: UserWarning: 
+Online softmax is disabled on the fly since Inductor decides to
+split the reduction. Cut an issue to PyTorch if this is an
+important use case and you want to speed it up with online
+softmax.
+
+  warnings.warn(
+step:6759/20000 val_loss:2.1809 val_bpb:1.2917 train_time:1200062ms step_avg:177.55ms
+stopping_early: wallclock_cap train_time:1200062ms step:6759/20000
+peak memory allocated: 3508 MiB reserved: 4614 MiB
+Serialized model: 67520039 bytes
+Code size: 67788 bytes
+Total submission size: 67587827 bytes
+Serialized model int8+zlib: 15941743 bytes (payload:17329512 raw_torch:17378369 payload_ratio:3.89x)
+Total submission size int8+zlib: 16009531 bytes
+final_int8_zlib_roundtrip val_loss:2.1809 val_bpb:1.2917 eval_time:13353ms
+final_int8_zlib_roundtrip_exact val_loss:2.18094572 val_bpb:1.29167890

--- a/records/track_non_record_16mb/2026-03-20_CTMTailQAT_Proxy1xH100_KHUCHAN/train_gpt.py
+++ b/records/track_non_record_16mb/2026-03-20_CTMTailQAT_Proxy1xH100_KHUCHAN/train_gpt.py
@@ -1,0 +1,1483 @@
+"""Good launch points for participants, not SOTA configs; hard stop: `train_gpt.py` and `train_gpt_mlx.py` must stay <= 1500 lines."""
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# Default baseline: 9x512 GPT, GQA, 1024 vocab/seq, tied embeddings, 524,288 train tokens/step.
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    raw_prep_mode = os.environ.get("RAW_PREP_MODE", "off")
+    curriculum_mode = os.environ.get("CURRICULUM_MODE", "none")
+    curriculum_progress_mode = os.environ.get("CURRICULUM_PROGRESS_MODE", "step")
+    curriculum_seq_lens = os.environ.get("CURRICULUM_SEQ_LENS", "128,256,512,1024")
+    curriculum_phase_ends = os.environ.get("CURRICULUM_PHASE_ENDS", "0.15,0.35,0.65,1.0")
+    doc_aware_probs = os.environ.get("DOC_AWARE_PROBS", "1.0,0.75,0.5,0.0")
+    doc_score_path = os.environ.get("DOC_SCORE_PATH", "")
+    kd_mode = os.environ.get("KD_MODE", "none")
+    kd_hard_fraction = float(os.environ.get("KD_HARD_FRACTION", 0.05))
+    kd_alpha = float(os.environ.get("KD_ALPHA", 0.0))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    compile_model = bool(int(os.environ.get("COMPILE_MODEL", "1")))
+    compile_zeropower = bool(int(os.environ.get("COMPILE_ZEROPOWER", "1")))
+    ctm_slots = int(os.environ.get("CTM_SLOTS", "0"))
+    ctm_dim = int(os.environ.get("CTM_DIM", "0"))
+    ctm_novelty_gain = float(os.environ.get("CTM_NOVELTY_GAIN", "1.0"))
+    ctm_salience_gain = float(os.environ.get("CTM_SALIENCE_GAIN", "0.0"))
+    ctm_share_read = bool(int(os.environ.get("CTM_SHARE_READ", "0")))
+    ctm_decoder_refresh_every = int(os.environ.get("CTM_DECODER_REFRESH_EVERY", "0"))
+    skip_gate_mode = os.environ.get("SKIP_GATE_MODE", "none")
+    block_gate_mode = os.environ.get("BLOCK_GATE_MODE", "none")
+    late_group_gate_mode = os.environ.get("LATE_GROUP_GATE_MODE", "none")
+    late_group_size = int(os.environ.get("LATE_GROUP_SIZE", "0"))
+    qat_mode = os.environ.get("QAT_MODE", "none")
+    qat_start_frac = float(os.environ.get("QAT_START_FRAC", 0.7))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 2))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+
+def parse_csv_ints(raw: str, *, name: str) -> list[int]:
+    values = [int(piece.strip()) for piece in raw.split(",") if piece.strip()]
+    if not values:
+        raise ValueError(f"{name} must contain at least one integer")
+    return values
+
+def parse_csv_floats(raw: str, *, name: str) -> list[float]:
+    values = [float(piece.strip()) for piece in raw.split(",") if piece.strip()]
+    if not values:
+        raise ValueError(f"{name} must contain at least one float")
+    return values
+
+class CurriculumSchedule:
+    def __init__(self, args: Hyperparameters):
+        self.enabled = args.curriculum_mode == "ctml"
+        self.progress_mode = args.curriculum_progress_mode
+        self.seq_lens = parse_csv_ints(args.curriculum_seq_lens, name="CURRICULUM_SEQ_LENS")
+        self.phase_ends = parse_csv_floats(args.curriculum_phase_ends, name="CURRICULUM_PHASE_ENDS")
+        self.doc_probs = parse_csv_floats(args.doc_aware_probs, name="DOC_AWARE_PROBS")
+        if not (len(self.seq_lens) == len(self.phase_ends) == len(self.doc_probs)):
+            raise ValueError("CURRICULUM_SEQ_LENS, CURRICULUM_PHASE_ENDS, and DOC_AWARE_PROBS must have the same length")
+        prev = 0.0
+        for end in self.phase_ends:
+            if end < prev or end <= 0.0 or end > 1.0:
+                raise ValueError("CURRICULUM_PHASE_ENDS must be increasing values in (0, 1]")
+            prev = end
+
+    def phase_index(self, step: int, total_steps: int, elapsed_ms: float = 0.0, max_wallclock_ms: float | None = None) -> int:
+        if not self.enabled:
+            return len(self.seq_lens) - 1
+        progress = min(elapsed_ms / max_wallclock_ms, 1.0) if self.progress_mode == "wallclock" and max_wallclock_ms and max_wallclock_ms > 0 else (1.0 if total_steps <= 1 else step / max(total_steps - 1, 1))
+        for i, end in enumerate(self.phase_ends):
+            if progress <= end + 1e-12:
+                return i
+        return len(self.phase_ends) - 1
+
+    def train_seq_len(self, step: int, total_steps: int, fallback: int, elapsed_ms: float = 0.0, max_wallclock_ms: float | None = None) -> int:
+        return fallback if not self.enabled else self.seq_lens[self.phase_index(step, total_steps, elapsed_ms, max_wallclock_ms)]
+
+    def doc_aware_prob(self, step: int, total_steps: int, elapsed_ms: float = 0.0, max_wallclock_ms: float | None = None) -> float:
+        return 0.0 if not self.enabled else self.doc_probs[self.phase_index(step, total_steps, elapsed_ms, max_wallclock_ms)]
+
+def should_use_doc_loader(step: int, micro_step: int, doc_prob: float) -> bool:
+    if doc_prob <= 0.0:
+        return False
+    if doc_prob >= 1.0:
+        return True
+    return ((step * 131 + micro_step * 17) % 1000) < int(doc_prob * 1000)
+
+def load_doc_priorities(path: str) -> np.ndarray | None:
+    if not path:
+        return None
+    payload = np.load(Path(path).expanduser().resolve())
+    if "priority" not in payload:
+        raise ValueError(f"DOC_SCORE_PATH must contain a 'priority' array: {path}")
+    return np.asarray(payload["priority"], dtype=np.float32)
+# Muon from modded-nanogpt: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+# Tokenizer-agnostic BPB evaluation setup.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# Post-training quantization for the int8+zlib submission artifact.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gate,skip_gates,mlp_gate,mlp_gates,ctm_scale,slot_mix,late_group_gate",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def fake_quantize_like_export(t: Tensor) -> Tensor:
+    q, s = quantize_float_tensor(t)
+    out = q.float() * s.to(dtype=torch.float32).view(q.shape[0], *([1] * (q.ndim - 1))) if s.ndim > 0 else q.float() * float(s.item())
+    return out.to(dtype=t.dtype).contiguous()
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+
+class DocTokenStream:
+    def __init__(self, pattern: str, bos_id: int, doc_priorities: np.ndarray | None = None):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.bos_id = bos_id
+        self.doc_priorities = doc_priorities
+        self.file_idx = 0
+        self.doc_base = 0
+        self.tokens = load_data_shard(self.files[0])
+        self._index_current_file()
+
+    def _index_current_file(self) -> None:
+        starts = torch.nonzero(self.tokens == self.bos_id, as_tuple=False).flatten().cpu().numpy().astype(np.int64, copy=False)
+        self.doc_starts = starts
+        self.doc_ends = (
+            np.concatenate([starts[1:], np.asarray([self.tokens.numel()], dtype=np.int64)], axis=0)
+            if starts.size
+            else np.empty((0,), dtype=np.int64)
+        )
+        self.doc_offsets: dict[int, int] = {}
+        self.cursor = 0
+        self.hard_cursor = 0
+        if starts.size:
+            order = np.arange(starts.size, dtype=np.int64)
+            if self.doc_priorities is not None:
+                score_end = self.doc_base + starts.size
+                if score_end > self.doc_priorities.size:
+                    raise ValueError(
+                        f"DOC_SCORE_PATH too short for shard traversal: need {score_end} docs, "
+                        f"have {self.doc_priorities.size}"
+                    )
+                local_scores = self.doc_priorities[self.doc_base : score_end]
+                order = np.argsort(-local_scores, kind="stable")
+            self.doc_order = order
+        else:
+            self.doc_order = np.empty((0,), dtype=np.int64)
+        self.doc_count = int(starts.size)
+
+    def _advance_file(self) -> None:
+        self.doc_base += self.doc_count
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        if self.file_idx == 0:
+            self.doc_base = 0
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self._index_current_file()
+
+    def _candidate_order(self, seq_len: int, *, hard_fraction: float, hard_subset: bool) -> np.ndarray:
+        if self.doc_order.size == 0:
+            return self.doc_order
+        lengths = self.doc_ends - self.doc_starts
+        valid = self.doc_order[lengths[self.doc_order] >= seq_len + 1]
+        if not hard_subset or valid.size == 0:
+            return valid
+        top_k = max(1, int(math.ceil(valid.size * max(min(hard_fraction, 1.0), 0.0))))
+        return valid[:top_k]
+
+    def _take_from_order(self, order: np.ndarray, seq_len: int, *, hard_subset: bool) -> Tensor | None:
+        if order.size == 0:
+            return None
+        cursor_name = "hard_cursor" if hard_subset else "cursor"
+        cursor = getattr(self, cursor_name)
+        for _ in range(order.size):
+            local_doc_idx = int(order[cursor % order.size])
+            doc_start = int(self.doc_starts[local_doc_idx])
+            doc_end = int(self.doc_ends[local_doc_idx])
+            doc_len = doc_end - doc_start
+            if doc_len < seq_len + 1:
+                cursor += 1
+                continue
+            offset = self.doc_offsets.get(local_doc_idx, 0)
+            if offset + seq_len + 1 > doc_len:
+                offset = 0
+            window_start = doc_start + offset
+            self.doc_offsets[local_doc_idx] = offset + seq_len
+            setattr(self, cursor_name, cursor + 1)
+            return self.tokens[window_start : window_start + seq_len + 1]
+        setattr(self, cursor_name, cursor)
+        return None
+
+    def take_windows(self, total_seqs: int, seq_len: int, *, kd_mode: str, kd_alpha: float, kd_hard_fraction: float) -> Tensor:
+        windows: list[Tensor] = []
+        hard_target = 0
+        if kd_mode == "hard_subset" and self.doc_priorities is not None and kd_alpha > 0:
+            hard_target = min(total_seqs, int(round(total_seqs * max(min(kd_alpha, 1.0), 0.0))))
+        file_attempts = 0
+        while len(windows) < total_seqs:
+            order = self._candidate_order(seq_len, hard_fraction=kd_hard_fraction, hard_subset=len(windows) < hard_target)
+            window = self._take_from_order(order, seq_len, hard_subset=len(windows) < hard_target)
+            if window is not None:
+                windows.append(window)
+                file_attempts = 0
+                continue
+            self._advance_file()
+            file_attempts += 1
+            if file_attempts > len(self.files) * 2:
+                raise ValueError(f"no doc-aware windows found for seq_len={seq_len} and bos_id={self.bos_id}")
+        return torch.stack(windows, dim=0)
+
+
+class DistributedDocTokenLoader:
+    def __init__(
+        self,
+        pattern: str,
+        rank: int,
+        world_size: int,
+        device: torch.device,
+        *,
+        bos_id: int,
+        doc_priorities: np.ndarray | None = None,
+        kd_mode: str = "none",
+        kd_hard_fraction: float = 0.05,
+        kd_alpha: float = 0.0,
+    ):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = DocTokenStream(pattern, bos_id=bos_id, doc_priorities=doc_priorities)
+        self.fallback_stream = TokenStream(pattern)
+        self.kd_mode = kd_mode
+        self.kd_hard_fraction = kd_hard_fraction
+        self.kd_alpha = kd_alpha
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        local_seqs = local_tokens // seq_len
+        total_seqs = local_seqs * self.world_size
+        try:
+            chunk = self.stream.take_windows(
+                total_seqs,
+                seq_len,
+                kd_mode=self.kd_mode,
+                kd_alpha=self.kd_alpha,
+                kd_hard_fraction=self.kd_hard_fraction,
+            )
+        except ValueError:
+            per_rank_span = local_tokens + 1
+            chunk = self.fallback_stream.take(per_rank_span * self.world_size).reshape(self.world_size, per_rank_span)
+            local = chunk[self.rank].to(dtype=torch.int64)
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+        local = chunk[self.rank * local_seqs : (self.rank + 1) * local_seqs].to(dtype=torch.int64)
+        x = local[:, :-1]
+        y = local[:, 1:]
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.register_buffer("qat_mix", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("qat_cached_weight", self.weight.detach().clone(), persistent=False)
+
+    def refresh_qat_cache(self) -> None:
+        with torch.no_grad():
+            self.qat_cached_weight.copy_(self.weight.detach() if self.weight.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL else fake_quantize_like_export(self.weight.detach()))
+
+    def forward(self, x: Tensor) -> Tensor:
+        weight = self.weight
+        if weight.numel() > INT8_KEEP_FLOAT_MAX_NUMEL:
+            cached = self.qat_cached_weight.to(dtype=weight.dtype)
+            weight = weight + self.qat_mix.to(dtype=weight.dtype) * (cached - weight).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, weight.to(x.dtype), bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+class MLP(nn.Module):
+    # relu^2 MLP from the original modded-nanogpt setup
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        block_gate_mode: str,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.mlp_gate = CastedLinear(dim, 1, bias=False) if block_gate_mode == "mlp_error" else None
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        x_in = x
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        mlp_out = self.mlp(self.mlp_norm(x))
+        mlp_resid = self.mlp_scale.to(dtype=x.dtype)[None, None, :] * mlp_out
+        if self.mlp_gate is not None:
+            err = F.rms_norm(x - x_in, (x.size(-1),))
+            mlp_resid = torch.sigmoid(self.mlp_gate(err)) * mlp_resid
+        x = x + mlp_resid
+        return x
+
+class CTMBridge(nn.Module):
+    # Mayer-style select-organize-integrate bottleneck:
+    # select salient tokens -> organize them in a tiny workspace -> integrate back once.
+    def __init__(
+        self, dim: int, workspace_dim: int, num_slots: int, novelty_gain: float, salience_gain: float, share_read: bool
+    ):
+        super().__init__()
+        self.norm = RMSNorm()
+        self.select_proj = CastedLinear(dim, num_slots, bias=False)
+        self.read_proj = None if share_read else CastedLinear(dim, num_slots, bias=False)
+        self.to_workspace = CastedLinear(dim, workspace_dim, bias=False)
+        self.to_model = CastedLinear(workspace_dim, dim, bias=False)
+        self.token_gate = CastedLinear(dim, 1, bias=False)
+        self.slot_mix = nn.Parameter(torch.eye(num_slots, dtype=torch.float32))
+        self.error_gain = nn.Parameter(torch.ones(num_slots, dtype=torch.float32))
+        self.ctm_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.novelty_gain = float(novelty_gain)
+        self.salience_gain = float(salience_gain)
+        self.share_read = share_read
+
+    @staticmethod
+    def _shift_right(x: Tensor) -> Tensor:
+        # Strictly past-only workspace reads: token t can only access summaries
+        # written by positions < t.
+        return torch.cat((torch.zeros_like(x[:, :1]), x[:, :-1]), dim=1)
+
+    @staticmethod
+    def _running_mean(x: Tensor) -> Tensor:
+        steps = torch.arange(1, x.size(1) + 1, device=x.device, dtype=x.dtype).view(1, -1, 1)
+        return torch.cumsum(x, dim=1) / steps
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        h = self.norm(x)
+        # Predictive-coding proxy: tokens that changed most from the input stream
+        # get more chance to enter the limited-capacity workspace.
+        novelty = (h - x0.to(dtype=h.dtype)).square().mean(dim=-1, keepdim=True)
+        novelty = novelty / self._running_mean(novelty).clamp_min(1e-6)
+        salience = h.square().mean(dim=-1, keepdim=True)
+        salience = salience / self._running_mean(salience).clamp_min(1e-6)
+        gate_signal = self.novelty_gain * novelty + self.salience_gain * salience
+        token_gate = torch.sigmoid(self.token_gate(h) + gate_signal)
+        write_logits = self.select_proj(h)
+        write_logits = write_logits + self.error_gain.to(dtype=h.dtype)[None, None, :] * gate_signal
+        write_weights = write_logits.softmax(dim=-1) * token_gate
+        workspace_values = self.to_workspace(h)[:, :, None, :]
+        slot_num = torch.cumsum(write_weights[..., None] * workspace_values, dim=1)
+        slot_den = torch.cumsum(write_weights, dim=1)
+        slot_num = self._shift_right(slot_num)
+        slot_den = self._shift_right(slot_den)
+        slot_state = slot_num / slot_den[..., None].clamp_min(1e-6)
+        mixed = torch.einsum("ij,btjd->btid", self.slot_mix.to(dtype=slot_state.dtype), slot_state)
+        read_logits = self.select_proj(h) if self.share_read else self.read_proj(h)
+        read_weights = read_logits.softmax(dim=-1)
+        context = torch.einsum("bts,btsd->btd", read_weights, mixed)
+        integrated = token_gate * self.to_model(context)
+        return x + self.ctm_scale.to(dtype=x.dtype)[None, None, :] * integrated
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        ctm_slots: int,
+        ctm_dim: int,
+        ctm_novelty_gain: float,
+        ctm_salience_gain: float,
+        ctm_share_read: bool,
+        ctm_decoder_refresh_every: int,
+        skip_gate_mode: str,
+        block_gate_mode: str,
+        late_group_gate_mode: str,
+        late_group_size: int,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.num_unique_layers = min(num_layers, max(1, int(os.environ.get("NUM_UNIQUE_LAYERS", "0")) or num_layers))
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.register_buffer("qat_mix", torch.zeros((), dtype=torch.float32), persistent=False)
+        self.register_buffer("tok_emb_qat_cached", self.tok_emb.weight.detach().clone(), persistent=False)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.ctm_decoder_refresh_every = max(0, ctm_decoder_refresh_every)
+        self.late_group_size = min(max(0, late_group_size), self.num_decoder_layers)
+        self.skip_gate_mode = skip_gate_mode
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.skip_gates = nn.ModuleList([CastedLinear(model_dim, 1, bias=False) for _ in range(self.num_skip_weights)]) if skip_gate_mode == "error" else None
+        self.late_group_gate = CastedLinear(model_dim, 1, bias=False) if late_group_gate_mode == "error" and self.late_group_size > 0 else None
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                    block_gate_mode,
+                )
+                for i in range(self.num_unique_layers)
+            ]
+        )
+        self.ctm = CTMBridge(model_dim, ctm_dim, ctm_slots, ctm_novelty_gain, ctm_salience_gain, ctm_share_read) if ctm_slots > 0 and ctm_dim > 0 else None
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+
+    def set_qat_mix(self, mix: float) -> None:
+        mix = float(min(max(mix, 0.0), 1.0))
+        self.qat_mix.fill_(mix)
+        for module in self.modules():
+            if isinstance(module, CastedLinear):
+                module.qat_mix.fill_(mix)
+
+    def refresh_qat_cache(self) -> None:
+        with torch.no_grad():
+            self.tok_emb_qat_cached.copy_(self.tok_emb.weight.detach() if self.tok_emb.weight.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL else fake_quantize_like_export(self.tok_emb.weight.detach()))
+        for module in self.modules():
+            if isinstance(module, CastedLinear):
+                module.refresh_qat_cache()
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        tok_weight = self.tok_emb.weight
+        if tok_weight.numel() > INT8_KEEP_FLOAT_MAX_NUMEL:
+            tok_weight = tok_weight + self.qat_mix.to(dtype=tok_weight.dtype) * (self.tok_emb_qat_cached.to(dtype=tok_weight.dtype) - tok_weight).detach()
+        x = F.embedding(input_ids, tok_weight)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+
+        # First half stores skips; second half reuses them in reverse order.
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i % self.num_unique_layers](x, x0)
+            skips.append(x)
+        if self.ctm is not None:
+            x = self.ctm(x, x0)
+        group_gate = None
+        for i in range(self.num_decoder_layers):
+            x_in = x
+            if self.late_group_gate is not None and i == self.num_decoder_layers - self.late_group_size:
+                probe = skips[-1] if skips else x
+                group_gate = torch.sigmoid(self.late_group_gate(F.rms_norm(x - probe.to(dtype=x.dtype), (x.size(-1),))))
+            if skips:
+                skip = skips.pop()
+                skip_resid = self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skip
+                if self.skip_gates is not None:
+                    err = F.rms_norm(x - skip.to(dtype=x.dtype), (x.size(-1),))
+                    skip_resid = torch.sigmoid(self.skip_gates[i](err)) * skip_resid
+                x = x + skip_resid
+            x = self.blocks[(self.num_encoder_layers + i) % self.num_unique_layers](x, x0)
+            if self.ctm is not None and self.ctm_decoder_refresh_every > 0 and i + 1 < self.num_decoder_layers and (i + 1) % self.ctm_decoder_refresh_every == 0:
+                x = self.ctm(x, x0)
+            if group_gate is not None:
+                x = x_in + group_gate * (x - x_in)
+
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, tok_weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+
+# TRAINING
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    if Hyperparameters.compile_zeropower:
+        zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    curriculum = CurriculumSchedule(args)
+    doc_priorities = load_doc_priorities(args.doc_score_path)
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+    log0(
+        f"data_strategy raw_prep_mode:{args.raw_prep_mode} curriculum_mode:{args.curriculum_mode} "
+        f"curriculum_progress_mode:{args.curriculum_progress_mode} curriculum_seq_lens:{curriculum.seq_lens} doc_aware_probs:{curriculum.doc_probs} "
+        f"kd_mode:{args.kd_mode} kd_alpha:{args.kd_alpha:.3f} kd_hard_fraction:{args.kd_hard_fraction:.3f}"
+    )
+    if args.doc_score_path:
+        log0(f"doc_score_path:{args.doc_score_path} priorities:{0 if doc_priorities is None else int(doc_priorities.size)}")
+
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        ctm_slots=args.ctm_slots,
+        ctm_dim=args.ctm_dim,
+        ctm_novelty_gain=args.ctm_novelty_gain,
+        ctm_salience_gain=args.ctm_salience_gain,
+        ctm_share_read=args.ctm_share_read,
+        ctm_decoder_refresh_every=args.ctm_decoder_refresh_every,
+        skip_gate_mode=args.skip_gate_mode,
+        block_gate_mode=args.block_gate_mode,
+        late_group_gate_mode=args.late_group_gate_mode,
+        late_group_size=args.late_group_size,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    base_model.set_qat_mix(0.0)
+    base_model.refresh_qat_cache()
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True) if args.compile_model else base_model
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    model_named_params = [
+        (name, p)
+        for name, p in base_model.named_parameters()
+        if not name.startswith("tok_emb.") and not name.startswith("lm_head.")
+    ]
+    matrix_params = [
+        p
+        for name, p in model_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in model_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads} unique_layers:{base_model.num_unique_layers}")
+    log0(f"ctm_bridge slots:{args.ctm_slots} dim:{args.ctm_dim} novelty_gain:{args.ctm_novelty_gain:.2f} salience_gain:{args.ctm_salience_gain:.2f} share_read:{int(args.ctm_share_read)}")
+    log0(f"skip_gate_mode:{args.skip_gate_mode}")
+    log0(f"block_gate_mode:{args.block_gate_mode}")
+    log0(f"ctm_decoder_refresh_every:{args.ctm_decoder_refresh_every}")
+    log0(f"late_group_gate_mode:{args.late_group_gate_mode} late_group_size:{args.late_group_size}")
+    log0(f"qat_mode:{args.qat_mode} qat_start_frac:{args.qat_start_frac:.2f}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    doc_train_loader: DistributedDocTokenLoader | None = None
+    bos_id = int(sp.bos_id())
+    if curriculum.enabled and bos_id >= 0:
+        doc_train_loader = DistributedDocTokenLoader(
+            args.train_files,
+            rank,
+            world_size,
+            device,
+            bos_id=bos_id,
+            doc_priorities=doc_priorities,
+            kd_mode=args.kd_mode,
+            kd_hard_fraction=args.kd_hard_fraction,
+            kd_alpha=args.kd_alpha,
+        )
+    elif curriculum.enabled and rank == 0:
+        log0("WARNING: disabling doc-aware sampling because tokenizer has no BOS token")
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    def qat_mix(step: int, elapsed_ms: float) -> float:
+        if args.qat_mode != "export_int8":
+            return 0.0
+        progress = min(elapsed_ms / max_wallclock_ms, 1.0) if max_wallclock_ms is not None else (1.0 if args.iterations <= 1 else step / max(args.iterations - 1, 1))
+        return 0.0 if progress <= args.qat_start_frac else (progress - args.qat_start_frac) / max(1.0 - args.qat_start_frac, 1e-6)
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            warmup_seq_len = curriculum.train_seq_len(warmup_step, args.iterations, args.train_seq_len, 0.0, max_wallclock_ms)
+            warmup_doc_prob = curriculum.doc_aware_prob(warmup_step, args.iterations, 0.0, max_wallclock_ms)
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                loader = doc_train_loader if doc_train_loader is not None and warmup_doc_prob >= 1.0 else train_loader
+                x, y = loader.next_batch(args.train_batch_tokens, warmup_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps} seq_len:{warmup_seq_len}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        base_model.set_qat_mix(0.0)
+        base_model.refresh_qat_cache()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+        if doc_train_loader is not None:
+            doc_train_loader = DistributedDocTokenLoader(
+                args.train_files,
+                rank,
+                world_size,
+                device,
+                bos_id=bos_id,
+                doc_priorities=doc_priorities,
+                kd_mode=args.kd_mode,
+                kd_hard_fraction=args.kd_hard_fraction,
+                kd_alpha=args.kd_alpha,
+            )
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        step_qat_mix = qat_mix(step, elapsed_ms)
+        base_model.set_qat_mix(step_qat_mix)
+        if step_qat_mix > 0.0:
+            base_model.refresh_qat_cache()
+        step_seq_len = curriculum.train_seq_len(step, args.iterations, args.train_seq_len, elapsed_ms, max_wallclock_ms)
+        step_doc_prob = curriculum.doc_aware_prob(step, args.iterations, elapsed_ms, max_wallclock_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            loader = (
+                doc_train_loader
+                if doc_train_loader is not None and should_use_doc_loader(step, micro_step, step_doc_prob)
+                else train_loader
+            )
+            x, y = loader.next_batch(args.train_batch_tokens, step_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms "
+                f"seq_len:{step_seq_len} doc_prob:{step_doc_prob:.2f} qat_mix:{step_qat_mix:.2f}"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    base_model.set_qat_mix(0.0)
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a standalone non-record snapshot under `records/track_non_record_16mb/2026-03-20_CTMTailQAT_Proxy1xH100_KHUCHAN`
- package the current best 1xH100 proxy run for the causal CTM + error-gated skip + export-matched tail-QAT recipe
- include the exact `train_gpt.py` snapshot, `train.log`, `README.md`, and `submission.json`

## Notes
- this is intentionally **not** a main-leaderboard claim
- the logged run is a `1xH100`, `10`-shard, `20 minute` proxy run
- the exact logged score is `val_bpb = 1.29167890`
- the logged standalone artifact is `16,009,531` bytes, so this folder is submitted as an honest non-record in-progress snapshot rather than a record attempt
- the README also notes that the root script was later code-trimmed, but that exact rerun is not included here