### PR TITLE
Draft: package DominationV2 cache candidate handoff

### DIFF
--- a/final/README.md
+++ b/final/README.md
@@ -1,0 +1,81 @@
+# Final Handoff
+
+This directory is the cleaned handoff for the current best candidate.
+
+## Decision
+
+Decision `A`: the current candidate remains the best thing to back next.
+
+Why it still stands:
+
+- The integrated evaluator was audited and two real correctness bugs were fixed before finalization:
+  - the sliding-window schedule now matches the research evaluator
+  - multi-rank document sharding is now non-overlapping
+- The integrated path now has local verification for single-rank parity, multi-rank aggregation, and the world-size-1 TTT loop used in the single-H100 probes.
+- The strongest existing proxy evidence still points in the same direction: on a strong 1xH100 checkpoint, the BOS-reset adaptive cache improved post-TTT bpb on three distant 1M-token validation slices.
+- The last focused replacement check did not beat it. A smoothed bigram plus unigram-backoff variant was worse on the local proxy checkpoint and was not promoted.
+
+## Primary Candidate
+
+### `dominationv2_cache`
+
+Upstream `DominationV2` training and export stack, plus one evaluation-time change:
+
+- final validation runs in sliding-window mode with a BOS-reset online bigram cache
+- cache strength is capped by `alpha`, grows with observed bigram counts via `total / (total + tau)`, and is scaled by normalized model entropy
+- the cache is applied after the quantized roundtrip and after optional TTT
+- the cache does not change training weights or the exported artifact
+
+Default settings in the packaged launcher:
+
+- `CACHE_ENABLED=1`
+- `CACHE_ALPHA=0.20`
+- `CACHE_TAU=8`
+- `CACHE_ENTROPY_POWER=1.0`
+- `TTT_ENABLED=1`
+- `TTT_EPOCHS=3`
+- `TTT_LR=1e-4`
+
+## What Is Demonstrated
+
+- Local 4080 verifier passes:
+  - exact parity between integrated and research evaluators for baseline sliding eval
+  - exact parity for cache eval
+  - exact multi-rank aggregation back to the single-rank answer for `world_size in {2,3,8,32}`
+  - exact TTT-loop equivalence in the `world_size=1` subset setting used in the 1xH100 probes
+- Prior 1xH100 proxy evidence after TTT still favors this cache:
+  - `start_token=0`: `1.61700285 -> 1.61190207`
+  - `start_token=20000000`: `1.58458543 -> 1.57923265`
+  - `start_token=40000000`: `1.56495388 -> 1.56022034`
+- On the middle slice, `alpha=0.20` remained the best value in the tested sweep:
+  - `0.10`: `1.58013994`
+  - `0.20`: `1.57923535`
+  - `0.30`: `1.57976811`
+  - `0.40`: `1.58128413`
+
+## What Is Still Inferred
+
+- Full end-to-end score on the official full validation run under the 8xH100 budget is not yet demonstrated.
+- Multi-rank evaluation aggregation is verified, but multi-rank TTT behavior has not been separately parity-tested against the research script.
+- The added code bytes are materially larger than the upstream control, so artifact margin must be checked on the real run.
+- Final runtime and score transfer from the 1xH100 proxy to the official 8xH100 setting still need confirmation.
+
+## Contents
+
+- `dominationv2_cache/train_gpt.py`
+  - packaged candidate training, export, quant-roundtrip, optional TTT, and final evaluation
+- `dominationv2_cache/train_8xH100.sh`
+  - intended launcher for the next 8xH100 run
+- `dominationv2_cache/eval_checkpoint.py`
+  - checkpoint probing wrapper around the research evaluator
+- `dominationv2_cache/README.md`
+  - operator runbook with exact commands, expected outputs, and caveats
+
+Supporting verification code lives outside this directory:
+
+- `research/eval_doc_cache.py`
+- `research/verify_domv2_cache.py`
+
+## Next Step
+
+Use [`dominationv2_cache/README.md`](dominationv2_cache/README.md) as the runbook for the next 8xH100 execution. If that run lands with a clean artifact margin, expected cache/TTT log markers, and a competitive `final_roundtrip_exact val_bpb`, then this package should be converted into the actual submission folder under `records/`.

--- a/final/dominationv2_cache/README.md
+++ b/final/dominationv2_cache/README.md
@@ -1,0 +1,219 @@
+# DominationV2 + BOS-Reset Entropy-Gated Bigram Cache
+
+This is the current best candidate to run next on 8xH100.
+
+It keeps the upstream `DominationV2` training and export stack and adds one evaluation-time modification:
+
+- final validation uses flat sliding-window scoring
+- an online bigram cache is built during evaluation and reset at each BOS boundary
+- cache interpolation is capped by `CACHE_ALPHA`
+- the effective interpolation weight grows with seen bigram counts via `total / (total + CACHE_TAU)`
+- that weight is multiplied by normalized model entropy raised to `CACHE_ENTROPY_POWER`
+- the cache is applied after the quantized roundtrip and after optional TTT
+
+The cache does not change training weights or the exported model. It only changes how the final validation pass is scored.
+
+## Status
+
+Decision: keep this candidate as the main bet.
+
+Why:
+
+- the integrated evaluator was audited and corrected before finalization
+- the corrected implementation now has local parity checks against the research evaluator
+- prior 1xH100 proxy evidence still shows post-TTT gains from this cache
+- a final narrow replacement search failed to find a better alternative quickly enough to justify swapping it out
+
+## What Is Verified
+
+### Local 4080 verification
+
+The following command passes:
+
+```bash
+conda run --no-capture-output -n torch-wsl python -u research/verify_domv2_cache.py
+```
+
+What it verifies:
+
+- exact single-rank parity between the integrated final evaluator and the research evaluator for plain sliding-window scoring
+- exact single-rank parity for cache scoring
+- exact multi-rank aggregation back to the single-rank answer for `world_size in {2,3,8,32}`
+- exact equivalence between the research `run_ttt` loop and the final script's TTT loop in the `world_size=1` subset setting used for the 1xH100 probes
+
+### 1xH100 proxy evidence
+
+On a strong 1xH100 checkpoint, after 3 epochs of TTT on matched 1M-token validation slices, the cache still improved bpb:
+
+| `start_token` | no cache | cache (`alpha=0.20`) | delta |
+| --- | ---: | ---: | ---: |
+| `0` | `1.61700285` | `1.61190207` | `-0.00510078` |
+| `20000000` | `1.58458543` | `1.57923265` | `-0.00535278` |
+| `40000000` | `1.56495388` | `1.56022034` | `-0.00473354` |
+
+On the middle slice, the tested `alpha` sweep was:
+
+- `0.10`: `1.58013994`
+- `0.20`: `1.57923535`
+- `0.30`: `1.57976811`
+- `0.40`: `1.58128413`
+
+## What Is Not Yet Verified
+
+- Full end-to-end performance on the official full validation run under the 8xH100 time budget.
+- Multi-rank TTT parity against the research evaluator. Multi-rank evaluation aggregation is verified; multi-rank TTT is still a reasonable extrapolation.
+- Final artifact margin on the target run. `train_gpt.py` is currently `55,299` bytes, which is about `9.8 KB` larger than the upstream control this was built from.
+- Whether the best cache strength on the final 8xH100 checkpoint stays exactly at `alpha=0.20`. It is the current best default, not a theorem.
+
+## Included Files
+
+- `train_gpt.py`
+  - packaged candidate. Trains, exports `final_model.pt`, quantizes and compresses to `final_model.int8.ptz`, reloads the round-tripped weights, optionally runs TTT, then performs the final evaluation.
+- `train_8xH100.sh`
+  - intended launcher for the next 8xH100 run.
+- `eval_checkpoint.py`
+  - wrapper around `research/eval_doc_cache.py` for probing a saved checkpoint with or without the cache.
+
+## Intended 8xH100 Workflow
+
+Run these commands from the repo root unless stated otherwise.
+
+### 1. Environment setup
+
+If you are using the OpenAI/Runpod challenge image, most dependencies may already be present. On a fresh Python environment, install:
+
+```bash
+python3 -m pip install --upgrade pip
+pip install -r requirements.txt zstandard
+```
+
+`zstandard` matters. Without it, the script falls back to `zlib-9`, which is functional but not the intended compressed-model path.
+
+### 2. Auth requirements
+
+- GitHub auth is not required to run the method.
+- Hugging Face auth was not required in the locally verified path for the default published dataset repo.
+- If your machine cannot access the default dataset repo anonymously, authenticate with Hugging Face before downloading data.
+
+### 3. Dataset and tokenizer preparation
+
+Download the default `sp1024` cached challenge data:
+
+```bash
+python3 data/cached_challenge_fineweb.py --variant sp1024
+```
+
+Expected paths after download:
+
+- `data/datasets/fineweb10B_sp1024/`
+- `data/tokenizers/fineweb_1024_bpe.model`
+
+The launcher expects those paths by default.
+
+### 4. Training command
+
+```bash
+cd final/dominationv2_cache
+bash train_8xH100.sh
+```
+
+Important default settings in `train_8xH100.sh`:
+
+- `NPROC_PER_NODE=8`
+- `MAX_WALLCLOCK_SECONDS=600`
+- `TRAIN_SEQ_LEN=2048`
+- `TRAIN_BATCH_TOKENS=524288`
+- `TTT_ENABLED=1`
+- `TTT_EPOCHS=3`
+- `TTT_LR=1e-4`
+- `CACHE_ENABLED=1`
+- `CACHE_ALPHA=0.20`
+- `CACHE_TAU=8`
+- `CACHE_ENTROPY_POWER=1.0`
+- `EVAL_STRIDE=64`
+- `EVAL_BATCH_SEQS=32`
+
+Useful overrides:
+
+```bash
+cd final/dominationv2_cache
+RUN_ID=dominationv2_cache_trial NPROC_PER_NODE=8 bash train_8xH100.sh
+```
+
+### 5. What outputs to expect
+
+Outputs are written in `final/dominationv2_cache/`:
+
+- `logs/<RUN_ID>.txt`
+- `final_model.pt`
+- `final_model.int8.ptz`
+
+### 6. What to verify in the training log
+
+Before trusting the run, inspect these markers in `logs/<RUN_ID>.txt`:
+
+- `cache_enabled:True` or `cache_enabled:1`
+- `ttt: done in ...`
+- `final_eval_mode:sliding_window_cache stride:64 batch_seqs:32 ...`
+- `final_int8_zlib_roundtrip compressed_model_bytes:... code_bytes:... total_artifact_bytes:...`
+- `final_roundtrip_exact val_loss:... val_bpb:...`
+
+The minimum trust checks are:
+
+- `total_artifact_bytes < 16000000`
+- the final evaluation mode is `sliding_window_cache`, not plain sliding
+- `final_model.int8.ptz` was actually written
+- the number you compare against other runs is `final_roundtrip_exact val_bpb`
+
+If the log shows `compression:zlib-9` or the compressed artifact is unexpectedly large, install `zstandard` and rerun.
+
+### 7. Evaluation and checkpoint probing
+
+To probe an existing checkpoint with the same evaluation path:
+
+```bash
+cd /path/to/repo
+python final/dominationv2_cache/eval_checkpoint.py \
+  --checkpoint experiments/domv2_ctrl3600/final_model.pt \
+  --quant-roundtrip \
+  --tokenizer data/tokenizers/fineweb_1024_bpe.model \
+  --val-files "data/datasets/fineweb10B_sp1024/fineweb_val_*.bin" \
+  --mode flat_cache_bigram_adaptive_entropy \
+  --reset-cache-on-bos \
+  --alphas 0 0.20 \
+  --tau 8 \
+  --entropy-power 1.0 \
+  --seq-len 2048 \
+  --stride 64 \
+  --batch-seqs 32 \
+  --max-tokens 1048576 \
+  --start-token 20000000 \
+  --ttt-epochs 3 \
+  --ttt-lr 1e-4 \
+  --ttt-batch-seqs 4
+```
+
+This is the main tool for narrow alpha sweeps or for checking whether a newly trained checkpoint still likes the cache.
+
+## Recommended Decision Rule After the 8xH100 Run
+
+Back this candidate if all of the following hold:
+
+- the artifact fits comfortably under `16,000,000` total bytes
+- the final log confirms `sliding_window_cache`
+- the run finishes cleanly inside the challenge wallclock budget
+- the final `val_bpb` is at least competitive with the control you are comparing against
+
+If the checkpoint is clearly stronger or weaker than expected, do one narrow post-hoc sweep with `eval_checkpoint.py` around `alpha in {0.15, 0.20, 0.25, 0.30}` before changing anything larger.
+
+## Alternatives Not Promoted
+
+- A smoothed bigram plus unigram-backoff cache variant was tested in the last focused search and was worse than the current cache on the local proxy checkpoint.
+- Broader architecture or tokenizer changes were not promoted in this final phase because they would require a fresh evidence cycle and would not beat the current artifact-quality priority.
+
+## Main Risks
+
+- The single-H100 subset gains may not transfer one-for-one to the full 8xH100 run.
+- The extra code bytes reduce artifact margin relative to the upstream control.
+- Multi-rank TTT is still an extrapolation rather than a separately parity-tested path.
+- If the final checkpoint has materially different entropy calibration, `alpha=0.20` may stop being the exact optimum even if the cache family remains good.

--- a/final/dominationv2_cache/eval_checkpoint.py
+++ b/final/dominationv2_cache/eval_checkpoint.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from research import eval_doc_cache
+
+
+def main() -> None:
+    train_script = str(Path(__file__).with_name("train_gpt.py"))
+    if "--train-script" not in sys.argv:
+        sys.argv[1:1] = ["--train-script", train_script]
+    eval_doc_cache.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/final/dominationv2_cache/train_8xH100.sh
+++ b/final/dominationv2_cache/train_8xH100.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT_DIR=$(cd "${SCRIPT_DIR}/../.." && pwd)
+
+export PYTHONPATH="${ROOT_DIR}${PYTHONPATH:+:${PYTHONPATH}}"
+export DATA_PATH="${DATA_PATH:-${ROOT_DIR}/data/datasets/fineweb10B_sp1024}"
+export TOKENIZER_PATH="${TOKENIZER_PATH:-${ROOT_DIR}/data/tokenizers/fineweb_1024_bpe.model}"
+export RUN_ID="${RUN_ID:-dominationv2_cache}"
+export VOCAB_SIZE="${VOCAB_SIZE:-1024}"
+
+export NUM_LAYERS="${NUM_LAYERS:-11}"
+export MODEL_DIM="${MODEL_DIM:-512}"
+export NUM_HEADS="${NUM_HEADS:-8}"
+export NUM_KV_HEADS="${NUM_KV_HEADS:-4}"
+export MLP_MULT="${MLP_MULT:-3}"
+export BIGRAM_VOCAB_SIZE="${BIGRAM_VOCAB_SIZE:-2048}"
+export XSA_LAST_N="${XSA_LAST_N:-4}"
+
+export EMA_ENABLED="${EMA_ENABLED:-1}"
+export EMA_DECAY="${EMA_DECAY:-0.997}"
+export SWA_ENABLED="${SWA_ENABLED:-0}"
+export TTT_ENABLED="${TTT_ENABLED:-1}"
+export TTT_EPOCHS="${TTT_EPOCHS:-3}"
+export TTT_LR="${TTT_LR:-0.0001}"
+
+export CACHE_ENABLED="${CACHE_ENABLED:-1}"
+export CACHE_ALPHA="${CACHE_ALPHA:-0.20}"
+export CACHE_TAU="${CACHE_TAU:-8}"
+export CACHE_ENTROPY_POWER="${CACHE_ENTROPY_POWER:-1.0}"
+
+export MUON_WD="${MUON_WD:-0.04}"
+export WEIGHT_DECAY="${WEIGHT_DECAY:-0.04}"
+export MATRIX_LR="${MATRIX_LR:-0.025}"
+export SCALAR_LR="${SCALAR_LR:-0.025}"
+export TIED_EMBED_LR="${TIED_EMBED_LR:-0.035}"
+export MUON_MOMENTUM="${MUON_MOMENTUM:-0.99}"
+export MUON_MOMENTUM_WARMUP_START="${MUON_MOMENTUM_WARMUP_START:-0.92}"
+export MUON_MOMENTUM_WARMUP_STEPS="${MUON_MOMENTUM_WARMUP_STEPS:-1500}"
+export WARMDOWN_ITERS="${WARMDOWN_ITERS:-3000}"
+
+export MIXED_QUANT_INT6_CATS="${MIXED_QUANT_INT6_CATS:-mlp,attn}"
+export TRAIN_BATCH_TOKENS="${TRAIN_BATCH_TOKENS:-524288}"
+export TRAIN_SEQ_LEN="${TRAIN_SEQ_LEN:-2048}"
+export MAX_WALLCLOCK_SECONDS="${MAX_WALLCLOCK_SECONDS:-600}"
+export EVAL_STRIDE="${EVAL_STRIDE:-64}"
+export EVAL_BATCH_SEQS="${EVAL_BATCH_SEQS:-32}"
+
+cd "${SCRIPT_DIR}"
+torchrun --standalone --nproc_per_node="${NPROC_PER_NODE:-8}" train_gpt.py

--- a/final/dominationv2_cache/train_gpt.py
+++ b/final/dominationv2_cache/train_gpt.py
@@ -1,0 +1,985 @@
+"""
+Domination V2: Full frontier technique stack for parameter golf.
+
+Adds XSA (Exclusive Self Attention, arXiv:2603.09078) on last N layers,
+EMA weight averaging (replacing SWA), and TTT (test-time training) at eval.
+Built on V1: 11L MLP-3x, per-dim SmearGate, BigramHash, OrthoInit, Muon WD.
+"""
+
+from __future__ import annotations
+
+import bisect
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+try:
+    import zstandard as zstd
+    HAS_ZSTD = True
+except ImportError:
+    HAS_ZSTD = False
+
+BOS_ID = 1
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 500))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 100))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 3))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.035))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.025))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.025))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 4))
+    ema_enabled = bool(int(os.environ.get("EMA_ENABLED", "1")))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 3))
+    ttt_lr = float(os.environ.get("TTT_LR", 1e-4))
+    cache_enabled = bool(int(os.environ.get("CACHE_ENABLED", "1")))
+    cache_alpha = float(os.environ.get("CACHE_ALPHA", 0.20))
+    cache_tau = float(os.environ.get("CACHE_TAU", 8.0))
+    cache_entropy_power = float(os.environ.get("CACHE_ENTROPY_POWER", 1.0))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    weight_decay = float(os.environ.get("WEIGHT_DECAY", 0.04))
+    muon_wd = float(os.environ.get("MUON_WD", 0.04))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 4096))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.5))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+
+# -----------------------------
+# MUON OPTIMIZER WITH WEIGHT DECAY
+# -----------------------------
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(params, dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                                     nesterov=nesterov, weight_decay=weight_decay))
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad(): loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+        for group in self.param_groups:
+            params = group["params"]
+            if not params: continue
+            lr, momentum = group["lr"], group["momentum"]
+            backend_steps, nesterov = group["backend_steps"], group["nesterov"]
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov: g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+            if distributed: dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                if wd > 0: p.data.mul_(1.0 - lr * wd)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+        return loss
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION
+# -----------------------------
+
+def build_sentencepiece_luts(sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id): continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id): base_bytes_np[token_id] = 1; continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"): has_leading_space_np[token_id] = True; piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+            torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+            torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device))
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files: raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0: raise ValueError(f"Validation split is too short for seq_len={seq_len}")
+    return tokens[: usable + 1]
+
+def find_docs(all_tokens: Tensor) -> list[tuple[int, int]]:
+    bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+    docs = []
+    for i, start in enumerate(bos_positions):
+        end = bos_positions[i + 1] + 1 if i + 1 < len(bos_positions) else int(all_tokens.numel())
+        if end - start >= 2: docs.append((int(start), int(end - start)))
+    return docs
+
+def shard_docs_by_tokens(docs: list[tuple[int, int]], rank: int, world_size: int) -> list[tuple[int, int]]:
+    if rank < 0 or rank >= world_size:
+        raise ValueError(f"rank {rank} out of range for world_size={world_size}")
+    if not docs:
+        return []
+    prefix = [0]
+    for _, doc_len in docs:
+        prefix.append(prefix[-1] + max(doc_len - 1, 0))
+    total_pred_tokens = prefix[-1]
+    bounds = [0]
+    prev = 0
+    for shard_idx in range(1, world_size):
+        target = (total_pred_tokens * shard_idx) / world_size
+        lo = bisect.bisect_left(prefix, target, lo=prev, hi=len(prefix))
+        candidates = [idx for idx in (lo - 1, lo) if prev <= idx <= len(docs)]
+        if not candidates:
+            cut = prev
+        else:
+            cut = min(candidates, key=lambda idx: (abs(prefix[idx] - target), -idx))
+        bounds.append(cut)
+        prev = cut
+    bounds.append(len(docs))
+    return docs[bounds[rank]:bounds[rank + 1]]
+
+def iter_flat_score_windows(total_tokens: int, seq_len: int, stride: int):
+    if total_tokens <= 0:
+        return
+    first_end = min(seq_len, total_tokens)
+    yield 0, first_end, 0, first_end
+    scored_end = first_end
+    while scored_end < total_tokens:
+        next_end = min(scored_end + stride, total_tokens)
+        ws = max(0, next_end - seq_len)
+        yield ws, next_end - ws, scored_end, next_end
+        scored_end = next_end
+
+def eval_val(args, model, rank, world_size, device, grad_accum_steps, val_tokens,
+             base_bytes_lut, has_leading_space_lut, is_boundary_token_lut):
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(f"VAL_BATCH_SIZE too small for world={world_size} accum={grad_accum_steps} seq={args.train_seq_len}")
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    vls = torch.zeros((), device=device, dtype=torch.float64)
+    vtc = torch.zeros((), device=device, dtype=torch.float64)
+    vbc = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+    with torch.inference_mode():
+        for bs in range(seq_start, seq_end, local_batch_seqs):
+            be = min(bs + local_batch_seqs, seq_end)
+            rs, re = bs * args.train_seq_len, be * args.train_seq_len + 1
+            local = val_tokens[rs:re].to(device=device, dtype=torch.int64, non_blocking=True)
+            x, y = local[:-1].reshape(-1, args.train_seq_len), local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                bl = model(x, y).detach()
+            bc = float(y.numel())
+            vls += bl.to(torch.float64) * bc; vtc += bc
+            pi, ti = x.reshape(-1), y.reshape(-1)
+            tb = base_bytes_lut[ti].to(dtype=torch.int16)
+            tb += (has_leading_space_lut[ti] & ~is_boundary_token_lut[pi]).to(dtype=torch.int16)
+            vbc += tb.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(vls, op=dist.ReduceOp.SUM); dist.all_reduce(vtc, op=dist.ReduceOp.SUM); dist.all_reduce(vbc, op=dist.ReduceOp.SUM)
+    vl = vls / vtc; bpt = vl.item() / math.log(2.0); tpb = vtc.item() / vbc.item()
+    model.train(); return float(vl.item()), float(bpt * tpb)
+
+def eval_val_sliding(args, base_model, rank, world_size, device, val_tokens,
+                     base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+                     stride, batch_seqs=32):
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    windows = list(iter_flat_score_windows(total_tokens, seq_len, stride))
+    total_windows = len(windows)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = windows[my_s:my_e]
+    ls = torch.zeros((), device=device, dtype=torch.float64)
+    tc = torch.zeros((), device=device, dtype=torch.float64)
+    bc = torch.zeros((), device=device, dtype=torch.float64)
+    base_model.eval()
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            bw = my_windows[bi:bi + batch_seqs]; bsz = len(bw)
+            xb = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            yb = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens = []
+            score_starts = []
+            for i, (ws, wl, score_start, _) in enumerate(bw):
+                wlens.append(wl); score_starts.append(score_start)
+                ch = val_tokens[ws:ws + wl + 1].to(dtype=torch.int64, device=device)
+                xb[i, :wl] = ch[:-1]; yb[i, :wl] = ch[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = base_model.forward_logits(xb)
+            nll = F.cross_entropy(logits.reshape(-1, logits.size(-1)).float(), yb.reshape(-1), reduction="none").reshape(bsz, seq_len)
+            for i, (ws, _, _, _) in enumerate(bw):
+                wl = wlens[i]; s = score_starts[i] - ws
+                sn = nll[i, s:wl].to(torch.float64); ls += sn.sum(); tc += float(wl - s)
+                tgt, prev = yb[i, s:wl], xb[i, s:wl]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                bc += tb.sum()
+            if rank == 0 and (bi // batch_seqs) % 50 == 0:
+                done = min(bi + batch_seqs, len(my_windows)); pct = done / len(my_windows) * 100
+                rb = 0.0
+                if tc.item() > 0: rl = (ls / tc).item(); rb = rl / math.log(2.0) * (tc.item() / bc.item())
+                print(f"  sliding_eval [{pct:5.1f}%] {done}/{len(my_windows)} windows running_bpb={rb:.6f}", flush=True)
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(ls, op=dist.ReduceOp.SUM); dist.all_reduce(tc, op=dist.ReduceOp.SUM); dist.all_reduce(bc, op=dist.ReduceOp.SUM)
+    vl = (ls / tc).item(); bpt = vl / math.log(2.0); tpb = tc.item() / bc.item()
+    base_model.train(); return vl, bpt * tpb
+
+def eval_val_sliding_cache(args, base_model, rank, world_size, device, val_tokens, docs,
+                           base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+                           stride, batch_seqs=32):
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    local_docs = shard_docs_by_tokens(docs, rank, world_size)
+    loss_sum = 0.0; token_count = 0.0; byte_count = 0.0
+    if not local_docs:
+        ls = torch.tensor(loss_sum, device=device, dtype=torch.float64)
+        tc = torch.tensor(token_count, device=device, dtype=torch.float64)
+        bc = torch.tensor(byte_count, device=device, dtype=torch.float64)
+        if dist.is_available() and dist.is_initialized():
+            dist.all_reduce(ls, op=dist.ReduceOp.SUM); dist.all_reduce(tc, op=dist.ReduceOp.SUM); dist.all_reduce(bc, op=dist.ReduceOp.SUM)
+        vl = (ls / tc).item(); bpt = vl / math.log(2.0); tpb = tc.item() / bc.item()
+        base_model.train(); return vl, bpt * tpb
+
+    local_start = local_docs[0][0]
+    local_end = local_docs[-1][0] + local_docs[-1][1] - 1
+    local_windows = []
+    for ws, wl, score_start, score_end in iter_flat_score_windows(total_tokens, seq_len, stride):
+        if score_end <= local_start: continue
+        if score_start >= local_end: break
+        ss = max(score_start, local_start); se = min(score_end, local_end)
+        if ss < se: local_windows.append((ws, wl, ss, se))
+
+    cache_active = args.cache_enabled
+    base_model.eval()
+    base_bytes_np = base_bytes_lut.cpu().numpy().astype(np.int64)
+    has_space_np = has_leading_space_lut.cpu().numpy().astype(np.bool_)
+    is_boundary_np = is_boundary_token_lut.cpu().numpy().astype(np.bool_)
+    max_entropy = math.log(base_bytes_np.shape[0])
+    max_count = np.iinfo(np.uint16).max
+    row_totals = np.zeros(base_bytes_np.shape[0], dtype=np.int32)
+    counts = np.zeros((base_bytes_np.shape[0], base_bytes_np.shape[0]), dtype=np.uint16)
+    touched_pairs: list[tuple[int, int]] = []
+    touched_rows: list[int] = []
+    doc_idx = 0
+    doc_end = local_docs[doc_idx][0] + local_docs[doc_idx][1] - 1
+
+    def reset_doc_cache():
+        for p, y in touched_pairs: counts[p, y] = 0
+        for p in touched_rows: row_totals[p] = 0
+        touched_pairs.clear(); touched_rows.clear()
+
+    with torch.inference_mode():
+        for bi in range(0, len(local_windows), batch_seqs):
+            batch = local_windows[bi:bi + batch_seqs]; bsz = len(batch)
+            xb = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            yb = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            for i, (ws, wl, _, _) in enumerate(batch):
+                ch = val_tokens[ws:ws + wl + 1].to(dtype=torch.int64, device=device)
+                xb[i, :wl] = ch[:-1]; yb[i, :wl] = ch[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = base_model.forward_logits(xb)
+
+            if cache_active:
+                log_probs = F.log_softmax(logits.float(), dim=-1)
+                entropy = -(log_probs.exp() * log_probs).sum(dim=-1)
+            else:
+                nll = F.cross_entropy(logits.reshape(-1, logits.size(-1)).float(), yb.reshape(-1), reduction="none").reshape(bsz, seq_len)
+
+            for i, (ws, _, score_start, score_end) in enumerate(batch):
+                lo = score_start - ws; hi = score_end - ws
+                if cache_active:
+                    tgt = yb[i, lo:hi]
+                    prev_np = xb[i, lo:hi].detach().cpu().numpy().astype(np.uint16, copy=True)
+                    tgt_np = tgt.detach().cpu().numpy().astype(np.uint16, copy=True)
+                    lp_np = log_probs[i, lo:hi].gather(1, tgt[:, None]).squeeze(1).detach().cpu().numpy().astype(np.float32, copy=True)
+                    ent_np = entropy[i, lo:hi].detach().cpu().numpy().astype(np.float32, copy=True)
+                    base_prob_np = np.exp(lp_np.astype(np.float64, copy=False))
+                    pos = score_start; off = 0
+                    while pos < score_end:
+                        seg_end = min(score_end, doc_end)
+                        take = seg_end - pos
+                        ps = prev_np[off:off + take]
+                        ys = tgt_np[off:off + take]
+                        probs = base_prob_np[off:off + take]
+                        ents = ent_np[off:off + take]
+                        for j in range(take):
+                            p = int(ps[j]); y = int(ys[j])
+                            total = int(row_totals[p]); seen = int(counts[p, y]); cache_p = (seen / total) if total > 0 else 0.0
+                            eff_alpha = args.cache_alpha * (total / (total + args.cache_tau)) if total > 0 else 0.0
+                            eff_alpha *= max(float(ents[j]) / max_entropy, 0.0) ** args.cache_entropy_power
+                            mix_p = (1.0 - eff_alpha) * float(probs[j]) + eff_alpha * cache_p
+                            loss_sum += -math.log(max(mix_p, 1e-30))
+                            if total == 0: touched_rows.append(p)
+                            if seen == 0: touched_pairs.append((p, y))
+                            counts[p, y] = min(seen + 1, max_count)
+                            row_totals[p] = total + 1
+                        tb = base_bytes_np[ys]
+                        tb = tb + np.logical_and(has_space_np[ys], np.logical_not(is_boundary_np[ps])).astype(np.int64)
+                        byte_count += float(tb.sum()); token_count += int(take)
+                        pos = seg_end; off += take
+                        if pos >= doc_end:
+                            reset_doc_cache(); doc_idx += 1
+                            if doc_idx < len(local_docs):
+                                doc_end = local_docs[doc_idx][0] + local_docs[doc_idx][1] - 1
+                else:
+                    sn = nll[i, lo:hi]; loss_sum += float(sn.sum().item()); token_count += float(hi - lo)
+                    prev, tgt = xb[i, lo:hi], yb[i, lo:hi]
+                    tb = base_bytes_lut[tgt].to(torch.float64)
+                    tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                    byte_count += float(tb.sum().item())
+            if rank == 0 and (bi // batch_seqs) % 50 == 0:
+                done = min(bi + batch_seqs, len(local_windows)); pct = done / len(local_windows) * 100
+                rb = (loss_sum / math.log(2.0)) / byte_count if byte_count > 0 else 0.0
+                print(f"  cache_eval [{pct:5.1f}%] {done}/{len(local_windows)} windows running_bpb={rb:.6f}", flush=True)
+
+    ls = torch.tensor(loss_sum, device=device, dtype=torch.float64)
+    tc = torch.tensor(token_count, device=device, dtype=torch.float64)
+    bc = torch.tensor(byte_count, device=device, dtype=torch.float64)
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(ls, op=dist.ReduceOp.SUM); dist.all_reduce(tc, op=dist.ReduceOp.SUM); dist.all_reduce(bc, op=dist.ReduceOp.SUM)
+    vl = (ls / tc).item(); bpt = vl / math.log(2.0); tpb = tc.item() / bc.item()
+    base_model.train(); return vl, bpt * tpb
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(p for p in os.environ.get("CONTROL_TENSOR_NAME_PATTERNS",
+    "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,bigram.scale").split(",") if p)
+
+INT6_QUANT_RANGE = 31
+MIXED_QUANT_INT6_CATS = frozenset(
+    c.strip() for c in os.environ.get("MIXED_QUANT_INT6_CATS", "mlp,attn").split(",") if c.strip()
+)
+STE_QAT_ENABLED = bool(int(os.environ.get("STE_QAT_ENABLED", "0")))
+STE_QAT_RANGE = int(os.environ.get("STE_QAT_RANGE", INT6_QUANT_RANGE))
+
+def _classify_param(name):
+    if "tok_emb" in name or "lm_head" in name: return "embed"
+    if ".mlp." in name: return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name): return "attn"
+    return "other"
+
+def _get_ste_range_for_param(name):
+    return STE_QAT_RANGE
+
+def quantize_int6_per_row(t):
+    t32 = t.float()
+    if t32.ndim == 2:
+        rm = t32.abs().amax(dim=1)
+        sc = (rm / 31.0).clamp_min(1.0 / 31.0).to(torch.float16)
+        q = torch.clamp(torch.round(t32 / sc.float()[:, None]), -32, 31).to(torch.int8)
+        return q, sc
+    am = t32.abs().max().item()
+    sc = torch.tensor(am / 31.0 if am > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / sc.float()), -32, 31).to(torch.int8)
+    return q, sc
+
+def quantize_int8_per_row(t):
+    t32 = t.float()
+    if t32.ndim == 2:
+        rm = t32.abs().amax(dim=1)
+        sc = (rm / 127.0).clamp_min(1e-8).to(torch.float16)
+        q = torch.clamp(torch.round(t32 / sc.float()[:, None]), -127, 127).to(torch.int8)
+        return q, sc
+    am = t32.abs().max().item()
+    sc = torch.tensor(am / 127.0 if am > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / sc.float()), -127, 127).to(torch.int8)
+    return q, sc
+
+def mixed_quantize(state_dict, int6_cats):
+    result, meta = {}, {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t)
+            result[name + ".q"] = q; result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_int8_per_row(t)
+            result[name + ".q"] = q; result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+
+def dequantize_mixed(result, meta, template_sd):
+    out = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None: continue
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig.dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig.dtype)
+            out[name] = t; continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig.dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig.dtype)
+    return out
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+def load_data_shard(file):
+    hb = 256 * np.dtype("<i4").itemsize; header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1: raise ValueError(f"Bad shard header: {file}")
+    nt = int(header[2])
+    if file.stat().st_size != hb + nt * 2: raise ValueError(f"Shard size mismatch: {file}")
+    tokens_np = np.fromfile(file, dtype="<u2", count=nt, offset=hb)
+    if tokens_np.size != nt: raise ValueError(f"Short read: {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files: raise FileNotFoundError(f"No files: {pattern}")
+        self.file_idx = 0; self.tokens = load_data_shard(self.files[0]); self.pos = 0
+    def _advance_file(self): self.file_idx = (self.file_idx + 1) % len(self.files); self.tokens = load_data_shard(self.files[self.file_idx]); self.pos = 0
+    def take(self, n):
+        chunks, remaining = [], n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0: self._advance_file(); continue
+            k = min(remaining, avail); chunks.append(self.tokens[self.pos:self.pos + k]); self.pos += k; remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+class DistributedTokenLoader:
+    def __init__(self, pattern, rank, world_size, device):
+        self.rank, self.world_size, self.device, self.stream = rank, world_size, device, TokenStream(pattern)
+    def next_batch(self, global_tokens, seq_len, grad_accum_steps):
+        lt = global_tokens // (self.world_size * grad_accum_steps); prs = lt + 1
+        chunk = self.stream.take(prs * self.world_size); s = self.rank * prs
+        local = chunk[s:s + prs].to(dtype=torch.int64)
+        x, y = local[:-1].reshape(-1, seq_len), local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None): super().__init__(); self.eps = eps
+    def forward(self, x): return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+class CastedLinear(nn.Linear):
+    def forward(self, x):
+        w = self.weight.to(x.dtype)
+        if self.training and STE_QAT_ENABLED and w.ndim == 2:
+            with torch.no_grad():
+                w32 = w.float(); rm = w32.abs().amax(dim=1).clamp_min(1e-8)
+                sc = rm / 31.0; wc = torch.clamp(w32, -rm[:, None], rm[:, None])
+                wq = (torch.round(wc / sc[:, None]) * sc[:, None]).to(x.dtype)
+            w = w + (wq - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+def restore_low_dim_params_to_fp32(module):
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=10000.0):
+        super().__init__()
+        self.register_buffer("inv_freq", 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim)), persistent=False)
+        self._seq_len_cached = 0; self._cos_cached = None; self._sin_cached = None
+    def forward(self, seq_len, device, dtype):
+        if self._cos_cached is None or self._seq_len_cached != seq_len or self._cos_cached.device != device:
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]; self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+def apply_rotary_emb(x, cos, sin):
+    h = x.size(-1) // 2; x1, x2 = x[..., :h], x[..., h:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init):
+        super().__init__()
+        self.num_heads, self.num_kv_heads = num_heads, num_kv_heads; self.head_dim = dim // num_heads
+        kv_dim = num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False); self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False); self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape
+        Hkv = v.size(2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x):
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q, k = F.rms_norm(q, (q.size(-1),)), F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q, k = apply_rotary_emb(q, cos, sin), apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True, enable_gqa=(self.num_kv_heads != self.num_heads))
+        y = y.transpose(1, 2).contiguous()
+        if self.use_xsa:
+            v_bthd = v.transpose(1, 2).contiguous()
+            y = self._xsa_efficient(y, v_bthd)
+        return self.proj(y.reshape(bsz, seqlen, dim))
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__(); hidden = mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False); self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+    def forward(self, x): return self.proj(torch.relu(self.fc(x)).square())
+
+class SmearGate(nn.Module):
+    """Per-dimension SmearGate (from PR #194): each dim has its own blend ratio."""
+    def __init__(self, dim):
+        super().__init__(); self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+    def forward(self, x):
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size, bigram_dim, model_dim):
+        super().__init__(); self.bvs = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim); nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None: nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+    def forward(self, token_ids):
+        t = token_ids.to(torch.int32); mod = self.bvs - 1
+        out = torch.empty_like(t); out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        h = self.embed(out.long())
+        if self.proj is not None: h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class Block(nn.Module):
+    def __init__(self, dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init):
+        super().__init__()
+        self.attn_norm, self.mlp_norm = RMSNorm(), RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+    def forward(self, x, x0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * self.attn(self.attn_norm(x))
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size, num_layers, model_dim, num_heads, num_kv_heads, mlp_mult,
+                 tie_embeddings, tied_embed_init_std, logit_softcap, rope_base, qk_gain_init,
+                 bigram_vocab_size=0, bigram_dim=128, xsa_last_n=0):
+        super().__init__()
+        self.tie_embeddings, self.tied_embed_init_std, self.logit_softcap = tie_embeddings, tied_embed_init_std, logit_softcap
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.smear = SmearGate(model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList([Block(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init) for _ in range(num_layers)])
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None: self.lm_head._zero_init = True
+        if xsa_last_n > 0:
+            for i in range(max(0, num_layers - xsa_last_n), num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.tie_embeddings: nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        nl = len(self.blocks)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False): nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj." in name or name.endswith(".proj"):
+                        with torch.no_grad(): module.weight.mul_(1.0 / math.sqrt(2 * nl))
+
+    def _run_blocks(self, x, x0):
+        skips = []
+        for i in range(self.num_encoder_layers): x = self.blocks[i](x, x0); skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips: x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+        return x
+
+    def _embed(self, input_ids):
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None: x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        return self.smear(x)
+
+    def _logits(self, x):
+        if self.tie_embeddings: lp = F.linear(x, self.tok_emb.weight)
+        else: lp = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(lp / self.logit_softcap)
+
+    def forward(self, input_ids, target_ids):
+        x0 = self._embed(input_ids)
+        x = self.final_norm(self._run_blocks(x0, x0)).reshape(-1, x0.size(-1))
+        return F.cross_entropy(self._logits(x).float(), target_ids.reshape(-1), reduction="mean")
+
+    def forward_logits(self, input_ids):
+        x0 = self._embed(input_ids)
+        return self._logits(self.final_norm(self._run_blocks(x0, x0)))
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main():
+    global zeropower_via_newtonschulz5
+    code = Path(__file__).read_text(encoding="utf-8"); args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank, world_size = int(os.environ.get("RANK", "0")), int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    grad_accum_steps = 8 // world_size; grad_scale = 1.0 / grad_accum_steps
+    device = torch.device("cuda", local_rank); torch.cuda.set_device(device)
+    if distributed: dist.init_process_group(backend="nccl", device_id=device); dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True; torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False); enable_flash_sdp(True); enable_mem_efficient_sdp(False); enable_math_sdp(False)
+    logfile = None
+    if master_process: os.makedirs("logs", exist_ok=True); logfile = f"logs/{args.run_id}.txt"; print(logfile)
+    def log0(msg, console=True):
+        if not master_process: return
+        if console: print(msg)
+        if logfile:
+            with open(logfile, "a", encoding="utf-8") as f: print(msg, file=f)
+    log0(code, console=False); log0("=" * 100, console=False)
+    log0(subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout, console=False)
+    log0("=" * 100, console=False)
+    random.seed(args.seed); np.random.seed(args.seed); torch.manual_seed(args.seed); torch.cuda.manual_seed_all(args.seed)
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(sp, args.vocab_size, device)
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:tokens:{val_tokens.numel() - 1}")
+
+    base_model = GPT(vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+                     num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+                     tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+                     logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+                     bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim,
+                     xsa_last_n=args.xsa_last_n).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear): module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [p for n, p in block_named_params if p.ndim == 2 and not any(pat in n for pat in CONTROL_TENSOR_NAME_PATTERNS)]
+    scalar_params = [p for n, p in block_named_params if p.ndim < 2 or any(pat in n for pat in CONTROL_TENSOR_NAME_PATTERNS)]
+    if base_model.skip_weights.numel() > 0: scalar_params.append(base_model.skip_weights)
+    for p in base_model.smear.parameters(): scalar_params.append(p)
+    if base_model.bigram is not None:
+        for n, p in base_model.bigram.named_parameters():
+            if p.ndim == 2 and p.shape[0] >= 64 and p.shape[1] >= 64: matrix_params.append(p)
+            else: scalar_params.append(p)
+
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.AdamW([{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+                                      betas=(args.beta1, args.beta2), eps=args.adam_eps, weight_decay=args.weight_decay, fused=True)
+    optimizer_muon = Muon(matrix_params, lr=args.matrix_lr, momentum=args.muon_momentum,
+                          backend_steps=args.muon_backend_steps, weight_decay=args.muon_wd)
+    for group in optimizer_muon.param_groups: group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW([{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+                                         betas=(args.beta1, args.beta2), eps=args.adam_eps, weight_decay=args.weight_decay, fused=True)
+    optimizers = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizers.insert(1, torch.optim.AdamW([{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+                                               betas=(args.beta1, args.beta2), eps=args.adam_eps, weight_decay=args.weight_decay, fused=True))
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params} swa:{args.swa_enabled} compression:{'zstd-22' if HAS_ZSTD else 'zlib-9'}")
+    log0(f"bigram_vocab:{args.bigram_vocab_size} bigram_dim:{args.bigram_dim} grad_clip:{args.grad_clip_norm} muon_wd:{args.muon_wd}")
+    log0(f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} warmdown:{args.warmdown_iters} seed:{args.seed}")
+    log0(f"ste_qat:{STE_QAT_ENABLED} ste_range:{STE_QAT_RANGE} int6_cats:{MIXED_QUANT_INT6_CATS}")
+    log0(f"xsa_last_n:{args.xsa_last_n} ema:{args.ema_enabled} ema_decay:{args.ema_decay} ttt:{args.ttt_enabled} ttt_epochs:{args.ttt_epochs}")
+    log0(f"cache_enabled:{args.cache_enabled} cache_alpha:{args.cache_alpha} cache_tau:{args.cache_tau} cache_entropy_power:{args.cache_entropy_power}")
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    def zero_grad_all():
+        for opt in optimizers: opt.zero_grad(set_to_none=True)
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    def lr_mul(step, elapsed_ms):
+        if args.warmdown_iters <= 0: return 1.0
+        if max_wallclock_ms is None:
+            ws = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if ws <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1); wms = args.warmdown_iters * step_ms
+        rms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return rms / max(wms, 1e-9) if rms <= wms else 1.0
+
+    if args.warmup_steps > 0:
+        init_sd = {n: t.detach().cpu().clone() for n, t in base_model.state_dict().items()}
+        init_opts = [copy.deepcopy(o.state_dict()) for o in optimizers]; model.train()
+        for ws in range(args.warmup_steps):
+            zero_grad_all()
+            for ms in range(grad_accum_steps):
+                if distributed: model.require_backward_grad_sync = ms == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True): wl = model(x, y)
+                (wl * grad_scale).backward()
+            for o in optimizers: o.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (ws + 1) % 10 == 0: log0(f"warmup_step:{ws + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(init_sd, strict=True)
+        for o, s in zip(optimizers, init_opts, strict=True): o.load_state_dict(s)
+        zero_grad_all()
+        if distributed: model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    training_time_ms = 0.0; stop_after_step = None; swa_state = None; swa_count = 0
+    ema_state = None
+    if args.ema_enabled:
+        ema_state = {n: t.detach().float().clone() for n, t in base_model.state_dict().items()}
+    torch.cuda.synchronize(); t0 = time.perf_counter(); step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+            torch.cuda.synchronize(); training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            vl, vb = eval_val(args, model, rank, world_size, device, grad_accum_steps, val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut)
+            log0(f"step:{step}/{args.iterations} val_loss:{vl:.4f} val_bpb:{vb:.4f} train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms")
+            torch.cuda.synchronize(); t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations: log0(f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms step:{step}/{args.iterations}")
+            break
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0); scale = lr_mul(step, elapsed_ms)
+        if args.swa_enabled and not args.ema_enabled and scale < args.swa_start_frac and step % args.swa_every == 0:
+            current = {k: v.detach().cpu().clone() for k, v in base_model.state_dict().items()}
+            if swa_state is None:
+                swa_state = current; swa_count = 1
+            else:
+                inv = 1.0 / (swa_count + 1); keep = 1.0 - inv
+                for k, t in current.items():
+                    if torch.is_floating_point(swa_state[k]): swa_state[k].mul_(keep).add_(t, alpha=inv)
+                    else: swa_state[k] = t
+                swa_count += 1
+        zero_grad_all(); train_loss = torch.zeros((), device=device)
+        for ms in range(grad_accum_steps):
+            if distributed: model.require_backward_grad_sync = ms == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True): loss = model(x, y)
+            train_loss += loss.detach(); (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        for group in optimizer_muon.param_groups: group["momentum"] = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups: group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0: torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers: opt.step()
+        if ema_state is not None:
+            d = args.ema_decay
+            with torch.no_grad():
+                for n, t in base_model.state_dict().items():
+                    ema_state[n].mul_(d).add_(t.detach().float(), alpha=1.0 - d)
+        zero_grad_all(); step += 1
+        approx_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        if args.train_log_every > 0 and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None):
+            log0(f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} train_time:{approx_ms:.0f}ms step_avg:{approx_ms / step:.2f}ms")
+        reached_cap = max_wallclock_ms is not None and approx_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            rct = torch.tensor(int(reached_cap), device=device); dist.all_reduce(rct, op=dist.ReduceOp.MAX); reached_cap = bool(rct.item())
+        if stop_after_step is None and reached_cap: stop_after_step = step
+
+    log0(f"peak memory: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB")
+    if ema_state is not None:
+        log0("ema: applying EMA weights")
+        avg_sd = {n: t.to(dtype=base_model.state_dict()[n].dtype) for n, t in ema_state.items()}
+        base_model.load_state_dict(avg_sd, strict=True); del ema_state, avg_sd
+    elif swa_state is not None:
+        log0(f"swa: averaging {swa_count} checkpoints")
+        base_model.load_state_dict(swa_state, strict=True); del swa_state
+
+    export_sd = base_model.state_dict()
+    if master_process:
+        torch.save(export_sd, "final_model.pt")
+        log0(f"Serialized model: {os.path.getsize('final_model.pt')} bytes  Code: {len(code.encode('utf-8'))} bytes")
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    quant_result, quant_meta = mixed_quantize(sd_cpu, MIXED_QUANT_INT6_CATS)
+    qbuf = io.BytesIO(); torch.save({"w": quant_result, "m": quant_meta}, qbuf); qraw = qbuf.getvalue()
+    if HAS_ZSTD: qblob = zstd.ZstdCompressor(level=22).compress(qraw); cl = "zstd-22"
+    else: qblob = zlib.compress(qraw, level=9); cl = "zlib-9"
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f: f.write(qblob)
+        qfb = len(qblob); cb = len(code.encode("utf-8"))
+        log0(f"final_int8_zlib_roundtrip compressed_model_bytes:{qfb} code_bytes:{cb} total_artifact_bytes:{qfb + cb}")
+        log0(f"Serialized {cl}: {qfb} bytes  Total: {qfb + cb} bytes")
+    if distributed: dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f: qbd = f.read()
+    rd = zstd.ZstdDecompressor().decompress(qbd) if HAS_ZSTD else zlib.decompress(qbd)
+    qs = torch.load(io.BytesIO(rd), map_location="cpu")
+    base_model.load_state_dict(dequantize_mixed(qs["w"], qs["m"], sd_cpu), strict=True)
+
+    if args.ttt_enabled and args.ttt_epochs > 0:
+        log0(f"ttt: starting {args.ttt_epochs} epochs of test-time training (lr={args.ttt_lr})")
+        torch.cuda.synchronize(); ttt_start = time.perf_counter()
+        base_model.train()
+        ttt_params = [p for p in base_model.parameters() if p.requires_grad]
+        ttt_opt = torch.optim.SGD(ttt_params, lr=args.ttt_lr)
+        ttt_seq_len = args.train_seq_len
+        total_val = val_tokens.numel() - 1
+        total_seqs = total_val // ttt_seq_len
+        my_start = (total_seqs * rank) // world_size
+        my_end = (total_seqs * (rank + 1)) // world_size
+        for ttt_ep in range(args.ttt_epochs):
+            ttt_loss_sum = 0.0; ttt_count = 0
+            for si in range(my_start, my_end, 4):
+                se = min(si + 4, my_end); bsz = se - si
+                rs = si * ttt_seq_len; re = se * ttt_seq_len + 1
+                local = val_tokens[rs:re].to(device=device, dtype=torch.int64)
+                x = local[:-1].reshape(bsz, ttt_seq_len)
+                y = local[1:].reshape(bsz, ttt_seq_len)
+                ttt_opt.zero_grad()
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    loss = base_model(x, y)
+                loss.backward()
+                ttt_opt.step()
+                ttt_loss_sum += loss.item() * bsz; ttt_count += bsz
+            if rank == 0:
+                log0(f"  ttt_epoch:{ttt_ep+1}/{args.ttt_epochs} loss:{ttt_loss_sum/max(ttt_count,1):.4f}")
+        torch.cuda.synchronize()
+        log0(f"ttt: done in {time.perf_counter() - ttt_start:.1f}s")
+
+    torch.cuda.synchronize(); tqe = time.perf_counter()
+    if args.eval_stride > 0 and args.eval_stride < args.train_seq_len:
+        if args.cache_enabled:
+            docs = find_docs(val_tokens)
+            log0(f"final_eval_mode:sliding_window_cache stride:{args.eval_stride} batch_seqs:{args.eval_batch_seqs} docs:{len(docs)}")
+            qvl, qvb = eval_val_sliding_cache(args, base_model, rank, world_size, device, val_tokens, docs, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut, stride=args.eval_stride, batch_seqs=args.eval_batch_seqs)
+        else:
+            log0(f"final_eval_mode:sliding_window stride:{args.eval_stride} batch_seqs:{args.eval_batch_seqs}")
+            qvl, qvb = eval_val_sliding(args, base_model, rank, world_size, device, val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut, stride=args.eval_stride, batch_seqs=args.eval_batch_seqs)
+    else:
+        qvl, qvb = eval_val(args, model, rank, world_size, device, grad_accum_steps, val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut)
+    torch.cuda.synchronize()
+    log0(f"final_roundtrip val_loss:{qvl:.4f} val_bpb:{qvb:.4f} eval_time:{1000.0 * (time.perf_counter() - tqe):.0f}ms")
+    log0(f"final_roundtrip_exact val_loss:{qvl:.8f} val_bpb:{qvb:.8f}")
+    if distributed: dist.destroy_process_group()
+
+if __name__ == "__main__":
+    main()

--- a/research/eval_doc_cache.py
+++ b/research/eval_doc_cache.py
@@ -1,0 +1,908 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import glob
+import importlib.util
+import inspect
+import math
+import sys
+import time
+import io
+import zlib
+from pathlib import Path
+from types import ModuleType
+from typing import Iterable
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.nn.functional as F
+try:
+    import zstandard
+except ImportError:
+    zstandard = None
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+BOS_ID = 1
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate doc-local sliding and cache interpolation.")
+    parser.add_argument(
+        "--train-script",
+        type=Path,
+        default=Path("train_gpt.py"),
+        help="Path to the train_gpt.py variant that defines the model/checkpoint schema.",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        default=Path("local_runs/proxy500/final_model.pt"),
+        help="Path to a saved fp checkpoint.",
+    )
+    parser.add_argument(
+        "--quant-roundtrip",
+        action="store_true",
+        help="Apply the train script's quantize/dequantize path to the loaded checkpoint before evaluation.",
+    )
+    parser.add_argument(
+        "--tokenizer",
+        type=Path,
+        default=Path("data/tokenizers/fineweb_1024_bpe.model"),
+        help="SentencePiece tokenizer path.",
+    )
+    parser.add_argument(
+        "--val-files",
+        type=str,
+        default="data/datasets/fineweb10B_sp1024/fineweb_val_*.bin",
+        help="Glob for validation token shards.",
+    )
+    parser.add_argument("--device", type=str, default="cuda")
+    parser.add_argument("--max-tokens", type=int, default=1_048_576)
+    parser.add_argument(
+        "--start-token",
+        type=int,
+        default=0,
+        help="Approximate starting token offset within validation stream; subset is BOS-aligned.",
+    )
+    parser.add_argument("--seq-len", type=int, default=1024)
+    parser.add_argument("--stride", type=int, default=64)
+    parser.add_argument("--batch-seqs", type=int, default=64)
+    parser.add_argument(
+        "--mode",
+        choices=(
+            "flat_sliding",
+            "flat_cache_bigram_adaptive",
+            "flat_cache_bigram_adaptive_entropy",
+            "doc_sliding",
+            "doc_cache_bigram",
+            "doc_cache_bigram_adaptive",
+            "doc_cache_bigram_adaptive_entropy",
+            "doc_cache_trigram_backoff",
+            "doc_cache_unigram",
+        ),
+        default="doc_cache_bigram",
+    )
+    parser.add_argument("--alpha", type=float, default=0.03)
+    parser.add_argument(
+        "--alphas",
+        type=float,
+        nargs="*",
+        default=None,
+        help="Optional alpha sweep; overrides --alpha if provided.",
+    )
+    parser.add_argument(
+        "--tau",
+        type=float,
+        default=8.0,
+        help="Adaptive bigram pseudo-count temperature for doc_cache_bigram_adaptive.",
+    )
+    parser.add_argument(
+        "--trigram-alpha",
+        type=float,
+        default=0.02,
+        help="Trigram component weight for trigram backoff mode.",
+    )
+    parser.add_argument(
+        "--entropy-power",
+        type=float,
+        default=1.0,
+        help="Exponent for entropy-normalized gating in doc_cache_bigram_adaptive_entropy.",
+    )
+    parser.add_argument(
+        "--reset-cache-on-bos",
+        action="store_true",
+        help="For flat cache modes, reset cache counts whenever the previous token is BOS.",
+    )
+    parser.add_argument(
+        "--compile",
+        action="store_true",
+        help="Compile the forward logits function. Useful for larger runs.",
+    )
+    parser.add_argument(
+        "--ttt-epochs",
+        type=int,
+        default=0,
+        help="Optional number of test-time training epochs to run on the evaluation subset before scoring.",
+    )
+    parser.add_argument(
+        "--ttt-lr",
+        type=float,
+        default=1e-4,
+        help="Learning rate for optional test-time training.",
+    )
+    parser.add_argument(
+        "--ttt-batch-seqs",
+        type=int,
+        default=4,
+        help="Number of sequences per TTT optimizer step.",
+    )
+    return parser.parse_args()
+
+
+def find_docs(all_tokens: torch.Tensor, include_next_bos: bool = True) -> list[tuple[int, int]]:
+    bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0].cpu().numpy()
+    docs: list[tuple[int, int]] = []
+    for i in range(len(bos_positions)):
+        start = int(bos_positions[i])
+        end = int(bos_positions[i + 1]) if i + 1 < len(bos_positions) else int(all_tokens.numel())
+        if include_next_bos and i + 1 < len(bos_positions):
+            end += 1
+        if end - start >= 2:
+            docs.append((start, end - start))
+    return docs
+
+
+def load_train_module(train_script: Path) -> ModuleType:
+    path = train_script.resolve()
+    spec = importlib.util.spec_from_file_location(f"pg_train_{path.stem}", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def instantiate_model(train_mod: ModuleType, device: torch.device, seq_len: int) -> torch.nn.Module:
+    args = train_mod.Hyperparameters()
+    if hasattr(args, "train_seq_len"):
+        setattr(args, "train_seq_len", seq_len)
+
+    sig = inspect.signature(train_mod.GPT)
+    kwargs = {}
+    missing: list[str] = []
+    for name, param in sig.parameters.items():
+        if name == "self":
+            continue
+        if hasattr(args, name):
+            kwargs[name] = getattr(args, name)
+        elif param.default is inspect._empty:
+            missing.append(name)
+    if missing:
+        raise TypeError(f"Could not build GPT from {train_mod.__file__}; missing args: {missing}")
+
+    model = train_mod.GPT(**kwargs).to(device).bfloat16()
+    casted_linear_cls = getattr(train_mod, "CastedLinear", None)
+    if casted_linear_cls is not None:
+        for module in model.modules():
+            if isinstance(module, casted_linear_cls):
+                module.float()
+    if hasattr(train_mod, "restore_low_dim_params_to_fp32"):
+        train_mod.restore_low_dim_params_to_fp32(model)
+    return model
+
+
+def roundtrip_state(train_mod: ModuleType, state: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    sd_cpu = {k: v.detach().cpu() for k, v in state.items()}
+
+    if hasattr(train_mod, "mixed_quantize") and hasattr(train_mod, "dequantize_mixed"):
+        int6_cats = getattr(train_mod, "MIXED_QUANT_INT6_CATS", {"mlp", "attn"})
+        q_state, q_meta = train_mod.mixed_quantize(sd_cpu, int6_cats)
+        return train_mod.dequantize_mixed(q_state, q_meta, sd_cpu)
+
+    if hasattr(train_mod, "mixed_quantize_int6") and hasattr(train_mod, "dequantize_mixed_int6"):
+        q_state, q_meta = train_mod.mixed_quantize_int6(sd_cpu, {"mlp", "attn"})
+        return train_mod.dequantize_mixed_int6(q_state, q_meta, sd_cpu)
+
+    if hasattr(train_mod, "quantize_state_dict_int6") and hasattr(train_mod, "dequantize_state_dict"):
+        q_obj, _ = train_mod.quantize_state_dict_int6(sd_cpu)
+        return train_mod.dequantize_state_dict(q_obj)
+
+    if hasattr(train_mod, "quantize_state_dict_int8") and hasattr(train_mod, "dequantize_state_dict_int8"):
+        q_obj = train_mod.quantize_state_dict_int8(sd_cpu)
+        if isinstance(q_obj, tuple):
+            q_obj = q_obj[0]
+        return train_mod.dequantize_state_dict_int8(q_obj)
+
+    raise RuntimeError(f"Don't know how to roundtrip-quantize using {train_mod.__file__}")
+
+
+def load_checkpoint_state(args: argparse.Namespace, train_mod: ModuleType) -> dict[str, torch.Tensor]:
+    # Support direct evaluation of .ptz artifacts when the raw container matches recent record formats.
+    if args.checkpoint.suffix == ".ptz":
+        blob = args.checkpoint.read_bytes()
+        last_err = None
+        for decompress in (
+            (lambda b: zstandard.ZstdDecompressor().decompress(b)) if zstandard is not None else None,
+            lambda b: zlib.decompress(b),
+        ):
+            if decompress is None:
+                continue
+            try:
+                payload = torch.load(io.BytesIO(decompress(blob)), map_location="cpu")
+                if isinstance(payload, dict):
+                    if "w" in payload and "m" in payload:
+                        if hasattr(train_mod, "dequantize_mixed"):
+                            raise RuntimeError("Dequantizing .ptz directly needs a fp reference state; pass --checkpoint final_model.pt --quant-roundtrip instead.")
+                        if hasattr(train_mod, "dequantize_mixed_int6"):
+                            raise RuntimeError("Dequantizing .ptz directly needs a fp reference state; pass --checkpoint final_model.pt --quant-roundtrip instead.")
+                        if hasattr(train_mod, "dequantize_state_dict"):
+                            return train_mod.dequantize_state_dict(payload)
+                    return payload
+            except Exception as exc:  # noqa: BLE001
+                last_err = exc
+        raise RuntimeError(f"Unable to load .ptz checkpoint {args.checkpoint}: {last_err}")
+
+    state_obj = torch.load(args.checkpoint, map_location="cpu")
+    if not isinstance(state_obj, dict):
+        raise TypeError(f"Unsupported checkpoint object type: {type(state_obj)}")
+
+    state = state_obj
+    if args.quant_roundtrip:
+        state = roundtrip_state(train_mod, state)
+    return state
+
+
+def forward_logits_fallback(model: torch.nn.Module, input_ids: torch.Tensor) -> torch.Tensor:
+    x = model.tok_emb(input_ids)
+    if hasattr(model, "bigram") and model.bigram is not None:
+        x = x + model.bigram(input_ids)
+    if hasattr(model, "smear") and model.smear is not None:
+        x = model.smear(x)
+    x = F.rms_norm(x, (x.size(-1),))
+    x0 = x
+    skips: list[torch.Tensor] = []
+    for i in range(model.num_encoder_layers):
+        x = model.blocks[i](x, x0)
+        skips.append(x)
+    for i in range(model.num_decoder_layers):
+        if skips:
+            x = x + model.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+        x = model.blocks[model.num_encoder_layers + i](x, x0)
+    x = model.final_norm(x)
+    if model.tie_embeddings:
+        logits_proj = F.linear(x, model.tok_emb.weight)
+    else:
+        if model.lm_head is None:
+            raise RuntimeError("lm_head is required when tie_embeddings=False")
+        logits_proj = model.lm_head(x)
+    return model.logit_softcap * torch.tanh(logits_proj / model.logit_softcap)
+
+
+def forward_logits(model: torch.nn.Module, input_ids: torch.Tensor) -> torch.Tensor:
+    if hasattr(model, "forward_logits"):
+        return model.forward_logits(input_ids)
+    return forward_logits_fallback(model, input_ids)
+
+
+def load_validation_subset(
+    train_mod: ModuleType, pattern: str, seq_len: int, max_tokens: int | None, start_token: int
+) -> torch.Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    all_tokens = torch.cat([train_mod.load_data_shard(file) for file in files]).contiguous()
+    total_tokens = int(all_tokens.numel()) - 1
+    start = max(0, min(start_token, total_tokens))
+    end = int(all_tokens.numel())
+    if max_tokens is not None and max_tokens > 0:
+        end = min(start + max_tokens + 1, int(all_tokens.numel()))
+    if start > 0 or end < int(all_tokens.numel()):
+        bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0]
+        if start > 0:
+            i = int(torch.searchsorted(bos_positions, torch.tensor(start), right=False).item())
+            if i < bos_positions.numel():
+                start = int(bos_positions[i].item())
+            else:
+                start = int(bos_positions[-1].item())
+        if end < int(all_tokens.numel()):
+            j = int(torch.searchsorted(bos_positions, torch.tensor(end), right=False).item())
+            if j > 0:
+                end = int(bos_positions[j - 1].item()) + 1
+        if end <= start:
+            raise ValueError(f"Invalid BOS-aligned slice for start_token={start_token}, max_tokens={max_tokens}")
+        all_tokens = all_tokens[start:end].contiguous()
+    usable = all_tokens.numel() - 1
+    if usable <= 0:
+        raise ValueError("Validation subset has no predictible tokens.")
+    if usable < seq_len:
+        return all_tokens
+    return all_tokens
+
+
+def build_metric_luts(
+    train_mod: ModuleType, tokenizer_path: Path, vocab_size: int, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    sp = spm.SentencePieceProcessor(model_file=str(tokenizer_path))
+    return train_mod.build_sentencepiece_luts(sp, vocab_size, device)
+
+
+def run_ttt(
+    model: torch.nn.Module,
+    val_tokens: torch.Tensor,
+    seq_len: int,
+    epochs: int,
+    lr: float,
+    batch_seqs: int,
+    device: torch.device,
+) -> None:
+    if epochs <= 0:
+        return
+    total_pred = int(val_tokens.numel()) - 1
+    total_seqs = total_pred // seq_len
+    if total_seqs <= 0:
+        print("ttt skipped: subset shorter than one sequence")
+        return
+
+    model.train()
+    params = [p for p in model.parameters() if p.requires_grad]
+    opt = torch.optim.SGD(params, lr=lr)
+    tic = time.perf_counter()
+    print(f"ttt start epochs={epochs} lr={lr} batch_seqs={batch_seqs} total_seqs={total_seqs}", flush=True)
+    for ep in range(epochs):
+        loss_sum = 0.0
+        count = 0
+        for si in range(0, total_seqs, batch_seqs):
+            se = min(si + batch_seqs, total_seqs)
+            bsz = se - si
+            rs = si * seq_len
+            re = se * seq_len + 1
+            local = val_tokens[rs:re].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(bsz, seq_len)
+            y = local[1:].reshape(bsz, seq_len)
+            opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                loss = model(x, y)
+            loss.backward()
+            opt.step()
+            loss_sum += float(loss.item()) * bsz
+            count += bsz
+        print(f"ttt epoch={ep + 1}/{epochs} loss={loss_sum / max(count, 1):.6f}", flush=True)
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+    print(f"ttt_time_sec={time.perf_counter() - tic:.3f}", flush=True)
+    model.eval()
+
+
+def iter_unique_windows(pred_len: int, seq_len: int, stride: int) -> Iterable[tuple[int, int, int]]:
+    if pred_len <= 0:
+        return
+    first_end = min(seq_len, pred_len)
+    yield 0, first_end, 0
+    scored_end = first_end
+    while scored_end < pred_len:
+        next_end = min(scored_end + stride, pred_len)
+        ws = max(0, next_end - seq_len)
+        wlen = next_end - ws
+        score_from = scored_end - ws
+        yield ws, wlen, score_from
+        scored_end = next_end
+
+
+def iter_flat_windows(total_tokens: int, seq_len: int, stride: int) -> Iterable[tuple[int, int, int]]:
+    yield from iter_unique_windows(total_tokens, seq_len, stride)
+
+
+def iter_doc_windows(doc_len: int, seq_len: int, stride: int) -> Iterable[tuple[int, int, int]]:
+    yield from iter_unique_windows(doc_len - 1, seq_len, stride)
+
+
+def gather_doc_scores(
+    model: torch.nn.Module,
+    val_tokens: torch.Tensor,
+    docs: list[tuple[int, int]],
+    seq_len: int,
+    stride: int,
+    batch_seqs: int,
+    device: torch.device,
+    compile_model: bool,
+) -> list[dict[str, np.ndarray]]:
+    run_forward = forward_logits
+    if compile_model:
+        run_forward = torch.compile(run_forward, dynamic=False, fullgraph=False)
+
+    doc_windows: list[tuple[int, int, int, int, int]] = []
+    for doc_id, (doc_start, doc_len) in enumerate(docs):
+        for rel_ws, wlen, score_from in iter_doc_windows(doc_len, seq_len, stride):
+            doc_windows.append((doc_id, doc_start, doc_len, rel_ws, score_from))
+
+    doc_bases: list[list[torch.Tensor]] = [[] for _ in docs]
+    doc_prevs: list[list[torch.Tensor]] = [[] for _ in docs]
+    doc_tgts: list[list[torch.Tensor]] = [[] for _ in docs]
+    doc_entropy: list[list[torch.Tensor]] = [[] for _ in docs]
+
+    model.eval()
+    tic = time.perf_counter()
+    with torch.inference_mode():
+        for bi in range(0, len(doc_windows), batch_seqs):
+            batch = doc_windows[bi : bi + batch_seqs]
+            max_wlen = 0
+            for _, _, doc_len, rel_ws, _ in batch:
+                pred_len = doc_len - 1
+                max_wlen = max(max_wlen, min(seq_len, pred_len - rel_ws))
+            x_batch = torch.zeros(len(batch), max_wlen, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(len(batch), max_wlen, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, (_, doc_start, doc_len, rel_ws, _) in enumerate(batch):
+                pred_len = doc_len - 1
+                wlen = min(seq_len, pred_len - rel_ws)
+                toks = val_tokens[doc_start + rel_ws : doc_start + rel_ws + wlen + 1]
+                wlens.append(wlen)
+                x_batch[i, :wlen] = toks[:-1].to(device=device, dtype=torch.int64)
+                y_batch[i, :wlen] = toks[1:].to(device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = run_forward(model, x_batch)
+            log_probs = F.log_softmax(logits.float(), dim=-1)
+            entropy = -(log_probs.exp() * log_probs).sum(dim=-1)
+            for i, (doc_id, _, _, _, score_from) in enumerate(batch):
+                wlen = wlens[i]
+                prev = x_batch[i, score_from:wlen].detach().cpu()
+                tgt = y_batch[i, score_from:wlen].detach().cpu()
+                lp = log_probs[i, score_from:wlen].gather(1, tgt[:, None].to(device=log_probs.device)).squeeze(1).detach().cpu()
+                ent = entropy[i, score_from:wlen].detach().cpu()
+                doc_prevs[doc_id].append(prev)
+                doc_tgts[doc_id].append(tgt)
+                doc_bases[doc_id].append(lp)
+                doc_entropy[doc_id].append(ent)
+            if (bi // batch_seqs) % 50 == 0:
+                done = min(bi + batch_seqs, len(doc_windows))
+                pct = 100.0 * done / max(len(doc_windows), 1)
+                print(f"gather [{pct:5.1f}%] {done}/{len(doc_windows)} windows", flush=True)
+
+    elapsed = time.perf_counter() - tic
+    print(f"gather_time_sec={elapsed:.3f}")
+
+    results: list[dict[str, np.ndarray]] = []
+    for doc_id, (doc_start, doc_len) in enumerate(docs):
+        prev = torch.cat(doc_prevs[doc_id]).numpy()
+        tgt = torch.cat(doc_tgts[doc_id]).numpy()
+        base = torch.cat(doc_bases[doc_id]).numpy()
+        ent = torch.cat(doc_entropy[doc_id]).numpy()
+        if prev.shape[0] != doc_len - 1:
+            raise RuntimeError(f"Doc {doc_id} expected {doc_len - 1} tokens, got {prev.shape[0]}")
+        results.append({"start": np.int64(doc_start), "prev": prev, "tgt": tgt, "base_logp": base, "entropy": ent})
+    return results
+
+
+def gather_flat_scores(
+    model: torch.nn.Module,
+    val_tokens: torch.Tensor,
+    seq_len: int,
+    stride: int,
+    batch_seqs: int,
+    device: torch.device,
+    compile_model: bool,
+) -> dict[str, np.ndarray]:
+    run_forward = forward_logits
+    if compile_model:
+        run_forward = torch.compile(run_forward, dynamic=False, fullgraph=False)
+
+    windows = list(iter_flat_windows(int(val_tokens.numel()) - 1, seq_len, stride))
+    prev_parts: list[torch.Tensor] = []
+    tgt_parts: list[torch.Tensor] = []
+    base_parts: list[torch.Tensor] = []
+    entropy_parts: list[torch.Tensor] = []
+
+    model.eval()
+    tic = time.perf_counter()
+    with torch.inference_mode():
+        for bi in range(0, len(windows), batch_seqs):
+            batch = windows[bi : bi + batch_seqs]
+            max_wlen = max(wlen for _, wlen, _ in batch)
+            x_batch = torch.zeros(len(batch), max_wlen, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(len(batch), max_wlen, dtype=torch.int64, device=device)
+            for i, (ws, wlen, _) in enumerate(batch):
+                toks = val_tokens[ws : ws + wlen + 1]
+                x_batch[i, :wlen] = toks[:-1].to(device=device, dtype=torch.int64)
+                y_batch[i, :wlen] = toks[1:].to(device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = run_forward(model, x_batch)
+            log_probs = F.log_softmax(logits.float(), dim=-1)
+            entropy = -(log_probs.exp() * log_probs).sum(dim=-1)
+            for i, (_, wlen, score_from) in enumerate(batch):
+                prev = x_batch[i, score_from:wlen].detach().cpu()
+                tgt = y_batch[i, score_from:wlen].detach().cpu()
+                lp = log_probs[i, score_from:wlen].gather(1, tgt[:, None].to(device=log_probs.device)).squeeze(1).detach().cpu()
+                ent = entropy[i, score_from:wlen].detach().cpu()
+                prev_parts.append(prev)
+                tgt_parts.append(tgt)
+                base_parts.append(lp)
+                entropy_parts.append(ent)
+            if (bi // batch_seqs) % 50 == 0:
+                done = min(bi + batch_seqs, len(windows))
+                pct = 100.0 * done / max(len(windows), 1)
+                print(f"gather_flat [{pct:5.1f}%] {done}/{len(windows)} windows", flush=True)
+
+    elapsed = time.perf_counter() - tic
+    print(f"gather_flat_time_sec={elapsed:.3f}")
+    prev = torch.cat(prev_parts).numpy()
+    tgt = torch.cat(tgt_parts).numpy()
+    base = torch.cat(base_parts).numpy()
+    ent = torch.cat(entropy_parts).numpy()
+    expected = int(val_tokens.numel()) - 1
+    if prev.shape[0] != expected:
+        raise RuntimeError(f"Flat gather expected {expected} tokens, got {prev.shape[0]}")
+    return {"prev": prev, "tgt": tgt, "base_logp": base, "entropy": ent}
+
+
+def eval_flat_sliding(
+    model: torch.nn.Module,
+    val_tokens: torch.Tensor,
+    seq_len: int,
+    stride: int,
+    batch_seqs: int,
+    device: torch.device,
+    compile_model: bool,
+    base_bytes_lut: torch.Tensor,
+    has_leading_space_lut: torch.Tensor,
+    is_boundary_token_lut: torch.Tensor,
+) -> tuple[float, float]:
+    run_forward = forward_logits
+    if compile_model:
+        run_forward = torch.compile(run_forward, dynamic=False, fullgraph=False)
+
+    windows = list(iter_flat_windows(int(val_tokens.numel()) - 1, seq_len, stride))
+    loss_sum = 0.0
+    token_count = 0
+    byte_count = 0.0
+    tic = time.perf_counter()
+    model.eval()
+    with torch.inference_mode():
+        for bi in range(0, len(windows), batch_seqs):
+            batch = windows[bi : bi + batch_seqs]
+            max_wlen = max(wlen for _, wlen, _ in batch)
+            x_batch = torch.zeros(len(batch), max_wlen, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(len(batch), max_wlen, dtype=torch.int64, device=device)
+            for i, (ws, wlen, _) in enumerate(batch):
+                toks = val_tokens[ws : ws + wlen + 1]
+                x_batch[i, :wlen] = toks[:-1].to(device=device, dtype=torch.int64)
+                y_batch[i, :wlen] = toks[1:].to(device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = run_forward(model, x_batch)
+            log_probs = F.log_softmax(logits.float(), dim=-1)
+            for i, (_, wlen, score_from) in enumerate(batch):
+                prev = x_batch[i, score_from:wlen]
+                tgt = y_batch[i, score_from:wlen]
+                lp = log_probs[i, score_from:wlen].gather(1, tgt[:, None]).squeeze(1)
+                loss_sum += float((-lp).sum().item())
+                token_count += int(tgt.numel())
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += float(tb.sum().item())
+            if (bi // batch_seqs) % 50 == 0:
+                done = min(bi + batch_seqs, len(windows))
+                pct = 100.0 * done / max(len(windows), 1)
+                running_bpb = (loss_sum / math.log(2.0)) / byte_count if byte_count else 0.0
+                print(f"flat [{pct:5.1f}%] {done}/{len(windows)} running_bpb={running_bpb:.6f}", flush=True)
+    elapsed = time.perf_counter() - tic
+    print(f"flat_time_sec={elapsed:.3f}")
+    val_loss = loss_sum / token_count
+    val_bpb = (loss_sum / math.log(2.0)) / byte_count
+    return val_loss, val_bpb
+
+
+def score_flat_cache(
+    flat_scores: dict[str, np.ndarray],
+    base_bytes_lut: torch.Tensor,
+    has_leading_space_lut: torch.Tensor,
+    is_boundary_token_lut: torch.Tensor,
+    mode: str,
+    alpha: float,
+    tau: float,
+    entropy_power: float,
+    reset_on_bos: bool,
+) -> tuple[float, float]:
+    base_bytes_np = base_bytes_lut.cpu().numpy().astype(np.int64)
+    has_space_np = has_leading_space_lut.cpu().numpy().astype(np.bool_)
+    is_boundary_np = is_boundary_token_lut.cpu().numpy().astype(np.bool_)
+    vocab_size = base_bytes_np.shape[0]
+
+    prev = flat_scores["prev"].astype(np.int64, copy=False)
+    tgt = flat_scores["tgt"].astype(np.int64, copy=False)
+    base_logp = flat_scores["base_logp"].astype(np.float64, copy=False)
+    entropy = flat_scores["entropy"].astype(np.float64, copy=False)
+    base_prob = np.exp(base_logp)
+
+    row_totals = np.zeros(vocab_size, dtype=np.int32)
+    counts = np.zeros((vocab_size, vocab_size), dtype=np.uint16)
+    touched_pairs: list[tuple[int, int]] = []
+    touched_rows: list[int] = []
+
+    total_loss = 0.0
+    max_entropy = math.log(vocab_size)
+    tic = time.perf_counter()
+    for i in range(len(tgt)):
+        p = int(prev[i])
+        y = int(tgt[i])
+        if reset_on_bos and p == BOS_ID:
+            for rp, ry in touched_pairs:
+                counts[rp, ry] = 0
+            for rp in touched_rows:
+                row_totals[rp] = 0
+            touched_pairs.clear()
+            touched_rows.clear()
+
+        total = int(row_totals[p])
+        seen = int(counts[p, y])
+        cache_p = (seen / total) if total > 0 else 0.0
+
+        eff_alpha = alpha
+        if mode in {"flat_cache_bigram_adaptive", "flat_cache_bigram_adaptive_entropy"}:
+            eff_alpha = alpha * (total / (total + tau)) if total > 0 else 0.0
+        if mode == "flat_cache_bigram_adaptive_entropy":
+            ent_scale = max(float(entropy[i]) / max_entropy, 0.0)
+            eff_alpha *= ent_scale ** entropy_power
+
+        mix_p = (1.0 - eff_alpha) * float(base_prob[i]) + eff_alpha * cache_p
+        total_loss += -math.log(max(mix_p, 1e-30))
+
+        if total == 0:
+            touched_rows.append(p)
+        if seen == 0:
+            touched_pairs.append((p, y))
+        counts[p, y] = min(seen + 1, np.iinfo(np.uint16).max)
+        row_totals[p] = total + 1
+
+        if i % 200000 == 0:
+            token_bytes_so_far = base_bytes_np[tgt[: i + 1]]
+            token_bytes_so_far = token_bytes_so_far + np.logical_and(
+                has_space_np[tgt[: i + 1]], np.logical_not(is_boundary_np[prev[: i + 1]])
+            ).astype(np.int64)
+            running_bpb = (total_loss / math.log(2.0)) / float(token_bytes_so_far.sum())
+            print(f"flat_cache tok={i}/{len(tgt)} running_bpb={running_bpb:.6f}", flush=True)
+
+    elapsed = time.perf_counter() - tic
+    print(f"flat_cache_time_sec={elapsed:.3f}")
+    tb = base_bytes_np[tgt]
+    tb = tb + np.logical_and(has_space_np[tgt], np.logical_not(is_boundary_np[prev])).astype(np.int64)
+    total_bytes = float(tb.sum())
+    total_tokens = int(len(tgt))
+    val_loss = total_loss / total_tokens
+    val_bpb = (total_loss / math.log(2.0)) / total_bytes
+    return val_loss, val_bpb
+
+
+def score_doc_cache(
+    doc_scores: list[dict[str, np.ndarray]],
+    base_bytes_lut: torch.Tensor,
+    has_leading_space_lut: torch.Tensor,
+    is_boundary_token_lut: torch.Tensor,
+    mode: str,
+    alpha: float,
+    tau: float,
+    trigram_alpha: float,
+    entropy_power: float,
+) -> tuple[float, float]:
+    base_bytes_np = base_bytes_lut.cpu().numpy().astype(np.int64)
+    has_space_np = has_leading_space_lut.cpu().numpy().astype(np.bool_)
+    is_boundary_np = is_boundary_token_lut.cpu().numpy().astype(np.bool_)
+    vocab_size = base_bytes_np.shape[0]
+
+    total_loss = 0.0
+    total_bytes = 0.0
+    total_tokens = 0
+
+    tic = time.perf_counter()
+    for doc_idx, doc in enumerate(doc_scores):
+        prev = doc["prev"].astype(np.int64, copy=False)
+        tgt = doc["tgt"].astype(np.int64, copy=False)
+        base_logp = doc["base_logp"].astype(np.float64, copy=False)
+        base_prob = np.exp(base_logp)
+        entropy = doc["entropy"].astype(np.float64, copy=False)
+
+        if mode == "doc_sliding":
+            total_loss += float((-base_logp).sum())
+        elif mode == "doc_cache_unigram":
+            unigram_total = 0
+            unigram = {}
+            losses = []
+            for i in range(len(tgt)):
+                y = int(tgt[i])
+                cache_p = unigram.get(y, 0) / unigram_total if unigram_total > 0 else 0.0
+                mix_p = (1.0 - alpha) * float(base_prob[i]) + alpha * cache_p
+                losses.append(-math.log(max(mix_p, 1e-30)))
+                unigram[y] = unigram.get(y, 0) + 1
+                unigram_total += 1
+            total_loss += float(sum(losses))
+        elif mode in {"doc_cache_bigram", "doc_cache_bigram_adaptive", "doc_cache_bigram_adaptive_entropy"}:
+            row_totals = np.zeros(vocab_size, dtype=np.int32)
+            counts = np.zeros((vocab_size, vocab_size), dtype=np.uint16)
+            touched_pairs: list[tuple[int, int]] = []
+            touched_rows: list[int] = []
+            doc_loss = 0.0
+            max_entropy = math.log(vocab_size)
+            for i in range(len(tgt)):
+                p = int(prev[i])
+                y = int(tgt[i])
+                total = int(row_totals[p])
+                seen = int(counts[p, y])
+                cache_p = (seen / total) if total > 0 else 0.0
+                eff_alpha = alpha
+                if mode in {"doc_cache_bigram_adaptive", "doc_cache_bigram_adaptive_entropy"}:
+                    eff_alpha = alpha * (total / (total + tau)) if total > 0 else 0.0
+                if mode == "doc_cache_bigram_adaptive_entropy":
+                    ent_scale = max(float(entropy[i]) / max_entropy, 0.0)
+                    eff_alpha *= ent_scale ** entropy_power
+                mix_p = (1.0 - eff_alpha) * float(base_prob[i]) + eff_alpha * cache_p
+                doc_loss += -math.log(max(mix_p, 1e-30))
+                if total == 0:
+                    touched_rows.append(p)
+                if seen == 0:
+                    touched_pairs.append((p, y))
+                counts[p, y] = min(seen + 1, np.iinfo(np.uint16).max)
+                row_totals[p] = total + 1
+            for p, y in touched_pairs:
+                counts[p, y] = 0
+            for p in touched_rows:
+                row_totals[p] = 0
+            total_loss += doc_loss
+        elif mode == "doc_cache_trigram_backoff":
+            unigram_total = 0
+            unigram: dict[int, int] = {}
+            bigram_total: dict[int, int] = {}
+            bigram: dict[tuple[int, int], int] = {}
+            trigram_total: dict[tuple[int, int], int] = {}
+            trigram: dict[tuple[int, int, int], int] = {}
+            doc_loss = 0.0
+            prev2 = BOS_ID
+            for i in range(len(tgt)):
+                p1 = int(prev[i])
+                y = int(tgt[i])
+                uni_p = unigram.get(y, 0) / unigram_total if unigram_total > 0 else 0.0
+                bi_total = bigram_total.get(p1, 0)
+                bi_p = bigram.get((p1, y), 0) / bi_total if bi_total > 0 else 0.0
+                tri_total = trigram_total.get((prev2, p1), 0)
+                tri_p = trigram.get((prev2, p1, y), 0) / tri_total if tri_total > 0 else 0.0
+                backoff_p = 0.5 * bi_p + 0.5 * uni_p
+                cache_p = trigram_alpha * tri_p + (1.0 - trigram_alpha) * backoff_p
+                mix_p = (1.0 - alpha) * float(base_prob[i]) + alpha * cache_p
+                doc_loss += -math.log(max(mix_p, 1e-30))
+                unigram[y] = unigram.get(y, 0) + 1
+                unigram_total += 1
+                bigram[(p1, y)] = bigram.get((p1, y), 0) + 1
+                bigram_total[p1] = bi_total + 1
+                trigram[(prev2, p1, y)] = trigram.get((prev2, p1, y), 0) + 1
+                trigram_total[(prev2, p1)] = tri_total + 1
+                prev2 = p1
+            total_loss += doc_loss
+        else:
+            raise ValueError(f"Unsupported mode: {mode}")
+
+        tb = base_bytes_np[tgt]
+        tb = tb + np.logical_and(has_space_np[tgt], np.logical_not(is_boundary_np[prev])).astype(np.int64)
+        total_bytes += float(tb.sum())
+        total_tokens += int(len(tgt))
+
+        if doc_idx % 2000 == 0:
+            running_bpb = (total_loss / math.log(2.0)) / total_bytes if total_bytes else 0.0
+            print(f"cache doc={doc_idx}/{len(doc_scores)} running_bpb={running_bpb:.6f}", flush=True)
+
+    elapsed = time.perf_counter() - tic
+    print(f"cache_time_sec={elapsed:.3f}")
+    val_loss = total_loss / total_tokens
+    val_bpb = (total_loss / math.log(2.0)) / total_bytes
+    return val_loss, val_bpb
+
+
+def main() -> None:
+    args = parse_args()
+    if args.device.startswith("cuda") and not torch.cuda.is_available():
+        raise RuntimeError("CUDA requested but not available.")
+    device = torch.device(args.device)
+
+    train_mod = load_train_module(args.train_script)
+    val_tokens = load_validation_subset(train_mod, args.val_files, args.seq_len, args.max_tokens, args.start_token)
+    docs = find_docs(val_tokens)
+    print(f"val_tokens={val_tokens.numel()} docs={len(docs)} seq_len={args.seq_len} stride={args.stride}")
+
+    model = instantiate_model(train_mod, device, args.seq_len)
+    state = load_checkpoint_state(args, train_mod)
+    model.load_state_dict(state, strict=True)
+    model.eval()
+
+    run_ttt(
+        model,
+        val_tokens,
+        args.seq_len,
+        args.ttt_epochs,
+        args.ttt_lr,
+        args.ttt_batch_seqs,
+        device,
+    )
+
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_metric_luts(
+        train_mod, args.tokenizer, model.tok_emb.num_embeddings, device
+    )
+
+    if args.mode == "flat_sliding":
+        val_loss, val_bpb = eval_flat_sliding(
+            model,
+            val_tokens,
+            args.seq_len,
+            args.stride,
+            args.batch_seqs,
+            device,
+            args.compile,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+        )
+        print(f"mode={args.mode} val_loss={val_loss:.8f} val_bpb={val_bpb:.8f}")
+        return
+
+    if args.mode in {"flat_cache_bigram_adaptive", "flat_cache_bigram_adaptive_entropy"}:
+        flat_scores = gather_flat_scores(
+            model,
+            val_tokens,
+            args.seq_len,
+            args.stride,
+            args.batch_seqs,
+            device,
+            args.compile,
+        )
+        alphas = args.alphas if args.alphas else [args.alpha]
+        for alpha in alphas:
+            val_loss, val_bpb = score_flat_cache(
+                flat_scores,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+                args.mode,
+                alpha,
+                args.tau,
+                args.entropy_power,
+                reset_on_bos=args.reset_cache_on_bos,
+            )
+            print(
+                f"mode={args.mode} alpha={alpha:.6f} tau={args.tau:.4f} trigram_alpha={args.trigram_alpha:.4f} entropy_power={args.entropy_power:.4f} reset_cache_on_bos={args.reset_cache_on_bos} "
+                f"val_loss={val_loss:.8f} val_bpb={val_bpb:.8f}"
+            )
+        return
+
+    doc_scores = gather_doc_scores(
+        model,
+        val_tokens,
+        docs,
+        args.seq_len,
+        args.stride,
+        args.batch_seqs,
+        device,
+        args.compile,
+    )
+
+    alphas = args.alphas if args.alphas else [args.alpha]
+    for alpha in alphas:
+        val_loss, val_bpb = score_doc_cache(
+            doc_scores,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            args.mode,
+            alpha,
+            args.tau,
+            args.trigram_alpha,
+            args.entropy_power,
+        )
+        print(
+            f"mode={args.mode} alpha={alpha:.6f} tau={args.tau:.4f} trigram_alpha={args.trigram_alpha:.4f} entropy_power={args.entropy_power:.4f} "
+            f"val_loss={val_loss:.8f} val_bpb={val_bpb:.8f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/research/verify_domv2_cache.py
+++ b/research/verify_domv2_cache.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import copy
+import random
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import final.dominationv2_cache.train_gpt as ft
+import research.eval_doc_cache as re
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Verify DominationV2 cache evaluator parity and sharding.")
+    parser.add_argument("--device", type=str, default="cuda")
+    return parser.parse_args()
+
+
+def make_model(device: torch.device, seed: int, vocab_size: int) -> torch.nn.Module:
+    torch.manual_seed(seed)
+    model = ft.GPT(
+        vocab_size=vocab_size,
+        num_layers=4,
+        model_dim=64,
+        num_heads=4,
+        num_kv_heads=2,
+        mlp_mult=2,
+        tie_embeddings=True,
+        tied_embed_init_std=0.02,
+        logit_softcap=30.0,
+        rope_base=10000.0,
+        qk_gain_init=1.5,
+        bigram_vocab_size=64,
+        bigram_dim=16,
+        xsa_last_n=1,
+    ).to(device).bfloat16()
+    for module in model.modules():
+        if isinstance(module, ft.CastedLinear):
+            module.float()
+    ft.restore_low_dim_params_to_fp32(model)
+    model.eval()
+    return model
+
+
+def make_tokens(seed: int, vocab_size: int, num_docs: int) -> torch.Tensor:
+    rng = random.Random(seed)
+    toks = []
+    for _ in range(num_docs):
+        doc_len = rng.randint(5, 31)
+        toks.append(ft.BOS_ID)
+        for _ in range(doc_len - 1):
+            tok = rng.randrange(vocab_size)
+            while tok == ft.BOS_ID:
+                tok = rng.randrange(vocab_size)
+            toks.append(tok)
+    toks.append(ft.BOS_ID)
+    return torch.tensor(toks, dtype=torch.int64)
+
+
+def make_metric_luts(vocab_size: int, device: torch.device) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return (
+        torch.ones(vocab_size, dtype=torch.int16, device=device),
+        torch.zeros(vocab_size, dtype=torch.bool, device=device),
+        torch.zeros(vocab_size, dtype=torch.bool, device=device),
+    )
+
+
+def verify_single_rank(device: torch.device) -> None:
+    for seed in range(3):
+        vocab_size = 32
+        model = make_model(device, seed, vocab_size)
+        val_tokens = make_tokens(seed, vocab_size, num_docs=12)
+        docs = ft.find_docs(val_tokens)
+        args = SimpleNamespace(train_seq_len=16, cache_enabled=True, cache_alpha=0.2, cache_tau=8.0, cache_entropy_power=1.0)
+        base_bytes_lut, has_space_lut, boundary_lut = make_metric_luts(vocab_size, device)
+
+        cache_loss, cache_bpb = ft.eval_val_sliding_cache(
+            args, model, 0, 1, device, val_tokens, docs, base_bytes_lut, has_space_lut, boundary_lut, stride=4, batch_seqs=8
+        )
+        flat_scores = re.gather_flat_scores(
+            model, val_tokens, seq_len=16, stride=4, batch_seqs=8, device=device, compile_model=False
+        )
+        ref_cache_loss, ref_cache_bpb = re.score_flat_cache(
+            flat_scores,
+            base_bytes_lut,
+            has_space_lut,
+            boundary_lut,
+            mode="flat_cache_bigram_adaptive_entropy",
+            alpha=0.2,
+            tau=8.0,
+            entropy_power=1.0,
+            reset_on_bos=True,
+        )
+        if abs(cache_loss - ref_cache_loss) >= 1e-7 or abs(cache_bpb - ref_cache_bpb) >= 1e-7:
+            raise AssertionError(
+                f"cache parity failed for seed={seed}: "
+                f"{cache_loss=} {ref_cache_loss=} {cache_bpb=} {ref_cache_bpb=}"
+            )
+
+        base_loss, base_bpb = ft.eval_val_sliding(
+            args, model, 0, 1, device, val_tokens, base_bytes_lut, has_space_lut, boundary_lut, stride=4, batch_seqs=8
+        )
+        ref_base_loss, ref_base_bpb = re.eval_flat_sliding(
+            model,
+            val_tokens,
+            seq_len=16,
+            stride=4,
+            batch_seqs=8,
+            device=device,
+            compile_model=False,
+            base_bytes_lut=base_bytes_lut,
+            has_leading_space_lut=has_space_lut,
+            is_boundary_token_lut=boundary_lut,
+        )
+        if abs(base_loss - ref_base_loss) >= 1e-7 or abs(base_bpb - ref_base_bpb) >= 1e-7:
+            raise AssertionError(
+                f"base parity failed for seed={seed}: "
+                f"{base_loss=} {ref_base_loss=} {base_bpb=} {ref_base_bpb=}"
+            )
+    print("single-rank parity: OK")
+
+
+def verify_multi_rank(device: torch.device) -> None:
+    vocab_size = 40
+    model = make_model(device, 0, vocab_size)
+    val_tokens = make_tokens(7, vocab_size, num_docs=17)
+    docs = ft.find_docs(val_tokens)
+    args = SimpleNamespace(train_seq_len=16, cache_enabled=True, cache_alpha=0.2, cache_tau=8.0, cache_entropy_power=1.0)
+    base_bytes_lut, has_space_lut, boundary_lut = make_metric_luts(vocab_size, device)
+    single_loss, single_bpb = ft.eval_val_sliding_cache(
+        args, model, 0, 1, device, val_tokens, docs, base_bytes_lut, has_space_lut, boundary_lut, stride=4, batch_seqs=8
+    )
+    total_tokens = sum(doc_len - 1 for _, doc_len in docs)
+
+    for world_size in (2, 3, 8, 32):
+        agg_loss = 0.0
+        agg_bpb = 0.0
+        seen_tokens = 0
+        for rank in range(world_size):
+            shard = ft.shard_docs_by_tokens(docs, rank, world_size)
+            shard_tokens = sum(doc_len - 1 for _, doc_len in shard)
+            if shard_tokens == 0:
+                continue
+            loss_i, bpb_i = ft.eval_val_sliding_cache(
+                args, model, rank, world_size, device, val_tokens, docs, base_bytes_lut, has_space_lut, boundary_lut, stride=4, batch_seqs=8
+            )
+            agg_loss += loss_i * shard_tokens
+            agg_bpb += bpb_i * shard_tokens
+            seen_tokens += shard_tokens
+        agg_loss /= seen_tokens
+        agg_bpb /= seen_tokens
+        if seen_tokens != total_tokens or abs(agg_loss - single_loss) >= 1e-7 or abs(agg_bpb - single_bpb) >= 1e-7:
+            raise AssertionError(
+                f"multi-rank aggregation failed for world_size={world_size}: "
+                f"{seen_tokens=} {total_tokens=} {agg_loss=} {single_loss=} {agg_bpb=} {single_bpb=}"
+            )
+    print("multi-rank aggregation: OK")
+
+
+def verify_ttt_equivalence(device: torch.device) -> None:
+    def run_final_style_ttt(model: torch.nn.Module, val_tokens: torch.Tensor, seq_len: int, epochs: int, lr: float, batch_seqs: int) -> None:
+        model.train()
+        ttt_params = [p for p in model.parameters() if p.requires_grad]
+        ttt_opt = torch.optim.SGD(ttt_params, lr=lr)
+        total_val = val_tokens.numel() - 1
+        total_seqs = total_val // seq_len
+        for _ in range(epochs):
+            for si in range(0, total_seqs, batch_seqs):
+                se = min(si + batch_seqs, total_seqs)
+                bsz = se - si
+                rs = si * seq_len
+                re_idx = se * seq_len + 1
+                local = val_tokens[rs:re_idx].to(device=device, dtype=torch.int64)
+                x = local[:-1].reshape(bsz, seq_len)
+                y = local[1:].reshape(bsz, seq_len)
+                ttt_opt.zero_grad()
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    loss = model(x, y)
+                loss.backward()
+                ttt_opt.step()
+        model.eval()
+
+    vocab_size = 32
+    base = make_model(device, 0, vocab_size)
+    val_tokens = make_tokens(11, vocab_size, num_docs=10)
+    model_a = copy.deepcopy(base)
+    model_b = copy.deepcopy(base)
+    re.run_ttt(model_a, val_tokens, seq_len=16, epochs=3, lr=1e-4, batch_seqs=4, device=device)
+    run_final_style_ttt(model_b, val_tokens, seq_len=16, epochs=3, lr=1e-4, batch_seqs=4)
+    max_diff = 0.0
+    for (_, pa), (_, pb) in zip(model_a.state_dict().items(), model_b.state_dict().items(), strict=True):
+        max_diff = max(max_diff, (pa.float() - pb.float()).abs().max().item())
+    if max_diff != 0.0:
+        raise AssertionError(f"TTT equivalence failed: max_diff={max_diff}")
+    print("TTT loop equivalence: OK")
+
+
+def main() -> None:
+    args = parse_args()
+    device = torch.device(args.device)
+    if device.type == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("CUDA requested but not available.")
+    verify_single_rank(device)
+    verify_multi_rank(device)
+    verify_ttt_equivalence(device)
+    print("all checks passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This draft packages the current best candidate as a clean handoff under `/final`.

The core method keeps the upstream `DominationV2` training and export stack and adds one evaluation-only change: after the quantized roundtrip and optional TTT, the final validation pass uses flat sliding-window scoring with a BOS-reset entropy-gated adaptive bigram cache.

In other words, this PR is not claiming an already-verified record submission. It packages the current best next bet in a form that is clean enough to hand off, rerun on 8xH100, and either promote into `records/` or kill quickly.

## Why This Approach Matters

- It optimizes the actual challenge objective rather than just the training recipe: final `val_bpb` after quant roundtrip, optional TTT, and evaluation-time scoring.
- The cache still helps after TTT on a strong 1xH100 proxy checkpoint, so it is not just a pre-TTT artifact.
- The integrated evaluator is more trustworthy now than it was before this pass because two real correctness issues were found and fixed before finalization:
  - the sliding-window schedule now matches the research evaluator
  - multi-rank document sharding is now non-overlapping

## What Changed

- Added `final/dominationv2_cache/train_gpt.py`
  - packaged candidate training, export, quant-roundtrip, optional TTT, and final evaluation
- Added `final/dominationv2_cache/train_8xH100.sh`
  - intended 8xH100 launcher with the current default cache and TTT settings
- Added `final/dominationv2_cache/eval_checkpoint.py`
  - wrapper for probing checkpoints through the research evaluator
- Added `research/eval_doc_cache.py`
  - research evaluator used for cache experiments and parity checks
- Added `research/verify_domv2_cache.py`
  - local verifier for evaluator parity, multi-rank aggregation, and TTT-loop equivalence in the world-size-1 subset setting used for the H100 probes
- Rewrote `/final` documentation into a minimal operator handoff

## What Was Tried In The Final Decision Pass

- Audited the integrated final evaluator instead of trusting the earlier H100 probes blindly.
- Re-ran local implementation checks on the 4080 until the integrated path matched the research path exactly where it should.
- Ran one last narrow replacement search rather than reopening broad exploration. A smoothed bigram plus unigram-backoff cache variant was worse than the current cache on the local proxy checkpoint and was not promoted.

## Verified Locally

The following is experimentally demonstrated on the local 4080 path:

- exact single-rank parity between the integrated final evaluator and the research evaluator for plain sliding-window scoring
- exact single-rank parity for cache scoring
- exact multi-rank aggregation back to the single-rank answer for `world_size in {2,3,8,32}`
- exact equivalence between the research `run_ttt` loop and the final script's TTT loop in the `world_size=1` subset setting used in the 1xH100 probes
- local verifier command passes:

```bash
conda run --no-capture-output -n torch-wsl python -u research/verify_domv2_cache.py
```

## Single-H100 Proxy Evidence

On a strong 1xH100 checkpoint, after 3 epochs of TTT on matched 1M-token validation slices, the cache still improved bpb:

| `start_token` | no cache | cache (`alpha=0.20`) | delta |
| --- | ---: | ---: | ---: |
| `0` | `1.61700285` | `1.61190207` | `-0.00510078` |
| `20000000` | `1.58458543` | `1.57923265` | `-0.00535278` |
| `40000000` | `1.56495388` | `1.56022034` | `-0.00473354` |

Mid-slice `alpha` sweep after TTT:

- `0.10`: `1.58013994`
- `0.20`: `1.57923535`
- `0.30`: `1.57976811`
- `0.40`: `1.58128413`

## What Still Needs 8xH100 Confirmation

- full end-to-end score on the official full validation run
- full runtime under the challenge budget on 8xH100
- final artifact margin after compression on the real run
- whether `alpha=0.20` stays the best cache strength on the final 8xH100 checkpoint
- multi-rank TTT behavior has not been separately parity-tested against the research evaluator, even though multi-rank evaluation aggregation is verified

## Important Caveats

- `final/dominationv2_cache/train_gpt.py` is currently about `55.3 KB`, roughly `9.8 KB` larger than the upstream control this was derived from. That code-byte increase is real and should be checked against the final artifact budget.
- This PR intentionally stops at a clean handoff package under `/final`. It does not yet add a `records/...` submission folder because the decisive next step is still the 8xH100 run.
