### PR TITLE
WIP: Triton-based quantization systems (non-record)

### DIFF
--- a/records/track_non_record_16mb/2026-03-21_TritonQuantSystems/README.md
+++ b/records/track_non_record_16mb/2026-03-21_TritonQuantSystems/README.md
@@ -1,0 +1,29 @@
+# Triton-Based Quantization Systems Approach
+
+**Status: WIP — Active Development**
+
+**val_bpb: TBD**
+
+## Summary
+
+Systems-level submission focused on custom Triton kernels for aggressive
+sub-int8 quantization, enabling higher effective parameter density within
+the 16MB artifact limit. Complementary to architecture-focused submissions
+on the leaderboard.
+
+## Approach
+
+- Custom fused Triton kernels for quantized matmuls (mixed-bitwidth)
+- Fused operator chains to reduce memory round-trips during training
+- Mixed-precision packing with per-layer bitwidth selection
+- Adopts proven community techniques (SWA, sliding window eval, Muon)
+
+## Hardware
+
+- Local iteration: RTX 3090 Ti (24GB)
+- Final submission runs: 8xH100 (RunPod)
+
+## Author
+
+- GitHub: turbo-indubitable
+- Name: Dan

--- a/records/track_non_record_16mb/2026-03-21_TritonQuantSystems/submission.json
+++ b/records/track_non_record_16mb/2026-03-21_TritonQuantSystems/submission.json
@@ -1,0 +1,8 @@
+{
+  "author": "Dan",
+  "github_id": "turbo-indubitable",
+  "val_bpb": null,
+  "status": "wip",
+  "track": "non_record_16mb",
+  "summary": "Triton-based quantization systems approach with custom fused kernels"
+}


### PR DESCRIPTION
## Summary

- WIP non-record submission: custom Triton kernels for aggressive sub-int8 quantization
- Targeting higher effective parameter density within the 16MB artifact limit
- Mixed-bitwidth fused matmuls, fused operator chains, per-layer bitwidth selection
- Adopting proven community techniques (SWA, sliding window eval, Muon)

## Status

Draft / work-in-progress. measurements and train logs forthcoming.

## Hardware

- Local iteration: RTX 3090 Ti (24GB)
- Final runs: 8xH100 (RunPod)

## Test plan

- [ ] Implement custom Triton quantized matmul kernels
- [ ] Benchmark kernel throughput vs baseline int8
- [ ] Full training run on 8xH100, measure val_bpb
- [ ] Add train_gpt.py and train logs to submission folder
- [ ] Verify artifact fits in 16MB