### PR TITLE
Non-record: MLX prototyping harness with validated technique stack (val_bpb=1.9588, Mac)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# Parameter Golf — Claude Working Practices
+
+## Project Overview
+
+Competitive submission for OpenAI's Parameter Golf challenge. Goal: train the best LM that fits in 16MB, trains in ≤10 min on 8×H100, scored by BPB on FineWeb validation. See `docs/PLAN.md` for full strategy.
+
+## Working Practices
+
+### 1. Plan Mode Default
+- Enter plan mode for ANY non-trivial task (3+ steps or architectural decisions)
+- Enter plan mode for structural changes, STOP plan immediately - don't keep pushing
+- Use plan mode to compose, not just build
+- Write detailed specs upfront to reduce ambiguity
+- Consider network volume data storage usage
+
+### 2. Subagent Strategy
+- Use subagents liberally to keep main context window clean
+- Always spawn sub agents for codebase exploration
+- Write detailed specs for sub-steps, not just a list of subagents
+- One task per subagent for the project
+
+### 3. Iteration Loop
+- After ANY user feedback: update `tasks/todo.md` with current state
+- Write rules to prevent making the same mistake twice
+- Ruthlessly iterate on these lessons until mistake rate drops
+- Review lessons at session start for the relevant project
+
+### 4. Verification Before Done
+- No subagent task is complete without proving it works
+- Ask yourself: "Would a senior engineer approve of this?"
+- Run tests; ensure they start with relevant correctness
+
+### 5. Demand Elegance (Balanced)
+- For non-trivial changes: pause and ask "Is there a more elegant way?"
+- If a fix feels hacky: "Knowing everything I know now, implement the elegant solution"
+- Skip this for simple, obvious fixes - don't over-engineer
+- Challenge your own work before presenting it
+- Always consider most recent prior work in `tasks/todo.md`
+- Document core findings in `tasks/lessons.md`
+
+### 6. Autonomous Bug Fixing
+- When first: Write a log just for approval with hand-holding
+- Point at logs, errors, failing tests - then resolve them
+- Ask if context switching is required from the user
+- Go fix failing CI tests without being told how
+
+### 7. Context Efficiency
+- Delegate verbose operations (large file reads, repetitive tests) to subagents to isolate context bloat
+- Filter noisy output before returning it - show only failures/errors from test runs, not full logs
+- Recommend `/clear` to user between unrelated tasks when context is stale
+- Prefer CLI tools (`gh`, `aws`, `gcloud`) over MCP servers when both can accomplish the task
+
+### 8. Agent Team Discipline
+- When spawning teammates: keep spawn prompts focused - don't duplicate CLAUDE.md (it loads automatically)
+- Use Sonnet for teammates unless task specifically requires Opus-level reasoning
+- Dismiss or clean up teammates once their work is complete - idle teammates still consume tokens
+- Keep teams small - only spawn teammates for genuinely parallel or specialized work
+
+### 9. Think Budget Awareness
+- For straightforward tasks: reduce extended thinking rather than deep-reasoning everything
+- Match effort to complexity - don't over-reason on simple fixes
+- When asked about costs: suggest `/cost` command for visibility
+
+## Task Management
+
+1. **Plan First**: Write plan to `tasks/todo.md` with checkable items
+2. **Verify Plan**: Check in before starting implementation
+3. **Track Progress**: Highlight items completed as you go
+4. **Explain Progress**: Markdown-level summary at each step
+5. **Explain Changes**: Add review section to `tasks/todo.md`
+6. **Capture Lessons**: Update `tasks/lessons.md` after corrections
+
+## Core Principles
+
+- **Simplicity First**: Make every change as simple as possible. Impact minimal code.
+- **No Laziness**: Find root cause, don't just apply top fixes. Senior developer standards.
+- **Minimal Impacts**: Find accuracy. Avoid introducing bugs.
+- **Iterate on MLX First**: Maximize local iteration before spending cloud compute. Get to a stage where we can request compute via https://openai.com/index/parameter-golf/#credit-form with really solid answers to all questions.

--- a/docs/H100_PLAN.md
+++ b/docs/H100_PLAN.md
@@ -1,0 +1,144 @@
+# Parameter Golf — H100 Execution Plan
+
+## Target: sub-1.14 BPB
+
+Current SOTA: 1.1428 (thwu1, 10L Int5-MLP + BigramHash(10240) + SWA(0.4) + WD=0.04)
+
+## Top 5 Breakdown
+
+| Rank | BPB | Layers | MLP | Seq | Quant | Key Differentiators |
+|---|---|---|---|---|---|---|
+| 1 (1.1428) | thwu1 | 10 | 3x | 2048 | int5 MLP / int6 attn | BigramHash(10240), SWA(0.4), WD=0.04 |
+| 2 (1.1458) | Raahil | 9 | 3x | 2048 | int6 | SmearGate, BigramHash(4096), SWA(0.5), WD=0.04 |
+| 3 (1.1502) | aruniyer | 11 | 3x | 2048 | int6 QAT | 11 layers, WD=0.04, zstd-22 |
+| 4 (1.1556) | aquarious | 9 | 3x | 1024 | int6 QAT | SmearGate, BigramHash, WD=0.01 |
+| 5 (1.1586) | yahya010 | 10 | 2.6x | 2048 | int6 QAT | MLP=1344, zero quant gap |
+
+## Consensus Techniques (all top 5 use)
+
+- Sliding window eval stride=64
+- FP16 tied embedding passthrough
+- Muon momentum=0.99, warmup from 0.92 over 1500 steps
+- Lower LRs: matrix=0.02, scalar=0.02, embed=0.03-0.04
+- Warmdown=3000 iters
+- Grad clip=0.3
+- zstd-22 compression
+- Int6 (minimum) quantization
+
+## What Separates #1 from the Pack
+
+1. **Int5 on MLP weights** — saves ~1.86MB vs int6, funding the 10th layer
+2. **BigramHash(10240)** — 2.5x larger hash table than #2's 4096 buckets (+0.001 BPB)
+3. **SWA start_frac=0.4** — only averages the most converged 40% of warmdown checkpoints
+4. **WD=0.04** — 4x higher than #4's 0.01, keeps weights small for better quantization
+
+## Execution Phases
+
+### Phase 1: Reproduce #2's recipe (~3 runs, baseline)
+
+```bash
+NUM_LAYERS=9 MLP_MULT=3 TRAIN_SEQ_LEN=2048 TRAIN_BATCH_TOKENS=786432
+MUON_MOMENTUM=0.99 MUON_WEIGHT_DECAY=0.04 WARMDOWN_ITERS=3000
+MATRIX_LR=0.02 SCALAR_LR=0.02 TIED_EMBED_LR=0.03
+GRAD_CLIP_NORM=0.3 FP16_EMBED=1 EVAL_STRIDE=64
+USE_SMEARGATE=1 BIGRAM_HASH_BUCKETS=4096 BIGRAM_HASH_DIM=128
+# + int6 + zstd-22 + SWA + OrthoInit
+```
+
+Target: ~1.146. This is the proven stack.
+
+### Phase 2: Push toward #1 (~5 runs)
+
+- Add int5 on MLP weights → fund 10th layer
+- BigramHash(10240) instead of 4096
+- SWA start_frac=0.4 (tighter averaging window)
+- Try 11L (like #3) if int5 saves enough space
+
+### Phase 3: Novel improvements (~10 runs)
+
+- Try 11L + int5 MLP (not yet on leaderboard)
+- BigramHash(16384) — even larger table
+- QAT (zero quant gap like #5) + int5 (best compression)
+- Muon-aware QAT (Gaussian noise mode from PR #130)
+- Explore WD sweep (0.02-0.06)
+
+### Phase 4: Submission (~5 runs)
+
+- 3+ seeds on best config, p<0.01
+- Target: sub-1.14 BPB
+
+## Implementation Needed for CUDA Port
+
+1. **SmearGate** — ~20 lines (gate + prev token blending)
+2. **BigramHash** — ~30 lines (hash table + projection)
+3. **SWA** — ~15 lines (checkpoint averaging in warmdown)
+4. **OrthoInit** — ~10 lines (orthogonal_ on weight matrices)
+5. **Int5 quantization** — ~10 lines (extend int6 to support step=8)
+6. **zstd-22** — swap zlib for zstandard
+7. **QAT with STE** — ~20 lines (fake quantize in forward pass)
+
+## Key Architecture Details from Top Submissions
+
+### SmearGate (~512 params)
+```python
+gate = sigmoid(self.gate)  # shape [dim], init via sigmoid(3.0) ≈ 0.95
+output = gate * current_emb + (1 - gate) * prev_token_emb
+```
+Applied after embedding lookup + bigram hash, before RMS norm.
+
+### BigramHash (4096-10240 buckets, dim=128)
+```python
+hash_idx = (prev_token * 31 + curr_token) % num_buckets  # or * 92821
+bigram_emb = self.bigram_table[hash_idx]  # (B, T, 128)
+bigram_proj = bigram_emb @ self.bigram_proj  # (B, T, model_dim)
+x = tok_emb + bigram_proj  # added before SmearGate
+```
+~524K params at 4096 buckets, ~1.3M at 10240.
+
+### SWA (Stochastic Weight Averaging)
+```python
+# During warmdown, every swa_every steps:
+if step >= swa_start and step % swa_every == 0:
+    swa_state = ema_update(swa_state, model.state, n_averaged)
+# At end of training, load swa_state into model before export
+```
+start_frac=0.4-0.5, every=50 steps.
+
+### OrthoInit
+```python
+for module in model.modules():
+    if hasattr(module, 'weight') and module.weight.ndim == 2:
+        nn.init.orthogonal_(module.weight)
+# Output projections scaled by 1/sqrt(2*num_layers)
+```
+
+### Int5 Quantization (MLP weights only)
+```python
+# Same as int6 but clip to [-16, 15], scale = clip_abs / 16.0
+# Stored in int8 container — top 3 bits are zero/sign, compresses extremely well
+```
+
+### QAT with STE
+```python
+def fake_quantize_int6(w):
+    scale = w.abs().amax(dim=-1, keepdim=True) / 31.0
+    w_q = (w / scale).round().clamp(-31, 31)
+    return w + (w_q * scale - w).detach()  # STE: forward uses quantized, backward uses original
+```
+
+## Compute Budget
+
+- Phase 1: 3 runs × 10 min = 30 min 8×H100
+- Phase 2: 5 runs × 10 min = 50 min 8×H100
+- Phase 3: 10 runs × 10 min = 100 min 8×H100
+- Phase 4: 5 runs × 10 min = 50 min 8×H100
+- Iteration on 1×H100: ~20 hours
+- **Total: ~4 hours 8×H100 + ~20 hours 1×H100**
+
+## MLX Validation (completed)
+
+- 25+ experiments on Mac (Apple M2)
+- Best Mac result: 1.9588 BPB (14L×416d, 750 steps, 10 shards, full val)
+- Near-zero quant gap validated (0.001 BPB with FP16 embed + Muon WD)
+- Dead ends eliminated: depth recurrence + int6, DWA, eval-time loops, NTK extrapolation
+- PR #328 submitted as non-record

--- a/docs/H100_PLAN.md
+++ b/docs/H100_PLAN.md
@@ -1,18 +1,18 @@
 # Parameter Golf — H100 Execution Plan
 
-## Target: sub-1.14 BPB
+## Target: sub-1.12 BPB
 
-Current SOTA: 1.1428 (thwu1, 10L Int5-MLP + BigramHash(10240) + SWA(0.4) + WD=0.04)
+Current SOTA: 1.1254 (alertcat, TTT + XSA + EMA + SmearGate + BigramHash(2048) + Int6 QAT + zstd-22)
 
 ## Top 5 Breakdown
 
-| Rank | BPB | Layers | MLP | Seq | Quant | Key Differentiators |
-|---|---|---|---|---|---|---|
-| 1 (1.1428) | thwu1 | 10 | 3x | 2048 | int5 MLP / int6 attn | BigramHash(10240), SWA(0.4), WD=0.04 |
-| 2 (1.1458) | Raahil | 9 | 3x | 2048 | int6 | SmearGate, BigramHash(4096), SWA(0.5), WD=0.04 |
-| 3 (1.1502) | aruniyer | 11 | 3x | 2048 | int6 QAT | 11 layers, WD=0.04, zstd-22 |
-| 4 (1.1556) | aquarious | 9 | 3x | 1024 | int6 QAT | SmearGate, BigramHash, WD=0.01 |
-| 5 (1.1586) | yahya010 | 10 | 2.6x | 2048 | int6 QAT | MLP=1344, zero quant gap |
+| Rank | BPB | User | Key Differentiators |
+|---|---|---|---|
+| 1 | 1.1254 | alertcat | TTT + XSA + EMA + SmearGate + BigramHash(2048) + Int6 QAT + zstd-22 |
+| 2 | 1.1320 | saml212 | Gradient-guided adaptive quant + 12L + LN Scale + Partial RoPE |
+| 3 | 1.1428 | thwu1 | 10L, Int5 MLP / int6 attn, BigramHash(10240), SWA(0.4), WD=0.04 |
+| 4 | 1.1458 | Raahil | 9L, SmearGate, BigramHash(4096), SWA(0.5), WD=0.04 |
+| 5 | 1.1502 | aruniyer | 11L, int6 QAT, WD=0.04, zstd-22 |
 
 ## Consensus Techniques (all top 5 use)
 
@@ -27,45 +27,55 @@ Current SOTA: 1.1428 (thwu1, 10L Int5-MLP + BigramHash(10240) + SWA(0.4) + WD=0.
 
 ## What Separates #1 from the Pack
 
-1. **Int5 on MLP weights** — saves ~1.86MB vs int6, funding the 10th layer
-2. **BigramHash(10240)** — 2.5x larger hash table than #2's 4096 buckets (+0.001 BPB)
-3. **SWA start_frac=0.4** — only averages the most converged 40% of warmdown checkpoints
-4. **WD=0.04** — 4x higher than #4's 0.01, keeps weights small for better quantization
+1. **TTT (Test-Time Training)** — 3 epochs SGD on val tokens at eval time, ~+0.002 BPB free
+2. **XSA (Cross-Sequence Attention)** — last 4 layers attend across sequences in the batch
+3. **EMA** — exponential moving average of weights (decay=0.997) replaces SWA
+4. **SmearGate + BigramHash(2048)** — smaller hash table than old #1 but combined with TTT/XSA/EMA
+
+## What Separates #2 from #3–5
+
+1. **Gradient-guided adaptive quantization** — sensitivity-aware mixed precision, saves ~1MB
+2. **12 layers** — deepest submission on the board, funded by quant savings
+3. **LN Scale** — zero-param RMSNorm scaling that stabilizes deep networks
+4. **Partial RoPE** — rotary on only 25% of head dims, frees capacity for content
 
 ## Execution Phases
 
-### Phase 1: Reproduce #2's recipe (~3 runs, baseline)
+### Phase 1: Reproduce #4's recipe + new techniques (~3 runs, baseline)
 
 ```bash
-NUM_LAYERS=9 MLP_MULT=3 TRAIN_SEQ_LEN=2048 TRAIN_BATCH_TOKENS=786432
+NUM_LAYERS=9 MLP_MULT=3 TRAIN_SEQ_LEN=2048 TRAIN_BATCH_TOKENS=524288
 MUON_MOMENTUM=0.99 MUON_WEIGHT_DECAY=0.04 WARMDOWN_ITERS=3000
 MATRIX_LR=0.02 SCALAR_LR=0.02 TIED_EMBED_LR=0.03
 GRAD_CLIP_NORM=0.3 FP16_EMBED=1 EVAL_STRIDE=64
 USE_SMEARGATE=1 BIGRAM_HASH_BUCKETS=4096 BIGRAM_HASH_DIM=128
-# + int6 + zstd-22 + SWA + OrthoInit
+EMA_DECAY=0.997
+# + int6 + zstd-22 + OrthoInit
 ```
 
-Target: ~1.146. This is the proven stack.
+Target: ~1.146 with EMA instead of SWA, batch 524K for more steps.
 
-### Phase 2: Push toward #1 (~5 runs)
+### Phase 2: Push toward #2's recipe (~5 runs)
 
-- Add int5 on MLP weights → fund 10th layer
-- BigramHash(10240) instead of 4096
-- SWA start_frac=0.4 (tighter averaging window)
-- Try 11L (like #3) if int5 saves enough space
+- Add gradient-guided adaptive quantization (int7/int6/int5 mixed)
+- Use quant savings (~1MB) to fund 12th layer
+- Add LN Scale (`1/sqrt(layer_idx+1)`) for 12L stability
+- Add Partial RoPE (25% of head dims)
+- Keep batch=524K, EMA=0.997
 
-### Phase 3: Novel improvements (~10 runs)
+### Phase 3: Push toward #1 (~10 runs)
 
-- Try 11L + int5 MLP (not yet on leaderboard)
-- BigramHash(16384) — even larger table
-- QAT (zero quant gap like #5) + int5 (best compression)
-- Muon-aware QAT (Gaussian noise mode from PR #130)
+- Add XSA on last 4 layers
+- Add TTT (3 epochs SGD, lr=0.002, freeze first 2 blocks)
+- BigramHash sweep: 2048 vs 4096 vs 10240 (alertcat uses 2048 — smaller may be better with XSA)
+- Muon-aware QAT (Gaussian noise mode from PR #130) — but NOT late QAT at 12L (known negative result)
 - Explore WD sweep (0.02-0.06)
+- Try 11L vs 12L tradeoff (12L needs LN Scale + adaptive quant)
 
 ### Phase 4: Submission (~5 runs)
 
 - 3+ seeds on best config, p<0.01
-- Target: sub-1.14 BPB
+- Target: sub-1.12 BPB
 
 ## Implementation Needed for CUDA Port
 
@@ -76,6 +86,46 @@ Target: ~1.146. This is the proven stack.
 5. **Int5 quantization** — ~10 lines (extend int6 to support step=8)
 6. **zstd-22** — swap zlib for zstandard
 7. **QAT with STE** — ~20 lines (fake quantize in forward pass)
+
+## New Techniques from Latest Leaderboard
+
+### TTT (Test-Time Training)
+3 epochs SGD on val tokens during eval, lr=0.002, freeze first 2 blocks. Runs in ~47s on 8xH100.
+Effectively free BPB improvement (~+0.002 BPB) since it runs at eval time, not training time.
+The model fine-tunes itself on the validation distribution before being scored.
+
+### Gradient-Guided Adaptive Quantization
+Accumulate squared gradients during the last 10% of warmdown. Rank tensors by sensitivity:
+- Top 10% (highest grad magnitude) → int7
+- Middle 70% → int6
+- Bottom 20% (least sensitive) → int5
+
+Saves ~1MB vs uniform int6 → enough budget to fund a 12th transformer layer.
+
+### LN Scale
+RMSNorm output scaled by `1/sqrt(layer_idx + 1)`. Damps activations in deeper layers.
+Zero additional parameters. Stabilizes training for 12L models that otherwise diverge.
+
+### Partial RoPE
+Apply rotary position embeddings on only 25% of head dimensions (16 of 64).
+Remaining 75% are position-free, acting as content-only dimensions.
+Reduces RoPE's interference with learned attention patterns.
+
+### EMA (Exponential Moving Average)
+Maintain a shadow copy of weights with decay=0.997, updated every step.
+Use the EMA weights for final export. Replaces SWA in alertcat's submission.
+
+### XSA (Cross-Sequence Attention)
+Last 4 layers attend across all sequences in the batch (not just within-sequence).
+Allows the model to leverage inter-sequence context at eval time.
+
+### Batch Size 524K (vs 786K)
+Smaller batch = 22% more gradient steps at the same wallclock budget.
+More updates can matter more than larger batches when training is step-limited.
+
+## Negative Results
+
+- **Late QAT at 12 layers**: Harmful at -0.004 BPB. The step overhead of fake-quantize ops in the forward pass costs too many training steps when the model is already deep. Better to use post-training quantization with gradient-guided sensitivity ranking.
 
 ## Key Architecture Details from Top Submissions
 

--- a/docs/H100_PLAN.md
+++ b/docs/H100_PLAN.md
@@ -77,15 +77,21 @@ Target: ~1.146 with EMA instead of SWA, batch 524K for more steps.
 - 3+ seeds on best config, p<0.01
 - Target: sub-1.12 BPB
 
-## Implementation Needed for CUDA Port
+## Implementation Status
 
-1. **SmearGate** — ~20 lines (gate + prev token blending)
-2. **BigramHash** — ~30 lines (hash table + projection)
-3. **SWA** — ~15 lines (checkpoint averaging in warmdown)
-4. **OrthoInit** — ~10 lines (orthogonal_ on weight matrices)
-5. **Int5 quantization** — ~10 lines (extend int6 to support step=8)
-6. **zstd-22** — swap zlib for zstandard
-7. **QAT with STE** — ~20 lines (fake quantize in forward pass)
+### Already implemented in train_gpt.py (CUDA):
+- SmearGate, BigramHash, SWA, OrthoInit, OvertoneInit, PhaseResidMix
+- Int5/Int6 quantization, QAT with STE, zstd-22, FP16 embed
+- Sliding window eval, Muon WD
+- Bug fixes: SWA float guard, rank-guarded quantization
+
+### Still needed for H100 (implement on pod):
+1. **EMA** — shadow weight copy with decay=0.997 (~15 lines, replaces SWA in Phase 1)
+2. **TTT** — SGD fine-tuning on val tokens at eval time (~30 lines, Phase 3)
+3. **XSA** — cross-sequence attention on last N layers (~25 lines, Phase 3)
+4. **Gradient-guided adaptive quant** — per-tensor sensitivity ranking (~20 lines, Phase 2)
+5. **LN Scale** — `1/sqrt(layer_idx+1)` in RMSNorm (~5 lines, Phase 2)
+6. **Partial RoPE** — rotary on 25% of head dims (~10 lines, Phase 2)
 
 ## New Techniques from Latest Leaderboard
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,173 @@
+# Parameter Golf — Competitive Submission Plan
+
+## Objective
+
+Beat the baseline **1.2244 BPB** by ≥0.005 nats on FineWeb validation (50k docs), with a 16MB artifact training in ≤10 min on 8×H100. Target: **~1.185–1.205 BPB** post-quantization.
+
+---
+
+## Baseline Anatomy
+
+| Component | Value |
+|-----------|-------|
+| Architecture | 9-layer encoder-decoder (4 enc + 5 dec, U-Net skips) |
+| Dims | 512 hidden, 8 Q heads, 4 KV heads, 1024 MLP hidden |
+| Vocab | 1024 SentencePiece BPE, tied embeddings |
+| Params | ~17M (int8 + zlib → 15.8MB compressed) |
+| Code | ~48KB |
+| Headroom | ~137KB unused in 16MB budget |
+| Score | **1.2244 BPB** (pre-quant 1.2172, quant tax = 0.0072) |
+| Training | 13,780 steps in 600s, 524K tok/step, ~7.2B tokens seen, 43.5ms/step |
+| Eval | ~2 seconds (trivially fast vs the 10-min eval cap) |
+
+---
+
+## Three Key Exploits
+
+### 1. Depth Recurrence → Wider Model at Same Depth (biggest win)
+
+The baseline stores 9 unique transformer blocks. With weight sharing:
+- Store **3 unique blocks**, loop **3×** = 9 effective layers (same depth)
+- Per-loop learned scalar gates + tiny LoRA adapters (rank 4-8) to differentiate iterations
+- Frees ~60% of block parameters → reinvest in **wider hidden dim (768 vs 512)**
+
+Budget estimate at 768-dim, 3 unique blocks:
+- tok_emb: 1024 × 768 = 786K params
+- 3 blocks @ 768-dim: ~3.9M each = 11.8M params
+- Per-loop adapters (8 adapters × ~4K): ~32K params
+- Skip weights, norms, etc.: ~5K params
+- **Total: ~12.6M unique params → ~12MB compressed, well under 16MB**
+
+The freed 3-4MB can fund even wider dims (896?) or a 4th unique block.
+
+### 2. QAT → Recover Quantization Tax (easy win, 0.005+ BPB)
+
+The baseline loses 0.0072 BPB from post-training int8 quantization. QAT with straight-through estimator (STE) during training nearly eliminates this:
+- Add `torch.fake_quantize_per_channel_affine()` in forward pass from ~step 5000 onward
+- Train "through" the quantization noise so weights learn to be robust to int8 rounding
+- Expected recovery: 0.005–0.007 BPB (nearly the full tax)
+
+### 3. Test-Time Compute → Free BPB at Eval (unique exploit)
+
+The README explicitly says:
+- *"We encourage competitors to push the bounds of evaluation methods as aggressively as with training methods"*
+- *"We won't accept submissions that take more than 10 minutes on 8xH100 to evaluate"*
+- Baseline eval takes ~2 seconds. **We have ~598 seconds of unused eval compute.**
+
+Options (ranked by safety/impact):
+1. **More recurrence loops at eval** — train with 3 loops, eval with 6-8. More iterations → closer to fixed-point equilibrium → better predictions. Zero risk.
+2. **Longer eval context** — eval at seq_len 2048-4096 instead of 1024. RoPE supports this. More context = better predictions.
+3. **Test-time training** — fine-tune on the val data during eval (explicitly listed as encouraged). Compute gradients on early tokens, update weights, evaluate later tokens. Nuclear option but legal.
+
+---
+
+## Estimated BPB Impact
+
+| Change | Est. BPB gain | Confidence |
+|--------|--------------|------------|
+| QAT (recover quant tax) | -0.005 to -0.007 | High |
+| Depth recurrence + wider model | -0.010 to -0.020 | Medium-High |
+| Extra eval loops | -0.002 to -0.005 | Medium |
+| Longer eval context | -0.001 to -0.003 | Medium |
+| Hyperparam tuning | -0.002 to -0.005 | Medium |
+| **Combined** | **-0.020 to -0.040** | |
+| **Target BPB** | **~1.185 – 1.205** | |
+
+---
+
+## Phased Execution
+
+### Phase 1: Prototype on MLX (Local Mac, Free)
+- Implement depth recurrence (3 blocks × 3 loops) in `train_gpt_mlx.py`
+- Add per-loop learned scalars + tiny LoRA adapters
+- Widen model to 768-dim, verify compressed size fits 16MB
+- Validate directional BPB improvement vs baseline
+- **Exit criteria**: recurrence working, compressed artifact under 16MB, BPB trending better than baseline
+
+### Phase 2: Validate on CUDA (1×H100, ~$85)
+- Port architecture changes to `train_gpt.py`
+- Add QAT with STE (fake quantization in forward pass, enable at step ~5000)
+- Verify on 1×H100 with 10-min wallclock cap
+- Compare pre-quant and post-quant BPB to confirm QAT recovers the tax
+- **Exit criteria**: CUDA training working, QAT reducing quant tax, BPB < 1.215
+
+### Phase 3: Hyperparameter Sweep (1×H100, ~$42)
+- Set up autoresearch loop (Karpathy pattern): agent edits config, runs 10-min train, measures BPB, keeps improvements
+- Sweep: learning rates, loop count, LoRA rank, width, warmdown schedule, entropy regularization weight
+- Run overnight (~100 experiments)
+- **Exit criteria**: best config identified, stable BPB improvement
+
+### Phase 4: Eval-Time Tricks (1×H100, ~$12)
+- Implement extra recurrence loops at eval (3 train → 6-8 eval)
+- Implement longer eval context (2048-4096 seq_len)
+- Optionally: test-time training (gradient steps on val data before measuring)
+- **Exit criteria**: eval tricks add measurable BPB improvement
+
+### Phase 5: Submit (8×H100, ~$120)
+- Final validation on 8×H100 with exact submission config
+- Multiple seeds for statistical significance (p < 0.01)
+- Prepare submission folder: README.md, submission.json, train.log, train_gpt.py
+- PR to `records/track_10min_16mb/`
+- **Exit criteria**: BPB beats 1.2244 by ≥0.005 nats, p < 0.01, artifact < 16MB
+
+---
+
+## Compute Requirements
+
+### Development (1×H100 on RunPod)
+- ~$2.50/hr (80GB SXM)
+- Architecture experiments: ~30 runs × 10 min = 5 hrs = $12
+- Hyperparameter sweeps: ~100 runs × 10 min = 17 hrs = $42
+- Autoresearch overnight loops: 12 hrs = $30
+- **Subtotal: ~$85**
+
+### Validation (8×H100 on RunPod)
+- ~$24/hr (8×H100 SXM pod)
+- Validation runs: ~20 runs × 10 min = 3.3 hrs = $80
+- Final submission (multiple seeds): ~10 runs × 10 min = 1.7 hrs = $40
+- **Subtotal: ~$120**
+
+### Total: ~$200
+
+**Priority: Apply for the OpenAI/RunPod compute grant** via https://openai.com/index/parameter-golf/#credit-form to make this free.
+
+### Local (Free)
+- Mac with Apple Silicon: MLX script for rapid architecture iteration
+- ~10-50× slower than H100 but fine for directional validation
+- All Phase 1 work happens here — minimize cloud spend
+
+---
+
+## Compute Grant Application Strategy
+
+When applying via the credit form, we should have ready:
+1. **Clear technical approach** — depth recurrence + QAT + eval-time compute (this plan)
+2. **Directional results from MLX** — showing the approach is promising before requesting H100 time
+3. **Estimated compute needs** — ~200 1×H100-hours + ~50 8×H100-hours
+4. **Submission timeline** — concrete phase plan with milestones
+
+Iterate as much as possible on MLX first, arrive at the grant application with validated architecture choices and only need cloud compute for final training and statistical validation.
+
+---
+
+## Key Technical Decisions Still Open
+
+1. **Loop count**: 3×3 vs 4×3 vs 3×4 — need MLX experiments
+2. **Width**: 768 vs 896 vs 640 — depends on compressed size budget
+3. **LoRA rank**: 4 vs 8 vs 16 — tradeoff between adaptation quality and param cost
+4. **QAT schedule**: enable at step 5000? 3000? From start?
+5. **Eval loops**: how many extra loops before diminishing returns?
+6. **Entropy regularization**: weight and schedule TBD
+7. **U-Net skip compatibility**: how do skips work with looped blocks?
+
+---
+
+## Risk Register
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Depth recurrence doesn't improve BPB at this scale | High | Fall back to QAT + hyperparam tuning alone |
+| QAT destabilizes training | Medium | Enable QAT late (last 30% of training) |
+| Compressed artifact exceeds 16MB | Medium | Reduce width, increase recurrence ratio |
+| Extra eval loops slow eval past 10 min | Low | Profile and cap loop count |
+| Grant not approved | Medium | Budget ~$200 personal spend |

--- a/records/track_non_record_16mb/2026-03-21_MLX_TechniqueStack_MacPrototyping/README.md
+++ b/records/track_non_record_16mb/2026-03-21_MLX_TechniqueStack_MacPrototyping/README.md
@@ -1,0 +1,59 @@
+# MLX Technique Stack — Mac Prototyping Harness
+
+**val_bpb: 1.9588** (Mac, 14L×416d, 750 steps, 10 shards, int8+zlib, full FineWeb val)
+
+## Status
+
+Non-record submission — Mac MLX prototyping only, pending H100 validation.
+Submitting to document systematic technique exploration and support compute grant application.
+
+## Approach
+
+Systematic validation of leaderboard techniques through 25+ MLX experiments,
+identifying what works, what doesn't, and why.
+
+### Implemented & Validated
+- 10-14 layer architectures with KV2 (GQA)
+- MLP 3x expansion (-0.013 BPB vs MLP 2x)
+- Int6 per-row quantization + FP16 tied embedding passthrough
+- Sliding window eval (stride-64, compiled forward)
+- Muon decoupled weight decay (0.02)
+- Overtone spectral embedding init (SVD power-law S_k ~ k^{-0.5})
+- Phase-transition resid_mix initialization
+- Multi-eval mode (EVAL_CONFIGS for multiple eval passes per run)
+- VAL_MAX_TOKENS for fast directional experiments
+- Compiled NTK-RoPE eval for sequence length extension
+
+### Key Finding
+FP16 embed + Muon WD achieves near-zero quantization gap (0.001 BPB).
+Post-quant ≈ pre-quant, critical for maximizing quality within 16MB.
+
+### Explored & Rejected (negative results)
+| Technique | Result | Why |
+|-----------|--------|-----|
+| Depth recurrence + int6 | +0.61 BPB quant gap | Shared weights amplify quantization error through loops |
+| DenseFormer DWA | +0.003 BPB regression | No benefit at this scale |
+| Eval-time loop scaling | +1.15 BPB regression | Model calibrated to exact training loop count |
+| NTK-RoPE extrapolation (1024->4096) | +0.06 BPB regression | Must train at target seq_len |
+
+### Results (750 steps, 10 shards, full val)
+
+| Config | Params | Compressed | Val BPB | Int8 BPB | Quant Gap |
+|--------|--------|-----------|---------|----------|-----------|
+| 14L×416d KV2 | 16.2M | 12.3MB | 1.9578 | 1.9588 | 0.0010 |
+| 10L×512d + all tricks | 19.0M | 10.8MB | 1.9800 | 1.9808 | 0.0008 |
+
+## Command
+
+```bash
+ITERATIONS=750 TRAIN_BATCH_TOKENS=8192 GRAD_ACCUM_STEPS=1 \
+NUM_LAYERS=14 MODEL_DIM=416 NUM_HEADS=8 NUM_KV_HEADS=2 \
+MAX_WALLCLOCK_SECONDS=0 VAL_LOSS_EVERY=0 VAL_BATCH_SIZE=32768 \
+python3 train_gpt_mlx.py
+```
+
+## Next Steps (require H100)
+- Port to train_gpt.py, train at seq2048
+- Stack MLP3x + int6 + QAT + BigramHash + SmearGate + SWA
+- Optimizer sweep + multi-seed validation
+- Target: sub-1.14 BPB

--- a/records/track_non_record_16mb/2026-03-21_MLX_TechniqueStack_MacPrototyping/submission.json
+++ b/records/track_non_record_16mb/2026-03-21_MLX_TechniqueStack_MacPrototyping/submission.json
@@ -1,0 +1,13 @@
+{
+  "author": "Julian Saks",
+  "github_id": "kingjulio8238",
+  "name": "MLX Technique Stack — Mac Prototyping",
+  "blurb": "25+ MLX experiments validating leaderboard techniques. Near-zero quant gap (0.001 BPB). Pending H100.",
+  "date": "2026-03-21",
+  "val_loss": 3.3073,
+  "val_bpb": 1.9588,
+  "bytes_total": 12288584,
+  "bytes_code": 52000,
+  "hardware": "Apple Silicon (MLX)",
+  "note": "Non-record, Mac-only. Supporting compute grant application."
+}

--- a/records/track_non_record_16mb/2026-03-21_MLX_TechniqueStack_MacPrototyping/train.log
+++ b/records/track_non_record_16mb/2026-03-21_MLX_TechniqueStack_MacPrototyping/train.log
@@ -1,0 +1,1319 @@
+#!/usr/bin/env python3
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: `train_gpt.py` and `train_gpt_mlx.py` must never be longer than 1500 lines.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import math
+import os
+import pickle
+import sys
+import time
+import uuid
+import zlib
+from collections.abc import Callable
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optim
+from mlx.utils import tree_flatten, tree_unflatten
+
+# ==============================================================================
+# SHARD FORMAT + COMPUTE DTYPE
+# ==============================================================================
+
+COMPUTE_DTYPE = mx.bfloat16
+
+# ==============================================================================
+# HYPERPARAMETERS
+# ==============================================================================
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+class Hyperparameters:
+    # Data / tokenizer.
+    data_path: str = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    tokenizer_path: str = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id: str = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed: int = int(os.environ.get("SEED", 1337))
+
+    # Training loop. These defaults now mirror train_gpt.py on a single process.
+    iterations: int = int(os.environ.get("ITERATIONS", 20_000))
+    val_loss_every: int = int(os.environ.get("VAL_LOSS_EVERY", 0))
+    # Validation always uses the full fineweb_val split.
+    val_batch_size: int = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    train_log_every: int = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+    train_batch_tokens: int = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    grad_accum_steps: int = int(os.environ.get("GRAD_ACCUM_STEPS", 8))
+    train_seq_len: int = int(os.environ.get("TRAIN_SEQ_LEN", os.environ.get("TRAIN_MAX_SEQ_LEN", 1024)))
+    # Chunk each logical MLX microbatch into smaller sub-batches to reduce peak
+    # memory pressure without changing the effective optimizer batch.
+    mlx_max_microbatch_tokens: int = int(os.environ.get("MLX_MAX_MICROBATCH_TOKENS", 8_192))
+    warmup_steps: int = int(os.environ.get("WARMUP_STEPS", 20))
+    warmdown_iters: int = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    max_wallclock_seconds: float = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+
+    # Model (defaults match the current baseline setup).
+    vocab_size: int = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers: int = int(os.environ.get("NUM_LAYERS", 9))
+    model_dim: int = int(os.environ.get("MODEL_DIM", 512))
+    num_heads: int = int(os.environ.get("NUM_HEADS", 8))
+    num_kv_heads: int = int(os.environ.get("NUM_KV_HEADS", 4))
+    mlp_mult: int = int(os.environ.get("MLP_MULT", 2))
+    tie_embeddings: bool = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    tied_embed_init_std: float = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    logit_chunk_tokens: int = int(os.environ.get("LOGIT_CHUNK_TOKENS", 0))
+    logit_softcap: float = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    rope_base: float = float(os.environ.get("ROPE_BASE", 10000.0))
+    qk_gain_init: float = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Depth recurrence: set NUM_UNIQUE_BLOCKS>0 and NUM_LOOPS>1 to share blocks.
+    # Effective depth = num_unique_blocks * num_loops. When disabled (default), uses num_layers unique blocks.
+    num_unique_blocks: int = int(os.environ.get("NUM_UNIQUE_BLOCKS", 0))
+    num_loops: int = int(os.environ.get("NUM_LOOPS", 1))
+
+    # Eval-time overrides (0 = use training defaults).
+    eval_num_loops: int = int(os.environ.get("EVAL_NUM_LOOPS", 0))
+    eval_stride: int = int(os.environ.get("EVAL_STRIDE", 0))
+    eval_seq_len: int = int(os.environ.get("EVAL_SEQ_LEN", 0))
+    val_max_tokens: int = int(os.environ.get("VAL_MAX_TOKENS", 0))
+    # Architecture additions.
+    use_loop_embed: bool = bool(int(os.environ.get("USE_LOOP_EMBED", "0")))
+    use_dwa: bool = bool(int(os.environ.get("USE_DWA", "0")))
+
+    # Optimizer. We keep the same per-group defaults as train_gpt.py.
+    beta1: float = float(os.environ.get("BETA1", 0.9))
+    beta2: float = float(os.environ.get("BETA2", 0.95))
+    adam_eps: float = float(os.environ.get("ADAM_EPS", 1e-8))
+    tied_embed_lr: float = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    matrix_lr: float = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr: float = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum: float = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps: int = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start: float = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps: int = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    grad_clip_norm: float = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+    muon_weight_decay: float = float(os.environ.get("MUON_WEIGHT_DECAY", 0.0))
+    overtone_init: bool = bool(int(os.environ.get("OVERTONE_INIT", "0")))
+    phase_resid_mix: bool = bool(int(os.environ.get("PHASE_RESID_MIX", "0")))
+
+    # Quantization.
+    quant_bits: int = int(os.environ.get("QUANT_BITS", 8))
+    fp16_embed: bool = bool(int(os.environ.get("FP16_EMBED", "0")))
+
+    out_dir: str = os.environ.get("OUT_DIR", "logs")
+
+    @property
+    def train_files(self) -> str:
+        return f"{self.data_path}/fineweb_train_*.bin"
+
+    @property
+    def val_files(self) -> str:
+        return f"{self.data_path}/fineweb_val_*.bin"
+
+    @property
+    def microbatch_tokens(self) -> int:
+        return self.train_batch_tokens // self.grad_accum_steps
+
+    def lr_mul(self, step: int, elapsed_ms: float) -> float:
+        if self.warmdown_iters <= 0:
+            return 1.0
+        if self.max_wallclock_seconds <= 0:
+            warmdown_start = max(self.iterations - self.warmdown_iters, 0)
+            return max((self.iterations - step) / max(self.warmdown_iters, 1), 0.0) if warmdown_start <= step < self.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = self.warmdown_iters * step_ms
+        remaining_ms = max(1000.0 * self.max_wallclock_seconds - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,dwa_logits,loop_embeds",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+
+
+def token_chunks(total_tokens: int, seq_len: int, max_chunk_tokens: int) -> list[int]:
+    usable_total = (total_tokens // seq_len) * seq_len
+    if usable_total <= 0:
+        raise ValueError(f"token budget too small for seq_len={seq_len}")
+    usable_chunk = max((max_chunk_tokens // seq_len) * seq_len, seq_len)
+    chunks: list[int] = []
+    remaining = usable_total
+    while remaining > 0:
+        chunk = min(remaining, usable_chunk)
+        chunks.append(chunk)
+        remaining -= chunk
+    return chunks
+
+
+def accumulate_flat_grads(
+    accum: dict[str, mx.array] | None,
+    grads_tree: dict,
+    scale: float,
+) -> dict[str, mx.array]:
+    flat = dict(tree_flatten(grads_tree))
+    if accum is None:
+        return {k: g * scale for k, g in flat.items()}
+    for k, g in flat.items():
+        accum[k] = accum[k] + g * scale
+    return accum
+
+
+# ==============================================================================
+# MATH HELPERS
+# ==============================================================================
+
+def rms_norm(x: mx.array, eps: float = 1e-6) -> mx.array:
+    return (x * mx.rsqrt(mx.mean(x * x, axis=-1, keepdims=True) + eps)).astype(x.dtype)
+
+
+def zeropower_newtonschulz5(g: mx.array, steps: int, eps: float = 1e-7) -> mx.array:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    # Background on Muon: https://kellerjordan.github.io/posts/muon/
+    a, b, c = 3.4445, -4.7750, 2.0315
+    x = g.astype(mx.float32)
+    x = x / (mx.sqrt(mx.sum(x * x)) + eps)
+    transposed = x.shape[0] > x.shape[1]
+    if transposed:
+        x = x.T
+    for _ in range(steps):
+        a_mat = x @ x.T
+        b_mat = b * a_mat + c * (a_mat @ a_mat)
+        x = a * x + b_mat @ x
+    if transposed:
+        x = x.T
+    return x.astype(g.dtype)
+
+
+def load_data_shard(path: Path) -> np.ndarray:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(path, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {path}")
+    num_tokens = int(header[2])
+    if path.stat().st_size != header_bytes + num_tokens * token_bytes:
+        raise ValueError(f"Shard size mismatch for {path}")
+    tokens = np.fromfile(path, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens.size != num_tokens:
+        raise ValueError(f"Short read for {path}")
+    return tokens.astype(np.int32, copy=False)
+
+
+# ==============================================================================
+# TOKEN STREAMING / BATCHING
+# ==============================================================================
+
+
+class TokenStream:
+    def __init__(
+        self,
+        pattern: str,
+        log_fn: Callable[[str], None] | None = None,
+        dataset_name: str = "",
+    ):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.epoch = 1
+        self.file_idx = 0
+        self.log_fn = log_fn
+        self.dataset_name = dataset_name
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def next_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        if self.file_idx == 0:
+            self.epoch += 1
+            if self.log_fn is not None:
+                self.log_fn(
+                    f"WARNING: starting epoch:{self.epoch} "
+                    f"dataset:{self.dataset_name} train_shards:{len(self.files)}"
+                )
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> np.ndarray:
+        chunks: list[np.ndarray] = []
+        left = n
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self.next_file()
+            k = min(left, int(self.tokens.size - self.pos))
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+        return chunks[0] if len(chunks) == 1 else np.concatenate(chunks, axis=0)
+
+
+class TokenLoader:
+    def __init__(
+        self,
+        pattern: str,
+        log_fn: Callable[[str], None] | None = None,
+        dataset_name: str = "",
+    ):
+        self.stream = TokenStream(pattern, log_fn=log_fn, dataset_name=dataset_name)
+
+    def next_batch(self, batch_tokens: int, seq_len: int) -> tuple[mx.array, mx.array]:
+        usable = (batch_tokens // seq_len) * seq_len
+        if usable <= 0:
+            raise ValueError(f"token budget too small for seq_len={seq_len}")
+        chunk = self.stream.take(usable + 1)
+        x = chunk[:-1].reshape(-1, seq_len)
+        y = chunk[1:].reshape(-1, seq_len)
+        return mx.array(x, dtype=mx.int32), mx.array(y, dtype=mx.int32)
+
+
+# ==============================================================================
+# MODEL BLOCKS
+# ==============================================================================
+
+class CastedLinear(nn.Module):
+    def __init__(self, in_dim: int, out_dim: int):
+        super().__init__()
+        self.weight = nn.Linear(in_dim, out_dim, bias=False).weight.astype(mx.float32)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x @ self.weight.astype(x.dtype).T
+
+
+class RMSNormNoWeight(nn.Module):
+    # MLX module wrapper around the functional RMSNorm helper so it composes nicely in blocks.
+    def __call__(self, x: mx.array) -> mx.array:
+        return rms_norm(x)
+
+
+class CausalSelfAttention(nn.Module):
+    # - separate q/k/v projections
+    # - RMSNorm on q and k before attention
+    # - RoPE on q and k
+    # - causal masked SDPA
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim)
+        self.c_k = CastedLinear(dim, kv_dim)
+        self.c_v = CastedLinear(dim, kv_dim)
+        self.proj = CastedLinear(dim, dim)
+        self.q_gain = mx.ones((num_heads,), dtype=mx.float32) * qk_gain_init
+        self.rope = nn.RoPE(self.head_dim, traditional=False, base=rope_base)
+        self.scale = self.head_dim ** -0.5
+
+    def __call__(self, x: mx.array) -> mx.array:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(0, 2, 1, 3)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+
+        q = self.rope(rms_norm(q).astype(COMPUTE_DTYPE))
+        k = self.rope(rms_norm(k).astype(COMPUTE_DTYPE))
+        q = q * self.q_gain.astype(q.dtype)[None, :, None, None]
+        y = mx.fast.scaled_dot_product_attention(q, k, v, scale=self.scale, mask="causal")
+        y = y.transpose(0, 2, 1, 3).reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    # Baseline MLP uses relu^2 instead of GELU/SiLU. It is cheap and works well in this setup.
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = dim * mlp_mult
+        self.fc = CastedLinear(dim, hidden)
+        self.proj = CastedLinear(hidden, dim)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = nn.relu(self.fc(x))
+        return self.proj(x * x)
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNormNoWeight()
+        self.mlp_norm = RMSNormNoWeight()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = mx.ones((dim,), dtype=mx.float32)
+        self.mlp_scale = mx.ones((dim,), dtype=mx.float32)
+        self.resid_mix = mx.array(np.stack((np.ones((dim,), dtype=np.float32), np.zeros((dim,), dtype=np.float32))))
+
+    def __call__(self, x: mx.array, x0: mx.array) -> mx.array:
+        mix = self.resid_mix.astype(x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.astype(x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.astype(x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    # - token embedding + RMSNorm
+    # - encoder half accumulates skip tensors (baseline mode)
+    # - decoder half consumes reversed skips with learned skip_weights (baseline mode)
+    # - OR: depth recurrence with shared blocks looped multiple times
+    # - tied embeddings for the LM head (the baseline default setup)
+    def __init__(self, vocab_size: int, num_layers: int, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int,
+                 logit_chunk_tokens: int, logit_softcap: float, rope_base: float, tied_embed_init_std: float,
+                 qk_gain_init: float, num_unique_blocks: int = 0, num_loops: int = 1,
+                 use_loop_embed: bool = False, use_dwa: bool = False,
+                 overtone_init: bool = False, phase_resid_mix: bool = False):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.logit_chunk_tokens = logit_chunk_tokens
+        self.logit_softcap = logit_softcap
+        self.use_recurrence = num_unique_blocks > 0 and num_loops > 1
+
+        self.tok_emb = nn.Embedding(vocab_size, dim)
+
+        if self.use_recurrence:
+            self.num_unique_blocks = num_unique_blocks
+            self.num_loops = num_loops
+            self.blocks = [
+                Block(dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init)
+                for _ in range(num_unique_blocks)
+            ]
+            # No encoder/decoder split or skip connections in recurrence mode.
+            self.num_encoder_layers = 0
+            self.num_decoder_layers = 0
+            self.num_skip_weights = 0
+            self.skip_weights = mx.zeros((0, dim), dtype=mx.float32)
+        else:
+            self.num_unique_blocks = num_layers
+            self.num_loops = 1
+            self.num_encoder_layers = num_layers // 2
+            self.num_decoder_layers = num_layers - self.num_encoder_layers
+            self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+            self.skip_weights = mx.ones((self.num_skip_weights, dim), dtype=mx.float32)
+            self.blocks = [
+                Block(dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init)
+                for _ in range(num_layers)
+            ]
+
+        # Loop-index embeddings (only meaningful with recurrence).
+        self.use_loop_embed = use_loop_embed and self.use_recurrence
+        if self.use_loop_embed:
+            self.loop_embeds = mx.random.normal((num_loops, dim)) * 0.01
+        # DenseFormer DWA: weighted average of all prior layer outputs.
+        self.use_dwa = use_dwa
+        if use_dwa:
+            ed = num_unique_blocks * num_loops if self.use_recurrence else num_layers
+            self._effective_depth = ed
+            init_logits = np.zeros((ed, ed + 1), dtype=np.float32)
+            for i in range(ed):
+                init_logits[i, i] = 5.0  # near-identity init
+            self.dwa_logits = mx.array(init_logits)
+        else:
+            self._effective_depth = 0
+
+        self.final_norm = RMSNormNoWeight()
+
+        for b in self.blocks:
+            b.attn.proj.weight = mx.zeros_like(b.attn.proj.weight)
+            b.mlp.proj.weight = mx.zeros_like(b.mlp.proj.weight)
+        self.tok_emb.weight = (
+            mx.random.normal(self.tok_emb.weight.shape, dtype=mx.float32) * tied_embed_init_std
+        ).astype(COMPUTE_DTYPE)
+
+        # Overtone spectral embedding init: SVD power-law shaping (S_k ~ k^{-0.5}).
+        if overtone_init:
+            w = np.array(self.tok_emb.weight.astype(mx.float32), dtype=np.float32)
+            U, S, Vt = np.linalg.svd(w, full_matrices=False)
+            target_S = S[0] * (1.0 / np.arange(1, S.shape[0] + 1, dtype=np.float32)) ** 0.5
+            self.tok_emb.weight = mx.array((U * target_S[None, :]) @ Vt, dtype=COMPUTE_DTYPE)
+
+        # Phase-transition resid_mix: sigmoid schedule from trusting x0 (early) to residual (late).
+        if phase_resid_mix:
+            n = len(self.blocks)
+            for i, b in enumerate(self.blocks):
+                phase = 1.0 / (1.0 + np.exp(-3.0 * (i / max(n - 1, 1) - 0.5)))
+                b.resid_mix = mx.array(np.stack((
+                    np.full((dim,), phase, dtype=np.float32),
+                    np.full((dim,), 1.0 - phase, dtype=np.float32),
+                )))
+
+    def softcap(self, logits: mx.array) -> mx.array:
+        c = self.logit_softcap
+        return c * mx.tanh(logits / c)
+
+    def __call__(self, input_ids: mx.array, num_loops_override: int = 0) -> mx.array:
+        x = rms_norm(self.tok_emb(input_ids).astype(COMPUTE_DTYPE))
+        x0 = x
+
+        if self.use_recurrence:
+            num_loops = num_loops_override if num_loops_override > 0 else self.num_loops
+            history: list[mx.array] = [x] if self.use_dwa else []
+            for loop_idx in range(num_loops):
+                for block_idx, block in enumerate(self.blocks):
+                    if self.use_dwa:
+                        step_idx = loop_idx * self.num_unique_blocks + block_idx
+                        dwa_i = step_idx % self._effective_depth
+                        n = min(dwa_i + 1, len(history))
+                        logits_row = self.dwa_logits[dwa_i, :n]
+                        weights = mx.softmax(logits_row)
+                        stacked = mx.stack(history[-n:], axis=0)
+                        x = (weights[:, None, None, None] * stacked).sum(axis=0)
+                    if self.use_loop_embed and block_idx == 0:
+                        x = x + self.loop_embeds[loop_idx % self.num_loops]
+                    x = block(x, x0)
+                    if self.use_dwa:
+                        history.append(x)
+        else:
+            skips: list[mx.array] = []
+            for i in range(self.num_encoder_layers):
+                x = self.blocks[i](x, x0)
+                skips.append(x)
+            for i in range(self.num_decoder_layers):
+                if skips:
+                    x = x + self.skip_weights[i].astype(x.dtype)[None, None, :] * skips.pop()
+                x = self.blocks[self.num_encoder_layers + i](x, x0)
+        return self.final_norm(x)
+
+    def loss(self, input_ids: mx.array, target_ids: mx.array) -> mx.array:
+        # Cross-entropy over flattened tokens. We keep optional logit chunking because it is a useful
+        # memory knob on Macs, but the common path is chunk_tokens=0 (single matmul + CE).
+        x = self(input_ids).reshape(-1, self.tok_emb.weight.shape[1])
+        y = target_ids.reshape(-1)
+        if self.logit_chunk_tokens <= 0 or x.shape[0] <= self.logit_chunk_tokens:
+            logits_proj = x @ self.tok_emb.weight.astype(x.dtype).T
+            logits = self.softcap(logits_proj)
+            return nn.losses.cross_entropy(logits.astype(mx.float32), y, reduction="mean")
+
+        loss_sum = mx.array(0.0, dtype=mx.float32)
+        n = int(x.shape[0])
+        for s in range(0, n, self.logit_chunk_tokens):
+            e = min(s + self.logit_chunk_tokens, n)
+            logits_proj = x[s:e] @ self.tok_emb.weight.astype(x.dtype).T
+            logits = self.softcap(logits_proj)
+            loss_sum = loss_sum + nn.losses.cross_entropy(logits.astype(mx.float32), y[s:e], reduction="sum")
+        return loss_sum / float(n)
+
+# ==============================================================================
+# OPTIMIZERS (MUON + ADAM SPLIT)
+# ==============================================================================
+class Muon:
+    # Muon applies SGD-momentum to matrix gradients, then orthogonalizes the result before the
+    # parameter update.
+    def __init__(self, keys: list[str], params: dict[str, mx.array], args: Hyperparameters):
+        self.keys = keys
+        self.args = args
+        self.buffers = {k: mx.zeros_like(params[k]) for k in keys}
+
+    def step(self, params: dict[str, mx.array], grads: dict[str, mx.array], step: int, lr_mul: float) -> dict[str, mx.array]:
+        if self.args.muon_momentum_warmup_steps:
+            t = min(step / self.args.muon_momentum_warmup_steps, 1.0)
+            momentum = (1.0 - t) * self.args.muon_momentum_warmup_start + t * self.args.muon_momentum
+        else:
+            momentum = self.args.muon_momentum
+        lr = self.args.matrix_lr * lr_mul
+        out: dict[str, mx.array] = {}
+        for k in self.keys:
+            p = params[k]
+            g = grads[k]
+            buf = momentum * self.buffers[k] + g
+            self.buffers[k] = buf
+            g_eff = g + momentum * buf
+            g_ortho = zeropower_newtonschulz5(g_eff, self.args.muon_backend_steps)
+            scale = math.sqrt(max(1.0, float(p.shape[0]) / float(p.shape[1])))
+            out[k] = p - lr * (g_ortho * scale).astype(p.dtype)
+        return out
+
+
+class SplitOptimizers:
+    # - embeddings: Adam with the tied-embedding LR
+    # - block matrices (2D): Muon
+    # - block scalars + skip weights: Adam
+    # This preserves the high-level optimization behavior even though MLX internals differ.
+    def __init__(self, model: GPT, args: Hyperparameters):
+        self.args = args
+        params = dict(tree_flatten(model.parameters()))
+        self.embed_key = "tok_emb.weight"
+        self.matrix_keys = [
+            k
+            for k, p in params.items()
+            if k.startswith("blocks.") and p.ndim == 2 and not any(pattern in k for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        self.scalar_keys = [
+            k
+            for k, p in params.items()
+            if (k == "skip_weights" and p.size > 0)
+            or (k in ("dwa_logits", "loop_embeds") and p.size > 0)
+            or (k.startswith("blocks.") and (p.ndim < 2 or any(pattern in k for pattern in CONTROL_TENSOR_NAME_PATTERNS)))
+        ]
+
+        self.muon = Muon(self.matrix_keys, params, args)
+        self.adam_embed = optim.Adam(
+            learning_rate=args.tied_embed_lr,
+            betas=[args.beta1, args.beta2],
+            eps=args.adam_eps,
+            bias_correction=True,
+        )
+        self.adam_scalar = optim.Adam(
+            learning_rate=args.scalar_lr,
+            betas=[args.beta1, args.beta2],
+            eps=args.adam_eps,
+            bias_correction=True,
+        )
+
+    def step(self, model: GPT, grads_tree: dict, step: int, lr_mul: float) -> None:
+        params = dict(tree_flatten(model.parameters()))
+        grads = dict(tree_flatten(grads_tree))
+        updated = dict(params)
+
+        updated.update(self.muon.step(params, grads, step=step, lr_mul=lr_mul))
+
+        self.adam_embed.learning_rate = self.args.tied_embed_lr * lr_mul
+        updated.update(
+            self.adam_embed.apply_gradients(
+                {self.embed_key: grads[self.embed_key]},
+                {self.embed_key: params[self.embed_key]},
+            )
+        )
+
+        self.adam_scalar.learning_rate = self.args.scalar_lr * lr_mul
+        scalar_grads = {k: grads[k] for k in self.scalar_keys}
+        scalar_params = {k: params[k] for k in self.scalar_keys}
+        updated.update(self.adam_scalar.apply_gradients(scalar_grads, scalar_params))
+
+        model.update(tree_unflatten(list(updated.items())))
+
+# ==============================================================================
+# QUANTIZATION (INT8 + ZLIB)
+# ==============================================================================
+# - per-row int8 for 2D float tensors
+# - per-tensor int8 for other float tensors
+# - fp16 passthrough for small float tensors
+# - exact passthrough for non-floats
+
+MX_DTYPE_FROM_NAME = {
+    "float32": mx.float32,
+    "float16": mx.float16,
+    "bfloat16": mx.bfloat16,
+}
+
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = np.float16
+INT8_PER_ROW_SCALE_DTYPE = np.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+
+def _np_float32(arr: mx.array) -> np.ndarray:
+    return np.array(arr.astype(mx.float32), dtype=np.float32, copy=False)
+
+
+def keep_float_array(name: str, arr: mx.array, passthrough_orig_dtypes: dict[str, str]) -> np.ndarray:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return np.ascontiguousarray(_np_float32(arr))
+    if arr.dtype in {mx.float32, mx.bfloat16}:
+        passthrough_orig_dtypes[name] = str(arr.dtype).split(".")[-1]
+        return np.ascontiguousarray(np.array(arr.astype(mx.float16), dtype=INT8_KEEP_FLOAT_STORE_DTYPE, copy=False))
+    return np.ascontiguousarray(np.array(arr, copy=True))
+
+
+def quantize_float_array(arr: mx.array, quant_bits: int = 8) -> tuple[np.ndarray, np.ndarray]:
+    f32 = _np_float32(arr)
+    # int6: clip to [-32, 31], stored in int8 (high 2 bits zero, compresses well).
+    # int8: clip to [-127, 127] as before.
+    if quant_bits == 6:
+        qmax, qmin = 31, -32
+    else:
+        qmax, qmin = 127, -127
+    scale_denom = float(qmax)  # 32.0 for int6, 127.0 for int8
+    if f32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = np.quantile(np.abs(f32), INT8_CLIP_Q, axis=1) if f32.size else np.empty((f32.shape[0],), dtype=np.float32)
+        clipped = np.clip(f32, -clip_abs[:, None], clip_abs[:, None])
+        scale = np.maximum(clip_abs / scale_denom, 1.0 / scale_denom).astype(np.float32, copy=False)
+        q = np.clip(np.round(clipped / scale[:, None]), qmin, qmax).astype(np.int8, copy=False)
+        return np.ascontiguousarray(q), np.ascontiguousarray(scale.astype(INT8_PER_ROW_SCALE_DTYPE, copy=False))
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = float(np.quantile(np.abs(f32).reshape(-1), INT8_CLIP_Q)) if f32.size else 0.0
+    scale = np.array(clip_abs / scale_denom if clip_abs > 0.0 else 1.0, dtype=np.float32)
+    q = np.clip(np.round(np.clip(f32, -clip_abs, clip_abs) / scale), qmin, qmax).astype(np.int8, copy=False)
+    return np.ascontiguousarray(q), scale
+
+
+def quantize_state_dict_int8(
+    flat_state: dict[str, mx.array],
+    quant_bits: int = 8,
+    fp16_embed: bool = False,
+) -> tuple[dict[str, object], dict[str, int]]:
+    quantized: dict[str, np.ndarray] = {}
+    scales: dict[str, np.ndarray] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, np.ndarray] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+    for name, arr in flat_state.items():
+        stats["param_count"] += int(arr.size)
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += int(arr.nbytes)
+        if not mx.issubdtype(arr.dtype, mx.floating):
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = np.ascontiguousarray(np.array(arr))
+            stats["int8_payload_bytes"] += int(passthrough[name].nbytes)
+            continue
+
+        # FP16 embedding passthrough: keep tok_emb.weight in fp16 regardless of size.
+        if fp16_embed and name == "tok_emb.weight":
+            kept = keep_float_array(name, arr, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += int(kept.nbytes)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if int(arr.size) <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_array(name, arr, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += int(kept.nbytes)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_array(arr, quant_bits=quant_bits)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(arr.dtype).split(".")[-1]
+        stats["int8_payload_bytes"] += int(q.nbytes + s.nbytes)
+    obj: dict[str, object] = {
+        "__quant_format__": f"int{quant_bits}_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+
+def dequantize_state_dict_int8(quant_obj: dict[str, object]) -> dict[str, mx.array]:
+    out: dict[str, mx.array] = {}
+    qmeta = quant_obj.get("qmeta", {})
+    passthrough_orig_dtypes = quant_obj.get("passthrough_orig_dtypes", {})
+    for name, q in quant_obj["quantized"].items():
+        q_np = np.asarray(q, dtype=np.int8)
+        dtype_name = quant_obj["dtypes"][name]
+        scale = np.asarray(quant_obj["scales"][name], dtype=np.float32)
+        if qmeta.get(name, {}).get("scheme") == "per_row" or scale.ndim > 0:
+            # Broadcast the saved row scale back across trailing dimensions.
+            out_arr = q_np.astype(np.float32) * scale.reshape((q_np.shape[0],) + (1,) * (q_np.ndim - 1))
+        else:
+            out_arr = q_np.astype(np.float32) * float(scale)
+        out[name] = mx.array(out_arr, dtype=MX_DTYPE_FROM_NAME[dtype_name])
+    for name, arr in quant_obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_arr = np.array(arr, copy=True)
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out[name] = mx.array(out_arr, dtype=MX_DTYPE_FROM_NAME[orig_dtype])
+        else:
+            out[name] = mx.array(out_arr)
+    return out
+
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_lut = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_lut = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_lut = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_lut[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_lut[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_lut[token_id] = True
+            piece = piece[1:]
+        base_bytes_lut[token_id] = len(piece.encode("utf-8"))
+    return base_bytes_lut, has_leading_space_lut, is_boundary_token_lut
+
+
+def validate_dataset_tokenizer_pair(data_path: str, tokenizer_path: str) -> tuple[str, int, int | None]:
+    # The shard directory and tokenizer are coupled: val_bpb is only meaningful if we
+    # decode bytes with the exact tokenizer that produced the shards. The manifest
+    # lets the training script fail fast on accidental dataset/tokenizer mismatches.
+    dataset_dir = Path(data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    if len(dataset_dir.parents) < 2:
+        return dataset_dir.name, actual_train_files, None
+    manifest_path = dataset_dir.parents[1] / "manifest.json"
+    if not manifest_path.is_file():
+        return dataset_dir.name, actual_train_files, None
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    dataset_entry = next((x for x in manifest.get("datasets", []) if x.get("name") == dataset_dir.name), None)
+    if dataset_entry is None:
+        return dataset_dir.name, actual_train_files, None
+
+    tokenizer_name = dataset_entry.get("tokenizer_name")
+    tokenizer_entry = (
+        next((x for x in manifest.get("tokenizers", []) if x.get("name") == tokenizer_name), None)
+        if tokenizer_name
+        else None
+    )
+    expected_name = Path((tokenizer_entry or {}).get("model_path") or (tokenizer_entry or {}).get("path") or "").name
+    if expected_name and Path(tokenizer_path).name != expected_name:
+        raise ValueError(f"{dataset_dir.name} expects tokenizer {expected_name}, got {Path(tokenizer_path).name}")
+    expected_train_files = (dataset_entry.get("stats") or {}).get("files_train")
+    if expected_train_files is not None:
+        expected_train_files = int(expected_train_files)
+        if actual_train_files > expected_train_files:
+            raise ValueError(
+                f"{dataset_dir.name} has more train shards than expected: found {actual_train_files}, "
+                f"manifest says {expected_train_files}"
+            )
+    return dataset_dir.name, actual_train_files, expected_train_files
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> np.ndarray:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = np.ascontiguousarray(np.concatenate([load_data_shard(file) for file in files], axis=0))
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def loss_and_grad_chunked(
+    args: Hyperparameters,
+    train_loader: TokenLoader,
+    compiled_loss_and_grad,
+) -> tuple[mx.array, dict]:
+    chunk_sizes = token_chunks(args.microbatch_tokens, args.train_seq_len, args.mlx_max_microbatch_tokens)
+    total_tokens = float(sum(chunk_sizes))
+    loss_value = mx.array(0.0, dtype=mx.float32)
+    grad_accum: dict[str, mx.array] | None = None
+    for chunk_tokens in chunk_sizes:
+        x, y = train_loader.next_batch(chunk_tokens, args.train_seq_len)
+        loss, grads = compiled_loss_and_grad(x, y)
+        scale = float(y.size) / total_tokens
+        loss_value = loss_value + loss.astype(mx.float32) * scale
+        grad_accum = accumulate_flat_grads(grad_accum, grads, scale)
+    return loss_value, tree_unflatten(list(grad_accum.items()))
+
+
+def set_rope_base(model: GPT, base: float) -> None:
+    for block in model.blocks:
+        block.attn.rope = nn.RoPE(block.attn.head_dim, traditional=False, base=base)
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: GPT,
+    val_tokens: np.ndarray,
+    base_bytes_lut: np.ndarray,
+    has_leading_space_lut: np.ndarray,
+    is_boundary_token_lut: np.ndarray,
+    compiled_forward=None,
+) -> tuple[float, float]:
+    # Sliding-window eval: each window is eval_seq_len tokens, scored on last stride tokens.
+    # When stride == eval_seq_len, this degrades to the non-overlapping baseline.
+    eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    stride = args.eval_stride if args.eval_stride > 0 else eval_seq_len
+    num_loops_override = args.eval_num_loops if args.eval_num_loops > 0 else 0
+
+    # NTK-RoPE scaling for longer eval sequences.
+    ntk_active = eval_seq_len != args.train_seq_len
+    if ntk_active:
+        head_dim = args.model_dim // args.num_heads
+        scaled_base = args.rope_base * (eval_seq_len / args.train_seq_len) ** (head_dim / (head_dim - 2))
+        set_rope_base(model, scaled_base)
+
+    # Use compiled forward when possible. Recompile after NTK RoPE swap so the
+    # compiled graph captures the scaled frequencies.
+    use_compiled = compiled_forward is not None and num_loops_override == 0
+    if ntk_active and use_compiled:
+        compiled_forward = mx.compile(lambda x: model(x), inputs=model.state, outputs=model.state)
+
+    n_tokens = val_tokens.size - 1
+    starts = list(range(0, n_tokens - eval_seq_len + 1, stride))
+    val_batch_seqs = max(args.val_batch_size // eval_seq_len, 1)
+
+    total_loss = mx.array(0.0, dtype=mx.float32)
+    total_scored = 0
+    total_bytes = 0.0
+    embed_dim = model.tok_emb.weight.shape[1]
+    for b_start in range(0, len(starts), val_batch_seqs):
+        batch_starts = starts[b_start : b_start + val_batch_seqs]
+        x_np = np.stack([val_tokens[s : s + eval_seq_len] for s in batch_starts])
+        y_np = np.stack([val_tokens[s + 1 : s + eval_seq_len + 1] for s in batch_starts])
+        x = mx.array(x_np, dtype=mx.int32)
+
+        hidden = compiled_forward(x) if use_compiled else model(x, num_loops_override=num_loops_override)
+        h_scored = hidden[:, -stride:, :].reshape(-1, embed_dim)
+        logits = model.softcap(h_scored @ model.tok_emb.weight.astype(h_scored.dtype).T)
+        y_scored = mx.array(y_np[:, -stride:], dtype=mx.int32).reshape(-1)
+        total_loss = total_loss + nn.losses.cross_entropy(logits.astype(mx.float32), y_scored, reduction="sum")
+
+        prev_np = x_np[:, -stride:].reshape(-1)
+        tgt_np = y_np[:, -stride:].reshape(-1)
+        bytes_arr = base_bytes_lut[tgt_np].astype(np.int16, copy=True)
+        bytes_arr += (has_leading_space_lut[tgt_np] & ~is_boundary_token_lut[prev_np]).astype(np.int16, copy=False)
+        total_scored += tgt_np.size
+        total_bytes += float(bytes_arr.astype(np.float64).sum())
+        # Periodically materialize to prevent lazy graph from growing unbounded.
+        if (b_start // val_batch_seqs) % 50 == 49:
+            mx.eval(total_loss)
+
+    total_loss = total_loss / total_scored
+    mx.eval(total_loss)
+    val_loss = float(total_loss.item())
+    val_bpb = (val_loss / math.log(2.0)) * (total_scored / total_bytes)
+
+    if eval_seq_len != args.train_seq_len:
+        set_rope_base(model, args.rope_base)
+    return val_loss, val_bpb
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def clip_grad_tree(grads_tree: dict, max_norm: float) -> dict:
+    if max_norm <= 0:
+        return grads_tree
+    flat = dict(tree_flatten(grads_tree))
+    total_sq = 0.0
+    for grad in flat.values():
+        total_sq += float(np.sum(np.square(_np_float32(grad)), dtype=np.float64))
+    if total_sq <= 0.0:
+        return grads_tree
+    total_norm = math.sqrt(total_sq)
+    if total_norm <= max_norm:
+        return grads_tree
+    scale = max_norm / (total_norm + 1e-12)
+    return tree_unflatten([(k, g * scale) for k, g in flat.items()])
+
+
+def main() -> None:
+    # ==============================================================================
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # ==============================================================================
+    args = Hyperparameters()
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    logfile = out_dir / f"{args.run_id}.txt"
+    print(logfile)
+
+    def log(msg: str, console: bool = True) -> None:
+        if console:
+            print(msg)
+        with logfile.open("a", encoding="utf-8") as f:
+            print(msg, file=f)
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    log(code, console=False)
+    log("=" * 100, console=False)
+    log(f"Running Python {sys.version}", console=False)
+    log(f"Running MLX {mx.__version__}", console=False)
+    log("=" * 100, console=False)
+
+    if not args.tie_embeddings:
+        raise NotImplementedError("train_gpt_mlx.py only supports tied embeddings")
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"TOKENIZER_PATH must point to a SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_name, actual_train_files, expected_train_files = validate_dataset_tokenizer_pair(
+        args.data_path,
+        args.tokenizer_path,
+    )
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    if args.val_max_tokens > 0:
+        cap = min(args.val_max_tokens, val_tokens.size - 1)
+        cap = (cap // args.train_seq_len) * args.train_seq_len
+        val_tokens = val_tokens[: cap + 1]
+
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size
+    )
+
+    # ==============================================================================
+    # TRAINING SETUP
+    # ==============================================================================
+    mx.random.seed(args.seed)
+
+    train_loader = TokenLoader(args.train_files, log_fn=log, dataset_name=dataset_name)
+
+    # ==============================================================================
+    # MODEL + OPTIMIZER SETUP
+    # ==============================================================================
+    model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        logit_chunk_tokens=args.logit_chunk_tokens,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        tied_embed_init_std=args.tied_embed_init_std,
+        qk_gain_init=args.qk_gain_init,
+        num_unique_blocks=args.num_unique_blocks,
+        num_loops=args.num_loops,
+        use_loop_embed=args.use_loop_embed,
+        use_dwa=args.use_dwa,
+        overtone_init=args.overtone_init,
+        phase_resid_mix=args.phase_resid_mix,
+    )
+    opt = SplitOptimizers(model, args)
+
+    # ==============================================================================
+    # COMPILED TRAIN / EVAL FUNCTIONS (MLX)
+    # ==============================================================================
+    # The crucial MLX detail is capture scope: this model contains non-trainable arrays too (for example
+    # inside RoPE modules), so compiling only against trainable parameters throws "uncaptured inputs".
+    # Compiling the model-bound functions and capturing the full model state fixes that while still
+    # returning gradients only for trainable parameters via nn.value_and_grad(...).
+    compiled_forward = mx.compile(lambda x: model(x), inputs=model.state, outputs=model.state)
+    compiled_loss_and_grad = mx.compile(
+        nn.value_and_grad(model, lambda x, y: model.loss(x, y)),
+        inputs=model.state,
+        outputs=model.state,
+    )
+
+    # Print config once so logs are self-describing.
+    n_params = sum(int(np.prod(p.shape)) for _, p in tree_flatten(model.parameters()))
+    log(f"run_id:{args.run_id}")
+    log(f"mlx_version:{mx.__version__}")
+    log(f"train_loader:shards pattern={args.train_files}")
+    log(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.size - 1}")
+    if expected_train_files is None:
+        log(f"train_loader:dataset:{dataset_name} train_shards:{actual_train_files}")
+    elif actual_train_files < expected_train_files:
+        log(
+            f"WARNING: train_loader:subset dataset:{dataset_name} "
+            f"train_shards:{actual_train_files}/{expected_train_files} "
+            f"new epochs will arrive sooner than the full dataset"
+        )
+    else:
+        log(f"train_loader:dataset:{dataset_name} train_shards:{actual_train_files}/{expected_train_files}")
+    log(f"tokenizer_path:{args.tokenizer_path}")
+    if model.use_recurrence:
+        log(
+            f"model_params:{n_params} vocab_size:{args.vocab_size} "
+            f"unique_blocks:{args.num_unique_blocks} loops:{args.num_loops} effective_layers:{args.num_unique_blocks * args.num_loops} "
+            f"dim:{args.model_dim} heads:{args.num_heads} kv_heads:{args.num_kv_heads} "
+            f"seq_len:{args.train_seq_len} tie_embeddings:{args.tie_embeddings}"
+        )
+    else:
+        log(
+            f"model_params:{n_params} vocab_size:{args.vocab_size} layers:{args.num_layers} "
+            f"dim:{args.model_dim} heads:{args.num_heads} kv_heads:{args.num_kv_heads} "
+            f"seq_len:{args.train_seq_len} tie_embeddings:{args.tie_embeddings}"
+        )
+    log(
+        f"iterations:{args.iterations} train_batch_tokens:{args.train_batch_tokens} grad_accum_steps:{args.grad_accum_steps} "
+        f"microbatch_tokens:{args.microbatch_tokens} microbatch_batch_size:{args.microbatch_tokens // args.train_seq_len} "
+        f"val_batch_size:{args.val_batch_size} "
+        f"warmup_steps:{args.warmup_steps} max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log(f"mlx_max_microbatch_tokens:{args.mlx_max_microbatch_tokens}")
+    log(
+        f"optimizer:muon+adam muon_matrix_params:{len(opt.matrix_keys)} scalar_params:{len(opt.scalar_keys)} "
+        f"embed_lr:{args.tied_embed_lr} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr} "
+        f"muon_momentum:{args.muon_momentum} muon_steps:{args.muon_backend_steps}"
+    )
+    log(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log(f"compute_dtype:{COMPUTE_DTYPE} compile:True")
+    log(
+        f"dtypes tok_emb:{model.tok_emb.weight.dtype} "
+        f"linear_weight:{model.blocks[0].attn.c_q.weight.dtype} "
+        f"skip_weights:{model.skip_weights.dtype}"
+    )
+
+    # ==============================================================================
+    # TRAINING LOOP
+    # ==============================================================================
+    if args.warmup_steps > 0:
+        # Warmup should only prime MLX compile/allocation paths. Updating parameters here forces us
+        # to snapshot and restore model/optimizer state, which is expensive on unified-memory Macs.
+        # Instead we run the real train shapes, force the loss/grads to materialize, and then reset
+        # the loader so measured training still starts from the true init and token window.
+        for warmup_step in range(args.warmup_steps):
+            accum: dict[str, mx.array] | None = None
+            warmup_loss = mx.array(0.0, dtype=mx.float32)
+            grad_scale = 1.0 / args.grad_accum_steps
+            for _ in range(args.grad_accum_steps):
+                warmup_loss, grads = loss_and_grad_chunked(args, train_loader, compiled_loss_and_grad)
+                accum = accumulate_flat_grads(accum, grads, grad_scale)
+            mx.eval(warmup_loss, accum)
+            mx.synchronize()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+
+        # Prime compiled eval forward pass too.
+        warm_seqs = min(args.val_batch_size // args.train_seq_len, (val_tokens.size - 1) // args.train_seq_len)
+        warm_x = mx.array(val_tokens[: warm_seqs * args.train_seq_len].reshape(-1, args.train_seq_len), dtype=mx.int32)
+        mx.eval(compiled_forward(warm_x))
+        mx.synchronize()
+
+        train_loader = TokenLoader(args.train_files, log_fn=log, dataset_name=dataset_name)
+
+    train_time_ms = 0.0
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    stop_after_step: int | None = None
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+            # Validation always scans the same fixed full validation split.
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+                compiled_forward,
+            )
+            train_time_ms += 1000.0 * (time.perf_counter() - t0)
+            if step % 25 == 0 or last_step:
+                log(
+                    f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                    f"train_time:{train_time_ms:.0f}ms step_avg:{train_time_ms / max(step, 1):.2f}ms"
+                )
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log(f"stopping_early: wallclock_cap train_time:{train_time_ms:.0f}ms step:{step}/{args.iterations}")
+            break
+
+        lr_mul = args.lr_mul(step, train_time_ms + 1000.0 * (time.perf_counter() - t0))
+        step_t0 = time.perf_counter()
+
+        accum: dict[str, mx.array] | None = None
+        train_loss = mx.array(0.0, dtype=mx.float32)
+        grad_scale = 1.0 / args.grad_accum_steps
+        for _ in range(args.grad_accum_steps):
+            loss, grads = loss_and_grad_chunked(args, train_loader, compiled_loss_and_grad)
+            accum = accumulate_flat_grads(accum, grads, grad_scale)
+            train_loss = train_loss + loss.astype(mx.float32) * grad_scale
+
+        grads = tree_unflatten(list(accum.items()))
+        grads = clip_grad_tree(grads, args.grad_clip_norm)
+        train_loss_value = float(train_loss.item())
+        opt.step(model, grads, step=step, lr_mul=lr_mul)
+        # Decoupled weight decay for Muon-managed matrix params.
+        if args.muon_weight_decay > 0:
+            decay = 1.0 - args.muon_weight_decay * args.matrix_lr * lr_mul
+            params = dict(tree_flatten(model.parameters()))
+            for k in opt.matrix_keys:
+                params[k] = params[k] * decay
+            model.update(tree_unflatten(list(params.items())))
+        mx.synchronize()
+
+        step_ms = 1000.0 * (time.perf_counter() - step_t0)
+        approx_train_time_ms = train_time_ms + 1000.0 * (time.perf_counter() - t0)
+        tok_s = args.train_batch_tokens / (step_ms / 1000.0)
+        step += 1
+        if args.train_log_every > 0 and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None):
+            log(
+                f"step:{step}/{args.iterations} train_loss:{train_loss_value:.4f} "
+                f"train_time:{approx_train_time_ms:.0f}ms step_avg:{approx_train_time_ms / step:.2f}ms tok_s:{tok_s:.0f}"
+            )
+        if max_wallclock_ms is not None and stop_after_step is None and approx_train_time_ms >= max_wallclock_ms:
+            stop_after_step = step
+
+    # ==============================================================================
+    # FINAL SERIALIZATION + QUANTIZED ROUNDTRIP EVAL
+    # ==============================================================================
+    # We always write a raw artifact and a quantized artifact, then validate the
+    # quantized roundtrip directly by loading the dequantized tensors back into the
+    # model and running one final validation pass.
+    out_path = out_dir / f"{args.run_id}_mlx_model.npz"
+    flat_state = {k: v for k, v in tree_flatten(model.state) if v.size > 0}
+    mx.savez(str(out_path), **flat_state)
+    log(f"saved_model:{out_path} bytes:{out_path.stat().st_size}")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(flat_state, quant_bits=args.quant_bits, fp16_embed=args.fp16_embed)
+    quant_raw = pickle.dumps(quant_obj, protocol=pickle.HIGHEST_PROTOCOL)
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_serialized_bytes = len(quant_raw)
+    quant_path = out_dir / f"{args.run_id}_mlx_model.int8.ptz"
+    with quant_path.open("wb") as f:
+        f.write(quant_blob)
+    quant_file_bytes = quant_path.stat().st_size
+    ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+    log(
+        f"serialized_model_int8_zlib:{quant_file_bytes} bytes "
+        f"(payload:{quant_stats['int8_payload_bytes']} raw_pickle:{quant_serialized_bytes} payload_ratio:{ratio:.2f}x)"
+    )
+
+    with quant_path.open("rb") as f:
+        quant_blob_disk = f.read()
+    quant_flat = dequantize_state_dict_int8(pickle.loads(zlib.decompress(quant_blob_disk)))
+    model.update(tree_unflatten(list(quant_flat.items())))
+    q_t0 = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        model,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+        compiled_forward,
+    )
+    q_eval_ms = 1000.0 * (time.perf_counter() - q_t0)
+    log(f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} eval_time:{q_eval_ms:.0f}ms")
+    log(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    # Multi-eval: run additional eval configs on the same trained (quantized) model.
+    # Format: semicolon-separated configs, each is comma-separated KEY=VAL overrides.
+    # Example: EVAL_CONFIGS="eval_stride=256;eval_stride=256,eval_seq_len=2048,eval_num_loops=6"
+    eval_configs_str = os.environ.get("EVAL_CONFIGS", "")
+    if eval_configs_str:
+        for cfg_str in eval_configs_str.split(";"):
+            if not cfg_str.strip():
+                continue
+            overrides = {}
+            for kv in cfg_str.strip().split(","):
+                k, v = kv.split("=", 1)
+                overrides[k.strip().lower()] = int(v.strip())
+            saved = {k: getattr(args, k) for k in overrides if hasattr(args, k)}
+            for k, v in overrides.items():
+                if hasattr(args, k):
+                    setattr(args, k, v)
+            e_t0 = time.perf_counter()
+            e_loss, e_bpb = eval_val(args, model, val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut, compiled_forward)
+            e_ms = 1000.0 * (time.perf_counter() - e_t0)
+            log(f"multi_eval config:{cfg_str.strip()} val_loss:{e_loss:.4f} val_bpb:{e_bpb:.4f} eval_time:{e_ms:.0f}ms")
+            log(f"multi_eval_exact config:{cfg_str.strip()} val_loss:{e_loss:.8f} val_bpb:{e_bpb:.8f}")
+            for k, v in saved.items():
+                setattr(args, k, v)
+
+
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
+Running Python 3.12.8 | packaged by Anaconda, Inc. | (main, Dec 11 2024, 10:37:40) [Clang 14.0.6 ]
+Running MLX 0.25.2
+====================================================================================================
+run_id:8211f248-1eef-44c1-95ea-8c3c1aecfbdb
+mlx_version:0.25.2
+train_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_train_*.bin
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+WARNING: train_loader:subset dataset:fineweb10B_sp1024 train_shards:10/195 new epochs will arrive sooner than the full dataset
+tokenizer_path:./data/tokenizers/fineweb_1024_bpe.model
+model_params:16200400 vocab_size:1024 layers:14 dim:416 heads:8 kv_heads:2 seq_len:1024 tie_embeddings:True
+iterations:750 train_batch_tokens:8192 grad_accum_steps:1 microbatch_tokens:8192 microbatch_batch_size:8 val_batch_size:32768 warmup_steps:20 max_wallclock_seconds:0.000
+mlx_max_microbatch_tokens:8192
+optimizer:muon+adam muon_matrix_params:84 scalar_params:57 embed_lr:0.05 matrix_lr:0.04 scalar_lr:0.04 muon_momentum:0.95 muon_steps:5
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+compute_dtype:mlx.core.bfloat16 compile:True
+dtypes tok_emb:mlx.core.bfloat16 linear_weight:mlx.core.float32 skip_weights:mlx.core.float32
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:1/750 train_loss:6.9382 train_time:453ms step_avg:453.22ms tok_s:18076
+step:2/750 train_loss:11.3066 train_time:1843ms step_avg:921.28ms tok_s:5898
+step:3/750 train_loss:8.7616 train_time:3165ms step_avg:1055.03ms tok_s:6197
+step:4/750 train_loss:7.3127 train_time:4484ms step_avg:1120.90ms tok_s:6214
+step:5/750 train_loss:6.8259 train_time:5802ms step_avg:1160.49ms tok_s:6212
+step:6/750 train_loss:6.5726 train_time:7123ms step_avg:1187.12ms tok_s:6206
+step:7/750 train_loss:6.3089 train_time:8440ms step_avg:1205.72ms tok_s:6220
+step:8/750 train_loss:6.3437 train_time:9763ms step_avg:1220.37ms tok_s:6193
+step:9/750 train_loss:6.2305 train_time:11082ms step_avg:1231.35ms tok_s:6211
+step:10/750 train_loss:6.2467 train_time:12427ms step_avg:1242.66ms tok_s:6094
+step:200/750 train_loss:3.9310 train_time:263086ms step_avg:1315.43ms tok_s:6214
+step:400/750 train_loss:3.7109 train_time:543714ms step_avg:1359.29ms tok_s:4588
+step:600/750 train_loss:3.3041 train_time:838621ms step_avg:1397.70ms tok_s:6102
+step:750/750 val_loss:3.3056 val_bpb:1.9578 train_time:4265269ms step_avg:5687.02ms
+saved_model:logs/8211f248-1eef-44c1-95ea-8c3c1aecfbdb_mlx_model.npz bytes:64834220
+serialized_model_int8_zlib:12288584 bytes (payload:17551040 raw_pickle:17564139 payload_ratio:3.69x)
+final_int8_zlib_roundtrip val_loss:3.3073 val_bpb:1.9588 eval_time:2940949ms
+final_int8_zlib_roundtrip_exact val_loss:3.30726862 val_bpb:1.95875077

--- a/records/track_non_record_16mb/2026-03-21_MLX_TechniqueStack_MacPrototyping/train_gpt_mlx.py
+++ b/records/track_non_record_16mb/2026-03-21_MLX_TechniqueStack_MacPrototyping/train_gpt_mlx.py
@@ -1,0 +1,1263 @@
+#!/usr/bin/env python3
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: `train_gpt.py` and `train_gpt_mlx.py` must never be longer than 1500 lines.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import math
+import os
+import pickle
+import sys
+import time
+import uuid
+import zlib
+from collections.abc import Callable
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx.optimizers as optim
+from mlx.utils import tree_flatten, tree_unflatten
+
+# ==============================================================================
+# SHARD FORMAT + COMPUTE DTYPE
+# ==============================================================================
+
+COMPUTE_DTYPE = mx.bfloat16
+
+# ==============================================================================
+# HYPERPARAMETERS
+# ==============================================================================
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+class Hyperparameters:
+    # Data / tokenizer.
+    data_path: str = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    tokenizer_path: str = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id: str = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed: int = int(os.environ.get("SEED", 1337))
+
+    # Training loop. These defaults now mirror train_gpt.py on a single process.
+    iterations: int = int(os.environ.get("ITERATIONS", 20_000))
+    val_loss_every: int = int(os.environ.get("VAL_LOSS_EVERY", 0))
+    # Validation always uses the full fineweb_val split.
+    val_batch_size: int = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    train_log_every: int = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+    train_batch_tokens: int = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    grad_accum_steps: int = int(os.environ.get("GRAD_ACCUM_STEPS", 8))
+    train_seq_len: int = int(os.environ.get("TRAIN_SEQ_LEN", os.environ.get("TRAIN_MAX_SEQ_LEN", 1024)))
+    # Chunk each logical MLX microbatch into smaller sub-batches to reduce peak
+    # memory pressure without changing the effective optimizer batch.
+    mlx_max_microbatch_tokens: int = int(os.environ.get("MLX_MAX_MICROBATCH_TOKENS", 8_192))
+    warmup_steps: int = int(os.environ.get("WARMUP_STEPS", 20))
+    warmdown_iters: int = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    max_wallclock_seconds: float = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+
+    # Model (defaults match the current baseline setup).
+    vocab_size: int = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers: int = int(os.environ.get("NUM_LAYERS", 9))
+    model_dim: int = int(os.environ.get("MODEL_DIM", 512))
+    num_heads: int = int(os.environ.get("NUM_HEADS", 8))
+    num_kv_heads: int = int(os.environ.get("NUM_KV_HEADS", 4))
+    mlp_mult: int = int(os.environ.get("MLP_MULT", 2))
+    tie_embeddings: bool = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    tied_embed_init_std: float = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    logit_chunk_tokens: int = int(os.environ.get("LOGIT_CHUNK_TOKENS", 0))
+    logit_softcap: float = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    rope_base: float = float(os.environ.get("ROPE_BASE", 10000.0))
+    qk_gain_init: float = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Depth recurrence: set NUM_UNIQUE_BLOCKS>0 and NUM_LOOPS>1 to share blocks.
+    # Effective depth = num_unique_blocks * num_loops. When disabled (default), uses num_layers unique blocks.
+    num_unique_blocks: int = int(os.environ.get("NUM_UNIQUE_BLOCKS", 0))
+    num_loops: int = int(os.environ.get("NUM_LOOPS", 1))
+
+    # Eval-time overrides (0 = use training defaults).
+    eval_num_loops: int = int(os.environ.get("EVAL_NUM_LOOPS", 0))
+    eval_stride: int = int(os.environ.get("EVAL_STRIDE", 0))
+    eval_seq_len: int = int(os.environ.get("EVAL_SEQ_LEN", 0))
+    val_max_tokens: int = int(os.environ.get("VAL_MAX_TOKENS", 0))
+    # Architecture additions.
+    use_loop_embed: bool = bool(int(os.environ.get("USE_LOOP_EMBED", "0")))
+    use_dwa: bool = bool(int(os.environ.get("USE_DWA", "0")))
+
+    # Optimizer. We keep the same per-group defaults as train_gpt.py.
+    beta1: float = float(os.environ.get("BETA1", 0.9))
+    beta2: float = float(os.environ.get("BETA2", 0.95))
+    adam_eps: float = float(os.environ.get("ADAM_EPS", 1e-8))
+    tied_embed_lr: float = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    matrix_lr: float = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr: float = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum: float = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps: int = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start: float = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps: int = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    grad_clip_norm: float = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+    muon_weight_decay: float = float(os.environ.get("MUON_WEIGHT_DECAY", 0.0))
+    overtone_init: bool = bool(int(os.environ.get("OVERTONE_INIT", "0")))
+    phase_resid_mix: bool = bool(int(os.environ.get("PHASE_RESID_MIX", "0")))
+
+    # Quantization.
+    quant_bits: int = int(os.environ.get("QUANT_BITS", 8))
+    fp16_embed: bool = bool(int(os.environ.get("FP16_EMBED", "0")))
+
+    out_dir: str = os.environ.get("OUT_DIR", "logs")
+
+    @property
+    def train_files(self) -> str:
+        return f"{self.data_path}/fineweb_train_*.bin"
+
+    @property
+    def val_files(self) -> str:
+        return f"{self.data_path}/fineweb_val_*.bin"
+
+    @property
+    def microbatch_tokens(self) -> int:
+        return self.train_batch_tokens // self.grad_accum_steps
+
+    def lr_mul(self, step: int, elapsed_ms: float) -> float:
+        if self.warmdown_iters <= 0:
+            return 1.0
+        if self.max_wallclock_seconds <= 0:
+            warmdown_start = max(self.iterations - self.warmdown_iters, 0)
+            return max((self.iterations - step) / max(self.warmdown_iters, 1), 0.0) if warmdown_start <= step < self.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = self.warmdown_iters * step_ms
+        remaining_ms = max(1000.0 * self.max_wallclock_seconds - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,dwa_logits,loop_embeds",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+
+
+def token_chunks(total_tokens: int, seq_len: int, max_chunk_tokens: int) -> list[int]:
+    usable_total = (total_tokens // seq_len) * seq_len
+    if usable_total <= 0:
+        raise ValueError(f"token budget too small for seq_len={seq_len}")
+    usable_chunk = max((max_chunk_tokens // seq_len) * seq_len, seq_len)
+    chunks: list[int] = []
+    remaining = usable_total
+    while remaining > 0:
+        chunk = min(remaining, usable_chunk)
+        chunks.append(chunk)
+        remaining -= chunk
+    return chunks
+
+
+def accumulate_flat_grads(
+    accum: dict[str, mx.array] | None,
+    grads_tree: dict,
+    scale: float,
+) -> dict[str, mx.array]:
+    flat = dict(tree_flatten(grads_tree))
+    if accum is None:
+        return {k: g * scale for k, g in flat.items()}
+    for k, g in flat.items():
+        accum[k] = accum[k] + g * scale
+    return accum
+
+
+# ==============================================================================
+# MATH HELPERS
+# ==============================================================================
+
+def rms_norm(x: mx.array, eps: float = 1e-6) -> mx.array:
+    return (x * mx.rsqrt(mx.mean(x * x, axis=-1, keepdims=True) + eps)).astype(x.dtype)
+
+
+def zeropower_newtonschulz5(g: mx.array, steps: int, eps: float = 1e-7) -> mx.array:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    # Background on Muon: https://kellerjordan.github.io/posts/muon/
+    a, b, c = 3.4445, -4.7750, 2.0315
+    x = g.astype(mx.float32)
+    x = x / (mx.sqrt(mx.sum(x * x)) + eps)
+    transposed = x.shape[0] > x.shape[1]
+    if transposed:
+        x = x.T
+    for _ in range(steps):
+        a_mat = x @ x.T
+        b_mat = b * a_mat + c * (a_mat @ a_mat)
+        x = a * x + b_mat @ x
+    if transposed:
+        x = x.T
+    return x.astype(g.dtype)
+
+
+def load_data_shard(path: Path) -> np.ndarray:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(path, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {path}")
+    num_tokens = int(header[2])
+    if path.stat().st_size != header_bytes + num_tokens * token_bytes:
+        raise ValueError(f"Shard size mismatch for {path}")
+    tokens = np.fromfile(path, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens.size != num_tokens:
+        raise ValueError(f"Short read for {path}")
+    return tokens.astype(np.int32, copy=False)
+
+
+# ==============================================================================
+# TOKEN STREAMING / BATCHING
+# ==============================================================================
+
+
+class TokenStream:
+    def __init__(
+        self,
+        pattern: str,
+        log_fn: Callable[[str], None] | None = None,
+        dataset_name: str = "",
+    ):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.epoch = 1
+        self.file_idx = 0
+        self.log_fn = log_fn
+        self.dataset_name = dataset_name
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def next_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        if self.file_idx == 0:
+            self.epoch += 1
+            if self.log_fn is not None:
+                self.log_fn(
+                    f"WARNING: starting epoch:{self.epoch} "
+                    f"dataset:{self.dataset_name} train_shards:{len(self.files)}"
+                )
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> np.ndarray:
+        chunks: list[np.ndarray] = []
+        left = n
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self.next_file()
+            k = min(left, int(self.tokens.size - self.pos))
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+        return chunks[0] if len(chunks) == 1 else np.concatenate(chunks, axis=0)
+
+
+class TokenLoader:
+    def __init__(
+        self,
+        pattern: str,
+        log_fn: Callable[[str], None] | None = None,
+        dataset_name: str = "",
+    ):
+        self.stream = TokenStream(pattern, log_fn=log_fn, dataset_name=dataset_name)
+
+    def next_batch(self, batch_tokens: int, seq_len: int) -> tuple[mx.array, mx.array]:
+        usable = (batch_tokens // seq_len) * seq_len
+        if usable <= 0:
+            raise ValueError(f"token budget too small for seq_len={seq_len}")
+        chunk = self.stream.take(usable + 1)
+        x = chunk[:-1].reshape(-1, seq_len)
+        y = chunk[1:].reshape(-1, seq_len)
+        return mx.array(x, dtype=mx.int32), mx.array(y, dtype=mx.int32)
+
+
+# ==============================================================================
+# MODEL BLOCKS
+# ==============================================================================
+
+class CastedLinear(nn.Module):
+    def __init__(self, in_dim: int, out_dim: int):
+        super().__init__()
+        self.weight = nn.Linear(in_dim, out_dim, bias=False).weight.astype(mx.float32)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x @ self.weight.astype(x.dtype).T
+
+
+class RMSNormNoWeight(nn.Module):
+    # MLX module wrapper around the functional RMSNorm helper so it composes nicely in blocks.
+    def __call__(self, x: mx.array) -> mx.array:
+        return rms_norm(x)
+
+
+class CausalSelfAttention(nn.Module):
+    # - separate q/k/v projections
+    # - RMSNorm on q and k before attention
+    # - RoPE on q and k
+    # - causal masked SDPA
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim)
+        self.c_k = CastedLinear(dim, kv_dim)
+        self.c_v = CastedLinear(dim, kv_dim)
+        self.proj = CastedLinear(dim, dim)
+        self.q_gain = mx.ones((num_heads,), dtype=mx.float32) * qk_gain_init
+        self.rope = nn.RoPE(self.head_dim, traditional=False, base=rope_base)
+        self.scale = self.head_dim ** -0.5
+
+    def __call__(self, x: mx.array) -> mx.array:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(0, 2, 1, 3)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(0, 2, 1, 3)
+
+        q = self.rope(rms_norm(q).astype(COMPUTE_DTYPE))
+        k = self.rope(rms_norm(k).astype(COMPUTE_DTYPE))
+        q = q * self.q_gain.astype(q.dtype)[None, :, None, None]
+        y = mx.fast.scaled_dot_product_attention(q, k, v, scale=self.scale, mask="causal")
+        y = y.transpose(0, 2, 1, 3).reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    # Baseline MLP uses relu^2 instead of GELU/SiLU. It is cheap and works well in this setup.
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = dim * mlp_mult
+        self.fc = CastedLinear(dim, hidden)
+        self.proj = CastedLinear(hidden, dim)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = nn.relu(self.fc(x))
+        return self.proj(x * x)
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNormNoWeight()
+        self.mlp_norm = RMSNormNoWeight()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = mx.ones((dim,), dtype=mx.float32)
+        self.mlp_scale = mx.ones((dim,), dtype=mx.float32)
+        self.resid_mix = mx.array(np.stack((np.ones((dim,), dtype=np.float32), np.zeros((dim,), dtype=np.float32))))
+
+    def __call__(self, x: mx.array, x0: mx.array) -> mx.array:
+        mix = self.resid_mix.astype(x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.astype(x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.astype(x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    # - token embedding + RMSNorm
+    # - encoder half accumulates skip tensors (baseline mode)
+    # - decoder half consumes reversed skips with learned skip_weights (baseline mode)
+    # - OR: depth recurrence with shared blocks looped multiple times
+    # - tied embeddings for the LM head (the baseline default setup)
+    def __init__(self, vocab_size: int, num_layers: int, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int,
+                 logit_chunk_tokens: int, logit_softcap: float, rope_base: float, tied_embed_init_std: float,
+                 qk_gain_init: float, num_unique_blocks: int = 0, num_loops: int = 1,
+                 use_loop_embed: bool = False, use_dwa: bool = False,
+                 overtone_init: bool = False, phase_resid_mix: bool = False):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.logit_chunk_tokens = logit_chunk_tokens
+        self.logit_softcap = logit_softcap
+        self.use_recurrence = num_unique_blocks > 0 and num_loops > 1
+
+        self.tok_emb = nn.Embedding(vocab_size, dim)
+
+        if self.use_recurrence:
+            self.num_unique_blocks = num_unique_blocks
+            self.num_loops = num_loops
+            self.blocks = [
+                Block(dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init)
+                for _ in range(num_unique_blocks)
+            ]
+            # No encoder/decoder split or skip connections in recurrence mode.
+            self.num_encoder_layers = 0
+            self.num_decoder_layers = 0
+            self.num_skip_weights = 0
+            self.skip_weights = mx.zeros((0, dim), dtype=mx.float32)
+        else:
+            self.num_unique_blocks = num_layers
+            self.num_loops = 1
+            self.num_encoder_layers = num_layers // 2
+            self.num_decoder_layers = num_layers - self.num_encoder_layers
+            self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+            self.skip_weights = mx.ones((self.num_skip_weights, dim), dtype=mx.float32)
+            self.blocks = [
+                Block(dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init)
+                for _ in range(num_layers)
+            ]
+
+        # Loop-index embeddings (only meaningful with recurrence).
+        self.use_loop_embed = use_loop_embed and self.use_recurrence
+        if self.use_loop_embed:
+            self.loop_embeds = mx.random.normal((num_loops, dim)) * 0.01
+        # DenseFormer DWA: weighted average of all prior layer outputs.
+        self.use_dwa = use_dwa
+        if use_dwa:
+            ed = num_unique_blocks * num_loops if self.use_recurrence else num_layers
+            self._effective_depth = ed
+            init_logits = np.zeros((ed, ed + 1), dtype=np.float32)
+            for i in range(ed):
+                init_logits[i, i] = 5.0  # near-identity init
+            self.dwa_logits = mx.array(init_logits)
+        else:
+            self._effective_depth = 0
+
+        self.final_norm = RMSNormNoWeight()
+
+        for b in self.blocks:
+            b.attn.proj.weight = mx.zeros_like(b.attn.proj.weight)
+            b.mlp.proj.weight = mx.zeros_like(b.mlp.proj.weight)
+        self.tok_emb.weight = (
+            mx.random.normal(self.tok_emb.weight.shape, dtype=mx.float32) * tied_embed_init_std
+        ).astype(COMPUTE_DTYPE)
+
+        # Overtone spectral embedding init: SVD power-law shaping (S_k ~ k^{-0.5}).
+        if overtone_init:
+            w = np.array(self.tok_emb.weight.astype(mx.float32), dtype=np.float32)
+            U, S, Vt = np.linalg.svd(w, full_matrices=False)
+            target_S = S[0] * (1.0 / np.arange(1, S.shape[0] + 1, dtype=np.float32)) ** 0.5
+            self.tok_emb.weight = mx.array((U * target_S[None, :]) @ Vt, dtype=COMPUTE_DTYPE)
+
+        # Phase-transition resid_mix: sigmoid schedule from trusting x0 (early) to residual (late).
+        if phase_resid_mix:
+            n = len(self.blocks)
+            for i, b in enumerate(self.blocks):
+                phase = 1.0 / (1.0 + np.exp(-3.0 * (i / max(n - 1, 1) - 0.5)))
+                b.resid_mix = mx.array(np.stack((
+                    np.full((dim,), phase, dtype=np.float32),
+                    np.full((dim,), 1.0 - phase, dtype=np.float32),
+                )))
+
+    def softcap(self, logits: mx.array) -> mx.array:
+        c = self.logit_softcap
+        return c * mx.tanh(logits / c)
+
+    def __call__(self, input_ids: mx.array, num_loops_override: int = 0) -> mx.array:
+        x = rms_norm(self.tok_emb(input_ids).astype(COMPUTE_DTYPE))
+        x0 = x
+
+        if self.use_recurrence:
+            num_loops = num_loops_override if num_loops_override > 0 else self.num_loops
+            history: list[mx.array] = [x] if self.use_dwa else []
+            for loop_idx in range(num_loops):
+                for block_idx, block in enumerate(self.blocks):
+                    if self.use_dwa:
+                        step_idx = loop_idx * self.num_unique_blocks + block_idx
+                        dwa_i = step_idx % self._effective_depth
+                        n = min(dwa_i + 1, len(history))
+                        logits_row = self.dwa_logits[dwa_i, :n]
+                        weights = mx.softmax(logits_row)
+                        stacked = mx.stack(history[-n:], axis=0)
+                        x = (weights[:, None, None, None] * stacked).sum(axis=0)
+                    if self.use_loop_embed and block_idx == 0:
+                        x = x + self.loop_embeds[loop_idx % self.num_loops]
+                    x = block(x, x0)
+                    if self.use_dwa:
+                        history.append(x)
+        else:
+            skips: list[mx.array] = []
+            for i in range(self.num_encoder_layers):
+                x = self.blocks[i](x, x0)
+                skips.append(x)
+            for i in range(self.num_decoder_layers):
+                if skips:
+                    x = x + self.skip_weights[i].astype(x.dtype)[None, None, :] * skips.pop()
+                x = self.blocks[self.num_encoder_layers + i](x, x0)
+        return self.final_norm(x)
+
+    def loss(self, input_ids: mx.array, target_ids: mx.array) -> mx.array:
+        # Cross-entropy over flattened tokens. We keep optional logit chunking because it is a useful
+        # memory knob on Macs, but the common path is chunk_tokens=0 (single matmul + CE).
+        x = self(input_ids).reshape(-1, self.tok_emb.weight.shape[1])
+        y = target_ids.reshape(-1)
+        if self.logit_chunk_tokens <= 0 or x.shape[0] <= self.logit_chunk_tokens:
+            logits_proj = x @ self.tok_emb.weight.astype(x.dtype).T
+            logits = self.softcap(logits_proj)
+            return nn.losses.cross_entropy(logits.astype(mx.float32), y, reduction="mean")
+
+        loss_sum = mx.array(0.0, dtype=mx.float32)
+        n = int(x.shape[0])
+        for s in range(0, n, self.logit_chunk_tokens):
+            e = min(s + self.logit_chunk_tokens, n)
+            logits_proj = x[s:e] @ self.tok_emb.weight.astype(x.dtype).T
+            logits = self.softcap(logits_proj)
+            loss_sum = loss_sum + nn.losses.cross_entropy(logits.astype(mx.float32), y[s:e], reduction="sum")
+        return loss_sum / float(n)
+
+# ==============================================================================
+# OPTIMIZERS (MUON + ADAM SPLIT)
+# ==============================================================================
+class Muon:
+    # Muon applies SGD-momentum to matrix gradients, then orthogonalizes the result before the
+    # parameter update.
+    def __init__(self, keys: list[str], params: dict[str, mx.array], args: Hyperparameters):
+        self.keys = keys
+        self.args = args
+        self.buffers = {k: mx.zeros_like(params[k]) for k in keys}
+
+    def step(self, params: dict[str, mx.array], grads: dict[str, mx.array], step: int, lr_mul: float) -> dict[str, mx.array]:
+        if self.args.muon_momentum_warmup_steps:
+            t = min(step / self.args.muon_momentum_warmup_steps, 1.0)
+            momentum = (1.0 - t) * self.args.muon_momentum_warmup_start + t * self.args.muon_momentum
+        else:
+            momentum = self.args.muon_momentum
+        lr = self.args.matrix_lr * lr_mul
+        out: dict[str, mx.array] = {}
+        for k in self.keys:
+            p = params[k]
+            g = grads[k]
+            buf = momentum * self.buffers[k] + g
+            self.buffers[k] = buf
+            g_eff = g + momentum * buf
+            g_ortho = zeropower_newtonschulz5(g_eff, self.args.muon_backend_steps)
+            scale = math.sqrt(max(1.0, float(p.shape[0]) / float(p.shape[1])))
+            out[k] = p - lr * (g_ortho * scale).astype(p.dtype)
+        return out
+
+
+class SplitOptimizers:
+    # - embeddings: Adam with the tied-embedding LR
+    # - block matrices (2D): Muon
+    # - block scalars + skip weights: Adam
+    # This preserves the high-level optimization behavior even though MLX internals differ.
+    def __init__(self, model: GPT, args: Hyperparameters):
+        self.args = args
+        params = dict(tree_flatten(model.parameters()))
+        self.embed_key = "tok_emb.weight"
+        self.matrix_keys = [
+            k
+            for k, p in params.items()
+            if k.startswith("blocks.") and p.ndim == 2 and not any(pattern in k for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        self.scalar_keys = [
+            k
+            for k, p in params.items()
+            if (k == "skip_weights" and p.size > 0)
+            or (k in ("dwa_logits", "loop_embeds") and p.size > 0)
+            or (k.startswith("blocks.") and (p.ndim < 2 or any(pattern in k for pattern in CONTROL_TENSOR_NAME_PATTERNS)))
+        ]
+
+        self.muon = Muon(self.matrix_keys, params, args)
+        self.adam_embed = optim.Adam(
+            learning_rate=args.tied_embed_lr,
+            betas=[args.beta1, args.beta2],
+            eps=args.adam_eps,
+            bias_correction=True,
+        )
+        self.adam_scalar = optim.Adam(
+            learning_rate=args.scalar_lr,
+            betas=[args.beta1, args.beta2],
+            eps=args.adam_eps,
+            bias_correction=True,
+        )
+
+    def step(self, model: GPT, grads_tree: dict, step: int, lr_mul: float) -> None:
+        params = dict(tree_flatten(model.parameters()))
+        grads = dict(tree_flatten(grads_tree))
+        updated = dict(params)
+
+        updated.update(self.muon.step(params, grads, step=step, lr_mul=lr_mul))
+
+        self.adam_embed.learning_rate = self.args.tied_embed_lr * lr_mul
+        updated.update(
+            self.adam_embed.apply_gradients(
+                {self.embed_key: grads[self.embed_key]},
+                {self.embed_key: params[self.embed_key]},
+            )
+        )
+
+        self.adam_scalar.learning_rate = self.args.scalar_lr * lr_mul
+        scalar_grads = {k: grads[k] for k in self.scalar_keys}
+        scalar_params = {k: params[k] for k in self.scalar_keys}
+        updated.update(self.adam_scalar.apply_gradients(scalar_grads, scalar_params))
+
+        model.update(tree_unflatten(list(updated.items())))
+
+# ==============================================================================
+# QUANTIZATION (INT8 + ZLIB)
+# ==============================================================================
+# - per-row int8 for 2D float tensors
+# - per-tensor int8 for other float tensors
+# - fp16 passthrough for small float tensors
+# - exact passthrough for non-floats
+
+MX_DTYPE_FROM_NAME = {
+    "float32": mx.float32,
+    "float16": mx.float16,
+    "bfloat16": mx.bfloat16,
+}
+
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = np.float16
+INT8_PER_ROW_SCALE_DTYPE = np.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+
+def _np_float32(arr: mx.array) -> np.ndarray:
+    return np.array(arr.astype(mx.float32), dtype=np.float32, copy=False)
+
+
+def keep_float_array(name: str, arr: mx.array, passthrough_orig_dtypes: dict[str, str]) -> np.ndarray:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return np.ascontiguousarray(_np_float32(arr))
+    if arr.dtype in {mx.float32, mx.bfloat16}:
+        passthrough_orig_dtypes[name] = str(arr.dtype).split(".")[-1]
+        return np.ascontiguousarray(np.array(arr.astype(mx.float16), dtype=INT8_KEEP_FLOAT_STORE_DTYPE, copy=False))
+    return np.ascontiguousarray(np.array(arr, copy=True))
+
+
+def quantize_float_array(arr: mx.array, quant_bits: int = 8) -> tuple[np.ndarray, np.ndarray]:
+    f32 = _np_float32(arr)
+    # int6: clip to [-32, 31], stored in int8 (high 2 bits zero, compresses well).
+    # int8: clip to [-127, 127] as before.
+    if quant_bits == 6:
+        qmax, qmin = 31, -32
+    else:
+        qmax, qmin = 127, -127
+    scale_denom = float(qmax)  # 32.0 for int6, 127.0 for int8
+    if f32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = np.quantile(np.abs(f32), INT8_CLIP_Q, axis=1) if f32.size else np.empty((f32.shape[0],), dtype=np.float32)
+        clipped = np.clip(f32, -clip_abs[:, None], clip_abs[:, None])
+        scale = np.maximum(clip_abs / scale_denom, 1.0 / scale_denom).astype(np.float32, copy=False)
+        q = np.clip(np.round(clipped / scale[:, None]), qmin, qmax).astype(np.int8, copy=False)
+        return np.ascontiguousarray(q), np.ascontiguousarray(scale.astype(INT8_PER_ROW_SCALE_DTYPE, copy=False))
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = float(np.quantile(np.abs(f32).reshape(-1), INT8_CLIP_Q)) if f32.size else 0.0
+    scale = np.array(clip_abs / scale_denom if clip_abs > 0.0 else 1.0, dtype=np.float32)
+    q = np.clip(np.round(np.clip(f32, -clip_abs, clip_abs) / scale), qmin, qmax).astype(np.int8, copy=False)
+    return np.ascontiguousarray(q), scale
+
+
+def quantize_state_dict_int8(
+    flat_state: dict[str, mx.array],
+    quant_bits: int = 8,
+    fp16_embed: bool = False,
+) -> tuple[dict[str, object], dict[str, int]]:
+    quantized: dict[str, np.ndarray] = {}
+    scales: dict[str, np.ndarray] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, np.ndarray] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+    for name, arr in flat_state.items():
+        stats["param_count"] += int(arr.size)
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += int(arr.nbytes)
+        if not mx.issubdtype(arr.dtype, mx.floating):
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = np.ascontiguousarray(np.array(arr))
+            stats["int8_payload_bytes"] += int(passthrough[name].nbytes)
+            continue
+
+        # FP16 embedding passthrough: keep tok_emb.weight in fp16 regardless of size.
+        if fp16_embed and name == "tok_emb.weight":
+            kept = keep_float_array(name, arr, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += int(kept.nbytes)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if int(arr.size) <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_array(name, arr, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += int(kept.nbytes)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_array(arr, quant_bits=quant_bits)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(arr.dtype).split(".")[-1]
+        stats["int8_payload_bytes"] += int(q.nbytes + s.nbytes)
+    obj: dict[str, object] = {
+        "__quant_format__": f"int{quant_bits}_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+
+def dequantize_state_dict_int8(quant_obj: dict[str, object]) -> dict[str, mx.array]:
+    out: dict[str, mx.array] = {}
+    qmeta = quant_obj.get("qmeta", {})
+    passthrough_orig_dtypes = quant_obj.get("passthrough_orig_dtypes", {})
+    for name, q in quant_obj["quantized"].items():
+        q_np = np.asarray(q, dtype=np.int8)
+        dtype_name = quant_obj["dtypes"][name]
+        scale = np.asarray(quant_obj["scales"][name], dtype=np.float32)
+        if qmeta.get(name, {}).get("scheme") == "per_row" or scale.ndim > 0:
+            # Broadcast the saved row scale back across trailing dimensions.
+            out_arr = q_np.astype(np.float32) * scale.reshape((q_np.shape[0],) + (1,) * (q_np.ndim - 1))
+        else:
+            out_arr = q_np.astype(np.float32) * float(scale)
+        out[name] = mx.array(out_arr, dtype=MX_DTYPE_FROM_NAME[dtype_name])
+    for name, arr in quant_obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_arr = np.array(arr, copy=True)
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out[name] = mx.array(out_arr, dtype=MX_DTYPE_FROM_NAME[orig_dtype])
+        else:
+            out[name] = mx.array(out_arr)
+    return out
+
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_lut = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_lut = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_lut = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_lut[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_lut[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_lut[token_id] = True
+            piece = piece[1:]
+        base_bytes_lut[token_id] = len(piece.encode("utf-8"))
+    return base_bytes_lut, has_leading_space_lut, is_boundary_token_lut
+
+
+def validate_dataset_tokenizer_pair(data_path: str, tokenizer_path: str) -> tuple[str, int, int | None]:
+    # The shard directory and tokenizer are coupled: val_bpb is only meaningful if we
+    # decode bytes with the exact tokenizer that produced the shards. The manifest
+    # lets the training script fail fast on accidental dataset/tokenizer mismatches.
+    dataset_dir = Path(data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    if len(dataset_dir.parents) < 2:
+        return dataset_dir.name, actual_train_files, None
+    manifest_path = dataset_dir.parents[1] / "manifest.json"
+    if not manifest_path.is_file():
+        return dataset_dir.name, actual_train_files, None
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    dataset_entry = next((x for x in manifest.get("datasets", []) if x.get("name") == dataset_dir.name), None)
+    if dataset_entry is None:
+        return dataset_dir.name, actual_train_files, None
+
+    tokenizer_name = dataset_entry.get("tokenizer_name")
+    tokenizer_entry = (
+        next((x for x in manifest.get("tokenizers", []) if x.get("name") == tokenizer_name), None)
+        if tokenizer_name
+        else None
+    )
+    expected_name = Path((tokenizer_entry or {}).get("model_path") or (tokenizer_entry or {}).get("path") or "").name
+    if expected_name and Path(tokenizer_path).name != expected_name:
+        raise ValueError(f"{dataset_dir.name} expects tokenizer {expected_name}, got {Path(tokenizer_path).name}")
+    expected_train_files = (dataset_entry.get("stats") or {}).get("files_train")
+    if expected_train_files is not None:
+        expected_train_files = int(expected_train_files)
+        if actual_train_files > expected_train_files:
+            raise ValueError(
+                f"{dataset_dir.name} has more train shards than expected: found {actual_train_files}, "
+                f"manifest says {expected_train_files}"
+            )
+    return dataset_dir.name, actual_train_files, expected_train_files
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> np.ndarray:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = np.ascontiguousarray(np.concatenate([load_data_shard(file) for file in files], axis=0))
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def loss_and_grad_chunked(
+    args: Hyperparameters,
+    train_loader: TokenLoader,
+    compiled_loss_and_grad,
+) -> tuple[mx.array, dict]:
+    chunk_sizes = token_chunks(args.microbatch_tokens, args.train_seq_len, args.mlx_max_microbatch_tokens)
+    total_tokens = float(sum(chunk_sizes))
+    loss_value = mx.array(0.0, dtype=mx.float32)
+    grad_accum: dict[str, mx.array] | None = None
+    for chunk_tokens in chunk_sizes:
+        x, y = train_loader.next_batch(chunk_tokens, args.train_seq_len)
+        loss, grads = compiled_loss_and_grad(x, y)
+        scale = float(y.size) / total_tokens
+        loss_value = loss_value + loss.astype(mx.float32) * scale
+        grad_accum = accumulate_flat_grads(grad_accum, grads, scale)
+    return loss_value, tree_unflatten(list(grad_accum.items()))
+
+
+def set_rope_base(model: GPT, base: float) -> None:
+    for block in model.blocks:
+        block.attn.rope = nn.RoPE(block.attn.head_dim, traditional=False, base=base)
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: GPT,
+    val_tokens: np.ndarray,
+    base_bytes_lut: np.ndarray,
+    has_leading_space_lut: np.ndarray,
+    is_boundary_token_lut: np.ndarray,
+    compiled_forward=None,
+) -> tuple[float, float]:
+    # Sliding-window eval: each window is eval_seq_len tokens, scored on last stride tokens.
+    # When stride == eval_seq_len, this degrades to the non-overlapping baseline.
+    eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    stride = args.eval_stride if args.eval_stride > 0 else eval_seq_len
+    num_loops_override = args.eval_num_loops if args.eval_num_loops > 0 else 0
+
+    # NTK-RoPE scaling for longer eval sequences.
+    ntk_active = eval_seq_len != args.train_seq_len
+    if ntk_active:
+        head_dim = args.model_dim // args.num_heads
+        scaled_base = args.rope_base * (eval_seq_len / args.train_seq_len) ** (head_dim / (head_dim - 2))
+        set_rope_base(model, scaled_base)
+
+    # Use compiled forward when possible. Recompile after NTK RoPE swap so the
+    # compiled graph captures the scaled frequencies.
+    use_compiled = compiled_forward is not None and num_loops_override == 0
+    if ntk_active and use_compiled:
+        compiled_forward = mx.compile(lambda x: model(x), inputs=model.state, outputs=model.state)
+
+    n_tokens = val_tokens.size - 1
+    starts = list(range(0, n_tokens - eval_seq_len + 1, stride))
+    val_batch_seqs = max(args.val_batch_size // eval_seq_len, 1)
+
+    total_loss = mx.array(0.0, dtype=mx.float32)
+    total_scored = 0
+    total_bytes = 0.0
+    embed_dim = model.tok_emb.weight.shape[1]
+    for b_start in range(0, len(starts), val_batch_seqs):
+        batch_starts = starts[b_start : b_start + val_batch_seqs]
+        x_np = np.stack([val_tokens[s : s + eval_seq_len] for s in batch_starts])
+        y_np = np.stack([val_tokens[s + 1 : s + eval_seq_len + 1] for s in batch_starts])
+        x = mx.array(x_np, dtype=mx.int32)
+
+        hidden = compiled_forward(x) if use_compiled else model(x, num_loops_override=num_loops_override)
+        h_scored = hidden[:, -stride:, :].reshape(-1, embed_dim)
+        logits = model.softcap(h_scored @ model.tok_emb.weight.astype(h_scored.dtype).T)
+        y_scored = mx.array(y_np[:, -stride:], dtype=mx.int32).reshape(-1)
+        total_loss = total_loss + nn.losses.cross_entropy(logits.astype(mx.float32), y_scored, reduction="sum")
+
+        prev_np = x_np[:, -stride:].reshape(-1)
+        tgt_np = y_np[:, -stride:].reshape(-1)
+        bytes_arr = base_bytes_lut[tgt_np].astype(np.int16, copy=True)
+        bytes_arr += (has_leading_space_lut[tgt_np] & ~is_boundary_token_lut[prev_np]).astype(np.int16, copy=False)
+        total_scored += tgt_np.size
+        total_bytes += float(bytes_arr.astype(np.float64).sum())
+        # Periodically materialize to prevent lazy graph from growing unbounded.
+        if (b_start // val_batch_seqs) % 50 == 49:
+            mx.eval(total_loss)
+
+    total_loss = total_loss / total_scored
+    mx.eval(total_loss)
+    val_loss = float(total_loss.item())
+    val_bpb = (val_loss / math.log(2.0)) * (total_scored / total_bytes)
+
+    if eval_seq_len != args.train_seq_len:
+        set_rope_base(model, args.rope_base)
+    return val_loss, val_bpb
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def clip_grad_tree(grads_tree: dict, max_norm: float) -> dict:
+    if max_norm <= 0:
+        return grads_tree
+    flat = dict(tree_flatten(grads_tree))
+    total_sq = 0.0
+    for grad in flat.values():
+        total_sq += float(np.sum(np.square(_np_float32(grad)), dtype=np.float64))
+    if total_sq <= 0.0:
+        return grads_tree
+    total_norm = math.sqrt(total_sq)
+    if total_norm <= max_norm:
+        return grads_tree
+    scale = max_norm / (total_norm + 1e-12)
+    return tree_unflatten([(k, g * scale) for k, g in flat.items()])
+
+
+def main() -> None:
+    # ==============================================================================
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # ==============================================================================
+    args = Hyperparameters()
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    logfile = out_dir / f"{args.run_id}.txt"
+    print(logfile)
+
+    def log(msg: str, console: bool = True) -> None:
+        if console:
+            print(msg)
+        with logfile.open("a", encoding="utf-8") as f:
+            print(msg, file=f)
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    log(code, console=False)
+    log("=" * 100, console=False)
+    log(f"Running Python {sys.version}", console=False)
+    log(f"Running MLX {mx.__version__}", console=False)
+    log("=" * 100, console=False)
+
+    if not args.tie_embeddings:
+        raise NotImplementedError("train_gpt_mlx.py only supports tied embeddings")
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"TOKENIZER_PATH must point to a SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_name, actual_train_files, expected_train_files = validate_dataset_tokenizer_pair(
+        args.data_path,
+        args.tokenizer_path,
+    )
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    if args.val_max_tokens > 0:
+        cap = min(args.val_max_tokens, val_tokens.size - 1)
+        cap = (cap // args.train_seq_len) * args.train_seq_len
+        val_tokens = val_tokens[: cap + 1]
+
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size
+    )
+
+    # ==============================================================================
+    # TRAINING SETUP
+    # ==============================================================================
+    mx.random.seed(args.seed)
+
+    train_loader = TokenLoader(args.train_files, log_fn=log, dataset_name=dataset_name)
+
+    # ==============================================================================
+    # MODEL + OPTIMIZER SETUP
+    # ==============================================================================
+    model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        logit_chunk_tokens=args.logit_chunk_tokens,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        tied_embed_init_std=args.tied_embed_init_std,
+        qk_gain_init=args.qk_gain_init,
+        num_unique_blocks=args.num_unique_blocks,
+        num_loops=args.num_loops,
+        use_loop_embed=args.use_loop_embed,
+        use_dwa=args.use_dwa,
+        overtone_init=args.overtone_init,
+        phase_resid_mix=args.phase_resid_mix,
+    )
+    opt = SplitOptimizers(model, args)
+
+    # ==============================================================================
+    # COMPILED TRAIN / EVAL FUNCTIONS (MLX)
+    # ==============================================================================
+    # The crucial MLX detail is capture scope: this model contains non-trainable arrays too (for example
+    # inside RoPE modules), so compiling only against trainable parameters throws "uncaptured inputs".
+    # Compiling the model-bound functions and capturing the full model state fixes that while still
+    # returning gradients only for trainable parameters via nn.value_and_grad(...).
+    compiled_forward = mx.compile(lambda x: model(x), inputs=model.state, outputs=model.state)
+    compiled_loss_and_grad = mx.compile(
+        nn.value_and_grad(model, lambda x, y: model.loss(x, y)),
+        inputs=model.state,
+        outputs=model.state,
+    )
+
+    # Print config once so logs are self-describing.
+    n_params = sum(int(np.prod(p.shape)) for _, p in tree_flatten(model.parameters()))
+    log(f"run_id:{args.run_id}")
+    log(f"mlx_version:{mx.__version__}")
+    log(f"train_loader:shards pattern={args.train_files}")
+    log(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.size - 1}")
+    if expected_train_files is None:
+        log(f"train_loader:dataset:{dataset_name} train_shards:{actual_train_files}")
+    elif actual_train_files < expected_train_files:
+        log(
+            f"WARNING: train_loader:subset dataset:{dataset_name} "
+            f"train_shards:{actual_train_files}/{expected_train_files} "
+            f"new epochs will arrive sooner than the full dataset"
+        )
+    else:
+        log(f"train_loader:dataset:{dataset_name} train_shards:{actual_train_files}/{expected_train_files}")
+    log(f"tokenizer_path:{args.tokenizer_path}")
+    if model.use_recurrence:
+        log(
+            f"model_params:{n_params} vocab_size:{args.vocab_size} "
+            f"unique_blocks:{args.num_unique_blocks} loops:{args.num_loops} effective_layers:{args.num_unique_blocks * args.num_loops} "
+            f"dim:{args.model_dim} heads:{args.num_heads} kv_heads:{args.num_kv_heads} "
+            f"seq_len:{args.train_seq_len} tie_embeddings:{args.tie_embeddings}"
+        )
+    else:
+        log(
+            f"model_params:{n_params} vocab_size:{args.vocab_size} layers:{args.num_layers} "
+            f"dim:{args.model_dim} heads:{args.num_heads} kv_heads:{args.num_kv_heads} "
+            f"seq_len:{args.train_seq_len} tie_embeddings:{args.tie_embeddings}"
+        )
+    log(
+        f"iterations:{args.iterations} train_batch_tokens:{args.train_batch_tokens} grad_accum_steps:{args.grad_accum_steps} "
+        f"microbatch_tokens:{args.microbatch_tokens} microbatch_batch_size:{args.microbatch_tokens // args.train_seq_len} "
+        f"val_batch_size:{args.val_batch_size} "
+        f"warmup_steps:{args.warmup_steps} max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log(f"mlx_max_microbatch_tokens:{args.mlx_max_microbatch_tokens}")
+    log(
+        f"optimizer:muon+adam muon_matrix_params:{len(opt.matrix_keys)} scalar_params:{len(opt.scalar_keys)} "
+        f"embed_lr:{args.tied_embed_lr} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr} "
+        f"muon_momentum:{args.muon_momentum} muon_steps:{args.muon_backend_steps}"
+    )
+    log(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log(f"compute_dtype:{COMPUTE_DTYPE} compile:True")
+    log(
+        f"dtypes tok_emb:{model.tok_emb.weight.dtype} "
+        f"linear_weight:{model.blocks[0].attn.c_q.weight.dtype} "
+        f"skip_weights:{model.skip_weights.dtype}"
+    )
+
+    # ==============================================================================
+    # TRAINING LOOP
+    # ==============================================================================
+    if args.warmup_steps > 0:
+        # Warmup should only prime MLX compile/allocation paths. Updating parameters here forces us
+        # to snapshot and restore model/optimizer state, which is expensive on unified-memory Macs.
+        # Instead we run the real train shapes, force the loss/grads to materialize, and then reset
+        # the loader so measured training still starts from the true init and token window.
+        for warmup_step in range(args.warmup_steps):
+            accum: dict[str, mx.array] | None = None
+            warmup_loss = mx.array(0.0, dtype=mx.float32)
+            grad_scale = 1.0 / args.grad_accum_steps
+            for _ in range(args.grad_accum_steps):
+                warmup_loss, grads = loss_and_grad_chunked(args, train_loader, compiled_loss_and_grad)
+                accum = accumulate_flat_grads(accum, grads, grad_scale)
+            mx.eval(warmup_loss, accum)
+            mx.synchronize()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+
+        # Prime compiled eval forward pass too.
+        warm_seqs = min(args.val_batch_size // args.train_seq_len, (val_tokens.size - 1) // args.train_seq_len)
+        warm_x = mx.array(val_tokens[: warm_seqs * args.train_seq_len].reshape(-1, args.train_seq_len), dtype=mx.int32)
+        mx.eval(compiled_forward(warm_x))
+        mx.synchronize()
+
+        train_loader = TokenLoader(args.train_files, log_fn=log, dataset_name=dataset_name)
+
+    train_time_ms = 0.0
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    stop_after_step: int | None = None
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+            # Validation always scans the same fixed full validation split.
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+                compiled_forward,
+            )
+            train_time_ms += 1000.0 * (time.perf_counter() - t0)
+            if step % 25 == 0 or last_step:
+                log(
+                    f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                    f"train_time:{train_time_ms:.0f}ms step_avg:{train_time_ms / max(step, 1):.2f}ms"
+                )
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log(f"stopping_early: wallclock_cap train_time:{train_time_ms:.0f}ms step:{step}/{args.iterations}")
+            break
+
+        lr_mul = args.lr_mul(step, train_time_ms + 1000.0 * (time.perf_counter() - t0))
+        step_t0 = time.perf_counter()
+
+        accum: dict[str, mx.array] | None = None
+        train_loss = mx.array(0.0, dtype=mx.float32)
+        grad_scale = 1.0 / args.grad_accum_steps
+        for _ in range(args.grad_accum_steps):
+            loss, grads = loss_and_grad_chunked(args, train_loader, compiled_loss_and_grad)
+            accum = accumulate_flat_grads(accum, grads, grad_scale)
+            train_loss = train_loss + loss.astype(mx.float32) * grad_scale
+
+        grads = tree_unflatten(list(accum.items()))
+        grads = clip_grad_tree(grads, args.grad_clip_norm)
+        train_loss_value = float(train_loss.item())
+        opt.step(model, grads, step=step, lr_mul=lr_mul)
+        # Decoupled weight decay for Muon-managed matrix params.
+        if args.muon_weight_decay > 0:
+            decay = 1.0 - args.muon_weight_decay * args.matrix_lr * lr_mul
+            params = dict(tree_flatten(model.parameters()))
+            for k in opt.matrix_keys:
+                params[k] = params[k] * decay
+            model.update(tree_unflatten(list(params.items())))
+        mx.synchronize()
+
+        step_ms = 1000.0 * (time.perf_counter() - step_t0)
+        approx_train_time_ms = train_time_ms + 1000.0 * (time.perf_counter() - t0)
+        tok_s = args.train_batch_tokens / (step_ms / 1000.0)
+        step += 1
+        if args.train_log_every > 0 and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None):
+            log(
+                f"step:{step}/{args.iterations} train_loss:{train_loss_value:.4f} "
+                f"train_time:{approx_train_time_ms:.0f}ms step_avg:{approx_train_time_ms / step:.2f}ms tok_s:{tok_s:.0f}"
+            )
+        if max_wallclock_ms is not None and stop_after_step is None and approx_train_time_ms >= max_wallclock_ms:
+            stop_after_step = step
+
+    # ==============================================================================
+    # FINAL SERIALIZATION + QUANTIZED ROUNDTRIP EVAL
+    # ==============================================================================
+    # We always write a raw artifact and a quantized artifact, then validate the
+    # quantized roundtrip directly by loading the dequantized tensors back into the
+    # model and running one final validation pass.
+    out_path = out_dir / f"{args.run_id}_mlx_model.npz"
+    flat_state = {k: v for k, v in tree_flatten(model.state) if v.size > 0}
+    mx.savez(str(out_path), **flat_state)
+    log(f"saved_model:{out_path} bytes:{out_path.stat().st_size}")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(flat_state, quant_bits=args.quant_bits, fp16_embed=args.fp16_embed)
+    quant_raw = pickle.dumps(quant_obj, protocol=pickle.HIGHEST_PROTOCOL)
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_serialized_bytes = len(quant_raw)
+    quant_path = out_dir / f"{args.run_id}_mlx_model.int8.ptz"
+    with quant_path.open("wb") as f:
+        f.write(quant_blob)
+    quant_file_bytes = quant_path.stat().st_size
+    ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+    log(
+        f"serialized_model_int8_zlib:{quant_file_bytes} bytes "
+        f"(payload:{quant_stats['int8_payload_bytes']} raw_pickle:{quant_serialized_bytes} payload_ratio:{ratio:.2f}x)"
+    )
+
+    with quant_path.open("rb") as f:
+        quant_blob_disk = f.read()
+    quant_flat = dequantize_state_dict_int8(pickle.loads(zlib.decompress(quant_blob_disk)))
+    model.update(tree_unflatten(list(quant_flat.items())))
+    q_t0 = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        model,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+        compiled_forward,
+    )
+    q_eval_ms = 1000.0 * (time.perf_counter() - q_t0)
+    log(f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} eval_time:{q_eval_ms:.0f}ms")
+    log(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    # Multi-eval: run additional eval configs on the same trained (quantized) model.
+    # Format: semicolon-separated configs, each is comma-separated KEY=VAL overrides.
+    # Example: EVAL_CONFIGS="eval_stride=256;eval_stride=256,eval_seq_len=2048,eval_num_loops=6"
+    eval_configs_str = os.environ.get("EVAL_CONFIGS", "")
+    if eval_configs_str:
+        for cfg_str in eval_configs_str.split(";"):
+            if not cfg_str.strip():
+                continue
+            overrides = {}
+            for kv in cfg_str.strip().split(","):
+                k, v = kv.split("=", 1)
+                overrides[k.strip().lower()] = int(v.strip())
+            saved = {k: getattr(args, k) for k in overrides if hasattr(args, k)}
+            for k, v in overrides.items():
+                if hasattr(args, k):
+                    setattr(args, k, v)
+            e_t0 = time.perf_counter()
+            e_loss, e_bpb = eval_val(args, model, val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut, compiled_forward)
+            e_ms = 1000.0 * (time.perf_counter() - e_t0)
+            log(f"multi_eval config:{cfg_str.strip()} val_loss:{e_loss:.4f} val_bpb:{e_bpb:.4f} eval_time:{e_ms:.0f}ms")
+            log(f"multi_eval_exact config:{cfg_str.strip()} val_loss:{e_loss:.8f} val_bpb:{e_bpb:.8f}")
+            for k, v in saved.items():
+                setattr(args, k, v)
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -98,6 +98,12 @@
 - Adding MLP3 + int6 increases quant gap to 0.030 — still usable, needs QAT to close
 - **This recipe is the path forward for H100 submission**
 
+### WD + LR sweep results
+- WD=0.02 + matrix_lr=0.02 is the best combo at 200 steps (-0.005 BPB over default)
+- WD=0.04 slightly worse than WD=0.02 at short training (may reverse at 10K+ steps on H100)
+- OvertoneInit + PhaseResidMix HURT when combined with WD+LR tuning — they conflict at short training
+- Best Mac recipe: SmearGate + BigramHash(4096) + WD=0.02 + LR=0.02 (no init tricks)
+
 ### Train at seq4096 needs H100 batch sizes
 - On Mac with batch=8192: only 2 seqs/step → severe underfitting (val_bpb 2.61 vs 2.34)
 - Top submissions use 393K+ tokens/step giving 96+ seqs at seq4096

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,104 @@
+# Parameter Golf — Lessons Learned
+
+## Session 1: Initial Setup & MLX Prototyping
+
+### MLX Performance
+- Baseline 200 steps with batch=8192 takes ~228 seconds on Apple Silicon (~1.14s/step)
+- Validation on full val set (62M tokens) with batch=8192 is EXTREMELY slow on Mac (~7,500 batches). Use VAL_BATCH_SIZE=131072 or higher for acceptable speed (~473 batches)
+- Warmup (20 steps) is compilation-only in MLX, doesn't update weights
+- Don't use `&` inside background bash commands — it orphans processes and loses output. Use `run_in_background: true` directly on the tool call
+
+### Architecture Notes
+- Baseline has 17.1M params, compresses to ~15.8MB with int8+zlib
+- Encoder/decoder U-Net split (4 enc + 5 dec) with skip connections is the default
+- Block has: attn (Q/K/V/proj) + MLP (fc/proj) + resid_mix + attn_scale + mlp_scale + q_gain
+- resid_mix blends current residual with original x0 — important for depth recurrence
+- Output projections (attn.proj, mlp.proj) are zero-initialized (cold start)
+
+### Implementation Decisions
+- Recurrence mode drops U-Net skips entirely (simplest first)
+- No per-loop gating in v1 — relying on resid_mix in shared blocks to adapt across loops
+- Will add LoRA adapters in v2 if plain recurrence shows promise
+
+## Session 2: Eval Improvements + Performance
+
+### Critical: mx.compile is mandatory for eval forward pass
+- Removing `compiled_loss` and using uncompiled `model(x)` for eval caused ~10-50x slowdown
+- Uncompiled MLX forward pass incurs full Python overhead per operation per batch
+- With 475 batches on full val, uncompiled eval takes 20+ minutes vs ~1 min compiled
+- **Fix**: create `compiled_forward = mx.compile(lambda x: model(x), ...)` for default eval path
+- Fall back to uncompiled ONLY when eval requires non-default loop count (EVAL_NUM_LOOPS>0) or NTK-RoPE scaling (EVAL_SEQ_LEN != train_seq_len), since compiled functions don't pick up replaced RoPE modules
+- Sliding window (EVAL_STRIDE) works fine with compiled forward — only the scoring window changes, not the forward pass
+
+### Eval batch size
+- Original divided val_batch_size by grad_accum_steps (artifact from training) — unnecessarily small batches
+- Removing the division entirely (128 seqs/batch) may work but is aggressive for Mac memory with DWA (9 history tensors)
+- Safe approach: remove grad_accum_steps division but keep val_batch_size as the memory knob users can tune
+
+### Full val eval is too slow for Mac iteration
+- 62M token val set with compiled forward on 9-layer model takes ~18 min per eval pass
+- With 2 eval passes (step 0 + final) + int8 roundtrip + multi-eval = 72+ min of eval per run
+- **Fix**: use VAL_MAX_TOKENS=6000000 (~10% val) for directional experiments, full val only for final numbers
+- **Fix**: use VAL_LOSS_EVERY=0 to skip step 0 eval (untrained baseline not needed)
+- Background bash commands have 10-min timeout by default — use `timeout: 600000` for long runs
+
+### Empty array serialization
+- Recurrence mode sets skip_weights to (0, dim) — MLX's mx.savez can't serialize empty arrays
+- Fixed by filtering `v.size > 0` in flat_state before save
+
+## Session 2: Experiment Results
+
+### DWA doesn't improve recurrence at this scale
+- DenseFormer DWA (weighted average of prior layer outputs) slightly hurt BPB vs plain recurrence (2.3396 vs 2.3368)
+- The near-identity init (logit 5.0 on current state) means DWA starts as almost no-op, but the training overhead and additional parameters don't pay off in 200 steps
+- At larger scale / more training steps, DWA might still help — but not worth the complexity for the competition
+
+### Extra eval loops are broken with cyclic DWA
+- Running 6 loops at eval (trained with 3) gave catastrophic BPB regression (3.49 vs 2.34)
+- The model's internal representations are deeply calibrated to exactly `num_loops` passes — you can't just add more loops
+- The cyclic DWA reuse (layer_idx % effective_depth) doesn't preserve the original DWA semantics when history is longer than training
+- **Lesson**: eval-time depth scaling requires training-time support (e.g., training with variable loop counts, or progressive depth)
+
+### Plain recurrence is the winner
+- 3×3 512-dim (6M params) slightly outperformed 9×512 baseline (17M params) at 200 steps
+- This means wider recurrence (3×3 768) could significantly beat baseline while compressing much smaller
+- Simple recurrence without bells and whistles is the right path for the competition
+
+### Width sweep: 768 is sweet spot at 200 steps
+- 512 → 768 → 896 → 1024: BPB goes 2.337 → **2.316** → 2.325 → 2.372
+- Wider models underfit at 200 steps (higher train loss) but have more capacity
+- On H100 with 20K steps, 896 or 1024 may overtake 768 — worth testing
+- All configs fit easily in 16MB: 768=6.2MB, 896=7.5MB, 1024=8.5MB compressed
+
+### More unique blocks > more loops
+- 4×3 768 (2.3117) beats 3×3 768 (2.3155) which beats 3×4 768 (2.3199)
+- Adding unique blocks (more params, same effective depth) helps more than adding loops (same params, more depth)
+- This makes sense: each unique block learns a distinct transformation, while extra loops just repeat
+- **Best config: 4×3 768-dim = 17.3M params, 7.4MB compressed, val_bpb 2.3117**
+
+### Int6 quantization is incompatible with depth recurrence
+- Int6 on baseline (no recurrence): quant gap = 0.023 BPB — works fine
+- Int6 on 4×3 768 recurrence: quant gap = **0.61 BPB** — catastrophic
+- Root cause: each shared weight is used N_LOOPS times, amplifying quantization error
+- Confirmed by competition PR #76 which also rejected recurrence due to quant gap
+- **Implication**: recurrence models MUST use int8 (or QAT), which limits how much the budget headroom can be exploited
+- With int8, 4×3 768 compresses to 7.4MB — leaving 8.6MB unused. Int6 could fill that space but only for non-recurrence models
+
+### MLP_MULT=3 is a confirmed improvement
+- Baseline 9×512 MLP2: val_bpb 2.3396 (10% val, 200 steps)
+- Baseline 9×512 MLP3: val_bpb 2.3262 (10% val, 200 steps)
+- Delta: -0.013 BPB. Consistent with competition PRs reporting ~-0.019 at full training
+
+### Leaderboard #1 recipe validated on Mac
+- 10L + MuonWD(0.02) + OvertoneInit + PhaseResidMix + FP16Embed + TIED_EMBED_LR=0.10
+- **Near-zero quantization gap (0.0002 BPB)** with int8 — the key insight
+- FP16 embed + Muon WD makes quantization virtually invisible
+- 10 layers underfits at 200 steps but wins at full training (proven on H100: 1.1748 BPB)
+- Sliding window stride-64 at native seq1024: small gain (-0.0015 BPB at 200 steps, -0.032 at full training)
+- Adding MLP3 + int6 increases quant gap to 0.030 — still usable, needs QAT to close
+- **This recipe is the path forward for H100 submission**
+
+### Train at seq4096 needs H100 batch sizes
+- On Mac with batch=8192: only 2 seqs/step → severe underfitting (val_bpb 2.61 vs 2.34)
+- Top submissions use 393K+ tokens/step giving 96+ seqs at seq4096
+- Cannot validate on MLX, must wait for H100

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,67 @@
+# Parameter Golf — Task Tracking
+
+## Current Status: MLX prototyping complete. Need H100 for remaining gains.
+
+### Best MLX Result
+**9×512 MLP3, int6, fp16_embed**: pre-quant **2.3087 BPB**, int6 **2.3460 BPB** (200 steps, 2M val)
+
+### Competition Leaders (H100 validated)
+- PR #135: **1.1539 BPB** (OrthoInit + Int6 MLP3x + BigramHash + SmearGate + seq2048 + sliding window)
+- PR #128: **1.1594 BPB** (Int6 MLP3x + STE QAT + sliding window stride-64 + seq4096)
+- PR #136: **1.2101 BPB** (just TRAIN_SEQ_LEN=2048 — single line change!)
+
+## What We've Validated on MLX
+
+### Proven Techniques (confirmed working)
+- [x] MLP_MULT=3: -0.013 BPB improvement (2.3396 → 2.3262)
+- [x] Int6 quantization: works on baseline (0.023-0.034 BPB gap), compresses 21.8M params to 3.9MB
+- [x] FP16 embed passthrough: implemented and working
+- [x] Compiled NTK forward: fixed so seq4096 eval is feasible on Mac
+
+### Validated Negative Results
+- [x] Depth recurrence + int6: catastrophic quant gap (0.61 BPB) — DEAD
+- [x] DWA (DenseFormer weighted avg): slight regression at this scale
+- [x] Loop embeddings: no benefit
+- [x] Extra eval loops: catastrophic regression
+- [x] NTK-RoPE extrapolation (train 1024 → eval 4096): degrades quality (+0.06 BPB)
+- [x] Sliding window at native seq_len: negligible benefit (-0.0005)
+
+### Cannot Validate on Mac (need H100)
+- Train at seq_len=2048+ (batch too small on Mac: 2 seqs/step)
+- Sliding window eval at seq2048+ (only works when model is trained at that length)
+- QAT (needs longer training to be meaningful)
+- Optimizer tuning (muon_momentum=0.99, lower LRs, warmdown=3000)
+
+## Full Experiment Results
+
+### Session 2: Architecture Experiments (10% val, 200 steps)
+
+| Config | Params | Compressed | Pre-quant BPB | Post-quant BPB |
+|--------|--------|-----------|---------------|----------------|
+| E0: Baseline 9×512 | 17.1M | 9.8MB (int8) | 2.3396 | 2.3413 |
+| E2: Recurrence 3×3 512 | 6.0M | 1.7MB (int8) | 2.3368 | 2.3399 |
+| D2: Recurrence 4×3 768 | 17.3M | 7.4MB (int8) | 2.3117 | 2.3170 |
+
+### Session 2: Proven Recipe Experiments (2M val, 200 steps)
+
+| Config | Params | Compressed | Pre-quant BPB | Post-quant BPB |
+|--------|--------|-----------|---------------|----------------|
+| Baseline MLP3 int8 | 21.8M | 11.7MB | 2.3262 | 2.3281 |
+| Baseline MLP3 int6+fp16e | 21.8M | 6.7MB | 2.3087 | 2.3460 |
+| + stride-256 (seq1024) | — | — | — | 2.3455 |
+| + NTK seq2048 stride-256 | — | — | — | 2.3666 (worse) |
+| + NTK seq4096 stride-256 | — | — | — | 2.4069 (much worse) |
+
+## Next Steps (require H100)
+
+### Phase 2: H100 Validation
+1. **Apply for compute grant** — we have validated results + clear technical plan
+2. **Baseline + seq2048**: single-line change, PR #136 shows -0.014 BPB
+3. **Full proven recipe**: MLP3 + int6 + fp16_embed + seq2048 + sliding window stride-64
+4. **Novel additions**: SmearGate, Bigram Hash, Orthogonal init (from PR #135)
+5. **QAT**: STE or Muon-Aware QAT (from PRs #128, #130)
+6. **Optimizer tuning**: matrix_lr=0.02, muon_momentum=0.99, warmdown=3000
+7. **zstd-22** compression (better than zlib-9 for int6)
+
+### Target: sub-1.15 BPB
+Current leader: 1.1539. Our stack (proven recipe + novel techniques) should be competitive.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,67 +1,56 @@
 # Parameter Golf — Task Tracking
 
-## Current Status: MLX prototyping complete. Need H100 for remaining gains.
+## Current Status: Ready for H100. Awaiting compute credits.
 
-### Best MLX Result
-**9×512 MLP3, int6, fp16_embed**: pre-quant **2.3087 BPB**, int6 **2.3460 BPB** (200 steps, 2M val)
+- PR #328 submitted (non-record, Mac MLX)
+- Compute grant application submitted
+- Both scripts (MLX + CUDA) have all techniques implemented
+- CUDA script bug-fixed and verified (1339 lines)
+- MLX script verified (1297 lines)
 
-### Competition Leaders (H100 validated)
-- PR #135: **1.1539 BPB** (OrthoInit + Int6 MLP3x + BigramHash + SmearGate + seq2048 + sliding window)
-- PR #128: **1.1594 BPB** (Int6 MLP3x + STE QAT + sliding window stride-64 + seq4096)
-- PR #136: **1.2101 BPB** (just TRAIN_SEQ_LEN=2048 — single line change!)
+## Best MLX Results
 
-## What We've Validated on MLX
+| Config | Pre-quant BPB | Int8 BPB | Notes |
+|--------|---------------|----------|-------|
+| SG+BH+WD=0.02+LR=0.02 | **2.3164** | **2.3189** | Best 200-step recipe |
+| 14L×416d KV2 (750 steps, full val) | 1.9578 | 1.9588 | Best absolute Mac result |
 
-### Proven Techniques (confirmed working)
-- [x] MLP_MULT=3: -0.013 BPB improvement (2.3396 → 2.3262)
-- [x] Int6 quantization: works on baseline (0.023-0.034 BPB gap), compresses 21.8M params to 3.9MB
-- [x] FP16 embed passthrough: implemented and working
-- [x] Compiled NTK forward: fixed so seq4096 eval is feasible on Mac
+## Competition Leaderboard (as of 2026-03-21)
 
-### Validated Negative Results
-- [x] Depth recurrence + int6: catastrophic quant gap (0.61 BPB) — DEAD
-- [x] DWA (DenseFormer weighted avg): slight regression at this scale
-- [x] Loop embeddings: no benefit
-- [x] Extra eval loops: catastrophic regression
-- [x] NTK-RoPE extrapolation (train 1024 → eval 4096): degrades quality (+0.06 BPB)
-- [x] Sliding window at native seq_len: negligible benefit (-0.0005)
+| Rank | BPB | Author | Key Techniques |
+|---|---|---|---|
+| 1 | **1.1254** | alertcat | TTT + XSA + EMA + SmearGate + BigramHash + Int6 QAT |
+| 2 | 1.1320 | saml212 | Gradient-guided adaptive quant + 12L + LN Scale |
+| 3 | 1.1428 | thwu1 | 10L + Int5 MLP + BigramHash(10240) + SWA(0.4) |
 
-### Cannot Validate on Mac (need H100)
-- Train at seq_len=2048+ (batch too small on Mac: 2 seqs/step)
-- Sliding window eval at seq2048+ (only works when model is trained at that length)
-- QAT (needs longer training to be meaningful)
-- Optimizer tuning (muon_momentum=0.99, lower LRs, warmdown=3000)
+## Implemented Techniques (both scripts)
 
-## Full Experiment Results
+| Technique | MLX | CUDA | Validated on Mac |
+|---|---|---|---|
+| SmearGate | yes | yes | yes (-0.006 BPB) |
+| BigramHash | yes | yes | yes (-0.006 BPB) |
+| Sliding window eval | yes | yes | yes (marginal at seq1024) |
+| Muon weight decay | yes | yes | yes (WD=0.02 best) |
+| Overtone init | yes | yes | yes (hurts at 200 steps with WD+LR) |
+| Phase resid_mix | yes | yes | yes (hurts at 200 steps with WD+LR) |
+| OrthoInit | — | yes | — |
+| FP16 embed | yes | yes | yes (near-zero quant gap) |
+| Int5/Int6 quant | yes | yes | yes (works on baseline, breaks recurrence) |
+| QAT with STE | — | yes | — |
+| zstd-22 | — | yes | — |
+| SWA | — | yes | — |
+| Multi-eval | yes | — | yes |
 
-### Session 2: Architecture Experiments (10% val, 200 steps)
+## H100 Execution Plan
 
-| Config | Params | Compressed | Pre-quant BPB | Post-quant BPB |
-|--------|--------|-----------|---------------|----------------|
-| E0: Baseline 9×512 | 17.1M | 9.8MB (int8) | 2.3396 | 2.3413 |
-| E2: Recurrence 3×3 512 | 6.0M | 1.7MB (int8) | 2.3368 | 2.3399 |
-| D2: Recurrence 4×3 768 | 17.3M | 7.4MB (int8) | 2.3117 | 2.3170 |
+See `docs/H100_PLAN.md` for full 4-phase plan targeting sub-1.12 BPB.
 
-### Session 2: Proven Recipe Experiments (2M val, 200 steps)
+## Key Lessons Learned
 
-| Config | Params | Compressed | Pre-quant BPB | Post-quant BPB |
-|--------|--------|-----------|---------------|----------------|
-| Baseline MLP3 int8 | 21.8M | 11.7MB | 2.3262 | 2.3281 |
-| Baseline MLP3 int6+fp16e | 21.8M | 6.7MB | 2.3087 | 2.3460 |
-| + stride-256 (seq1024) | — | — | — | 2.3455 |
-| + NTK seq2048 stride-256 | — | — | — | 2.3666 (worse) |
-| + NTK seq4096 stride-256 | — | — | — | 2.4069 (much worse) |
-
-## Next Steps (require H100)
-
-### Phase 2: H100 Validation
-1. **Apply for compute grant** — we have validated results + clear technical plan
-2. **Baseline + seq2048**: single-line change, PR #136 shows -0.014 BPB
-3. **Full proven recipe**: MLP3 + int6 + fp16_embed + seq2048 + sliding window stride-64
-4. **Novel additions**: SmearGate, Bigram Hash, Orthogonal init (from PR #135)
-5. **QAT**: STE or Muon-Aware QAT (from PRs #128, #130)
-6. **Optimizer tuning**: matrix_lr=0.02, muon_momentum=0.99, warmdown=3000
-7. **zstd-22** compression (better than zlib-9 for int6)
-
-### Target: sub-1.15 BPB
-Current leader: 1.1539. Our stack (proven recipe + novel techniques) should be competitive.
+See `tasks/lessons.md` for full documentation. Highlights:
+- Depth recurrence + int6 = catastrophic quant gap (0.61 BPB) — dead end
+- FP16 embed + Muon WD = near-zero quant gap (0.001 BPB)
+- WD=0.02 + LR=0.02 is best at short training
+- OvertoneInit + PhaseResidMix conflict with WD+LR tuning at 200 steps
+- SmearGate + BigramHash = -0.006 BPB (cheap, effective)
+- Sliding window needs seq2048+ training to show big gains

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -70,6 +70,13 @@ class Hyperparameters:
     rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
     logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
 
+    # Architecture additions.
+    use_smeargate: bool = bool(int(os.environ.get("USE_SMEARGATE", "0")))
+    bigram_hash_buckets: int = int(os.environ.get("BIGRAM_HASH_BUCKETS", 0))
+    bigram_hash_dim: int = int(os.environ.get("BIGRAM_HASH_DIM", 128))
+    # Eval overrides.
+    eval_stride: int = int(os.environ.get("EVAL_STRIDE", 0))
+
     # Optimizer hyperparameters.
     embed_lr = float(os.environ.get("EMBED_LR", 0.6))
     head_lr = float(os.environ.get("HEAD_LR", 0.008))
@@ -85,6 +92,18 @@ class Hyperparameters:
     beta2 = float(os.environ.get("BETA2", 0.95))
     adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
     grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+    muon_weight_decay: float = float(os.environ.get("MUON_WEIGHT_DECAY", 0.0))
+    overtone_init: bool = bool(int(os.environ.get("OVERTONE_INIT", "0")))
+    phase_resid_mix: bool = bool(int(os.environ.get("PHASE_RESID_MIX", "0")))
+    ortho_init: bool = bool(int(os.environ.get("ORTHO_INIT", "0")))
+    # Quantization.
+    quant_bits: int = int(os.environ.get("QUANT_BITS", 8))
+    fp16_embed: bool = bool(int(os.environ.get("FP16_EMBED", "0")))
+    qat_enabled: bool = bool(int(os.environ.get("QAT_ENABLED", "0")))
+    use_zstd: bool = bool(int(os.environ.get("USE_ZSTD", "0")))
+    # SWA (Stochastic Weight Averaging).
+    swa_every: int = int(os.environ.get("SWA_EVERY", 0))
+    swa_start_frac: float = float(os.environ.get("SWA_START_FRAC", 0.5))
 
 # -----------------------------
 # MUON OPTIMIZER 
@@ -277,6 +296,51 @@ def eval_val(
     model.train()
     return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
 
+
+def eval_val_sliding(
+    args: Hyperparameters, model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, stride: int,
+    base_bytes_lut: Tensor, has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    """Sliding-window eval: score only the last `stride` tokens per window."""
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    nll_sum = torch.zeros((), device=device, dtype=torch.float64)
+    tok_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    positions = list(range(0, total_tokens - seq_len + 1, stride))
+    my_positions = positions[rank::world_size]
+    model.eval()
+    with torch.inference_mode():
+        for pos in my_positions:
+            chunk = val_tokens[pos:pos + seq_len + 1].to(device=device, dtype=torch.int64)
+            x = chunk[:-1].unsqueeze(0)
+            y = chunk[1:].unsqueeze(0)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                base = model.module if hasattr(model, 'module') else model
+                base = base._orig_mod if hasattr(base, '_orig_mod') else base
+                logits = base.forward_logits(x)
+            logits_score = logits[:, -stride:, :].reshape(-1, logits.size(-1))
+            targets = y[:, -stride:].reshape(-1)
+            loss = F.cross_entropy(logits_score.float(), targets, reduction="sum")
+            nll_sum += loss.to(torch.float64)
+            tok_count += stride
+            prev_ids = x[:, -stride:].reshape(-1)
+            tgt_ids = targets
+            tbytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            tbytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            byte_count += tbytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(nll_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(tok_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = nll_sum / tok_count
+    bpt = val_loss.item() / math.log(2.0)
+    tpb = tok_count.item() / byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bpt * tpb)
+
+
 # -----------------------------
 # POST-TRAINING QUANTIZATION
 # -----------------------------
@@ -318,33 +382,28 @@ def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, s
         return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
     return t
 
-def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+def quantize_float_tensor(t: Tensor, quant_bits: int = 8) -> tuple[Tensor, Tensor]:
+    qmax_map = {5: (16, 15), 6: (32, 31), 8: (127, 127)}
+    qneg, qpos = qmax_map.get(quant_bits, (127, 127))
+    qscale_denom = float(qpos)
     t32 = t.float()
     if t32.ndim == 2:
-        # Matrices get one scale per row, which usually tracks output-channel
-        # ranges much better than a single tensor-wide scale.
         clip_abs = (
             torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
             if t32.numel()
             else torch.empty((t32.shape[0],), dtype=torch.float32)
         )
         clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
-        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
-        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        scale = (clip_abs / qscale_denom).clamp_min(1.0 / qscale_denom)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -qneg, qpos).to(torch.int8).contiguous()
         return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
 
-    # Vectors / scalars use a simpler per-tensor scale.
     clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
-    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
-    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    scale = torch.tensor(clip_abs / qscale_denom if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -qneg, qpos).to(torch.int8).contiguous()
     return q, scale
 
-def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
-    # Single supported clean-script export format:
-    # - per-row int8 for 2D float tensors
-    # - per-tensor int8 for other float tensors
-    # - exact passthrough for non-floats
-    # - passthrough for small float tensors, stored as fp16 to save bytes
+def quantize_state_dict_int8(state_dict: dict[str, Tensor], quant_bits: int = 8, fp16_embed: bool = False):
     quantized: dict[str, Tensor] = {}
     scales: dict[str, Tensor] = {}
     dtypes: dict[str, str] = {}
@@ -368,8 +427,14 @@ def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
             stats["int8_payload_bytes"] += tensor_nbytes(t)
             continue
 
-        # Small float tensors are cheap enough to keep directly. We still downcast
-        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        # FP16 embed passthrough: store tok_emb as fp16 regardless of size
+        if fp16_embed and "tok_emb" in name:
+            passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+            kept = t.to(dtype=torch.float16).contiguous()
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
         if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
             kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
             passthrough[name] = kept
@@ -377,7 +442,7 @@ def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
             continue
 
         stats["num_float_tensors"] += 1
-        q, s = quantize_float_tensor(t)
+        q, s = quantize_float_tensor(t, quant_bits=quant_bits)
         if s.ndim > 0:
             qmeta[name] = {"scheme": "per_row", "axis": 0}
         quantized[name] = q
@@ -386,7 +451,7 @@ def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
         stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
 
     obj: dict[str, object] = {
-        "__quant_format__": "int8_clean_per_row_v1",
+        "__quant_format__": f"int{quant_bits}_clean_per_row_v1",
         "quantized": quantized,
         "scales": scales,
         "dtypes": dtypes,
@@ -506,11 +571,24 @@ class RMSNorm(nn.Module):
         return F.rms_norm(x, (x.size(-1),), eps=self.eps)
 
 
+_QAT_ENABLED = False
+_QAT_BITS = 6
+
+def fake_quantize(w, bits=6):
+    qmax = {5: 15, 6: 31, 8: 127}[bits]
+    scale = w.detach().abs().amax(dim=-1, keepdim=True) / qmax
+    scale = scale.clamp(min=1e-8)
+    w_q = (w / scale).round().clamp(-qmax, qmax)
+    return w + (w_q * scale - w).detach()  # STE
+
 class CastedLinear(nn.Linear):
     # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.
     def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if _QAT_ENABLED:
+            w = fake_quantize(w, bits=_QAT_BITS)
         bias = self.bias.to(x.dtype) if self.bias is not None else None
-        return F.linear(x, self.weight.to(x.dtype), bias)
+        return F.linear(x, w, bias)
 
 
 def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
@@ -659,6 +737,11 @@ class GPT(nn.Module):
         logit_softcap: float,
         rope_base: float,
         qk_gain_init: float,
+        use_smeargate: bool = False,
+        bigram_hash_buckets: int = 0,
+        bigram_hash_dim: int = 128,
+        overtone_init: bool = False,
+        phase_resid_mix: bool = False,
     ):
         super().__init__()
         if logit_softcap <= 0.0:
@@ -666,21 +749,28 @@ class GPT(nn.Module):
         self.tie_embeddings = tie_embeddings
         self.tied_embed_init_std = tied_embed_init_std
         self.logit_softcap = logit_softcap
+        self.overtone_init = overtone_init
+        self.phase_resid_mix = phase_resid_mix
         self.tok_emb = nn.Embedding(vocab_size, model_dim)
+
+        # BigramHash
+        self.bigram_hash_buckets = bigram_hash_buckets
+        if bigram_hash_buckets > 0:
+            self.bigram_table = nn.Parameter(torch.randn(bigram_hash_buckets, bigram_hash_dim) * 0.01)
+            self.bigram_proj = nn.Parameter(torch.randn(bigram_hash_dim, model_dim) * (bigram_hash_dim ** -0.5))
+
+        # SmearGate
+        self.use_smeargate = use_smeargate
+        if use_smeargate:
+            self.smear_gate = nn.Parameter(torch.full((model_dim,), 3.0))
+
         self.num_encoder_layers = num_layers // 2
         self.num_decoder_layers = num_layers - self.num_encoder_layers
         self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
         self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
         self.blocks = nn.ModuleList(
             [
-                Block(
-                    model_dim,
-                    num_heads,
-                    num_kv_heads,
-                    mlp_mult,
-                    rope_base,
-                    qk_gain_init,
-                )
+                Block(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init)
                 for i in range(num_layers)
             ]
         )
@@ -696,14 +786,41 @@ class GPT(nn.Module):
         for module in self.modules():
             if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
                 nn.init.zeros_(module.weight)
+        # Overtone spectral init
+        if self.overtone_init:
+            with torch.no_grad():
+                w = self.tok_emb.weight.float()
+                U, S, Vt = torch.linalg.svd(w, full_matrices=False)
+                target_S = S[0] * (1.0 / torch.arange(1, S.shape[0]+1, device=w.device, dtype=torch.float32)) ** 0.5
+                self.tok_emb.weight.copy_((U * target_S.unsqueeze(0)) @ Vt)
+        # Phase-transition resid_mix
+        if self.phase_resid_mix:
+            with torch.no_grad():
+                n = len(self.blocks)
+                for i, b in enumerate(self.blocks):
+                    phase = torch.sigmoid(torch.tensor(3.0 * (i / max(n-1, 1) - 0.5)))
+                    b.resid_mix.data[0].fill_(phase.item())
+                    b.resid_mix.data[1].fill_(1.0 - phase.item())
 
-    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+    def _embed_forward(self, input_ids: Tensor) -> tuple[Tensor, Tensor]:
+        """Shared embedding logic for forward and forward_logits."""
         x = self.tok_emb(input_ids)
+        if self.bigram_hash_buckets > 0:
+            prev_ids = torch.cat([input_ids[:, :1], input_ids[:, :-1]], dim=1)
+            hash_idx = (prev_ids * 31 + input_ids) % self.bigram_hash_buckets
+            bigram_emb = self.bigram_table[hash_idx.reshape(-1)].reshape(*input_ids.shape, -1)
+            x = x + (bigram_emb @ self.bigram_proj.to(x.dtype))
+        if self.use_smeargate:
+            gate = torch.sigmoid(self.smear_gate).to(x.dtype)
+            prev_x = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+            x = gate * x + (1.0 - gate) * prev_x
         x = F.rms_norm(x, (x.size(-1),))
         x0 = x
-        skips: list[Tensor] = []
+        return x, x0
 
-        # First half stores skips; second half reuses them in reverse order.
+    def _run_blocks(self, x: Tensor, x0: Tensor) -> Tensor:
+        """Shared transformer block logic."""
+        skips: list[Tensor] = []
         for i in range(self.num_encoder_layers):
             x = self.blocks[i](x, x0)
             skips.append(x)
@@ -711,7 +828,11 @@ class GPT(nn.Module):
             if skips:
                 x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
             x = self.blocks[self.num_encoder_layers + i](x, x0)
+        return x
 
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x, x0 = self._embed_forward(input_ids)
+        x = self._run_blocks(x, x0)
         x = self.final_norm(x).reshape(-1, x.size(-1))
         targets = target_ids.reshape(-1)
         if self.tie_embeddings:
@@ -722,6 +843,19 @@ class GPT(nn.Module):
             logits_proj = self.lm_head(x)
         logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
         return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Returns logits (B, T, V) instead of loss."""
+        x, x0 = self._embed_forward(input_ids)
+        x = self._run_blocks(x, x0)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight.to(x.dtype))
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
 
 
 # -----------------------------
@@ -823,6 +957,12 @@ def main() -> None:
     # MODEL + OPTIMIZER SETUP
     # -----------------------------
 
+    # Enable QAT globally if requested
+    global _QAT_ENABLED, _QAT_BITS
+    if args.qat_enabled:
+        _QAT_ENABLED = True
+        _QAT_BITS = args.quant_bits
+
     base_model = GPT(
         vocab_size=args.vocab_size,
         num_layers=args.num_layers,
@@ -835,11 +975,26 @@ def main() -> None:
         logit_softcap=args.logit_softcap,
         rope_base=args.rope_base,
         qk_gain_init=args.qk_gain_init,
+        use_smeargate=args.use_smeargate,
+        bigram_hash_buckets=args.bigram_hash_buckets,
+        bigram_hash_dim=args.bigram_hash_dim,
+        overtone_init=args.overtone_init,
+        phase_resid_mix=args.phase_resid_mix,
     ).to(device).bfloat16()
     for module in base_model.modules():
         if isinstance(module, CastedLinear):
             module.float()
     restore_low_dim_params_to_fp32(base_model)
+
+    # Orthogonal weight initialization
+    if args.ortho_init:
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if p.ndim == 2 and 'tok_emb' not in name:
+                    nn.init.orthogonal_(p)
+                    if 'proj' in name:
+                        p.data.mul_(1.0 / math.sqrt(2 * args.num_layers))
+
     compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
     model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
 
@@ -861,6 +1016,13 @@ def main() -> None:
     ]
     if base_model.skip_weights.numel() > 0:
         scalar_params.append(base_model.skip_weights)
+    # Add bigram/smear params to scalar optimizer
+    if args.bigram_hash_buckets > 0:
+        scalar_params.extend([base_model.bigram_table, base_model.bigram_proj])
+    if args.use_smeargate:
+        scalar_params.append(base_model.smear_gate)
+    # Keep reference for Muon weight decay
+    muon_params = matrix_params
     token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
     optimizer_tok = torch.optim.Adam(
         [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
@@ -966,6 +1128,8 @@ def main() -> None:
 
     training_time_ms = 0.0
     stop_after_step: int | None = None
+    swa_state = None
+    swa_count = 0
     torch.cuda.synchronize()
     t0 = time.perf_counter()
 
@@ -1031,7 +1195,27 @@ def main() -> None:
             torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
         for opt in optimizers:
             opt.step()
+        # Muon weight decay
+        if args.muon_weight_decay > 0:
+            current_lr = optimizer_muon.param_groups[0]["lr"]
+            with torch.no_grad():
+                for p in muon_params:
+                    p.mul_(1.0 - args.muon_weight_decay * current_lr)
         zero_grad_all()
+
+        # SWA collection
+        if args.swa_every > 0:
+            warmdown_start = args.iterations - args.warmdown_iters
+            swa_start = warmdown_start + int(args.warmdown_iters * (1.0 - args.swa_start_frac))
+            if step >= swa_start and step % args.swa_every == 0:
+                sd = {k: v.detach().cpu().clone() for k, v in base_model.state_dict().items()}
+                if swa_state is None:
+                    swa_state = sd
+                else:
+                    swa_count_f = float(swa_count)
+                    for k in swa_state:
+                        swa_state[k] = swa_state[k] + (sd[k] - swa_state[k]) / (swa_count_f + 1)
+                swa_count += 1
 
         step += 1
         approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
@@ -1059,6 +1243,14 @@ def main() -> None:
         f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
     )
 
+    # Apply SWA if collected
+    if swa_state is not None and swa_count > 0:
+        base_model.load_state_dict(swa_state, strict=True)
+        log0(f"SWA applied: averaged {swa_count} checkpoints")
+
+    # Disable QAT for serialization/eval
+    _QAT_ENABLED = False
+
     # -----------------------------
     # SERIALIZATION + ROUNDTRIP VALIDATION
     # -----------------------------
@@ -1073,50 +1265,65 @@ def main() -> None:
         log0(f"Code size: {code_bytes} bytes")
         log0(f"Total submission size: {model_bytes + code_bytes} bytes")
 
-    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_obj, quant_stats = quantize_state_dict_int8(
+        base_model.state_dict(), quant_bits=args.quant_bits, fp16_embed=args.fp16_embed
+    )
     quant_buf = io.BytesIO()
     torch.save(quant_obj, quant_buf)
     quant_raw = quant_buf.getvalue()
-    quant_blob = zlib.compress(quant_raw, level=9)
+    if args.use_zstd:
+        import zstandard
+        quant_blob = zstandard.ZstdCompressor(level=22).compress(quant_raw)
+        quant_ext = ".int8.zst"
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+        quant_ext = ".int8.ptz"
     quant_raw_bytes = len(quant_raw)
+    quant_filename = f"final_model{quant_ext}"
     if master_process:
-        with open("final_model.int8.ptz", "wb") as f:
+        with open(quant_filename, "wb") as f:
             f.write(quant_blob)
-        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        quant_file_bytes = os.path.getsize(quant_filename)
         code_bytes = len(code.encode("utf-8"))
         ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
         log0(
-            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
+            f"Serialized model int{args.quant_bits}+{'zstd' if args.use_zstd else 'zlib'}: {quant_file_bytes} bytes "
             f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
         )
-        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+        log0(f"Total submission size: {quant_file_bytes + code_bytes} bytes")
 
     if distributed:
         dist.barrier()
-    with open("final_model.int8.ptz", "rb") as f:
+    with open(quant_filename, "rb") as f:
         quant_blob_disk = f.read()
-    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    if args.use_zstd:
+        import zstandard
+        quant_raw_disk = zstandard.ZstdDecompressor().decompress(quant_blob_disk)
+    else:
+        quant_raw_disk = zlib.decompress(quant_blob_disk)
+    quant_state = torch.load(io.BytesIO(quant_raw_disk), map_location="cpu")
     base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
     torch.cuda.synchronize()
     t_qeval = time.perf_counter()
-    q_val_loss, q_val_bpb = eval_val(
-        args,
-        model,
-        rank,
-        world_size,
-        device,
-        grad_accum_steps,
-        val_tokens,
-        base_bytes_lut,
-        has_leading_space_lut,
-        is_boundary_token_lut,
-    )
+
+    # Use sliding window eval if stride is set, otherwise standard eval
+    if args.eval_stride > 0:
+        q_val_loss, q_val_bpb = eval_val_sliding(
+            args, model, rank, world_size, device, val_tokens, args.eval_stride,
+            base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        )
+    else:
+        q_val_loss, q_val_bpb = eval_val(
+            args, model, rank, world_size, device, grad_accum_steps, val_tokens,
+            base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        )
     torch.cuda.synchronize()
+    compress_tag = f"int{args.quant_bits}_{'zstd' if args.use_zstd else 'zlib'}"
     log0(
-        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"final_{compress_tag}_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
         f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
     )
-    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+    log0(f"final_{compress_tag}_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
 
     if distributed:
         dist.destroy_process_group()

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -1214,7 +1214,8 @@ def main() -> None:
                 else:
                     swa_count_f = float(swa_count)
                     for k in swa_state:
-                        swa_state[k] = swa_state[k] + (sd[k] - swa_state[k]) / (swa_count_f + 1)
+                        if swa_state[k].is_floating_point():
+                            swa_state[k] = swa_state[k] + (sd[k] - swa_state[k]) / (swa_count_f + 1)
                 swa_count += 1
 
         step += 1
@@ -1265,22 +1266,22 @@ def main() -> None:
         log0(f"Code size: {code_bytes} bytes")
         log0(f"Total submission size: {model_bytes + code_bytes} bytes")
 
-    quant_obj, quant_stats = quantize_state_dict_int8(
-        base_model.state_dict(), quant_bits=args.quant_bits, fp16_embed=args.fp16_embed
-    )
-    quant_buf = io.BytesIO()
-    torch.save(quant_obj, quant_buf)
-    quant_raw = quant_buf.getvalue()
-    if args.use_zstd:
-        import zstandard
-        quant_blob = zstandard.ZstdCompressor(level=22).compress(quant_raw)
-        quant_ext = ".int8.zst"
-    else:
-        quant_blob = zlib.compress(quant_raw, level=9)
-        quant_ext = ".int8.ptz"
-    quant_raw_bytes = len(quant_raw)
-    quant_filename = f"final_model{quant_ext}"
     if master_process:
+        quant_obj, quant_stats = quantize_state_dict_int8(
+            base_model.state_dict(), quant_bits=args.quant_bits, fp16_embed=args.fp16_embed
+        )
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+        if args.use_zstd:
+            import zstandard
+            quant_blob = zstandard.ZstdCompressor(level=22).compress(quant_raw)
+            quant_ext = ".int8.zst"
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+            quant_ext = ".int8.ptz"
+        quant_raw_bytes = len(quant_raw)
+        quant_filename = f"final_model{quant_ext}"
         with open(quant_filename, "wb") as f:
             f.write(quant_blob)
         quant_file_bytes = os.path.getsize(quant_filename)
@@ -1291,6 +1292,10 @@ def main() -> None:
             f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
         )
         log0(f"Total submission size: {quant_file_bytes + code_bytes} bytes")
+
+    # Determine quant_filename on all ranks (needed for roundtrip eval below)
+    quant_ext = ".int8.zst" if args.use_zstd else ".int8.ptz"
+    quant_filename = f"final_model{quant_ext}"
 
     if distributed:
         dist.barrier()

--- a/train_gpt_mlx.py
+++ b/train_gpt_mlx.py
@@ -82,6 +82,15 @@ class Hyperparameters:
     num_unique_blocks: int = int(os.environ.get("NUM_UNIQUE_BLOCKS", 0))
     num_loops: int = int(os.environ.get("NUM_LOOPS", 1))
 
+    # Eval-time overrides (0 = use training defaults).
+    eval_num_loops: int = int(os.environ.get("EVAL_NUM_LOOPS", 0))
+    eval_stride: int = int(os.environ.get("EVAL_STRIDE", 0))
+    eval_seq_len: int = int(os.environ.get("EVAL_SEQ_LEN", 0))
+    val_max_tokens: int = int(os.environ.get("VAL_MAX_TOKENS", 0))
+    # Architecture additions.
+    use_loop_embed: bool = bool(int(os.environ.get("USE_LOOP_EMBED", "0")))
+    use_dwa: bool = bool(int(os.environ.get("USE_DWA", "0")))
+
     # Optimizer. We keep the same per-group defaults as train_gpt.py.
     beta1: float = float(os.environ.get("BETA1", 0.9))
     beta2: float = float(os.environ.get("BETA2", 0.95))
@@ -94,6 +103,13 @@ class Hyperparameters:
     muon_momentum_warmup_start: float = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
     muon_momentum_warmup_steps: int = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
     grad_clip_norm: float = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+    muon_weight_decay: float = float(os.environ.get("MUON_WEIGHT_DECAY", 0.0))
+    overtone_init: bool = bool(int(os.environ.get("OVERTONE_INIT", "0")))
+    phase_resid_mix: bool = bool(int(os.environ.get("PHASE_RESID_MIX", "0")))
+
+    # Quantization.
+    quant_bits: int = int(os.environ.get("QUANT_BITS", 8))
+    fp16_embed: bool = bool(int(os.environ.get("FP16_EMBED", "0")))
 
     out_dir: str = os.environ.get("OUT_DIR", "logs")
 
@@ -125,7 +141,7 @@ CONTROL_TENSOR_NAME_PATTERNS = tuple(
     pattern
     for pattern in os.environ.get(
         "CONTROL_TENSOR_NAME_PATTERNS",
-        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,dwa_logits,loop_embeds",
     ).split(",")
     if pattern
 )
@@ -388,7 +404,9 @@ class GPT(nn.Module):
     # - tied embeddings for the LM head (the baseline default setup)
     def __init__(self, vocab_size: int, num_layers: int, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int,
                  logit_chunk_tokens: int, logit_softcap: float, rope_base: float, tied_embed_init_std: float,
-                 qk_gain_init: float, num_unique_blocks: int = 0, num_loops: int = 1):
+                 qk_gain_init: float, num_unique_blocks: int = 0, num_loops: int = 1,
+                 use_loop_embed: bool = False, use_dwa: bool = False,
+                 overtone_init: bool = False, phase_resid_mix: bool = False):
         super().__init__()
         if logit_softcap <= 0.0:
             raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
@@ -422,6 +440,22 @@ class GPT(nn.Module):
                 for _ in range(num_layers)
             ]
 
+        # Loop-index embeddings (only meaningful with recurrence).
+        self.use_loop_embed = use_loop_embed and self.use_recurrence
+        if self.use_loop_embed:
+            self.loop_embeds = mx.random.normal((num_loops, dim)) * 0.01
+        # DenseFormer DWA: weighted average of all prior layer outputs.
+        self.use_dwa = use_dwa
+        if use_dwa:
+            ed = num_unique_blocks * num_loops if self.use_recurrence else num_layers
+            self._effective_depth = ed
+            init_logits = np.zeros((ed, ed + 1), dtype=np.float32)
+            for i in range(ed):
+                init_logits[i, i] = 5.0  # near-identity init
+            self.dwa_logits = mx.array(init_logits)
+        else:
+            self._effective_depth = 0
+
         self.final_norm = RMSNormNoWeight()
 
         for b in self.blocks:
@@ -431,18 +465,49 @@ class GPT(nn.Module):
             mx.random.normal(self.tok_emb.weight.shape, dtype=mx.float32) * tied_embed_init_std
         ).astype(COMPUTE_DTYPE)
 
+        # Overtone spectral embedding init: SVD power-law shaping (S_k ~ k^{-0.5}).
+        if overtone_init:
+            w = np.array(self.tok_emb.weight.astype(mx.float32), dtype=np.float32)
+            U, S, Vt = np.linalg.svd(w, full_matrices=False)
+            target_S = S[0] * (1.0 / np.arange(1, S.shape[0] + 1, dtype=np.float32)) ** 0.5
+            self.tok_emb.weight = mx.array((U * target_S[None, :]) @ Vt, dtype=COMPUTE_DTYPE)
+
+        # Phase-transition resid_mix: sigmoid schedule from trusting x0 (early) to residual (late).
+        if phase_resid_mix:
+            n = len(self.blocks)
+            for i, b in enumerate(self.blocks):
+                phase = 1.0 / (1.0 + np.exp(-3.0 * (i / max(n - 1, 1) - 0.5)))
+                b.resid_mix = mx.array(np.stack((
+                    np.full((dim,), phase, dtype=np.float32),
+                    np.full((dim,), 1.0 - phase, dtype=np.float32),
+                )))
+
     def softcap(self, logits: mx.array) -> mx.array:
         c = self.logit_softcap
         return c * mx.tanh(logits / c)
 
-    def __call__(self, input_ids: mx.array) -> mx.array:
+    def __call__(self, input_ids: mx.array, num_loops_override: int = 0) -> mx.array:
         x = rms_norm(self.tok_emb(input_ids).astype(COMPUTE_DTYPE))
         x0 = x
 
         if self.use_recurrence:
-            for _loop in range(self.num_loops):
-                for block in self.blocks:
+            num_loops = num_loops_override if num_loops_override > 0 else self.num_loops
+            history: list[mx.array] = [x] if self.use_dwa else []
+            for loop_idx in range(num_loops):
+                for block_idx, block in enumerate(self.blocks):
+                    if self.use_dwa:
+                        step_idx = loop_idx * self.num_unique_blocks + block_idx
+                        dwa_i = step_idx % self._effective_depth
+                        n = min(dwa_i + 1, len(history))
+                        logits_row = self.dwa_logits[dwa_i, :n]
+                        weights = mx.softmax(logits_row)
+                        stacked = mx.stack(history[-n:], axis=0)
+                        x = (weights[:, None, None, None] * stacked).sum(axis=0)
+                    if self.use_loop_embed and block_idx == 0:
+                        x = x + self.loop_embeds[loop_idx % self.num_loops]
                     x = block(x, x0)
+                    if self.use_dwa:
+                        history.append(x)
         else:
             skips: list[mx.array] = []
             for i in range(self.num_encoder_layers):
@@ -521,7 +586,9 @@ class SplitOptimizers:
         self.scalar_keys = [
             k
             for k, p in params.items()
-            if (k == "skip_weights" and p.size > 0) or (k.startswith("blocks.") and (p.ndim < 2 or any(pattern in k for pattern in CONTROL_TENSOR_NAME_PATTERNS)))
+            if (k == "skip_weights" and p.size > 0)
+            or (k in ("dwa_logits", "loop_embeds") and p.size > 0)
+            or (k.startswith("blocks.") and (p.ndim < 2 or any(pattern in k for pattern in CONTROL_TENSOR_NAME_PATTERNS)))
         ]
 
         self.muon = Muon(self.matrix_keys, params, args)
@@ -594,25 +661,36 @@ def keep_float_array(name: str, arr: mx.array, passthrough_orig_dtypes: dict[str
     return np.ascontiguousarray(np.array(arr, copy=True))
 
 
-def quantize_float_array(arr: mx.array) -> tuple[np.ndarray, np.ndarray]:
+def quantize_float_array(arr: mx.array, quant_bits: int = 8) -> tuple[np.ndarray, np.ndarray]:
     f32 = _np_float32(arr)
+    # int6: clip to [-32, 31], stored in int8 (high 2 bits zero, compresses well).
+    # int8: clip to [-127, 127] as before.
+    if quant_bits == 6:
+        qmax, qmin = 31, -32
+    else:
+        qmax, qmin = 127, -127
+    scale_denom = float(qmax)  # 32.0 for int6, 127.0 for int8
     if f32.ndim == 2:
         # Matrices get one scale per row, which usually tracks output-channel
         # ranges much better than a single tensor-wide scale.
         clip_abs = np.quantile(np.abs(f32), INT8_CLIP_Q, axis=1) if f32.size else np.empty((f32.shape[0],), dtype=np.float32)
         clipped = np.clip(f32, -clip_abs[:, None], clip_abs[:, None])
-        scale = np.maximum(clip_abs / 127.0, 1.0 / 127.0).astype(np.float32, copy=False)
-        q = np.clip(np.round(clipped / scale[:, None]), -127, 127).astype(np.int8, copy=False)
+        scale = np.maximum(clip_abs / scale_denom, 1.0 / scale_denom).astype(np.float32, copy=False)
+        q = np.clip(np.round(clipped / scale[:, None]), qmin, qmax).astype(np.int8, copy=False)
         return np.ascontiguousarray(q), np.ascontiguousarray(scale.astype(INT8_PER_ROW_SCALE_DTYPE, copy=False))
 
     # Vectors / scalars use a simpler per-tensor scale.
     clip_abs = float(np.quantile(np.abs(f32).reshape(-1), INT8_CLIP_Q)) if f32.size else 0.0
-    scale = np.array(clip_abs / 127.0 if clip_abs > 0.0 else 1.0, dtype=np.float32)
-    q = np.clip(np.round(np.clip(f32, -clip_abs, clip_abs) / scale), -127, 127).astype(np.int8, copy=False)
+    scale = np.array(clip_abs / scale_denom if clip_abs > 0.0 else 1.0, dtype=np.float32)
+    q = np.clip(np.round(np.clip(f32, -clip_abs, clip_abs) / scale), qmin, qmax).astype(np.int8, copy=False)
     return np.ascontiguousarray(q), scale
 
 
-def quantize_state_dict_int8(flat_state: dict[str, mx.array]) -> tuple[dict[str, object], dict[str, int]]:
+def quantize_state_dict_int8(
+    flat_state: dict[str, mx.array],
+    quant_bits: int = 8,
+    fp16_embed: bool = False,
+) -> tuple[dict[str, object], dict[str, int]]:
     quantized: dict[str, np.ndarray] = {}
     scales: dict[str, np.ndarray] = {}
     dtypes: dict[str, str] = {}
@@ -633,6 +711,13 @@ def quantize_state_dict_int8(flat_state: dict[str, mx.array]) -> tuple[dict[str,
             stats["int8_payload_bytes"] += int(passthrough[name].nbytes)
             continue
 
+        # FP16 embedding passthrough: keep tok_emb.weight in fp16 regardless of size.
+        if fp16_embed and name == "tok_emb.weight":
+            kept = keep_float_array(name, arr, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += int(kept.nbytes)
+            continue
+
         # Small float tensors are cheap enough to keep directly. We still downcast
         # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
         if int(arr.size) <= INT8_KEEP_FLOAT_MAX_NUMEL:
@@ -642,7 +727,7 @@ def quantize_state_dict_int8(flat_state: dict[str, mx.array]) -> tuple[dict[str,
             continue
 
         stats["num_float_tensors"] += 1
-        q, s = quantize_float_array(arr)
+        q, s = quantize_float_array(arr, quant_bits=quant_bits)
         if s.ndim > 0:
             qmeta[name] = {"scheme": "per_row", "axis": 0}
         quantized[name] = q
@@ -650,7 +735,7 @@ def quantize_state_dict_int8(flat_state: dict[str, mx.array]) -> tuple[dict[str,
         dtypes[name] = str(arr.dtype).split(".")[-1]
         stats["int8_payload_bytes"] += int(q.nbytes + s.nbytes)
     obj: dict[str, object] = {
-        "__quant_format__": "int8_clean_per_row_v1",
+        "__quant_format__": f"int{quant_bits}_clean_per_row_v1",
         "quantized": quantized,
         "scales": scales,
         "dtypes": dtypes,
@@ -778,53 +863,73 @@ def loss_and_grad_chunked(
     return loss_value, tree_unflatten(list(grad_accum.items()))
 
 
+def set_rope_base(model: GPT, base: float) -> None:
+    for block in model.blocks:
+        block.attn.rope = nn.RoPE(block.attn.head_dim, traditional=False, base=base)
+
+
 def eval_val(
     args: Hyperparameters,
-    compiled_loss,
+    model: GPT,
     val_tokens: np.ndarray,
     base_bytes_lut: np.ndarray,
     has_leading_space_lut: np.ndarray,
     is_boundary_token_lut: np.ndarray,
+    compiled_forward=None,
 ) -> tuple[float, float]:
-    # Validation computes two metrics:
-    # - val_loss: token cross-entropy (natural log)
-    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
-    val_batch_tokens = args.val_batch_size // args.grad_accum_steps
-    if val_batch_tokens < args.train_seq_len:
-        raise ValueError(
-            "VAL_BATCH_SIZE must provide at least one sequence; "
-            f"got VAL_BATCH_SIZE={args.val_batch_size}, GRAD_ACCUM_STEPS={args.grad_accum_steps}, "
-            f"TRAIN_SEQ_LEN={args.train_seq_len}"
-        )
-    val_batch_seqs = val_batch_tokens // args.train_seq_len
-    total_seqs = (val_tokens.size - 1) // args.train_seq_len
+    # Sliding-window eval: each window is eval_seq_len tokens, scored on last stride tokens.
+    # When stride == eval_seq_len, this degrades to the non-overlapping baseline.
+    eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    stride = args.eval_stride if args.eval_stride > 0 else eval_seq_len
+    num_loops_override = args.eval_num_loops if args.eval_num_loops > 0 else 0
+
+    # NTK-RoPE scaling for longer eval sequences.
+    ntk_active = eval_seq_len != args.train_seq_len
+    if ntk_active:
+        head_dim = args.model_dim // args.num_heads
+        scaled_base = args.rope_base * (eval_seq_len / args.train_seq_len) ** (head_dim / (head_dim - 2))
+        set_rope_base(model, scaled_base)
+
+    # Use compiled forward when possible. Recompile after NTK RoPE swap so the
+    # compiled graph captures the scaled frequencies.
+    use_compiled = compiled_forward is not None and num_loops_override == 0
+    if ntk_active and use_compiled:
+        compiled_forward = mx.compile(lambda x: model(x), inputs=model.state, outputs=model.state)
+
+    n_tokens = val_tokens.size - 1
+    starts = list(range(0, n_tokens - eval_seq_len + 1, stride))
+    val_batch_seqs = max(args.val_batch_size // eval_seq_len, 1)
+
     total_loss = mx.array(0.0, dtype=mx.float32)
-    total_tokens = 0.0
+    total_scored = 0
     total_bytes = 0.0
-    for batch_seq_start in range(0, total_seqs, val_batch_seqs):
-        batch_seq_end = min(batch_seq_start + val_batch_seqs, total_seqs)
-        raw_start = batch_seq_start * args.train_seq_len
-        raw_end = batch_seq_end * args.train_seq_len + 1
-        chunk = val_tokens[raw_start:raw_end]
-        x_np = chunk[:-1].reshape(-1, args.train_seq_len)
-        y_np = chunk[1:].reshape(-1, args.train_seq_len)
+    embed_dim = model.tok_emb.weight.shape[1]
+    for b_start in range(0, len(starts), val_batch_seqs):
+        batch_starts = starts[b_start : b_start + val_batch_seqs]
+        x_np = np.stack([val_tokens[s : s + eval_seq_len] for s in batch_starts])
+        y_np = np.stack([val_tokens[s + 1 : s + eval_seq_len + 1] for s in batch_starts])
         x = mx.array(x_np, dtype=mx.int32)
-        y = mx.array(y_np, dtype=mx.int32)
-        chunk_token_count = float(y.size)
-        total_loss = total_loss + compiled_loss(x, y).astype(mx.float32) * chunk_token_count
-        prev_ids = x_np.reshape(-1)
-        tgt_ids = y_np.reshape(-1)
-        bytes_np = base_bytes_lut[tgt_ids].astype(np.int16, copy=True)
-        bytes_np += (
-            has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]
-        ).astype(np.int16, copy=False)
-        total_tokens += chunk_token_count
-        total_bytes += float(bytes_np.astype(np.float64).sum())
-    total_loss = total_loss / total_tokens
+
+        hidden = compiled_forward(x) if use_compiled else model(x, num_loops_override=num_loops_override)
+        h_scored = hidden[:, -stride:, :].reshape(-1, embed_dim)
+        logits = model.softcap(h_scored @ model.tok_emb.weight.astype(h_scored.dtype).T)
+        y_scored = mx.array(y_np[:, -stride:], dtype=mx.int32).reshape(-1)
+        total_loss = total_loss + nn.losses.cross_entropy(logits.astype(mx.float32), y_scored, reduction="sum")
+
+        prev_np = x_np[:, -stride:].reshape(-1)
+        tgt_np = y_np[:, -stride:].reshape(-1)
+        bytes_arr = base_bytes_lut[tgt_np].astype(np.int16, copy=True)
+        bytes_arr += (has_leading_space_lut[tgt_np] & ~is_boundary_token_lut[prev_np]).astype(np.int16, copy=False)
+        total_scored += tgt_np.size
+        total_bytes += float(bytes_arr.astype(np.float64).sum())
+
+    total_loss = total_loss / total_scored
     mx.eval(total_loss)
     val_loss = float(total_loss.item())
-    bits_per_token = val_loss / math.log(2.0)
-    val_bpb = bits_per_token * (total_tokens / total_bytes)
+    val_bpb = (val_loss / math.log(2.0)) * (total_scored / total_bytes)
+
+    if eval_seq_len != args.train_seq_len:
+        set_rope_base(model, args.rope_base)
     return val_loss, val_bpb
 
 # -----------------------------
@@ -884,6 +989,10 @@ def main() -> None:
         args.tokenizer_path,
     )
     val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    if args.val_max_tokens > 0:
+        cap = min(args.val_max_tokens, val_tokens.size - 1)
+        cap = (cap // args.train_seq_len) * args.train_seq_len
+        val_tokens = val_tokens[: cap + 1]
 
     base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
         sp, args.vocab_size
@@ -913,6 +1022,10 @@ def main() -> None:
         qk_gain_init=args.qk_gain_init,
         num_unique_blocks=args.num_unique_blocks,
         num_loops=args.num_loops,
+        use_loop_embed=args.use_loop_embed,
+        use_dwa=args.use_dwa,
+        overtone_init=args.overtone_init,
+        phase_resid_mix=args.phase_resid_mix,
     )
     opt = SplitOptimizers(model, args)
 
@@ -923,7 +1036,7 @@ def main() -> None:
     # inside RoPE modules), so compiling only against trainable parameters throws "uncaptured inputs".
     # Compiling the model-bound functions and capturing the full model state fixes that while still
     # returning gradients only for trainable parameters via nn.value_and_grad(...).
-    compiled_loss = mx.compile(lambda x, y: model.loss(x, y), inputs=model.state, outputs=model.state)
+    compiled_forward = mx.compile(lambda x: model(x), inputs=model.state, outputs=model.state)
     compiled_loss_and_grad = mx.compile(
         nn.value_and_grad(model, lambda x, y: model.loss(x, y)),
         inputs=model.state,
@@ -1001,20 +1114,10 @@ def main() -> None:
             if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
                 log(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
 
-        # Prime the standalone eval graph once too. It is compiled separately from value_and_grad.
-        val_batch_tokens = args.val_batch_size // args.grad_accum_steps
-        if val_batch_tokens < args.train_seq_len:
-            raise ValueError(
-                "VAL_BATCH_SIZE must provide at least one sequence; "
-                f"got VAL_BATCH_SIZE={args.val_batch_size}, GRAD_ACCUM_STEPS={args.grad_accum_steps}, "
-                f"TRAIN_SEQ_LEN={args.train_seq_len}"
-            )
-        warm_val_seqs = min(val_batch_tokens // args.train_seq_len, (val_tokens.size - 1) // args.train_seq_len)
-        warm_chunk = val_tokens[: warm_val_seqs * args.train_seq_len + 1]
-        x_val = mx.array(warm_chunk[:-1].reshape(-1, args.train_seq_len), dtype=mx.int32)
-        y_val = mx.array(warm_chunk[1:].reshape(-1, args.train_seq_len), dtype=mx.int32)
-        warm_val_loss = compiled_loss(x_val, y_val)
-        mx.eval(warm_val_loss)
+        # Prime compiled eval forward pass too.
+        warm_seqs = min(args.val_batch_size // args.train_seq_len, (val_tokens.size - 1) // args.train_seq_len)
+        warm_x = mx.array(val_tokens[: warm_seqs * args.train_seq_len].reshape(-1, args.train_seq_len), dtype=mx.int32)
+        mx.eval(compiled_forward(warm_x))
         mx.synchronize()
 
         train_loader = TokenLoader(args.train_files, log_fn=log, dataset_name=dataset_name)
@@ -1030,11 +1133,12 @@ def main() -> None:
             # Validation always scans the same fixed full validation split.
             val_loss, val_bpb = eval_val(
                 args,
-                compiled_loss,
+                model,
                 val_tokens,
                 base_bytes_lut,
                 has_leading_space_lut,
                 is_boundary_token_lut,
+                compiled_forward,
             )
             train_time_ms += 1000.0 * (time.perf_counter() - t0)
             if step % 25 == 0 or last_step:
@@ -1063,6 +1167,13 @@ def main() -> None:
         grads = clip_grad_tree(grads, args.grad_clip_norm)
         train_loss_value = float(train_loss.item())
         opt.step(model, grads, step=step, lr_mul=lr_mul)
+        # Decoupled weight decay for Muon-managed matrix params.
+        if args.muon_weight_decay > 0:
+            decay = 1.0 - args.muon_weight_decay * args.matrix_lr * lr_mul
+            params = dict(tree_flatten(model.parameters()))
+            for k in opt.matrix_keys:
+                params[k] = params[k] * decay
+            model.update(tree_unflatten(list(params.items())))
         mx.synchronize()
 
         step_ms = 1000.0 * (time.perf_counter() - step_t0)
@@ -1084,11 +1195,11 @@ def main() -> None:
     # quantized roundtrip directly by loading the dequantized tensors back into the
     # model and running one final validation pass.
     out_path = out_dir / f"{args.run_id}_mlx_model.npz"
-    flat_state = {k: v for k, v in tree_flatten(model.state)}
+    flat_state = {k: v for k, v in tree_flatten(model.state) if v.size > 0}
     mx.savez(str(out_path), **flat_state)
     log(f"saved_model:{out_path} bytes:{out_path.stat().st_size}")
 
-    quant_obj, quant_stats = quantize_state_dict_int8(flat_state)
+    quant_obj, quant_stats = quantize_state_dict_int8(flat_state, quant_bits=args.quant_bits, fp16_embed=args.fp16_embed)
     quant_raw = pickle.dumps(quant_obj, protocol=pickle.HIGHEST_PROTOCOL)
     quant_blob = zlib.compress(quant_raw, level=9)
     quant_serialized_bytes = len(quant_raw)
@@ -1109,15 +1220,40 @@ def main() -> None:
     q_t0 = time.perf_counter()
     q_val_loss, q_val_bpb = eval_val(
         args,
-        compiled_loss,
+        model,
         val_tokens,
         base_bytes_lut,
         has_leading_space_lut,
         is_boundary_token_lut,
+        compiled_forward,
     )
     q_eval_ms = 1000.0 * (time.perf_counter() - q_t0)
     log(f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} eval_time:{q_eval_ms:.0f}ms")
     log(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    # Multi-eval: run additional eval configs on the same trained (quantized) model.
+    # Format: semicolon-separated configs, each is comma-separated KEY=VAL overrides.
+    # Example: EVAL_CONFIGS="eval_stride=256;eval_stride=256,eval_seq_len=2048,eval_num_loops=6"
+    eval_configs_str = os.environ.get("EVAL_CONFIGS", "")
+    if eval_configs_str:
+        for cfg_str in eval_configs_str.split(";"):
+            if not cfg_str.strip():
+                continue
+            overrides = {}
+            for kv in cfg_str.strip().split(","):
+                k, v = kv.split("=", 1)
+                overrides[k.strip().lower()] = int(v.strip())
+            saved = {k: getattr(args, k) for k in overrides if hasattr(args, k)}
+            for k, v in overrides.items():
+                if hasattr(args, k):
+                    setattr(args, k, v)
+            e_t0 = time.perf_counter()
+            e_loss, e_bpb = eval_val(args, model, val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut, compiled_forward)
+            e_ms = 1000.0 * (time.perf_counter() - e_t0)
+            log(f"multi_eval config:{cfg_str.strip()} val_loss:{e_loss:.4f} val_bpb:{e_bpb:.4f} eval_time:{e_ms:.0f}ms")
+            log(f"multi_eval_exact config:{cfg_str.strip()} val_loss:{e_loss:.8f} val_bpb:{e_bpb:.8f}")
+            for k, v in saved.items():
+                setattr(args, k, v)
 
 
 if __name__ == "__main__":

--- a/train_gpt_mlx.py
+++ b/train_gpt_mlx.py
@@ -77,6 +77,11 @@ class Hyperparameters:
     rope_base: float = float(os.environ.get("ROPE_BASE", 10000.0))
     qk_gain_init: float = float(os.environ.get("QK_GAIN_INIT", 1.5))
 
+    # Depth recurrence: set NUM_UNIQUE_BLOCKS>0 and NUM_LOOPS>1 to share blocks.
+    # Effective depth = num_unique_blocks * num_loops. When disabled (default), uses num_layers unique blocks.
+    num_unique_blocks: int = int(os.environ.get("NUM_UNIQUE_BLOCKS", 0))
+    num_loops: int = int(os.environ.get("NUM_LOOPS", 1))
+
     # Optimizer. We keep the same per-group defaults as train_gpt.py.
     beta1: float = float(os.environ.get("BETA1", 0.9))
     beta2: float = float(os.environ.get("BETA2", 0.95))
@@ -377,27 +382,46 @@ class Block(nn.Module):
 
 class GPT(nn.Module):
     # - token embedding + RMSNorm
-    # - encoder half accumulates skip tensors
-    # - decoder half consumes reversed skips with learned skip_weights
+    # - encoder half accumulates skip tensors (baseline mode)
+    # - decoder half consumes reversed skips with learned skip_weights (baseline mode)
+    # - OR: depth recurrence with shared blocks looped multiple times
     # - tied embeddings for the LM head (the baseline default setup)
     def __init__(self, vocab_size: int, num_layers: int, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int,
                  logit_chunk_tokens: int, logit_softcap: float, rope_base: float, tied_embed_init_std: float,
-                 qk_gain_init: float):
+                 qk_gain_init: float, num_unique_blocks: int = 0, num_loops: int = 1):
         super().__init__()
         if logit_softcap <= 0.0:
             raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
         self.logit_chunk_tokens = logit_chunk_tokens
         self.logit_softcap = logit_softcap
+        self.use_recurrence = num_unique_blocks > 0 and num_loops > 1
 
         self.tok_emb = nn.Embedding(vocab_size, dim)
-        self.num_encoder_layers = num_layers // 2
-        self.num_decoder_layers = num_layers - self.num_encoder_layers
-        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
-        self.skip_weights = mx.ones((self.num_skip_weights, dim), dtype=mx.float32)
-        self.blocks = [
-            Block(dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init)
-            for i in range(num_layers)
-        ]
+
+        if self.use_recurrence:
+            self.num_unique_blocks = num_unique_blocks
+            self.num_loops = num_loops
+            self.blocks = [
+                Block(dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init)
+                for _ in range(num_unique_blocks)
+            ]
+            # No encoder/decoder split or skip connections in recurrence mode.
+            self.num_encoder_layers = 0
+            self.num_decoder_layers = 0
+            self.num_skip_weights = 0
+            self.skip_weights = mx.zeros((0, dim), dtype=mx.float32)
+        else:
+            self.num_unique_blocks = num_layers
+            self.num_loops = 1
+            self.num_encoder_layers = num_layers // 2
+            self.num_decoder_layers = num_layers - self.num_encoder_layers
+            self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+            self.skip_weights = mx.ones((self.num_skip_weights, dim), dtype=mx.float32)
+            self.blocks = [
+                Block(dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init)
+                for _ in range(num_layers)
+            ]
+
         self.final_norm = RMSNormNoWeight()
 
         for b in self.blocks:
@@ -414,18 +438,20 @@ class GPT(nn.Module):
     def __call__(self, input_ids: mx.array) -> mx.array:
         x = rms_norm(self.tok_emb(input_ids).astype(COMPUTE_DTYPE))
         x0 = x
-        skips: list[mx.array] = []
 
-        for i in range(self.num_encoder_layers):
-            x = self.blocks[i](x, x0)
-            skips.append(x)
-        for i in range(self.num_decoder_layers):
-            # Odd layer counts have one more decoder block than encoder block. The baseline only
-            # applies a skip connection when one exists, then runs the remaining decoder block(s)
-            # without an added skip.
-            if skips:
-                x = x + self.skip_weights[i].astype(x.dtype)[None, None, :] * skips.pop()
-            x = self.blocks[self.num_encoder_layers + i](x, x0)
+        if self.use_recurrence:
+            for _loop in range(self.num_loops):
+                for block in self.blocks:
+                    x = block(x, x0)
+        else:
+            skips: list[mx.array] = []
+            for i in range(self.num_encoder_layers):
+                x = self.blocks[i](x, x0)
+                skips.append(x)
+            for i in range(self.num_decoder_layers):
+                if skips:
+                    x = x + self.skip_weights[i].astype(x.dtype)[None, None, :] * skips.pop()
+                x = self.blocks[self.num_encoder_layers + i](x, x0)
         return self.final_norm(x)
 
     def loss(self, input_ids: mx.array, target_ids: mx.array) -> mx.array:
@@ -495,7 +521,7 @@ class SplitOptimizers:
         self.scalar_keys = [
             k
             for k, p in params.items()
-            if k == "skip_weights" or (k.startswith("blocks.") and (p.ndim < 2 or any(pattern in k for pattern in CONTROL_TENSOR_NAME_PATTERNS)))
+            if (k == "skip_weights" and p.size > 0) or (k.startswith("blocks.") and (p.ndim < 2 or any(pattern in k for pattern in CONTROL_TENSOR_NAME_PATTERNS)))
         ]
 
         self.muon = Muon(self.matrix_keys, params, args)
@@ -885,6 +911,8 @@ def main() -> None:
         rope_base=args.rope_base,
         tied_embed_init_std=args.tied_embed_init_std,
         qk_gain_init=args.qk_gain_init,
+        num_unique_blocks=args.num_unique_blocks,
+        num_loops=args.num_loops,
     )
     opt = SplitOptimizers(model, args)
 
@@ -919,11 +947,19 @@ def main() -> None:
     else:
         log(f"train_loader:dataset:{dataset_name} train_shards:{actual_train_files}/{expected_train_files}")
     log(f"tokenizer_path:{args.tokenizer_path}")
-    log(
-        f"model_params:{n_params} vocab_size:{args.vocab_size} layers:{args.num_layers} "
-        f"dim:{args.model_dim} heads:{args.num_heads} kv_heads:{args.num_kv_heads} "
-        f"seq_len:{args.train_seq_len} tie_embeddings:{args.tie_embeddings}"
-    )
+    if model.use_recurrence:
+        log(
+            f"model_params:{n_params} vocab_size:{args.vocab_size} "
+            f"unique_blocks:{args.num_unique_blocks} loops:{args.num_loops} effective_layers:{args.num_unique_blocks * args.num_loops} "
+            f"dim:{args.model_dim} heads:{args.num_heads} kv_heads:{args.num_kv_heads} "
+            f"seq_len:{args.train_seq_len} tie_embeddings:{args.tie_embeddings}"
+        )
+    else:
+        log(
+            f"model_params:{n_params} vocab_size:{args.vocab_size} layers:{args.num_layers} "
+            f"dim:{args.model_dim} heads:{args.num_heads} kv_heads:{args.num_kv_heads} "
+            f"seq_len:{args.train_seq_len} tie_embeddings:{args.tie_embeddings}"
+        )
     log(
         f"iterations:{args.iterations} train_batch_tokens:{args.train_batch_tokens} grad_accum_steps:{args.grad_accum_steps} "
         f"microbatch_tokens:{args.microbatch_tokens} microbatch_batch_size:{args.microbatch_tokens // args.train_seq_len} "

--- a/train_gpt_mlx.py
+++ b/train_gpt_mlx.py
@@ -90,6 +90,9 @@ class Hyperparameters:
     # Architecture additions.
     use_loop_embed: bool = bool(int(os.environ.get("USE_LOOP_EMBED", "0")))
     use_dwa: bool = bool(int(os.environ.get("USE_DWA", "0")))
+    use_smeargate: bool = bool(int(os.environ.get("USE_SMEARGATE", "0")))
+    bigram_hash_buckets: int = int(os.environ.get("BIGRAM_HASH_BUCKETS", 0))
+    bigram_hash_dim: int = int(os.environ.get("BIGRAM_HASH_DIM", 128))
 
     # Optimizer. We keep the same per-group defaults as train_gpt.py.
     beta1: float = float(os.environ.get("BETA1", 0.9))
@@ -141,7 +144,7 @@ CONTROL_TENSOR_NAME_PATTERNS = tuple(
     pattern
     for pattern in os.environ.get(
         "CONTROL_TENSOR_NAME_PATTERNS",
-        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,dwa_logits,loop_embeds",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,dwa_logits,loop_embeds,smear_gate",
     ).split(",")
     if pattern
 )
@@ -406,7 +409,8 @@ class GPT(nn.Module):
                  logit_chunk_tokens: int, logit_softcap: float, rope_base: float, tied_embed_init_std: float,
                  qk_gain_init: float, num_unique_blocks: int = 0, num_loops: int = 1,
                  use_loop_embed: bool = False, use_dwa: bool = False,
-                 overtone_init: bool = False, phase_resid_mix: bool = False):
+                 overtone_init: bool = False, phase_resid_mix: bool = False,
+                 use_smeargate: bool = False, bigram_hash_buckets: int = 0, bigram_hash_dim: int = 128):
         super().__init__()
         if logit_softcap <= 0.0:
             raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
@@ -456,6 +460,17 @@ class GPT(nn.Module):
         else:
             self._effective_depth = 0
 
+        # BigramHash: hash table mapping token pairs to learned embeddings.
+        self.bigram_hash_buckets = bigram_hash_buckets
+        if bigram_hash_buckets > 0:
+            self.bigram_table = mx.random.normal((bigram_hash_buckets, bigram_hash_dim)) * 0.01
+            self.bigram_proj = mx.random.normal((bigram_hash_dim, dim)) * (bigram_hash_dim ** -0.5)
+
+        # SmearGate: learned gate blending current token with previous token embedding.
+        self.use_smeargate = use_smeargate
+        if use_smeargate:
+            self.smear_gate = mx.full((dim,), 3.0, dtype=mx.float32)  # sigmoid(3) ≈ 0.95
+
         self.final_norm = RMSNormNoWeight()
 
         for b in self.blocks:
@@ -487,7 +502,22 @@ class GPT(nn.Module):
         return c * mx.tanh(logits / c)
 
     def __call__(self, input_ids: mx.array, num_loops_override: int = 0) -> mx.array:
-        x = rms_norm(self.tok_emb(input_ids).astype(COMPUTE_DTYPE))
+        x = self.tok_emb(input_ids).astype(COMPUTE_DTYPE)
+
+        # BigramHash: add token-pair embeddings before normalization.
+        if self.bigram_hash_buckets > 0:
+            prev_ids = mx.concatenate([input_ids[:, :1], input_ids[:, :-1]], axis=1)
+            hash_idx = (prev_ids * 31 + input_ids) % self.bigram_hash_buckets
+            bigram_emb = mx.take(self.bigram_table, hash_idx.reshape(-1), axis=0).reshape(*input_ids.shape, -1)
+            x = x + (bigram_emb @ self.bigram_proj.astype(x.dtype))
+
+        # SmearGate: blend current token with previous token embedding.
+        if self.use_smeargate:
+            gate = mx.sigmoid(self.smear_gate).astype(x.dtype)
+            prev_x = mx.concatenate([mx.zeros_like(x[:, :1]), x[:, :-1]], axis=1)
+            x = gate * x + (1.0 - gate) * prev_x
+
+        x = rms_norm(x)
         x0 = x
 
         if self.use_recurrence:
@@ -587,7 +617,7 @@ class SplitOptimizers:
             k
             for k, p in params.items()
             if (k == "skip_weights" and p.size > 0)
-            or (k in ("dwa_logits", "loop_embeds") and p.size > 0)
+            or (k in ("dwa_logits", "loop_embeds", "bigram_table", "bigram_proj", "smear_gate") and p.size > 0)
             or (k.startswith("blocks.") and (p.ndim < 2 or any(pattern in k for pattern in CONTROL_TENSOR_NAME_PATTERNS)))
         ]
 
@@ -922,6 +952,9 @@ def eval_val(
         bytes_arr += (has_leading_space_lut[tgt_np] & ~is_boundary_token_lut[prev_np]).astype(np.int16, copy=False)
         total_scored += tgt_np.size
         total_bytes += float(bytes_arr.astype(np.float64).sum())
+        # Periodically materialize to prevent lazy graph from growing unbounded.
+        if (b_start // val_batch_seqs) % 50 == 49:
+            mx.eval(total_loss)
 
     total_loss = total_loss / total_scored
     mx.eval(total_loss)
@@ -1026,6 +1059,9 @@ def main() -> None:
         use_dwa=args.use_dwa,
         overtone_init=args.overtone_init,
         phase_resid_mix=args.phase_resid_mix,
+        use_smeargate=args.use_smeargate,
+        bigram_hash_buckets=args.bigram_hash_buckets,
+        bigram_hash_dim=args.bigram_hash_dim,
     )
     opt = SplitOptimizers(model, args)
 


### PR DESCRIPTION
## Summary

Non-record submission — Mac MLX prototyping only, pending H100 validation.
Submitting to document systematic technique exploration and support compute grant application.

**val_bpb: 1.9588** (14L×416d, 750 steps, 10 shards, int8+zlib, full FineWeb val, Apple Silicon)

## Approach

25+ MLX experiments validating leaderboard techniques, identifying what works and what doesn't.

### Implemented & Validated
- 10-14 layer architectures with KV2 (GQA)
- MLP 3x expansion (-0.013 BPB vs MLP 2x)
- Int6 per-row quantization + FP16 tied embedding passthrough
- Sliding window eval (stride-64, compiled forward)
- Muon decoupled weight decay (0.02)
- Overtone spectral embedding init (SVD power-law)
- Phase-transition resid_mix initialization
- Multi-eval mode (multiple eval configs per training run)

### Key Finding
FP16 embed + Muon WD achieves **near-zero quantization gap (0.001 BPB)**. Post-quant ≈ pre-quant.

### Negative Results (documented)
| Technique | Result | Why |
|-----------|--------|-----|
| Depth recurrence + int6 | +0.61 BPB quant gap | Shared weights amplify quantization error |
| DenseFormer DWA | +0.003 regression | No benefit at this scale |
| Eval-time loop scaling | +1.15 regression | Model calibrated to exact loop count |
| NTK-RoPE extrapolation (1024→4096) | +0.06 regression | Must train at target seq_len |

## Results

| Config | Params | Compressed | Val BPB | Int8 BPB |
|--------|--------|-----------|---------|----------|
| 14L×416d KV2 | 16.2M | 12.3MB | 1.9578 | 1.9588 |
| 10L×512d + all tricks | 19.0M | 10.8MB | 1.9800 | 1.9808 |

## Test plan
- [x] train_gpt_mlx.py compiles and runs from records folder
- [x] Full FineWeb val evaluation (62M tokens)
- [x] Int8+zlib roundtrip verified
- [x] Artifact under 16MB (12.3MB)
- [ ] H100 validation (pending compute grant)