### PR TITLE
[Record Submission] QAT Int5/Int6 + Backout + U-Net Skips + BigramHash(10240) + SWA50 — val_bpb=1.1477

### DIFF
--- a/records/track_10min_16mb/2026-03-20_QAT_Int5Int6_BigramHash_Backout_SWA50/README.md
+++ b/records/track_10min_16mb/2026-03-20_QAT_Int5Int6_BigramHash_Backout_SWA50/README.md
@@ -1,0 +1,68 @@
+# QAT Int5/Int6 + Backout + U-Net Skips + BigramHash(10240) + SWA50
+
+**val_bpb: 1.1477** (seed=42, sliding window stride=64, post int5/int6+zstd quantization roundtrip, 15.94 MB)
+
+## Run Command
+
+```bash
+pip install zstandard  # optional but recommended for better compression
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+All parameters are set as defaults in `train_gpt.py`. No env vars needed.
+Falls back to zlib if zstandard is not installed.
+
+## Key Techniques
+
+### Quantization-Aware Training (QAT)
+During training, large weight matrices pass through a simulated quantization bottleneck using the
+straight-through estimator (STE). MLP weights see int5 noise, attention weights see int6 noise.
+The model learns to be robust to quantization, reducing the post-quant penalty from ~0.016 BPB
+to ~0.005 BPB — roughly 0.01 BPB free compared to post-training quantization alone.
+
+### Backout (Learned Residual Subtraction)
+A learned scalar λ (init=0.2) subtracts the midpoint layer's activation from the final output:
+`x = x - λ * x_mid`. Prevents over-reliance on early representations.
+
+### U-Net Skip Connections
+Encoder-decoder structure (5+5 layers) with learned per-dimension skip weights connecting
+encoder to decoder layers.
+
+### SVD Embedding Initialization
+Tied embeddings initialized via SVD spectral decay: singular values reshaped to follow a
+1/√k profile for better initial token representations.
+
+### Mixed Int5/Int6 Quantization + zstd-22
+- Int5 [-16,15] for MLP weights (most compressible)
+- Int6 [-32,31] for attention weights (precision-sensitive)
+- FP16 for tied embeddings and last-2-layer key projections (Late-K)
+
+### BigramHash(10240) + SmearGate
+Hash consecutive token pairs into 10240-bucket embedding table (dim=128, projected to 512).
+SmearGate blends each token with the previous token's embedding.
+
+### Stochastic Weight Averaging
+SWA every 50 steps during warmdown (start_frac=0.4). Smoother weight distributions quantize better.
+
+## Architecture
+- 10 layers, 512 dim, 8 heads, 4 KV heads (GQA)
+- MLP 3x expansion (hidden=1536), relu² activation
+- Tied embeddings, logit softcap=30
+- Orthogonal init with muP-scaled output projections
+
+## Hyperparameters
+
+| Parameter | Value |
+|-----------|-------|
+| matrix_lr (Muon) | 0.02 |
+| scalar_lr (AdamW) | 0.02 |
+| tied_embed_lr | 0.03 |
+| muon_weight_decay | 0.04 |
+| adamw_weight_decay | 0.01 |
+| warmdown_iters | 3000 |
+| swa_every / start_frac | 50 / 0.4 |
+| prune_frac | 0.08 |
+| eval_stride | 64 |
+| compressor | zstd-22 |
+
+Built on PR #162 by @unnir (SmearGate, BigramHash, OrthoInit) and techniques from @thwu1 and @raahilshah.

--- a/records/track_10min_16mb/2026-03-20_QAT_Int5Int6_BigramHash_Backout_SWA50/submission.json
+++ b/records/track_10min_16mb/2026-03-20_QAT_Int5Int6_BigramHash_Backout_SWA50/submission.json
@@ -1,0 +1,10 @@
+{
+  "name": "QAT Int5/Int6 + BigramHash(10240) + Backout + SWA50 + U-Net Skips",
+  "val_loss": 1.93785918,
+  "val_bpb": 1.14770936,
+  "bytes_total": 15935368,
+  "blurb": "Quantization-Aware Training (straight-through estimator) with int5 MLP / int6 attention. BigramHash 10240, SmearGate, Backout (learned residual subtraction), U-Net skip connections, SVD embedding init. Simple Muon + compiled Newton-Schulz5. SWA every 50 steps (start_frac=0.4). 8% magnitude pruning + zstd-22.",
+  "author": "gowtham0992",
+  "github_id": "gowtham0992",
+  "date": "2026-03-20"
+}

--- a/records/track_10min_16mb/2026-03-20_QAT_Int5Int6_BigramHash_Backout_SWA50/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-20_QAT_Int5Int6_BigramHash_Backout_SWA50/train_gpt.py
@@ -1,0 +1,750 @@
+"""Parameter Golf v17: Simple Muon + QAT + BigramHash + SWA50 + lower LRs. Targeting ~82ms/step."""
+from __future__ import annotations
+import copy, glob, io, math, os, random, subprocess, sys, time, uuid, zlib
+try:
+    import zstandard as zstd; HAS_ZSTD = True
+except ImportError: HAS_ZSTD = False
+from pathlib import Path
+import numpy as np
+import sentencepiece as spm
+import torch, torch.distributed as dist, torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# ── HYPERPARAMETERS ──
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 42))
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 500))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 0))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 256))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 10))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 3))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    # ── LRs: aligned with #1/#2 ──
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    # ── Simple Muon (no NorMuon) ──
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_ns_steps = int(os.environ.get("MUON_NS_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_wd = float(os.environ.get("MUON_WD", 0.04))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.01))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    smear_enabled = bool(int(os.environ.get("SMEAR_ENABLED", "1")))
+    backout_enabled = bool(int(os.environ.get("BACKOUT_ENABLED", "1")))
+    backout_init = float(os.environ.get("BACKOUT_INIT", 0.2))
+    # ── SWA: aggressive like #1 ──
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_interval = int(os.environ.get("SWA_INTERVAL", 50))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.4))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 10240))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    prune_frac = float(os.environ.get("PRUNE_FRAC", 0.08))
+
+# ── SIMPLE MUON (Newton-Schulz5 with fixed coefficients, like #1/#2) ──
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed: X = X.T
+    for _ in range(steps):
+        A = X @ X.T; B = b * A + c * A @ A; X = a * X + B @ X
+    return X.T if transposed else X
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr, momentum, ns_steps, wd=0.0, nesterov=True):
+        super().__init__(params, dict(lr=lr, momentum=momentum, ns_steps=ns_steps, wd=wd, nesterov=nesterov))
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad(): loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+        for group in self.param_groups:
+            params = group["params"]
+            if not params: continue
+            lr, momentum, ns_steps = group["lr"], group["momentum"], group["ns_steps"]
+            nesterov = group["nesterov"]
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad; state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]; buf.mul_(momentum).add_(g)
+                    if nesterov: g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=ns_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+            if distributed: dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+            wd = group.get("wd", 0.0)
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                if wd > 0: p.data.mul_(1.0 - lr * wd)
+                p.add_(g, alpha=-lr); curr += p.numel()
+        return loss
+
+# ── TOKENIZER-AGNOSTIC EVALUATION ──
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sp_vocab_size = int(sp.vocab_size()); table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for tid in range(sp_vocab_size):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid): continue
+        is_boundary_token_np[tid] = False
+        if sp.is_byte(tid): base_bytes_np[tid] = 1; continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"): has_leading_space_np[tid] = True; piece = piece[1:]
+        base_bytes_np[tid] = len(piece.encode("utf-8"))
+    return (torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+            torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+            torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device))
+
+def load_validation_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files: raise FileNotFoundError(f"No files: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0: raise ValueError(f"Val too short for seq_len={seq_len}")
+    return tokens[:usable + 1]
+
+def eval_val(args, model, rank, world_size, device, grad_accum_steps,
+             val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut, seq_len_override=0):
+    seq_len = seq_len_override if seq_len_override > 0 else args.train_seq_len
+    local_batch_seqs = args.val_batch_size // (world_size * grad_accum_steps) // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * rank) // world_size; seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+    with torch.inference_mode():
+        for bss in range(seq_start, seq_end, local_batch_seqs):
+            bse = min(bss + local_batch_seqs, seq_end)
+            local = val_tokens[bss*seq_len:(bse*seq_len)+1].to(device=device, dtype=torch.int64, non_blocking=True)
+            x, y = local[:-1].reshape(-1, seq_len), local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            val_loss_sum += batch_loss.to(torch.float64) * float(y.numel())
+            val_token_count += float(y.numel())
+            tb = base_bytes_lut[y.reshape(-1)].to(dtype=torch.int16)
+            tb += (has_leading_space_lut[y.reshape(-1)] & ~is_boundary_token_lut[x.reshape(-1)]).to(dtype=torch.int16)
+            val_byte_count += tb.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        for t in [val_loss_sum, val_token_count, val_byte_count]: dist.all_reduce(t, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bpt = val_loss.item() / math.log(2.0); tpb = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bpt * tpb)
+
+# ── QUANTIZATION (int5 MLP / int6 attn per-row + Late-K fp16) ──
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    p for p in os.environ.get("CONTROL_TENSOR_NAME_PATTERNS",
+    "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,"
+    "skip_weight,skip_weights,smear,backout_lambda,bigram.scale").split(",") if p)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    p for p in os.environ.get("INT8_KEEP_FLOAT_FP32_NAME_PATTERNS", ",".join(CONTROL_TENSOR_NAME_PATTERNS)).split(",") if p)
+FP16_KEEP_NAME_PATTERNS = tuple(
+    p for p in os.environ.get("FP16_KEEP_NAME_PATTERNS", "tok_emb").split(",") if p)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_Q = 99.99984 / 100.0
+
+def tensor_nbytes(t): return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name, t, po):
+    if any(p in name for p in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS): return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        po[name] = str(t.dtype).removeprefix("torch."); return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def _classify_param(name):
+    if "tok_emb" in name or "lm_head" in name: return "embed"
+    if ".mlp." in name: return "mlp"
+    if "bigram" in name: return "bigram"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name): return "attn"
+    return "other"
+
+def quantize_intN_per_row(t, clip_range=31):
+    t32 = t.float()
+    if t32.ndim == 2:
+        row_max = t32.abs().amax(dim=1)
+        scale = (row_max / clip_range).clamp_min(1e-12).to(torch.float16)
+        scale = scale.clamp_min(torch.finfo(torch.float16).tiny)
+        q = torch.clamp(torch.round(t32 / scale.float()[:, None]), -(clip_range+1), clip_range).to(torch.int8)
+        return q, scale
+    amax = t32.abs().max().item()
+    scale = torch.tensor(max(amax / clip_range, 1e-12), dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -(clip_range+1), clip_range).to(torch.int8)
+    return q, scale
+
+def quantize_state_dict_mixed(state_dict):
+    """Mixed int5/int6/int8 quantization with per-row scales."""
+    result, meta = {}, {}
+    num_layers_total = max((int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")), default=0) + 1
+    late_k_layers = set(range(num_layers_total - 2, num_layers_total))
+    int6_cats = {"mlp", "attn", "bigram"}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 8192:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"; continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float(); meta[name] = "passthrough_ctrl"; continue
+        if any(p in name for p in FP16_KEEP_NAME_PATTERNS):
+            result[name] = t.to(dtype=torch.float16).contiguous(); meta[name] = "passthrough_fp16"; continue
+        if name.endswith("c_k.weight") and any(f"blocks.{i}." in name for i in late_k_layers):
+            result[name] = t.to(dtype=torch.float16).contiguous(); meta[name] = "passthrough_fp16"; continue
+        if cat in int6_cats and t.ndim >= 1 and t.numel() > INT8_KEEP_FLOAT_MAX_NUMEL:
+            clip = 15 if cat == "mlp" else 31
+            q, s = quantize_intN_per_row(t, clip_range=clip)
+            result[name + ".q"] = q; result[name + ".scale"] = s
+            meta[name] = {"type": f"int{5 if cat == 'mlp' else 6}"}; continue
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, {}); result[name] = kept
+            meta[name] = "passthrough"; continue
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1) if t32.numel() else torch.empty((t32.shape[0],), dtype=torch.float32)
+            clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+            result[name + ".q"] = q; result[name + ".scale"] = scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+            scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+            result[name + ".q"] = q; result[name + ".scale"] = scale
+        meta[name] = {"type": "int8"}
+    return result, meta
+
+def dequantize_state_dict_mixed(result, meta, template_sd):
+    out = {}
+    for name, orig in template_sd.items():
+        info = meta[name]; orig_dtype = orig.dtype
+        if isinstance(info, str) and info.startswith("passthrough"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16): t = t.to(orig_dtype)
+            out[name] = t; continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1]*(q.ndim-1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+# ── DATA LOADING ──
+def load_data_shard(file):
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1: raise ValueError(f"Bad header: {file}")
+    num_tokens = int(header[2])
+    if file.stat().st_size != header_bytes + num_tokens * np.dtype("<u2").itemsize: raise ValueError(f"Size mismatch: {file}")
+    return torch.from_numpy(np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes).astype(np.uint16, copy=False))
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files: raise FileNotFoundError(f"No files: {pattern}")
+        self.file_idx = 0; self.tokens = load_data_shard(self.files[0]); self.pos = 0
+    def _advance_file(self):
+        self.file_idx = (self.file_idx + 1) % len(self.files); self.tokens = load_data_shard(self.files[self.file_idx]); self.pos = 0
+    def take(self, n):
+        chunks, remaining = [], n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0: self._advance_file(); continue
+            k = min(remaining, avail); chunks.append(self.tokens[self.pos:self.pos+k]); self.pos += k; remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+class DistributedTokenLoader:
+    def __init__(self, pattern, rank, world_size, device):
+        self.rank, self.world_size, self.device = rank, world_size, device; self.stream = TokenStream(pattern)
+    def next_batch(self, global_tokens, seq_len, grad_accum_steps):
+        per_rank_span = global_tokens // (self.world_size * grad_accum_steps) + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span; local = chunk[start:start+per_rank_span].to(dtype=torch.int64)
+        x, y = local[:-1].reshape(-1, seq_len), local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# ── TRANSFORMER MODULES ──
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None): super().__init__(); self.eps = eps
+    def forward(self, x): return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+class CastedLinear(nn.Linear):
+    _qat_levels: int = 0
+    def forward(self, x):
+        w = self.weight
+        if self._qat_levels > 0 and self.training and w.ndim == 2:
+            w_f = w.float()
+            clip_abs = w_f.abs().amax(dim=1, keepdim=True).clamp_min(1e-12)
+            scale = clip_abs / float(self._qat_levels)
+            w_q = (w_f / scale).round().clamp(-self._qat_levels, self._qat_levels) * scale
+            w = w + (w_q - w_f).detach()
+        return F.linear(x, w.to(x.dtype), self.bias.to(x.dtype) if self.bias is not None else None)
+
+def restore_low_dim_params_to_fp32(module):
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=10000.0, train_seq_len=1024):
+        super().__init__(); self.dim, self.base, self.train_seq_len = dim, base, train_seq_len
+        self.register_buffer("inv_freq", 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim)), persistent=False)
+        self._seq_len_cached = 0; self._cos_cached = self._sin_cached = None
+    def forward(self, seq_len, device, dtype):
+        if self._cos_cached is None or self._seq_len_cached != seq_len or self._cos_cached.device != device:
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                adjusted_base = self.base * (scale ** (self.dim / (self.dim - 2)))
+                inv_freq = 1.0 / (adjusted_base ** (torch.arange(0, self.dim, 2, dtype=torch.float32, device=device) / self.dim))
+            else: inv_freq = self.inv_freq.to(device)
+            freqs = torch.outer(torch.arange(seq_len, device=device, dtype=inv_freq.dtype), inv_freq)
+            self._cos_cached = freqs.cos()[None, None, :, :]; self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+def apply_rotary_emb(x, cos, sin):
+    half = x.size(-1) // 2; x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len=1024):
+        super().__init__()
+        self.num_heads, self.num_kv_heads = num_heads, num_kv_heads; self.head_dim = dim // num_heads
+        kv_dim = num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False); self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False); self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len)
+    def forward(self, x):
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q, k = apply_rotary_emb(q, cos, sin), apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True, enable_gqa=(self.num_kv_heads != self.num_heads))
+        return self.proj(y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim))
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        self.fc = CastedLinear(dim, mlp_mult * dim, bias=False); self.proj = CastedLinear(mlp_mult * dim, dim, bias=False)
+        self.proj._zero_init = True
+    def forward(self, x): return self.proj(torch.relu(self.fc(x)).square())
+
+class SmearGate(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+    def forward(self, x):
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size, bigram_dim, model_dim):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None: nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+    def bigram_hash(self, tokens):
+        t = tokens.to(torch.int32); mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t); out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+    def forward(self, token_ids):
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None: h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class Block(nn.Module):
+    def __init__(self, dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init, train_seq_len=1024):
+        super().__init__()
+        self.attn_norm, self.mlp_norm = RMSNorm(), RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+    def forward(self, x, x0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None,None,:] * x + mix[1][None,None,:] * x0
+        n = self.attn_norm(x); x = x + self.attn_scale.to(dtype=x.dtype)[None,None,:] * self.attn(n)
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None,None,:] * self.mlp(self.mlp_norm(x)); return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size, num_layers, model_dim, num_heads, num_kv_heads,
+                 mlp_mult, tie_embeddings, tied_embed_init_std, logit_softcap,
+                 rope_base, qk_gain_init, train_seq_len=1024,
+                 smear_enabled=True, backout_enabled=True, backout_init=0.2,
+                 bigram_vocab_size=0, bigram_dim=128):
+        super().__init__()
+        self.tie_embeddings, self.tied_embed_init_std = tie_embeddings, tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.smear_enabled, self.backout_enabled, self.num_layers = smear_enabled, backout_enabled, num_layers
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList([Block(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init, train_seq_len) for _ in range(num_layers)])
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None: self.lm_head._zero_init = True
+        self.smear = SmearGate(model_dim) if smear_enabled else None
+        self.backout_lambda = nn.Parameter(backout_init * torch.ones(1)) if backout_enabled else None
+        self._init_weights()
+    def _init_weights(self):
+        for name, param in self.named_parameters():
+            if param.ndim == 2 and param.numel() > INT8_KEEP_FLOAT_MAX_NUMEL:
+                nn.init.orthogonal_(param, gain=1.0)
+                if "proj.weight" in name:
+                    with torch.no_grad(): param.mul_(1.0 / math.sqrt(2 * self.num_layers))
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+            with torch.no_grad():
+                U, S, V = torch.linalg.svd(self.tok_emb.weight.data, full_matrices=False)
+                target_S = S[0] * (1.0 / torch.arange(1, S.shape[0]+1, dtype=S.dtype)) ** 0.5
+                self.tok_emb.weight.data = (U * target_S[None, :]) @ V
+        for m in self.modules():
+            if isinstance(m, nn.Linear) and getattr(m, "_zero_init", False): nn.init.zeros_(m.weight)
+        nl = len(self.blocks)
+        for i, block in enumerate(self.blocks):
+            with torch.no_grad():
+                phase = torch.sigmoid(torch.tensor(3.0 * (i / max(nl-1, 1) - 0.5)))
+                block.resid_mix.data[0] = phase * torch.ones(block.resid_mix.shape[1])
+                block.resid_mix.data[1] = (1-phase) * torch.ones(block.resid_mix.shape[1])
+    def _run_layers(self, x, x0):
+        skips, backout_layer, x_backout = [], self.num_layers // 2, None
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0); skips.append(x)
+            if i == backout_layer: x_backout = x
+        for i in range(self.num_decoder_layers):
+            li = self.num_encoder_layers + i
+            if skips: x = x + self.skip_weights[i].to(dtype=x.dtype)[None,None,:] * skips.pop()
+            x = self.blocks[li](x, x0)
+            if li == backout_layer and x_backout is None: x_backout = x
+        if self.backout_lambda is not None and x_backout is not None: x = x - self.backout_lambda.to(x.dtype) * x_backout
+        return x
+    def _embed(self, input_ids):
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None: x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (self.tok_emb.weight.shape[1],))
+        if self.smear is not None: x = self.smear(x)
+        return x
+    def forward(self, input_ids, target_ids):
+        x0 = self._embed(input_ids); x = self._run_layers(x0, x0)
+        x_flat = self.final_norm(x).reshape(-1, x.size(-1)); targets = target_ids.reshape(-1)
+        logits_proj = F.linear(x_flat, self.tok_emb.weight) if self.tie_embeddings else self.lm_head(x_flat)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+    def forward_logits(self, input_ids):
+        x0 = self._embed(input_ids); x = self.final_norm(self._run_layers(x0, x0))
+        logits = F.linear(x, self.tok_emb.weight.to(x.dtype)) if self.tie_embeddings else self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+
+# ── SLIDING WINDOW EVAL ──
+def eval_val_sliding(logits_fn, rank, world_size, device, val_tokens,
+                     base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+                     seq_len, stride, eval_batch_seqs=256):
+    total = val_tokens.numel() - 1; windows, p = [], 0
+    while p + seq_len <= total:
+        s = 0 if p == 0 else (seq_len - stride); windows.append((p, s)); p += stride
+    n = len(windows); per_rank = (n + world_size - 1) // world_size
+    my_windows = windows[rank*per_rank:min((rank+1)*per_rank, n)]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    tok_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    with torch.inference_mode():
+        for i in range(0, len(my_windows), eval_batch_seqs):
+            batch = my_windows[i:i+eval_batch_seqs]; bs = len(batch)
+            x_list = [val_tokens[w:w+seq_len] for w, _ in batch]
+            y_list = [val_tokens[w+1:w+seq_len+1] for w, _ in batch]
+            pad = eval_batch_seqs - bs
+            if pad > 0: x_list.extend([x_list[-1]]*pad); y_list.extend([y_list[-1]]*pad)
+            x = torch.stack(x_list).to(device=device, dtype=torch.int64)
+            y = torch.stack(y_list).to(device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16): logits = logits_fn(x)
+            for b in range(bs):
+                s = batch[b][1]; sl, st = logits[b, s:], y[b, s:]
+                loss_sum += F.cross_entropy(sl.float(), st, reduction="sum").to(torch.float64)
+                ns = st.numel(); tok_count += ns
+                prev, tgt = x[b, s:s+ns], st
+                tb = base_bytes_lut[tgt].to(torch.int16)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.int16)
+                byte_count += tb.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        for t in [loss_sum, tok_count, byte_count]: dist.all_reduce(t, op=dist.ReduceOp.SUM)
+    vl = (loss_sum / tok_count).item()
+    return vl, vl / math.log(2.0) * (tok_count.item() / byte_count.item())
+
+# ── MAIN ──
+def main():
+    global zeropower_via_newtonschulz5
+    code = Path(__file__).read_text(encoding="utf-8"); args = Hyperparameters()
+    # Compile Newton-Schulz for speed (like #1)
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0")); world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0 or 8 % world_size != 0: raise ValueError(f"Bad WORLD_SIZE={world_size}")
+    grad_accum_steps = 8 // world_size; grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available(): raise RuntimeError("CUDA required")
+    device = torch.device("cuda", local_rank); torch.cuda.set_device(device)
+    if distributed: dist.init_process_group(backend="nccl", device_id=device); dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True; torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False); enable_flash_sdp(True); enable_mem_efficient_sdp(False); enable_math_sdp(False)
+    logfile = None
+    if master_process: os.makedirs("logs", exist_ok=True); logfile = f"logs/{args.run_id}.txt"; print(logfile)
+    def log0(msg, console=True):
+        if not master_process: return
+        if console: print(msg)
+        if logfile:
+            with open(logfile, "a", encoding="utf-8") as f: print(msg, file=f)
+    log0(code, console=False); log0("=" * 100, console=False)
+    log0(f"Python {sys.version}", console=False); log0(f"PyTorch {torch.__version__}", console=False)
+    log0(subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout, console=False)
+    random.seed(args.seed); np.random.seed(args.seed); torch.manual_seed(args.seed); torch.cuda.manual_seed_all(args.seed)
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(sp, args.vocab_size, device)
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_tokens:{val_tokens.numel()-1}")
+    base_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init, train_seq_len=args.train_seq_len,
+        smear_enabled=args.smear_enabled, backout_enabled=args.backout_enabled,
+        backout_init=args.backout_init,
+        bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim,
+    ).to(device).bfloat16()
+    for m in base_model.modules():
+        if isinstance(m, CastedLinear): m.float()
+    restore_low_dim_params_to_fp32(base_model)
+    # Enable QAT: int5 for MLP weights, int6 for attention weights
+    for name, m in base_model.named_modules():
+        if isinstance(m, CastedLinear) and m.weight.ndim == 2 and m.weight.numel() > INT8_KEEP_FLOAT_MAX_NUMEL:
+            m._qat_levels = 15 if ".mlp." in name else 31
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True) if not bool(int(os.environ.get("TORCH_COMPILE_DISABLE", "0"))) else base_model
+    model = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [p for n, p in block_named_params if p.ndim == 2 and not any(pat in n for pat in CONTROL_TENSOR_NAME_PATTERNS)]
+    scalar_params = [p for n, p in block_named_params if p.ndim < 2 or any(pat in n for pat in CONTROL_TENSOR_NAME_PATTERNS)]
+    if base_model.skip_weights.numel() > 0: scalar_params.append(base_model.skip_weights)
+    if base_model.smear is not None: scalar_params.append(base_model.smear.gate)
+    if base_model.backout_lambda is not None: scalar_params.append(base_model.backout_lambda)
+    if base_model.bigram is not None: scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_param_groups = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_param_groups.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None: matrix_params.append(base_model.bigram.proj.weight)
+    optimizer_tok = torch.optim.AdamW(tok_param_groups,
+                                       betas=(args.beta1, args.beta2), eps=args.adam_eps, weight_decay=args.adam_wd, fused=True)
+    optimizer_muon = Muon(matrix_params, lr=args.matrix_lr, momentum=args.muon_momentum,
+                          ns_steps=args.muon_ns_steps, wd=args.muon_wd)
+    for group in optimizer_muon.param_groups: group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW([{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+                                          betas=(args.beta1, args.beta2), eps=args.adam_eps, weight_decay=args.adam_wd, fused=True)
+    optimizers = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam([{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+                                           betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True)
+        optimizers.insert(1, optimizer_head)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}"); log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    def zero_grad_all():
+        for opt in optimizers: opt.zero_grad(set_to_none=True)
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    def lr_mul(step, elapsed_ms):
+        if args.warmdown_iters <= 0: return 1.0
+        if max_wallclock_ms is None:
+            ws = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if step >= ws else 1.0
+        step_ms = elapsed_ms / max(step, 1); wd_ms = args.warmdown_iters * step_ms
+        rem_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return rem_ms / max(wd_ms, 1e-9) if rem_ms <= wd_ms else 1.0
+    # WARMUP
+    if args.warmup_steps > 0:
+        initial_model_state = {n: t.detach().cpu().clone() for n, t in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for ws in range(args.warmup_steps):
+            zero_grad_all()
+            for ms in range(grad_accum_steps):
+                if distributed: model.require_backward_grad_sync = ms == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    wl = model(x, y)
+                (wl * grad_scale).backward()
+            for opt in optimizers: opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (ws+1) % 10 == 0: log0(f"warmup_step:{ws+1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True): opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed: model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    # MAIN TRAINING LOOP
+    training_time_ms, stop_after_step = 0.0, None
+    swa_state, swa_count = None, 0
+    torch.cuda.synchronize(); t0 = time.perf_counter(); step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize(); training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            vl, vb = eval_val(args, model, rank, world_size, device, grad_accum_steps,
+                              val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut)
+            log0(f"step:{step}/{args.iterations} val_loss:{vl:.4f} val_bpb:{vb:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step,1):.2f}ms")
+            torch.cuda.synchronize(); t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms step:{step}/{args.iterations}")
+            break
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all(); train_loss = torch.zeros((), device=device)
+        for ms in range(grad_accum_steps):
+            if distributed: model.require_backward_grad_sync = ms == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True): loss = model(x, y)
+            train_loss += loss.detach(); (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = (1-frac)*args.muon_momentum_warmup_start + frac*args.muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups: group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0: torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers: opt.step()
+        zero_grad_all(); step += 1
+        approx_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        # SWA: collect during warmdown (like #1, every 50 steps when lr_scale < swa_start_frac)
+        if args.swa_enabled and scale < args.swa_start_frac and step % args.swa_interval == 0:
+            if swa_state is None:
+                swa_state = {n: t.detach().cpu().clone() for n, t in base_model.state_dict().items()}
+                swa_count = 1; log0(f"swa:start step:{step}")
+            else:
+                for n, t in base_model.state_dict().items(): swa_state[n] += t.detach().cpu()
+                swa_count += 1
+        if args.train_log_every > 0 and (step <= 10 or step % args.train_log_every == 0):
+            log0(f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} train_time:{approx_ms:.0f}ms step_avg:{approx_ms/step:.2f}ms")
+        reached_cap = max_wallclock_ms is not None and approx_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            rct = torch.tensor(int(reached_cap), device=device); dist.all_reduce(rct, op=dist.ReduceOp.MAX); reached_cap = bool(rct.item())
+        if stop_after_step is None and reached_cap: stop_after_step = step
+    log0(f"peak memory allocated: {torch.cuda.max_memory_allocated()//1024//1024} MiB reserved: {torch.cuda.max_memory_reserved()//1024//1024} MiB")
+    # SWA
+    if args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"SWA: averaging {swa_count} checkpoints")
+        current_sd = base_model.state_dict()
+        avg = {n: (t / swa_count).to(dtype=current_sd[n].dtype) for n, t in swa_state.items()}
+        base_model.load_state_dict(avg, strict=True); swa_state = None
+    # MAGNITUDE PRUNING
+    if args.prune_frac > 0:
+        with torch.no_grad():
+            for name, param in base_model.named_parameters():
+                if param.ndim == 2 and param.numel() > INT8_KEEP_FLOAT_MAX_NUMEL:
+                    threshold = torch.quantile(param.abs().float().flatten(), args.prune_frac)
+                    param.masked_fill_(param.abs() < threshold, 0.0)
+        log0(f"Magnitude pruning: zeroed {args.prune_frac*100:.1f}% of large weight entries")
+    # QUANTIZE + COMPRESS + SAVE
+    sd_cpu = {k: v.detach().cpu() for k, v in base_model.state_dict().items()}
+    quant_result, quant_meta = quantize_state_dict_mixed(sd_cpu)
+    quant_buf = io.BytesIO(); torch.save({"w": quant_result, "m": quant_meta}, quant_buf); quant_raw = quant_buf.getvalue()
+    if HAS_ZSTD:
+        model_blob = zstd.ZstdCompressor(level=22).compress(quant_raw); comp_name = "zstd22"
+    else:
+        model_blob = zlib.compress(quant_raw, level=9); comp_name = "zlib9"
+    code_bytes = len(code.encode("utf-8")); model_bytes = len(model_blob)
+    total_size = code_bytes + model_bytes
+    log0(f"Compressed model: {model_bytes} bytes ({comp_name})")
+    log0(f"Code size: {code_bytes} bytes")
+    log0(f"Total submission size: {total_size} bytes ({total_size/1e6:.2f} MB)")
+    if total_size > 16_000_000: log0(f"WARNING: Total size {total_size} exceeds 16MB limit!")
+    else: log0(f"Size OK: {total_size/1e6:.2f} MB")
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f: f.write(model_blob)
+    if distributed: dist.barrier()
+    # ROUNDTRIP DEQUANTIZE + SLIDING WINDOW EVAL
+    with open("final_model.int6.ptz", "rb") as f: model_blob_loaded = f.read()
+    if HAS_ZSTD: quant_state = torch.load(io.BytesIO(zstd.ZstdDecompressor().decompress(model_blob_loaded)), map_location="cpu")
+    else: quant_state = torch.load(io.BytesIO(zlib.decompress(model_blob_loaded)), map_location="cpu")
+    deq_state = dequantize_state_dict_mixed(quant_state["w"], quant_state["m"], sd_cpu)
+    base_model.load_state_dict(deq_state, strict=True)
+    eval_sl = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    val_tokens_eval = load_validation_tokens(args.val_files, eval_sl) if eval_sl != args.train_seq_len else val_tokens
+    raw_logits_fn = torch.compile(base_model.forward_logits, dynamic=False) if not bool(int(os.environ.get("TORCH_COMPILE_DISABLE", "0"))) else base_model.forward_logits
+    warmup_x = torch.zeros(args.eval_batch_seqs, eval_sl, dtype=torch.int64, device=device)
+    base_model.eval()
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16): _ = raw_logits_fn(warmup_x)
+    torch.cuda.synchronize(); t_eval = time.perf_counter()
+    q_vl, q_vb = eval_val_sliding(raw_logits_fn, rank, world_size, device,
+        val_tokens_eval, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        eval_sl, args.eval_stride, eval_batch_seqs=args.eval_batch_seqs)
+    torch.cuda.synchronize(); eval_time = time.perf_counter() - t_eval
+    log0(f"final_int6_zstd_roundtrip val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f} eval_time:{eval_time*1000:.0f}ms")
+    log0(f"final_int6_zstd_roundtrip_exact val_loss:{q_vl:.8f} val_bpb:{q_vb:.8f}")
+    if distributed: dist.destroy_process_group()
+
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-03-20_QAT_Int5Int6_BigramHash_Backout_SWA50/train_v17b.txt
+++ b/records/track_10min_16mb/2026-03-20_QAT_Int5Int6_BigramHash_Backout_SWA50/train_v17b.txt
@@ -1,0 +1,893 @@
+"""Parameter Golf v17: Simple Muon + QAT + BigramHash + SWA50 + lower LRs. Targeting ~82ms/step."""
+from __future__ import annotations
+import copy, glob, io, math, os, random, subprocess, sys, time, uuid, zlib
+try:
+    import zstandard as zstd; HAS_ZSTD = True
+except ImportError: HAS_ZSTD = False
+from pathlib import Path
+import numpy as np
+import sentencepiece as spm
+import torch, torch.distributed as dist, torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# ── HYPERPARAMETERS ──
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 42))
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 500))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 0))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 256))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 10))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 3))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    # ── LRs: aligned with #1/#2 ──
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    # ── Simple Muon (no NorMuon) ──
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_ns_steps = int(os.environ.get("MUON_NS_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_wd = float(os.environ.get("MUON_WD", 0.04))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.01))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    smear_enabled = bool(int(os.environ.get("SMEAR_ENABLED", "1")))
+    backout_enabled = bool(int(os.environ.get("BACKOUT_ENABLED", "1")))
+    backout_init = float(os.environ.get("BACKOUT_INIT", 0.2))
+    # ── SWA: aggressive like #1 ──
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_interval = int(os.environ.get("SWA_INTERVAL", 50))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.4))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 10240))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    prune_frac = float(os.environ.get("PRUNE_FRAC", 0.08))
+
+# ── SIMPLE MUON (Newton-Schulz5 with fixed coefficients, like #1/#2) ──
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed: X = X.T
+    for _ in range(steps):
+        A = X @ X.T; B = b * A + c * A @ A; X = a * X + B @ X
+    return X.T if transposed else X
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr, momentum, ns_steps, wd=0.0, nesterov=True):
+        super().__init__(params, dict(lr=lr, momentum=momentum, ns_steps=ns_steps, wd=wd, nesterov=nesterov))
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad(): loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+        for group in self.param_groups:
+            params = group["params"]
+            if not params: continue
+            lr, momentum, ns_steps = group["lr"], group["momentum"], group["ns_steps"]
+            nesterov = group["nesterov"]
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad; state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]; buf.mul_(momentum).add_(g)
+                    if nesterov: g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=ns_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+            if distributed: dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+            wd = group.get("wd", 0.0)
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                if wd > 0: p.data.mul_(1.0 - lr * wd)
+                p.add_(g, alpha=-lr); curr += p.numel()
+        return loss
+
+# ── TOKENIZER-AGNOSTIC EVALUATION ──
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sp_vocab_size = int(sp.vocab_size()); table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for tid in range(sp_vocab_size):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid): continue
+        is_boundary_token_np[tid] = False
+        if sp.is_byte(tid): base_bytes_np[tid] = 1; continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"): has_leading_space_np[tid] = True; piece = piece[1:]
+        base_bytes_np[tid] = len(piece.encode("utf-8"))
+    return (torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+            torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+            torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device))
+
+def load_validation_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files: raise FileNotFoundError(f"No files: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0: raise ValueError(f"Val too short for seq_len={seq_len}")
+    return tokens[:usable + 1]
+
+def eval_val(args, model, rank, world_size, device, grad_accum_steps,
+             val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut, seq_len_override=0):
+    seq_len = seq_len_override if seq_len_override > 0 else args.train_seq_len
+    local_batch_seqs = args.val_batch_size // (world_size * grad_accum_steps) // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * rank) // world_size; seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+    with torch.inference_mode():
+        for bss in range(seq_start, seq_end, local_batch_seqs):
+            bse = min(bss + local_batch_seqs, seq_end)
+            local = val_tokens[bss*seq_len:(bse*seq_len)+1].to(device=device, dtype=torch.int64, non_blocking=True)
+            x, y = local[:-1].reshape(-1, seq_len), local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            val_loss_sum += batch_loss.to(torch.float64) * float(y.numel())
+            val_token_count += float(y.numel())
+            tb = base_bytes_lut[y.reshape(-1)].to(dtype=torch.int16)
+            tb += (has_leading_space_lut[y.reshape(-1)] & ~is_boundary_token_lut[x.reshape(-1)]).to(dtype=torch.int16)
+            val_byte_count += tb.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        for t in [val_loss_sum, val_token_count, val_byte_count]: dist.all_reduce(t, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bpt = val_loss.item() / math.log(2.0); tpb = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bpt * tpb)
+
+# ── QUANTIZATION (int5 MLP / int6 attn per-row + Late-K fp16) ──
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    p for p in os.environ.get("CONTROL_TENSOR_NAME_PATTERNS",
+    "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,"
+    "skip_weight,skip_weights,smear,backout_lambda,bigram.scale").split(",") if p)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    p for p in os.environ.get("INT8_KEEP_FLOAT_FP32_NAME_PATTERNS", ",".join(CONTROL_TENSOR_NAME_PATTERNS)).split(",") if p)
+FP16_KEEP_NAME_PATTERNS = tuple(
+    p for p in os.environ.get("FP16_KEEP_NAME_PATTERNS", "tok_emb").split(",") if p)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_Q = 99.99984 / 100.0
+
+def tensor_nbytes(t): return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name, t, po):
+    if any(p in name for p in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS): return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        po[name] = str(t.dtype).removeprefix("torch."); return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def _classify_param(name):
+    if "tok_emb" in name or "lm_head" in name: return "embed"
+    if ".mlp." in name: return "mlp"
+    if "bigram" in name: return "bigram"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name): return "attn"
+    return "other"
+
+def quantize_intN_per_row(t, clip_range=31):
+    t32 = t.float()
+    if t32.ndim == 2:
+        row_max = t32.abs().amax(dim=1)
+        scale = (row_max / clip_range).clamp_min(1e-12).to(torch.float16)
+        scale = scale.clamp_min(torch.finfo(torch.float16).tiny)
+        q = torch.clamp(torch.round(t32 / scale.float()[:, None]), -(clip_range+1), clip_range).to(torch.int8)
+        return q, scale
+    amax = t32.abs().max().item()
+    scale = torch.tensor(max(amax / clip_range, 1e-12), dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -(clip_range+1), clip_range).to(torch.int8)
+    return q, scale
+
+def quantize_state_dict_mixed(state_dict):
+    """Mixed int5/int6/int8 quantization with per-row scales."""
+    result, meta = {}, {}
+    num_layers_total = max((int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")), default=0) + 1
+    late_k_layers = set(range(num_layers_total - 2, num_layers_total))
+    int6_cats = {"mlp", "attn", "bigram"}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 8192:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"; continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float(); meta[name] = "passthrough_ctrl"; continue
+        if any(p in name for p in FP16_KEEP_NAME_PATTERNS):
+            result[name] = t.to(dtype=torch.float16).contiguous(); meta[name] = "passthrough_fp16"; continue
+        if name.endswith("c_k.weight") and any(f"blocks.{i}." in name for i in late_k_layers):
+            result[name] = t.to(dtype=torch.float16).contiguous(); meta[name] = "passthrough_fp16"; continue
+        if cat in int6_cats and t.ndim >= 1 and t.numel() > INT8_KEEP_FLOAT_MAX_NUMEL:
+            clip = 15 if cat == "mlp" else 31
+            q, s = quantize_intN_per_row(t, clip_range=clip)
+            result[name + ".q"] = q; result[name + ".scale"] = s
+            meta[name] = {"type": f"int{5 if cat == 'mlp' else 6}"}; continue
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, {}); result[name] = kept
+            meta[name] = "passthrough"; continue
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1) if t32.numel() else torch.empty((t32.shape[0],), dtype=torch.float32)
+            clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+            result[name + ".q"] = q; result[name + ".scale"] = scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+            scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+            result[name + ".q"] = q; result[name + ".scale"] = scale
+        meta[name] = {"type": "int8"}
+    return result, meta
+
+def dequantize_state_dict_mixed(result, meta, template_sd):
+    out = {}
+    for name, orig in template_sd.items():
+        info = meta[name]; orig_dtype = orig.dtype
+        if isinstance(info, str) and info.startswith("passthrough"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16): t = t.to(orig_dtype)
+            out[name] = t; continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1]*(q.ndim-1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+# ── DATA LOADING ──
+def load_data_shard(file):
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1: raise ValueError(f"Bad header: {file}")
+    num_tokens = int(header[2])
+    if file.stat().st_size != header_bytes + num_tokens * np.dtype("<u2").itemsize: raise ValueError(f"Size mismatch: {file}")
+    return torch.from_numpy(np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes).astype(np.uint16, copy=False))
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files: raise FileNotFoundError(f"No files: {pattern}")
+        self.file_idx = 0; self.tokens = load_data_shard(self.files[0]); self.pos = 0
+    def _advance_file(self):
+        self.file_idx = (self.file_idx + 1) % len(self.files); self.tokens = load_data_shard(self.files[self.file_idx]); self.pos = 0
+    def take(self, n):
+        chunks, remaining = [], n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0: self._advance_file(); continue
+            k = min(remaining, avail); chunks.append(self.tokens[self.pos:self.pos+k]); self.pos += k; remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+class DistributedTokenLoader:
+    def __init__(self, pattern, rank, world_size, device):
+        self.rank, self.world_size, self.device = rank, world_size, device; self.stream = TokenStream(pattern)
+    def next_batch(self, global_tokens, seq_len, grad_accum_steps):
+        per_rank_span = global_tokens // (self.world_size * grad_accum_steps) + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span; local = chunk[start:start+per_rank_span].to(dtype=torch.int64)
+        x, y = local[:-1].reshape(-1, seq_len), local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# ── TRANSFORMER MODULES ──
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None): super().__init__(); self.eps = eps
+    def forward(self, x): return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+class CastedLinear(nn.Linear):
+    _qat_levels: int = 0
+    def forward(self, x):
+        w = self.weight
+        if self._qat_levels > 0 and self.training and w.ndim == 2:
+            w_f = w.float()
+            clip_abs = w_f.abs().amax(dim=1, keepdim=True).clamp_min(1e-12)
+            scale = clip_abs / float(self._qat_levels)
+            w_q = (w_f / scale).round().clamp(-self._qat_levels, self._qat_levels) * scale
+            w = w + (w_q - w_f).detach()
+        return F.linear(x, w.to(x.dtype), self.bias.to(x.dtype) if self.bias is not None else None)
+
+def restore_low_dim_params_to_fp32(module):
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=10000.0, train_seq_len=1024):
+        super().__init__(); self.dim, self.base, self.train_seq_len = dim, base, train_seq_len
+        self.register_buffer("inv_freq", 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim)), persistent=False)
+        self._seq_len_cached = 0; self._cos_cached = self._sin_cached = None
+    def forward(self, seq_len, device, dtype):
+        if self._cos_cached is None or self._seq_len_cached != seq_len or self._cos_cached.device != device:
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                adjusted_base = self.base * (scale ** (self.dim / (self.dim - 2)))
+                inv_freq = 1.0 / (adjusted_base ** (torch.arange(0, self.dim, 2, dtype=torch.float32, device=device) / self.dim))
+            else: inv_freq = self.inv_freq.to(device)
+            freqs = torch.outer(torch.arange(seq_len, device=device, dtype=inv_freq.dtype), inv_freq)
+            self._cos_cached = freqs.cos()[None, None, :, :]; self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+def apply_rotary_emb(x, cos, sin):
+    half = x.size(-1) // 2; x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len=1024):
+        super().__init__()
+        self.num_heads, self.num_kv_heads = num_heads, num_kv_heads; self.head_dim = dim // num_heads
+        kv_dim = num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False); self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False); self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len)
+    def forward(self, x):
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q, k = apply_rotary_emb(q, cos, sin), apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True, enable_gqa=(self.num_kv_heads != self.num_heads))
+        return self.proj(y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim))
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        self.fc = CastedLinear(dim, mlp_mult * dim, bias=False); self.proj = CastedLinear(mlp_mult * dim, dim, bias=False)
+        self.proj._zero_init = True
+    def forward(self, x): return self.proj(torch.relu(self.fc(x)).square())
+
+class SmearGate(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+    def forward(self, x):
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size, bigram_dim, model_dim):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None: nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+    def bigram_hash(self, tokens):
+        t = tokens.to(torch.int32); mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t); out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+    def forward(self, token_ids):
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None: h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class Block(nn.Module):
+    def __init__(self, dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init, train_seq_len=1024):
+        super().__init__()
+        self.attn_norm, self.mlp_norm = RMSNorm(), RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+    def forward(self, x, x0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None,None,:] * x + mix[1][None,None,:] * x0
+        n = self.attn_norm(x); x = x + self.attn_scale.to(dtype=x.dtype)[None,None,:] * self.attn(n)
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None,None,:] * self.mlp(self.mlp_norm(x)); return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size, num_layers, model_dim, num_heads, num_kv_heads,
+                 mlp_mult, tie_embeddings, tied_embed_init_std, logit_softcap,
+                 rope_base, qk_gain_init, train_seq_len=1024,
+                 smear_enabled=True, backout_enabled=True, backout_init=0.2,
+                 bigram_vocab_size=0, bigram_dim=128):
+        super().__init__()
+        self.tie_embeddings, self.tied_embed_init_std = tie_embeddings, tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.smear_enabled, self.backout_enabled, self.num_layers = smear_enabled, backout_enabled, num_layers
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList([Block(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init, train_seq_len) for _ in range(num_layers)])
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None: self.lm_head._zero_init = True
+        self.smear = SmearGate(model_dim) if smear_enabled else None
+        self.backout_lambda = nn.Parameter(backout_init * torch.ones(1)) if backout_enabled else None
+        self._init_weights()
+    def _init_weights(self):
+        for name, param in self.named_parameters():
+            if param.ndim == 2 and param.numel() > INT8_KEEP_FLOAT_MAX_NUMEL:
+                nn.init.orthogonal_(param, gain=1.0)
+                if "proj.weight" in name:
+                    with torch.no_grad(): param.mul_(1.0 / math.sqrt(2 * self.num_layers))
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+            with torch.no_grad():
+                U, S, V = torch.linalg.svd(self.tok_emb.weight.data, full_matrices=False)
+                target_S = S[0] * (1.0 / torch.arange(1, S.shape[0]+1, dtype=S.dtype)) ** 0.5
+                self.tok_emb.weight.data = (U * target_S[None, :]) @ V
+        for m in self.modules():
+            if isinstance(m, nn.Linear) and getattr(m, "_zero_init", False): nn.init.zeros_(m.weight)
+        nl = len(self.blocks)
+        for i, block in enumerate(self.blocks):
+            with torch.no_grad():
+                phase = torch.sigmoid(torch.tensor(3.0 * (i / max(nl-1, 1) - 0.5)))
+                block.resid_mix.data[0] = phase * torch.ones(block.resid_mix.shape[1])
+                block.resid_mix.data[1] = (1-phase) * torch.ones(block.resid_mix.shape[1])
+    def _run_layers(self, x, x0):
+        skips, backout_layer, x_backout = [], self.num_layers // 2, None
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0); skips.append(x)
+            if i == backout_layer: x_backout = x
+        for i in range(self.num_decoder_layers):
+            li = self.num_encoder_layers + i
+            if skips: x = x + self.skip_weights[i].to(dtype=x.dtype)[None,None,:] * skips.pop()
+            x = self.blocks[li](x, x0)
+            if li == backout_layer and x_backout is None: x_backout = x
+        if self.backout_lambda is not None and x_backout is not None: x = x - self.backout_lambda.to(x.dtype) * x_backout
+        return x
+    def _embed(self, input_ids):
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None: x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (self.tok_emb.weight.shape[1],))
+        if self.smear is not None: x = self.smear(x)
+        return x
+    def forward(self, input_ids, target_ids):
+        x0 = self._embed(input_ids); x = self._run_layers(x0, x0)
+        x_flat = self.final_norm(x).reshape(-1, x.size(-1)); targets = target_ids.reshape(-1)
+        logits_proj = F.linear(x_flat, self.tok_emb.weight) if self.tie_embeddings else self.lm_head(x_flat)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+    def forward_logits(self, input_ids):
+        x0 = self._embed(input_ids); x = self.final_norm(self._run_layers(x0, x0))
+        logits = F.linear(x, self.tok_emb.weight.to(x.dtype)) if self.tie_embeddings else self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+
+# ── SLIDING WINDOW EVAL ──
+def eval_val_sliding(logits_fn, rank, world_size, device, val_tokens,
+                     base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+                     seq_len, stride, eval_batch_seqs=256):
+    total = val_tokens.numel() - 1; windows, p = [], 0
+    while p + seq_len <= total:
+        s = 0 if p == 0 else (seq_len - stride); windows.append((p, s)); p += stride
+    n = len(windows); per_rank = (n + world_size - 1) // world_size
+    my_windows = windows[rank*per_rank:min((rank+1)*per_rank, n)]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    tok_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    with torch.inference_mode():
+        for i in range(0, len(my_windows), eval_batch_seqs):
+            batch = my_windows[i:i+eval_batch_seqs]; bs = len(batch)
+            x_list = [val_tokens[w:w+seq_len] for w, _ in batch]
+            y_list = [val_tokens[w+1:w+seq_len+1] for w, _ in batch]
+            pad = eval_batch_seqs - bs
+            if pad > 0: x_list.extend([x_list[-1]]*pad); y_list.extend([y_list[-1]]*pad)
+            x = torch.stack(x_list).to(device=device, dtype=torch.int64)
+            y = torch.stack(y_list).to(device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16): logits = logits_fn(x)
+            for b in range(bs):
+                s = batch[b][1]; sl, st = logits[b, s:], y[b, s:]
+                loss_sum += F.cross_entropy(sl.float(), st, reduction="sum").to(torch.float64)
+                ns = st.numel(); tok_count += ns
+                prev, tgt = x[b, s:s+ns], st
+                tb = base_bytes_lut[tgt].to(torch.int16)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.int16)
+                byte_count += tb.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        for t in [loss_sum, tok_count, byte_count]: dist.all_reduce(t, op=dist.ReduceOp.SUM)
+    vl = (loss_sum / tok_count).item()
+    return vl, vl / math.log(2.0) * (tok_count.item() / byte_count.item())
+
+# ── MAIN ──
+def main():
+    global zeropower_via_newtonschulz5
+    code = Path(__file__).read_text(encoding="utf-8"); args = Hyperparameters()
+    # Compile Newton-Schulz for speed (like #1)
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0")); world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0 or 8 % world_size != 0: raise ValueError(f"Bad WORLD_SIZE={world_size}")
+    grad_accum_steps = 8 // world_size; grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available(): raise RuntimeError("CUDA required")
+    device = torch.device("cuda", local_rank); torch.cuda.set_device(device)
+    if distributed: dist.init_process_group(backend="nccl", device_id=device); dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True; torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False); enable_flash_sdp(True); enable_mem_efficient_sdp(False); enable_math_sdp(False)
+    logfile = None
+    if master_process: os.makedirs("logs", exist_ok=True); logfile = f"logs/{args.run_id}.txt"; print(logfile)
+    def log0(msg, console=True):
+        if not master_process: return
+        if console: print(msg)
+        if logfile:
+            with open(logfile, "a", encoding="utf-8") as f: print(msg, file=f)
+    log0(code, console=False); log0("=" * 100, console=False)
+    log0(f"Python {sys.version}", console=False); log0(f"PyTorch {torch.__version__}", console=False)
+    log0(subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout, console=False)
+    random.seed(args.seed); np.random.seed(args.seed); torch.manual_seed(args.seed); torch.cuda.manual_seed_all(args.seed)
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(sp, args.vocab_size, device)
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_tokens:{val_tokens.numel()-1}")
+    base_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init, train_seq_len=args.train_seq_len,
+        smear_enabled=args.smear_enabled, backout_enabled=args.backout_enabled,
+        backout_init=args.backout_init,
+        bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim,
+    ).to(device).bfloat16()
+    for m in base_model.modules():
+        if isinstance(m, CastedLinear): m.float()
+    restore_low_dim_params_to_fp32(base_model)
+    # Enable QAT: int5 for MLP weights, int6 for attention weights
+    for name, m in base_model.named_modules():
+        if isinstance(m, CastedLinear) and m.weight.ndim == 2 and m.weight.numel() > INT8_KEEP_FLOAT_MAX_NUMEL:
+            m._qat_levels = 15 if ".mlp." in name else 31
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True) if not bool(int(os.environ.get("TORCH_COMPILE_DISABLE", "0"))) else base_model
+    model = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [p for n, p in block_named_params if p.ndim == 2 and not any(pat in n for pat in CONTROL_TENSOR_NAME_PATTERNS)]
+    scalar_params = [p for n, p in block_named_params if p.ndim < 2 or any(pat in n for pat in CONTROL_TENSOR_NAME_PATTERNS)]
+    if base_model.skip_weights.numel() > 0: scalar_params.append(base_model.skip_weights)
+    if base_model.smear is not None: scalar_params.append(base_model.smear.gate)
+    if base_model.backout_lambda is not None: scalar_params.append(base_model.backout_lambda)
+    if base_model.bigram is not None: scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_param_groups = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_param_groups.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None: matrix_params.append(base_model.bigram.proj.weight)
+    optimizer_tok = torch.optim.AdamW(tok_param_groups,
+                                       betas=(args.beta1, args.beta2), eps=args.adam_eps, weight_decay=args.adam_wd, fused=True)
+    optimizer_muon = Muon(matrix_params, lr=args.matrix_lr, momentum=args.muon_momentum,
+                          ns_steps=args.muon_ns_steps, wd=args.muon_wd)
+    for group in optimizer_muon.param_groups: group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW([{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+                                          betas=(args.beta1, args.beta2), eps=args.adam_eps, weight_decay=args.adam_wd, fused=True)
+    optimizers = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam([{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+                                           betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True)
+        optimizers.insert(1, optimizer_head)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}"); log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    def zero_grad_all():
+        for opt in optimizers: opt.zero_grad(set_to_none=True)
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    def lr_mul(step, elapsed_ms):
+        if args.warmdown_iters <= 0: return 1.0
+        if max_wallclock_ms is None:
+            ws = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if step >= ws else 1.0
+        step_ms = elapsed_ms / max(step, 1); wd_ms = args.warmdown_iters * step_ms
+        rem_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return rem_ms / max(wd_ms, 1e-9) if rem_ms <= wd_ms else 1.0
+    # WARMUP
+    if args.warmup_steps > 0:
+        initial_model_state = {n: t.detach().cpu().clone() for n, t in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for ws in range(args.warmup_steps):
+            zero_grad_all()
+            for ms in range(grad_accum_steps):
+                if distributed: model.require_backward_grad_sync = ms == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    wl = model(x, y)
+                (wl * grad_scale).backward()
+            for opt in optimizers: opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (ws+1) % 10 == 0: log0(f"warmup_step:{ws+1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True): opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed: model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    # MAIN TRAINING LOOP
+    training_time_ms, stop_after_step = 0.0, None
+    swa_state, swa_count = None, 0
+    torch.cuda.synchronize(); t0 = time.perf_counter(); step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize(); training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            vl, vb = eval_val(args, model, rank, world_size, device, grad_accum_steps,
+                              val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut)
+            log0(f"step:{step}/{args.iterations} val_loss:{vl:.4f} val_bpb:{vb:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms/max(step,1):.2f}ms")
+            torch.cuda.synchronize(); t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms step:{step}/{args.iterations}")
+            break
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all(); train_loss = torch.zeros((), device=device)
+        for ms in range(grad_accum_steps):
+            if distributed: model.require_backward_grad_sync = ms == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True): loss = model(x, y)
+            train_loss += loss.detach(); (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = (1-frac)*args.muon_momentum_warmup_start + frac*args.muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups: group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0: torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers: opt.step()
+        zero_grad_all(); step += 1
+        approx_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        # SWA: collect during warmdown (like #1, every 50 steps when lr_scale < swa_start_frac)
+        if args.swa_enabled and scale < args.swa_start_frac and step % args.swa_interval == 0:
+            if swa_state is None:
+                swa_state = {n: t.detach().cpu().clone() for n, t in base_model.state_dict().items()}
+                swa_count = 1; log0(f"swa:start step:{step}")
+            else:
+                for n, t in base_model.state_dict().items(): swa_state[n] += t.detach().cpu()
+                swa_count += 1
+        if args.train_log_every > 0 and (step <= 10 or step % args.train_log_every == 0):
+            log0(f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} train_time:{approx_ms:.0f}ms step_avg:{approx_ms/step:.2f}ms")
+        reached_cap = max_wallclock_ms is not None and approx_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            rct = torch.tensor(int(reached_cap), device=device); dist.all_reduce(rct, op=dist.ReduceOp.MAX); reached_cap = bool(rct.item())
+        if stop_after_step is None and reached_cap: stop_after_step = step
+    log0(f"peak memory allocated: {torch.cuda.max_memory_allocated()//1024//1024} MiB reserved: {torch.cuda.max_memory_reserved()//1024//1024} MiB")
+    # SWA
+    if args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"SWA: averaging {swa_count} checkpoints")
+        current_sd = base_model.state_dict()
+        avg = {n: (t / swa_count).to(dtype=current_sd[n].dtype) for n, t in swa_state.items()}
+        base_model.load_state_dict(avg, strict=True); swa_state = None
+    # MAGNITUDE PRUNING
+    if args.prune_frac > 0:
+        with torch.no_grad():
+            for name, param in base_model.named_parameters():
+                if param.ndim == 2 and param.numel() > INT8_KEEP_FLOAT_MAX_NUMEL:
+                    threshold = torch.quantile(param.abs().float().flatten(), args.prune_frac)
+                    param.masked_fill_(param.abs() < threshold, 0.0)
+        log0(f"Magnitude pruning: zeroed {args.prune_frac*100:.1f}% of large weight entries")
+    # QUANTIZE + COMPRESS + SAVE
+    sd_cpu = {k: v.detach().cpu() for k, v in base_model.state_dict().items()}
+    quant_result, quant_meta = quantize_state_dict_mixed(sd_cpu)
+    quant_buf = io.BytesIO(); torch.save({"w": quant_result, "m": quant_meta}, quant_buf); quant_raw = quant_buf.getvalue()
+    if HAS_ZSTD:
+        model_blob = zstd.ZstdCompressor(level=22).compress(quant_raw); comp_name = "zstd22"
+    else:
+        model_blob = zlib.compress(quant_raw, level=9); comp_name = "zlib9"
+    code_bytes = len(code.encode("utf-8")); model_bytes = len(model_blob)
+    total_size = code_bytes + model_bytes
+    log0(f"Compressed model: {model_bytes} bytes ({comp_name})")
+    log0(f"Code size: {code_bytes} bytes")
+    log0(f"Total submission size: {total_size} bytes ({total_size/1e6:.2f} MB)")
+    if total_size > 16_000_000: log0(f"WARNING: Total size {total_size} exceeds 16MB limit!")
+    else: log0(f"Size OK: {total_size/1e6:.2f} MB")
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f: f.write(model_blob)
+    if distributed: dist.barrier()
+    # ROUNDTRIP DEQUANTIZE + SLIDING WINDOW EVAL
+    with open("final_model.int6.ptz", "rb") as f: model_blob_loaded = f.read()
+    if HAS_ZSTD: quant_state = torch.load(io.BytesIO(zstd.ZstdDecompressor().decompress(model_blob_loaded)), map_location="cpu")
+    else: quant_state = torch.load(io.BytesIO(zlib.decompress(model_blob_loaded)), map_location="cpu")
+    deq_state = dequantize_state_dict_mixed(quant_state["w"], quant_state["m"], sd_cpu)
+    base_model.load_state_dict(deq_state, strict=True)
+    eval_sl = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    val_tokens_eval = load_validation_tokens(args.val_files, eval_sl) if eval_sl != args.train_seq_len else val_tokens
+    raw_logits_fn = torch.compile(base_model.forward_logits, dynamic=False) if not bool(int(os.environ.get("TORCH_COMPILE_DISABLE", "0"))) else base_model.forward_logits
+    warmup_x = torch.zeros(args.eval_batch_seqs, eval_sl, dtype=torch.int64, device=device)
+    base_model.eval()
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16): _ = raw_logits_fn(warmup_x)
+    torch.cuda.synchronize(); t_eval = time.perf_counter()
+    q_vl, q_vb = eval_val_sliding(raw_logits_fn, rank, world_size, device,
+        val_tokens_eval, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        eval_sl, args.eval_stride, eval_batch_seqs=args.eval_batch_seqs)
+    torch.cuda.synchronize(); eval_time = time.perf_counter() - t_eval
+    log0(f"final_int6_zstd_roundtrip val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f} eval_time:{eval_time*1000:.0f}ms")
+    log0(f"final_int6_zstd_roundtrip_exact val_loss:{q_vl:.8f} val_bpb:{q_vb:.8f}")
+    if distributed: dist.destroy_process_group()
+
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
+Python 3.12.3 (main, Nov  6 2025, 13:44:16) [GCC 13.3.0]
+PyTorch 2.9.1+cu128
+Sat Mar 21 00:08:12 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 560.35.05              Driver Version: 560.35.05      CUDA Version: 12.6     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   33C    P0            122W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:06:00.0 Off |                    0 |
+| N/A   27C    P0            114W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:07:00.0 Off |                    0 |
+| N/A   27C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:08:00.0 Off |                    0 |
+| N/A   33C    P0            115W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:09:00.0 Off |                    0 |
+| N/A   32C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   27C    P0            116W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   26C    P0            111W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:0C:00.0 Off |                    0 |
+| N/A   33C    P0            117W /  700W |    1520MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_tokens:62021632
+model_params:25517138
+world_size:8 grad_accum_steps:1
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9343 val_bpb:4.1069 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9347 train_time:143ms step_avg:142.95ms
+step:2/20000 train_loss:8.6927 train_time:216ms step_avg:108.04ms
+step:3/20000 train_loss:7.7000 train_time:313ms step_avg:104.40ms
+step:4/20000 train_loss:7.0922 train_time:409ms step_avg:102.33ms
+step:5/20000 train_loss:6.8276 train_time:506ms step_avg:101.17ms
+step:6/20000 train_loss:6.7315 train_time:603ms step_avg:100.44ms
+step:7/20000 train_loss:6.6100 train_time:699ms step_avg:99.87ms
+step:8/20000 train_loss:6.4724 train_time:796ms step_avg:99.48ms
+step:9/20000 train_loss:6.2142 train_time:893ms step_avg:99.21ms
+step:10/20000 train_loss:6.0053 train_time:989ms step_avg:98.89ms
+step:200/20000 train_loss:2.3519 train_time:18412ms step_avg:92.06ms
+step:400/20000 train_loss:2.4040 train_time:36891ms step_avg:92.23ms
+step:500/20000 val_loss:2.3539 val_bpb:1.3941 train_time:46121ms step_avg:92.24ms
+step:600/20000 train_loss:2.3368 train_time:55396ms step_avg:92.33ms
+step:800/20000 train_loss:2.2466 train_time:73965ms step_avg:92.46ms
+step:1000/20000 train_loss:2.2824 train_time:92454ms step_avg:92.45ms
+step:1000/20000 val_loss:2.2316 val_bpb:1.3217 train_time:92485ms step_avg:92.48ms
+step:1200/20000 train_loss:2.3635 train_time:111035ms step_avg:92.53ms
+step:1400/20000 train_loss:2.1949 train_time:129649ms step_avg:92.61ms
+step:1500/20000 val_loss:2.1934 val_bpb:1.2990 train_time:138905ms step_avg:92.60ms
+step:1600/20000 train_loss:2.0951 train_time:148194ms step_avg:92.62ms
+step:1800/20000 train_loss:2.1726 train_time:166813ms step_avg:92.67ms
+step:2000/20000 train_loss:2.0787 train_time:185372ms step_avg:92.69ms
+step:2000/20000 val_loss:2.1444 val_bpb:1.2700 train_time:185404ms step_avg:92.70ms
+step:2200/20000 train_loss:2.1532 train_time:203987ms step_avg:92.72ms
+step:2400/20000 train_loss:2.0805 train_time:222534ms step_avg:92.72ms
+step:2500/20000 val_loss:2.1158 val_bpb:1.2531 train_time:231857ms step_avg:92.74ms
+step:2600/20000 train_loss:2.1198 train_time:241156ms step_avg:92.75ms
+step:2800/20000 train_loss:2.1671 train_time:259745ms step_avg:92.77ms
+step:3000/20000 train_loss:2.1736 train_time:278261ms step_avg:92.75ms
+step:3000/20000 val_loss:2.1011 val_bpb:1.2444 train_time:278294ms step_avg:92.76ms
+step:3200/20000 train_loss:2.1835 train_time:296845ms step_avg:92.76ms
+step:3400/20000 train_loss:2.0281 train_time:315348ms step_avg:92.75ms
+step:3500/20000 val_loss:2.0903 val_bpb:1.2380 train_time:324650ms step_avg:92.76ms
+step:3600/20000 train_loss:2.1092 train_time:333901ms step_avg:92.75ms
+step:3800/20000 train_loss:2.0823 train_time:352407ms step_avg:92.74ms
+step:4000/20000 train_loss:1.9828 train_time:370990ms step_avg:92.75ms
+step:4000/20000 val_loss:2.0701 val_bpb:1.2260 train_time:371021ms step_avg:92.76ms
+step:4200/20000 train_loss:2.1546 train_time:389575ms step_avg:92.76ms
+step:4400/20000 train_loss:2.0401 train_time:408080ms step_avg:92.75ms
+step:4500/20000 val_loss:2.0484 val_bpb:1.2132 train_time:417398ms step_avg:92.76ms
+step:4600/20000 train_loss:1.8476 train_time:426663ms step_avg:92.75ms
+step:4800/20000 train_loss:2.4334 train_time:445152ms step_avg:92.74ms
+step:5000/20000 train_loss:2.1114 train_time:463717ms step_avg:92.74ms
+step:5000/20000 val_loss:2.0287 val_bpb:1.2015 train_time:463748ms step_avg:92.75ms
+step:5200/20000 train_loss:2.0487 train_time:482195ms step_avg:92.73ms
+swa:start step:5300
+step:5400/20000 train_loss:2.0556 train_time:500847ms step_avg:92.75ms
+step:5500/20000 val_loss:2.0073 val_bpb:1.1888 train_time:510279ms step_avg:92.78ms
+step:5600/20000 train_loss:1.9622 train_time:519588ms step_avg:92.78ms
+step:5800/20000 train_loss:2.0038 train_time:538251ms step_avg:92.80ms
+step:6000/20000 train_loss:1.9471 train_time:557073ms step_avg:92.85ms
+step:6000/20000 val_loss:1.9850 val_bpb:1.1756 train_time:557145ms step_avg:92.86ms
+step:6200/20000 train_loss:1.9560 train_time:575804ms step_avg:92.87ms
+step:6400/20000 train_loss:2.0100 train_time:594627ms step_avg:92.91ms
+step:6457/20000 val_loss:1.9685 val_bpb:1.1658 train_time:599995ms step_avg:92.92ms
+stopping_early: wallclock_cap train_time:599995ms step:6457/20000
+peak memory allocated: 18873 MiB reserved: 19462 MiB
+SWA: averaging 24 checkpoints
+Magnitude pruning: zeroed 8.0% of large weight entries
+Compressed model: 15888496 bytes (zstd22)
+Code size: 46872 bytes
+Total submission size: 15935368 bytes (15.94 MB)
+Size OK: 15.94 MB
+final_int6_zstd_roundtrip val_loss:1.9379 val_bpb:1.1477 eval_time:71973ms
+final_int6_zstd_roundtrip_exact val_loss:1.93785918 val_bpb:1.14770936


### PR DESCRIPTION
## Summary
val_bpb: **1.1477** (sliding window, stride=64, post int5/int6 quantization roundtrip)
Artifact size: 15.94 MB

## Novel Contributions
- **Quantization-Aware Training (QAT)**: STE with int5 MLP / int6 attention during training — reduces quant gap from ~0.016 to ~0.005 BPB
- **Backout**: Learned residual subtraction (λ·x_mid) from final output
- **U-Net Skip Connections**: 5+5 encoder-decoder with learned per-dim skip weights
- **SVD Embedding Init**: Spectral decay 1/√k for tied embeddings

## Shared Techniques
BigramHash(10240), SmearGate, Simple Muon + compiled NS5, SWA every 50 steps, orthogonal init, 8% magnitude pruning, zstd-22

## Run Details
- 6457 steps in 10 min, 92.9ms/step avg
- 8xH100 SXM (RunPod)
- seed=42, single run

See README.md for full details.