### PR TITLE
docs: add local NVIDIA GPU workflow

### DIFF
--- a/Dockerfile.local-gpu
+++ b/Dockerfile.local-gpu
@@ -1,0 +1,25 @@
+FROM pytorch/pytorch:2.4.1-cuda12.4-cudnn9-runtime
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PYTHONUNBUFFERED=1
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash build-essential ca-certificates curl git jq \
+  && rm -rf /var/lib/apt/lists/*
+
+# Parameter Golf currently expects torch 2.10 features such as enable_gqa in
+# scaled_dot_product_attention. The base image gives us a working CUDA user-space
+# stack; pip upgrades torch to the challenge-expected version.
+RUN pip install --no-cache-dir --upgrade pip \
+  && pip install --no-cache-dir --upgrade \
+    torch==2.10.0 \
+    numpy \
+    tqdm \
+    huggingface-hub \
+    datasets \
+    sentencepiece \
+    tiktoken
+
+WORKDIR /workspace
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -79,6 +79,45 @@ python3 train_gpt_mlx.py
 
 Validation always runs on the full `fineweb_val_*` split, which is the fixed first-50k-document set. The smoke command above skips periodic validation and just prints the final `val_loss` and `val_bpb` once at the end.
 
+### Local NVIDIA GPU workflow (consumer / workstation Linux)
+
+If you have a local NVIDIA GPU and Docker with the NVIDIA container runtime, you can use the repo-local helper image to validate the trainer on a consumer GPU before moving to cloud runs.
+
+Build the image:
+
+```bash
+docker build -f Dockerfile.local-gpu -t parameter-golf-local:torch2.10-cu128-gcc .
+```
+
+This image intentionally:
+- starts from a CUDA-capable PyTorch runtime,
+- upgrades to `torch==2.10.0` (needed for current trainer features such as GQA support in `scaled_dot_product_attention`), and
+- installs `build-essential` so Triton/Inductor can compile local kernels.
+
+Then run a local one-GPU smoke:
+
+```bash
+docker run --rm --gpus all \
+  -v "$PWD":/workspace/parameter-golf \
+  -w /workspace/parameter-golf \
+  parameter-golf-local:torch2.10-cu128-gcc \
+  bash -lc '
+    python3 data/cached_challenge_fineweb.py --variant sp1024 --train-shards 1 &&
+    RUN_ID=local_cuda_smoke \
+    DATA_PATH=./data/datasets/fineweb10B_sp1024 \
+    TOKENIZER_PATH=./data/tokenizers/fineweb_1024_bpe.model \
+    VOCAB_SIZE=1024 \
+    ITERATIONS=80 \
+    WARMUP_STEPS=4 \
+    TRAIN_LOG_EVERY=10 \
+    VAL_LOSS_EVERY=0 \
+    MAX_WALLCLOCK_SECONDS=240 \
+    torchrun --standalone --nproc_per_node=1 train_gpt.py
+  '
+```
+
+This local path is for iteration and compatibility checking only; official leaderboard submissions still need to satisfy the published artifact and runtime rules.
+
 ### Scaling Up to a Remote Machine
 
 Once you're happy with your local tests, or you want more compute, switch to a remote CUDA machine.


### PR DESCRIPTION
## Summary
- add a repo-local `Dockerfile.local-gpu` for local NVIDIA GPU iteration on consumer/workstation Linux machines
- document a local single-GPU Docker workflow in the README
- pin the helper image to `torch==2.10.0` and include `build-essential` because the current trainer uses features and local Triton/Inductor compilation paths that fail on the stock 2.4.1 runtime image

## Why
The repo already has a friendly local Apple Silicon path and a remote Runpod/H100 path.
This PR adds a middle path for contributors who want to validate trainer compatibility and run short local ablations on an existing NVIDIA GPU before spending cloud credits.

## Notes
- this is explicitly an iteration/compatibility workflow, not a change to the official leaderboard rules
- the helper image is intentionally narrow and lives in the repo so the local command in the README is copy/pasteable
- I verified the containerized runtime on a local RTX 4070 path while debugging torch/triton compatibility issues around the current trainer
