### PR TITLE
Record: 11L Int6+Zstd MLP3x SmearGate BigramHash OrthoInit MuonWD EMA (mean val_bpb=1.1497)

### DIFF
--- a/records/track_10min_16mb/2026-03-21_11L_MLP3x_Int6_SmearGate_BigramHash_OrthoInit_WD_EMA/README.md
+++ b/records/track_10min_16mb/2026-03-21_11L_MLP3x_Int6_SmearGate_BigramHash_OrthoInit_WD_EMA/README.md
@@ -1,0 +1,61 @@
+# 11L MLP3x Int6+Zstd + SmearGate + BigramHash + OrthoInit + Muon WD + EMA
+
+## Approach
+
+combine established best practices identified through extensive ablation testing:
+
+- **11 transformer layers** (optimal depth for the 10-min step budget)
+- **3x MLP expansion** (1536 hidden dim, enabled by int6 compression savings)
+- **Int6 quantization + zstd-22 compression** (fits ~33% more params vs int8+zlib)
+- **SmearGate** (learned per-dim gate blending each token with predecessor)
+- **BigramHash** (4096-bucket hash embedding for bigram context)
+- **OrthoInit** (orthogonal weight initialization with proj scaling)
+- **Muon weight decay 0.02** (decoupled, improves compressibility)
+- **EMA 0.997** (exponential moving average of weights)
+- **FP16 tied embeddings** (avoids quantization degradation on shared input/output projection)
+- **Sliding window evaluation** (stride=256, maximal left-context scoring)
+- **Sequence length 2048** for training and evaluation
+
+## Key Findings from Ablation
+
+During development, we systematically tested several novel approaches:
+
+1. **Attention Residuals (AttnRes)**: Learned softmax attention over depth to replace residual connections. Both Full and Block AttnRes variants were tested. Result: compute overhead outweighs quality gains at this model scale (~54% slower per step with Full AttnRes).
+
+2. **Depth recurrence (looped transformers)**: Weight sharing across layers with 2-6 loop iterations. Result: looping multiplies compute per step without adding parameters, reducing total training steps in the wall-clock budget.
+
+3. **Sequence length curriculum**: Starting training with shorter sequences (256-512) for more gradient updates, ramping to 2048. Result: torch.compile recompilation overhead (~15s per shape transition) negates the step-count benefit.
+
+4. **Test-time training (TTT)**: Full-parameter SGD on validation data before scoring. Result: only helps on well-converged models (0.001 BPB gain with 20-min trained model), actively hurts under-trained models.
+
+5. **Undertrained larger model + TTT**: Using 13L instead of 11L with TTT as extended training. Result: 13L outperforms 11L given sufficient training steps (1.2375 vs 1.2444 at 20 min), but compression degrades with more training steps, creating a fundamental tension.
+
+## Configuration
+
+```bash
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+Environment variables (all have defaults in the script):
+- `NUM_LAYERS=11 MLP_MULT=3 MODEL_DIM=512 NUM_HEADS=8 NUM_KV_HEADS=4`
+- `TRAIN_SEQ_LEN=2048 EVAL_STRIDE=256`
+- `MATRIX_LR=0.025 SCALAR_LR=0.025 TIED_EMBED_LR=0.035`
+- `WARMDOWN_ITERS=1200 GRAD_CLIP_NORM=1.0`
+- `WEIGHT_DECAY=0.02 EMA_ENABLED=1 EMA_DECAY=0.997`
+- `USE_SMEARGATE=1 USE_BIGRAM_HASH=1 USE_ORTHO_INIT=1`
+- `FP16_EMBED=1 QUANT_BITS=6 USE_ZSTD=1`
+
+## Results
+
+3-seed validation on 8xH100 SXM:
+
+| Seed | Steps | val_bpb | Artifact |
+|------|-------|---------|----------|
+| 1337 | 8611 | 1.1501 | 14,823,663 |
+| 42 | 8825 | 1.1495 | 14,862,217 |
+| 7 | 8827 | 1.1495 | 14,857,489 |
+
+- **Mean val_bpb: 1.14971 ± 0.00036**
+- **95% CI: [1.14930, 1.15012]**
+- Training time: 600s (wallclock cap)
+- Step avg: ~68ms on 8xH100

--- a/records/track_10min_16mb/2026-03-21_11L_MLP3x_Int6_SmearGate_BigramHash_OrthoInit_WD_EMA/submission.json
+++ b/records/track_10min_16mb/2026-03-21_11L_MLP3x_Int6_SmearGate_BigramHash_OrthoInit_WD_EMA/submission.json
@@ -1,0 +1,14 @@
+{
+  "author": "mkenn",
+  "github_id": "mkenney2",
+  "name": "11L MLP3x Int6+Zstd SmearGate BigramHash OrthoInit MuonWD EMA",
+  "blurb": "11-layer 512d MLP3x with int6+zstd-22 compression, SmearGate, BigramHash(4096x128), OrthoInit, Muon WD=0.02, EMA(0.997), FP16 embed, seq2048, sliding window eval stride=256. Extensive ablation of novel techniques (AttnRes, depth recurrence, seq-len curriculum, TTT) documented in README.",
+  "date": "2026-03-21T19:26:00Z",
+  "val_loss": 1.94950115,
+  "val_bpb": 1.14950115,
+  "val_bpb_mean": 1.14971214,
+  "val_bpb_std": 0.00036195,
+  "seeds": [1337, 42, 7],
+  "bytes_total": 14857489,
+  "bytes_code": 64153
+}

--- a/records/track_10min_16mb/2026-03-21_11L_MLP3x_Int6_SmearGate_BigramHash_OrthoInit_WD_EMA/train.log
+++ b/records/track_10min_16mb/2026-03-21_11L_MLP3x_Int6_SmearGate_BigramHash_OrthoInit_WD_EMA/train.log
@@ -1,0 +1,109 @@
+W0321 19:13:37.265000 9269 torch/distributed/run.py:852] 
+W0321 19:13:37.265000 9269 torch/distributed/run.py:852] *****************************************
+W0321 19:13:37.265000 9269 torch/distributed/run.py:852] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0321 19:13:37.265000 9269 torch/distributed/run.py:852] *****************************************
+logs/submission_seed7.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:10
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:27092056
+world_size:8 grad_accum_steps:1
+attention_mode:gqa num_heads:8 num_kv_heads:4
+num_layers:11 mlp_mult:3
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:524288 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:7
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9366 val_bpb:4.1082 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9372 train_time:150ms step_avg:150.04ms
+step:2/20000 train_loss:13.0707 train_time:220ms step_avg:109.91ms
+step:3/20000 train_loss:8.8455 train_time:294ms step_avg:98.01ms
+step:4/20000 train_loss:6.7718 train_time:368ms step_avg:92.05ms
+step:5/20000 train_loss:6.6675 train_time:442ms step_avg:88.43ms
+step:6/20000 train_loss:7.3875 train_time:516ms step_avg:85.99ms
+step:7/20000 train_loss:6.4894 train_time:590ms step_avg:84.31ms
+step:8/20000 train_loss:6.3061 train_time:664ms step_avg:82.99ms
+step:9/20000 train_loss:6.0510 train_time:738ms step_avg:81.96ms
+step:10/20000 train_loss:5.7221 train_time:811ms step_avg:81.09ms
+step:200/20000 train_loss:2.7656 train_time:13778ms step_avg:68.89ms
+step:400/20000 train_loss:2.2658 train_time:27401ms step_avg:68.50ms
+step:600/20000 train_loss:2.4626 train_time:41014ms step_avg:68.36ms
+step:800/20000 train_loss:2.2026 train_time:54607ms step_avg:68.26ms
+step:1000/20000 train_loss:2.3023 train_time:68202ms step_avg:68.20ms
+step:1000/20000 val_loss:2.2475 val_bpb:1.3311 train_time:68213ms step_avg:68.21ms
+step:1200/20000 train_loss:2.3130 train_time:81799ms step_avg:68.17ms
+step:1400/20000 train_loss:2.3369 train_time:95386ms step_avg:68.13ms
+step:1600/20000 train_loss:2.0048 train_time:108975ms step_avg:68.11ms
+step:1800/20000 train_loss:2.1166 train_time:122561ms step_avg:68.09ms
+step:2000/20000 train_loss:2.1458 train_time:136142ms step_avg:68.07ms
+step:2000/20000 val_loss:2.1515 val_bpb:1.2742 train_time:136153ms step_avg:68.08ms
+step:2200/20000 train_loss:2.2594 train_time:149733ms step_avg:68.06ms
+step:2400/20000 train_loss:2.2679 train_time:163323ms step_avg:68.05ms
+step:2600/20000 train_loss:2.1344 train_time:176914ms step_avg:68.04ms
+step:2800/20000 train_loss:2.0852 train_time:190494ms step_avg:68.03ms
+step:3000/20000 train_loss:3.1524 train_time:204074ms step_avg:68.02ms
+step:3000/20000 val_loss:2.1181 val_bpb:1.2545 train_time:204086ms step_avg:68.03ms
+step:3200/20000 train_loss:2.1881 train_time:217659ms step_avg:68.02ms
+step:3400/20000 train_loss:2.0138 train_time:231248ms step_avg:68.01ms
+step:3600/20000 train_loss:2.1342 train_time:244831ms step_avg:68.01ms
+step:3800/20000 train_loss:2.0828 train_time:258428ms step_avg:68.01ms
+step:4000/20000 train_loss:2.1973 train_time:272012ms step_avg:68.00ms
+step:4000/20000 val_loss:2.0929 val_bpb:1.2395 train_time:272023ms step_avg:68.01ms
+step:4200/20000 train_loss:2.1462 train_time:285680ms step_avg:68.02ms
+step:4400/20000 train_loss:2.0841 train_time:299252ms step_avg:68.01ms
+step:4600/20000 train_loss:2.1306 train_time:312835ms step_avg:68.01ms
+step:4800/20000 train_loss:2.0683 train_time:326418ms step_avg:68.00ms
+step:5000/20000 train_loss:2.1541 train_time:340003ms step_avg:68.00ms
+step:5000/20000 val_loss:2.0822 val_bpb:1.2332 train_time:340014ms step_avg:68.00ms
+step:5200/20000 train_loss:2.2160 train_time:353596ms step_avg:68.00ms
+step:5400/20000 train_loss:2.1695 train_time:367182ms step_avg:68.00ms
+step:5600/20000 train_loss:2.0702 train_time:380763ms step_avg:67.99ms
+step:5800/20000 train_loss:2.1195 train_time:394347ms step_avg:67.99ms
+step:6000/20000 train_loss:2.0370 train_time:407926ms step_avg:67.99ms
+step:6000/20000 val_loss:2.0705 val_bpb:1.2263 train_time:407938ms step_avg:67.99ms
+step:6200/20000 train_loss:2.0151 train_time:421507ms step_avg:67.99ms
+step:6400/20000 train_loss:1.7872 train_time:435093ms step_avg:67.98ms
+step:6600/20000 train_loss:2.0178 train_time:448666ms step_avg:67.98ms
+step:6800/20000 train_loss:2.0726 train_time:462243ms step_avg:67.98ms
+step:7000/20000 train_loss:2.0190 train_time:475829ms step_avg:67.98ms
+step:7000/20000 val_loss:2.0645 val_bpb:1.2227 train_time:475840ms step_avg:67.98ms
+step:7200/20000 train_loss:1.9051 train_time:489412ms step_avg:67.97ms
+step:7400/20000 train_loss:1.8394 train_time:502983ms step_avg:67.97ms
+step:7600/20000 train_loss:2.1009 train_time:516565ms step_avg:67.97ms
+step:7800/20000 train_loss:2.0519 train_time:530136ms step_avg:67.97ms
+step:8000/20000 train_loss:1.9602 train_time:543715ms step_avg:67.96ms
+step:8000/20000 val_loss:2.0316 val_bpb:1.2032 train_time:543727ms step_avg:67.97ms
+step:8200/20000 train_loss:2.0847 train_time:557298ms step_avg:67.96ms
+step:8400/20000 train_loss:2.0578 train_time:570972ms step_avg:67.97ms
+step:8600/20000 train_loss:2.0730 train_time:584556ms step_avg:67.97ms
+step:8800/20000 train_loss:1.9151 train_time:598142ms step_avg:67.97ms
+step:8827/20000 val_loss:1.9615 val_bpb:1.1617 train_time:599976ms step_avg:67.97ms
+stopping_early: wallclock_cap train_time:599976ms step:8827/20000
+peak memory allocated: 14004 MiB reserved: 14070 MiB
+ema:applying EMA weights
+Serialized model: 106313405 bytes
+Code size: 64153 bytes
+Total submission size: 106377558 bytes
+Serialized model int6+zstd-22: 14793336 bytes (payload:27845984 raw_torch:27901971 payload_ratio:3.82x)
+Total submission size int6+zstd-22: 14857489 bytes
+final_int8_zlib_roundtrip val_loss:1.9409 val_bpb:1.1495 eval_mode:sliding eval_time:45196ms
+final_int8_zlib_roundtrip_exact val_loss:1.94088454 val_bpb:1.14950115

--- a/records/track_10min_16mb/2026-03-21_11L_MLP3x_Int6_SmearGate_BigramHash_OrthoInit_WD_EMA/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-21_11L_MLP3x_Int6_SmearGate_BigramHash_OrthoInit_WD_EMA/train_gpt.py
@@ -1,0 +1,1494 @@
+"""Parameter Golf submission: 11L MLP3x + int6 + SmearGate + BigramHash + OrthoInit + WD + EMA + TTT + curriculum."""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+try:
+    import zstandard as zstd
+    HAS_ZSTD = True
+except ImportError:
+    HAS_ZSTD = False
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+# 11L MLP3x 512d, int6+zstd, SmearGate+BigramHash+OrthoInit, WD+EMA, TTT, curriculum
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    seq_schedule = os.environ.get("SEQ_SCHEDULE", "")  # curriculum: "seq:frac,seq:frac,..."
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Evaluation.
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))  # sliding window stride (0 = disabled)
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))  # batch size for sliding eval
+    # Test-Time Training (TTT): SGD on val data before scoring
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.002))
+    ttt_max_seconds = float(os.environ.get("TTT_MAX_SECONDS", 540.0))  # max time for TTT (save 60s for eval)
+    ttt_freeze_blocks = int(os.environ.get("TTT_FREEZE_BLOCKS", 0))  # freeze first N blocks during TTT
+
+    # Quantization.
+    fp16_embed = bool(int(os.environ.get("FP16_EMBED", "1")))  # keep embeddings in FP16
+    quant_bits = int(os.environ.get("QUANT_BITS", 6))  # quantization bit width for attention (6 or 8)
+    quant_bits_mlp = int(os.environ.get("QUANT_BITS_MLP", 0))  # MLP bit width (0 = same as quant_bits)
+    use_zstd = bool(int(os.environ.get("USE_ZSTD", "1")))  # use zstd instead of zlib
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))  # unique layers
+    n_loops = int(os.environ.get("N_LOOPS", 1))  # loop iterations (1 = no looping)
+    attn_res_mode = os.environ.get("ATTN_RES_MODE", "none")  # "full", "block", or "none"
+
+    # SmearGate + BigramHash.
+    use_smeargate = bool(int(os.environ.get("USE_SMEARGATE", "1")))
+    use_bigram_hash = bool(int(os.environ.get("USE_BIGRAM_HASH", "1")))
+    bigram_buckets = int(os.environ.get("BIGRAM_BUCKETS", 4096))
+    bigram_hash_dim = int(os.environ.get("BIGRAM_HASH_DIM", 128))
+
+    # OrthoInit + SWA.
+    use_ortho_init = bool(int(os.environ.get("USE_ORTHO_INIT", "1")))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.4))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 2))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    weight_decay = float(os.environ.get("WEIGHT_DECAY", 0.02))  # Muon WD for compressibility
+    ema_enabled = bool(int(os.environ.get("EMA_ENABLED", "1")))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+
+# MUON OPTIMIZER
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, weight_decay=weight_decay),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            weight_decay = group.get("weight_decay", 0.0)
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                # Decoupled weight decay: p *= (1 - lr * wd) before gradient step
+                if weight_decay > 0:
+                    p.data.mul_(1.0 - lr * weight_decay)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# TOKENIZER + EVALUATION
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    """
+    Sliding window evaluation: score each token with maximal left-context.
+
+    Windows of length seq_len advance by stride tokens. For each window,
+    only the last `stride` tokens are scored (the rest serve as context).
+    First window scores all its tokens. This gives every token near-maximum
+    context, improving BPB by ~0.03 vs non-overlapping chunks.
+    """
+    seq_len = args.train_seq_len
+    stride = args.eval_stride
+    batch_size = args.eval_batch_seqs
+    total_tokens = val_tokens.numel() - 1  # -1 for target shift
+
+    # Build window starts
+    window_starts = [ws for ws in range(0, total_tokens - seq_len + 1, stride)]
+    # Add final window if there are remaining tokens
+    if window_starts[-1] + seq_len < total_tokens:
+        window_starts.append(total_tokens - seq_len)
+
+    # Distribute windows across ranks
+    my_starts = window_starts[rank::world_size]
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    with torch.inference_mode():
+        for batch_start in range(0, len(my_starts), batch_size):
+            batch_ws = my_starts[batch_start:batch_start + batch_size]
+            bsz = len(batch_ws)
+
+            # Build input/target batches
+            x_list, y_list = [], []
+            for ws in batch_ws:
+                chunk = val_tokens[ws:ws + seq_len + 1].to(dtype=torch.int64)
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            x_batch = torch.stack(x_list).to(device=device, non_blocking=True)
+            y_batch = torch.stack(y_list).to(device=device, non_blocking=True)
+
+            # Get per-token NLL
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = base_model.forward_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+
+            # Score only the last `stride` tokens per window
+            # (first window scores all tokens since it has no prior context)
+            for i, ws in enumerate(batch_ws):
+                wlen = min(seq_len, total_tokens - ws)
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+
+                # Byte counting for scored tokens
+                prev_ids = x_batch[i, s:wlen]
+                tgt_ids = y_batch[i, s:wlen]
+                tbytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                tbytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+                byte_count += tbytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return float(val_loss), float(bits_per_token * tokens_per_byte)
+
+
+# QUANTIZATION
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,attn_res_queries,smeargate",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor, bits: int = 8) -> tuple[Tensor, Tensor]:
+    # For int6: clip to [-32, 31], stored in int8 containers.
+    # zlib/zstd compresses these much better since only 64 of 256 byte values are used.
+    qmax = (1 << (bits - 1)) - 1  # 127 for int8, 31 for int6
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / qmax).clamp_min(1.0 / qmax)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -qmax, qmax).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / qmax if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -qmax, qmax).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor], fp16_embed: bool = False, quant_bits: int = 8, quant_bits_mlp: int = 0):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # FP16 embedding passthrough: keep tied embedding in FP16 to avoid
+        # quantization degradation on the shared input/output projection.
+        if fp16_embed and "tok_emb" in name:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        # Mixed precision: use lower bits for MLP weights (less sensitive)
+        bits = quant_bits
+        if quant_bits_mlp > 0 and ("mlp" in name or "fc" in name or "proj" in name):
+            # Only apply to MLP-specific projections, not attention proj
+            if "mlp" in name:
+                bits = quant_bits_mlp
+        q, s = quantize_float_tensor(t, bits=bits)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING 
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, self.weight.to(x.dtype), bias)
+
+
+class SmearGate(nn.Module):
+    """Learned per-dim gate blending each token with its predecessor (bigram context)."""
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.full((dim,), 3.0, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate).to(dtype=x.dtype)
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return g * x + (1.0 - g) * x_prev
+
+
+class BigramHash(nn.Module):
+    """Hash-table embedding for (prev_token, cur_token) bigram pairs."""
+    def __init__(self, num_buckets: int, hash_dim: int, model_dim: int):
+        super().__init__()
+        self.num_buckets = num_buckets
+        self.table = nn.Embedding(num_buckets, hash_dim)
+        self.proj = CastedLinear(hash_dim, model_dim, bias=False)
+        self.proj._zero_init = True
+        nn.init.normal_(self.table.weight, std=0.01)
+
+    def forward(self, input_ids: Tensor) -> Tensor:
+        bsz, seqlen = input_ids.shape
+        prev_ids = torch.cat([torch.zeros(bsz, 1, dtype=input_ids.dtype, device=input_ids.device),
+                              input_ids[:, :-1]], dim=1)
+        h = ((prev_ids.long() * 92821 + input_ids.long()) % self.num_buckets).long()
+        return self.proj(self.table(h))
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q, k, v, attn_mask=None, is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    # relu^2 MLP from the original modded-nanogpt setup
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        n_loops: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        attn_res_mode: str = "full",
+        use_smeargate: bool = False,
+        use_bigram_hash: bool = False,
+        bigram_buckets: int = 4096,
+        bigram_hash_dim: int = 128,
+        use_ortho_init: bool = False,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        if attn_res_mode not in ("full", "block", "none"):
+            raise ValueError(f"attn_res_mode must be 'full', 'block', or 'none', got '{attn_res_mode}'")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.n_loops = n_loops
+        self.attn_res_mode = attn_res_mode
+        self.effective_depth = num_layers * n_loops
+        self.use_ortho_init = use_ortho_init
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+
+        # SmearGate + BigramHash (applied before RMSNorm in forward)
+        self.smeargate = SmearGate(model_dim) if use_smeargate else None
+        self.bigram_hash = BigramHash(bigram_buckets, bigram_hash_dim, model_dim) if use_bigram_hash else None
+
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+
+        # U-Net skip connections: only for block/none modes (full AttnRes subsumes them)
+        if attn_res_mode != "full":
+            self.skip_weights = nn.Parameter(
+                torch.ones(n_loops, self.num_skip_weights, model_dim, dtype=torch.float32)
+            )
+
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        # attn_res_queries zero-initialized via torch.zeros (critical for stability)
+        num_layers = len(self.blocks)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif self.use_ortho_init and module.weight.ndim == 2 and min(module.weight.shape) >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    # Scale output projections by 1/sqrt(2*num_layers) for residual stream
+                    if ".proj." in name or name.endswith(".proj"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+
+    def _compute_logits_and_loss(self, x: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def _embed(self, input_ids: Tensor) -> Tensor:
+        """Token embedding + BigramHash + SmearGate + RMSNorm."""
+        x = self.tok_emb(input_ids)
+        if self.bigram_hash is not None:
+            x = x + self.bigram_hash(input_ids)
+        if self.smeargate is not None:
+            x = self.smeargate(x)
+        return F.rms_norm(x, (x.size(-1),))
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self._embed(input_ids)
+        x0 = x
+        skips: list[Tensor] = []
+
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[0, i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+
+        return self._compute_logits_and_loss(x, target_ids)
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Forward pass returning logits [B, T, V] (for sliding window eval)."""
+        bsz, seqlen = input_ids.shape
+        x = self._embed(input_ids)
+        x0 = x
+        skips: list[Tensor] = []
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[0, i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        w = self.tok_emb.weight if self.tie_embeddings else self.lm_head.weight
+        logits = self.logit_softcap * torch.tanh(F.linear(x, w) / self.logit_softcap)
+        return logits.reshape(bsz, seqlen, -1)
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def parse_seq_schedule(s: str) -> list[tuple[int, float]]:
+    if not s.strip(): return []
+    return sorted([(int(p.split(":")[0]), float(p.split(":")[1])) for p in s.split(",")], key=lambda x: x[1])
+
+def get_curriculum_seq_len(schedule: list[tuple[int, float]], frac: float, default: int) -> int:
+    for seq_len, end_frac in schedule:
+        if frac <= end_frac: return seq_len
+    return schedule[-1][0] if schedule else default
+
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        n_loops=args.n_loops,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        attn_res_mode=args.attn_res_mode,
+        use_smeargate=args.use_smeargate,
+        use_bigram_hash=args.use_bigram_hash,
+        bigram_buckets=args.bigram_buckets,
+        bigram_hash_dim=args.bigram_hash_dim,
+        use_ortho_init=args.use_ortho_init,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    if args.seq_schedule:
+        torch._dynamo.config.cache_size_limit = 64  # allow recompiles for curriculum shapes
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if hasattr(base_model, 'skip_weights') and base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    # AttnRes pseudo-queries are small control tensors, treat like scalars
+    if hasattr(base_model, 'attn_res_queries'):
+        scalar_params.append(base_model.attn_res_queries)
+    # SmearGate gate is a scalar control param
+    if base_model.smeargate is not None:
+        scalar_params.append(base_model.smeargate.gate)
+    # BigramHash: table treated like embedding (Adam), proj goes to Muon with blocks
+    if base_model.bigram_hash is not None:
+        scalar_params.append(base_model.bigram_hash.table.weight)
+        matrix_params.append(base_model.bigram_hash.proj.weight)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.weight_decay,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(f"num_layers:{args.num_layers} mlp_mult:{args.mlp_mult}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    seq_schedule = parse_seq_schedule(args.seq_schedule)
+    if seq_schedule: log0(f"seq_curriculum:{args.seq_schedule}")
+    prev_seq_len = args.train_seq_len
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+
+    # EMA: exponential moving average of weights
+    ema_state: dict[str, Tensor] | None = None
+    if args.ema_enabled:
+        ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        # Curriculum: select seq_len based on elapsed fraction of wall-clock budget
+        if seq_schedule and max_wallclock_ms:
+            elapsed_frac = elapsed_ms / max_wallclock_ms
+            cur_seq_len = get_curriculum_seq_len(seq_schedule, elapsed_frac, args.train_seq_len)
+        else:
+            cur_seq_len = args.train_seq_len
+        if cur_seq_len != prev_seq_len:
+            log0(f"curriculum:seq_len {prev_seq_len}->{cur_seq_len} at step {step}")
+            prev_seq_len = cur_seq_len
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, cur_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+
+        # EMA: update exponential moving average
+        if ema_state is not None:
+            d = args.ema_decay
+            with torch.no_grad():
+                for name, t in base_model.state_dict().items():
+                    ema_state[name].mul_(d).add_(t.detach().float(), alpha=1.0 - d)
+
+        # SWA: collect checkpoints during warmdown phase
+        if args.swa_enabled and scale < args.swa_start_frac and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone().float() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu().float()
+                swa_count += 1
+
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # Apply EMA or SWA weights
+    if ema_state is not None:
+        log0("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+        del ema_state
+        base_model.load_state_dict(avg_state, strict=True)
+    elif args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"swa:applying averaged {swa_count} checkpoints")
+        current_state = base_model.state_dict()
+        avg_state = {
+            name: (tensor / swa_count).to(dtype=current_state[name].dtype)
+            for name, tensor in swa_state.items()
+        }
+        del swa_state
+        base_model.load_state_dict(avg_state, strict=True)
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed int8+zlib artifact and validate the round-tripped weights.
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    mlp_bits = args.quant_bits_mlp if args.quant_bits_mlp > 0 else args.quant_bits
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict(), fp16_embed=args.fp16_embed, quant_bits=args.quant_bits, quant_bits_mlp=args.quant_bits_mlp)
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    if args.use_zstd and HAS_ZSTD:
+        cctx = zstd.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+        compress_fmt = "zstd-22"
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+        compress_fmt = "zlib-9"
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int{args.quant_bits}+{compress_fmt}: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int{args.quant_bits}+{compress_fmt}: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    if args.use_zstd and HAS_ZSTD:
+        dctx = zstd.ZstdDecompressor()
+        quant_decompressed = dctx.decompress(quant_blob_disk)
+    else:
+        quant_decompressed = zlib.decompress(quant_blob_disk)
+    quant_state = torch.load(io.BytesIO(quant_decompressed), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+
+    # --- Test-Time Training: SGD on val data before scoring ---
+    if args.ttt_enabled:
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        base_model.train()
+        # Optionally freeze early blocks for speed
+        for i in range(min(args.ttt_freeze_blocks, len(base_model.blocks))):
+            for p in base_model.blocks[i].parameters():
+                p.requires_grad_(False)
+        ttt_params = [p for p in base_model.parameters() if p.requires_grad]
+        ttt_opt = torch.optim.SGD(ttt_params, lr=args.ttt_lr)
+        ttt_seq_len = args.train_seq_len
+        ttt_tokens_per_step = args.train_batch_tokens // (world_size * grad_accum_steps)
+        ttt_step = 0
+        ttt_epoch = 0
+        ttt_pos = 0
+        val_total = val_tokens.numel() - 1
+        while True:
+            elapsed = time.perf_counter() - t_ttt
+            if elapsed >= args.ttt_max_seconds:
+                break
+            # Get next chunk from val_tokens (wrap around for multiple epochs)
+            end = ttt_pos + ttt_tokens_per_step + 1
+            if end > val_tokens.numel():
+                ttt_pos = 0
+                ttt_epoch += 1
+                end = ttt_tokens_per_step + 1
+            chunk = val_tokens[ttt_pos:end].to(device=device, dtype=torch.int64)
+            ttt_pos = end - 1
+            x = chunk[:-1].reshape(-1, ttt_seq_len)
+            y = chunk[1:].reshape(-1, ttt_seq_len)
+            ttt_opt.zero_grad()
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                loss = base_model(x, y)
+            loss.backward()
+            ttt_opt.step()
+            ttt_step += 1
+        # Unfreeze
+        for p in base_model.parameters():
+            p.requires_grad_(True)
+        base_model.eval()
+        log0(f"ttt:completed steps:{ttt_step} epochs:{ttt_epoch} time:{time.perf_counter() - t_ttt:.1f}s")
+
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+
+    # Use sliding window eval for final score if enabled
+    use_sliding = args.eval_stride > 0 and args.eval_stride < args.train_seq_len
+    if use_sliding:
+        q_val_loss, q_val_bpb = eval_val_sliding(
+            args,
+            base_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+        )
+    else:
+        q_val_loss, q_val_bpb = eval_val(
+            args,
+            model,
+            rank,
+            world_size,
+            device,
+            grad_accum_steps,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+        )
+    torch.cuda.synchronize()
+    eval_mode = "sliding" if use_sliding else "standard"
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_mode:{eval_mode} eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
  - 11L 512d MLP3x with int6+zstd-22, SmearGate, BigramHash, OrthoInit, Muon WD=0.02, EMA(0.997)
  - FP16 tied embeddings, seq2048, sliding window eval stride=256
  - **Mean val_bpb: 1.1497 ± 0.0004 (3 seeds: 1337, 42, 7)**
  - Artifact: ~14.8MB

  ## Test plan
  - [x] 3-seed validation on 8xH100 SXM (all under 16MB, all under 600s)
  - [x] train.log included (seed 7, val_bpb=1.1495)
  - [x] Extensive ablation documented in README (AttnRes, depth recurrence, seq-len curriculum, TTT)