### PR TITLE
Non-record: Value Residual (-0.015 BPB) + Gated Attention (-0.003 BPB) with ablations

### DIFF
--- a/records/track_non_record_16mb/2026-03-22_ValueResidual_GatedAttention_anantdgoel/README.md
+++ b/records/track_non_record_16mb/2026-03-22_ValueResidual_GatedAttention_anantdgoel/README.md
@@ -1,0 +1,59 @@
+**val_bpb: 1.4525** (sliding window, stride=128, GA+VR combined) | **13.2 MB** (control model) | 1xRTX3090, 1000 steps, 131K batch
+
+## Non-record: Value Residual (-0.015 BPB) + Gated Attention (-0.003 BPB) with ablations
+
+Two novel architecture modifications and one negative result. The goal is to share validated techniques with controlled ablation data.
+
+### Contributions
+
+1. **Value Residual (ResFormer)** -- -0.015 BPB standalone. Caches raw V vectors from layer 0 and mixes them into all subsequent layers: `V_n = lambda1 * V_0 + lambda2 * V_current`. Both lambdas are learnable (init 0.5), 18 scalars total for 9L. Preserves token identity through depth, especially beneficial for deep-narrow architectures (512d). Based on arXiv:2410.17897 (ACL 2025). Enable: `VALUE_RESIDUAL=1`.
+
+2. **Gated Attention** -- -0.003 BPB standalone. Per-head sigmoid gate after SDPA: `Y' = Y * sigmoid(X @ W_gate + b_gate)`. Bias init 4.0 (sigmoid ~0.98, near no-op at start). Eliminates attention sinks where softmax forces distribution over irrelevant keys. ~37K params for 9L/8H. Based on arXiv:2505.06708 (NeurIPS 2025 Best Paper). Enable: `GATED_ATTENTION=1`.
+
+3. **PPM-C Context Mixer** -- +0.0018 BPB (negative result). Classical Prediction by Partial Matching (order 2) blended with neural softmax at eval time (`mixed = 0.95*neural + 0.05*ppm`). On SmearGate+BigramHash models, the neural predictions already capture bigram patterns; PPM just dilutes them. Zero artifact cost but no benefit.
+
+The two positive techniques **stack additively** for -0.017 BPB combined (no interference).
+
+### Ablation Results
+
+Controlled A/B test: v1024 9L 2xMLP, SmearGate + BigramHash(4096) + OrthoInit + WD 0.04, 131K batch, 1000 steps, RTX 3090.
+
+| Config | Sliding BPB | Delta vs Control |
+|--------|-------------|------------------|
+| Control (no novel techniques) | 1.4697 | -- |
+| Gated Attention only | 1.4665 | -0.0032 |
+| **Value Residual only** | **1.4546** | **-0.0151** |
+| **GA + VR combined** | **1.4525** | **-0.0172** |
+| PPM-C (alpha=0.95, order=2) | 1.2900* | +0.0018 (worse) |
+
+*PPM-C tested on stronger pre-trained model (524K batch, 2000 steps, baseline 1.2882 BPB).
+
+### Relationship to community techniques
+
+**Value Residual vs VE128 (Shared Value Embeddings):** Both preserve value information across depth, but through different mechanisms. VE128 shares a learned embedding matrix; Value Residual skip-connects layer 0's computed V vectors. Whether they are complementary or redundant has not been tested.
+
+**Gated Attention vs XSA:** Both address attention quality through different failure modes. XSA removes self-value bias; Gated Attention allows heads to suppress output entirely. They may be complementary.
+
+### Reproducibility
+
+Ablation cost: ~$0.70 (3x RTX 3090 pods, ~20 min each).
+
+```bash
+TORCHDYNAMO_DISABLE=1 VOCAB_SIZE=1024 NUM_LAYERS=9 MLP_MULT=2 \
+TRAIN_SEQ_LEN=1024 TRAIN_BATCH_TOKENS=131072 ITERATIONS=1000 \
+SMEAR_GATE=1 BIGRAM_HASH=1 BIGRAM_BUCKETS=4096 ORTHO_INIT=1 \
+WEIGHT_DECAY_MUON=0.04 WEIGHT_DECAY_ADAM=0.04 \
+GATED_ATTENTION=1 VALUE_RESIDUAL=1 \
+EVAL_SEQ_LEN=1024 EVAL_STRIDE=128 QUANT_BITS=6 \
+torchrun --standalone --nproc_per_node=1 train_gpt.py
+```
+
+### What we'd do with more compute
+
+A production run (11L MLP3x + full community stack + VR + GA, 9500 steps, 524K batch) is in progress on 1xA6000. If Value Residual's -0.015 BPB holds at the frontier, it could push SOTA from ~1.125 to ~1.110 BPB. Results will be submitted in a follow-up record PR if competitive.
+
+### Files
+
+- `README.md` -- This writeup
+- `submission.json` -- Submission metadata
+- `train_gpt.py` -- Training script with Value Residual, Gated Attention, XSA, EMA, Partial RoPE, LN Scale implementations

--- a/records/track_non_record_16mb/2026-03-22_ValueResidual_GatedAttention_anantdgoel/submission.json
+++ b/records/track_non_record_16mb/2026-03-22_ValueResidual_GatedAttention_anantdgoel/submission.json
@@ -1,0 +1,18 @@
+{
+  "author": "Anant Goel",
+  "github_id": "anantdgoel",
+  "name": "Value Residual + Gated Attention ablation",
+  "blurb": "Two novel architecture modifications: Value Residual (-0.015 BPB) caches layer-0 V vectors as skip connections, Gated Attention (-0.003 BPB) adds per-head sigmoid gates. They stack additively for -0.017 BPB. PPM-C context mixing is a negative result (+0.002 BPB) on SmearGate+BigramHash models.",
+  "date": "2026-03-22",
+  "track": "non-record-16mb",
+  "val_bpb": 1.4525,
+  "pre_quant_val_bpb": 1.4525,
+  "step_stop": 1000,
+  "wallclock_seconds": 5506,
+  "hardware": "1xRTX3090 (ablations), 1xA6000 (validation)",
+  "novel_contributions": [
+    "Value Residual: layer-0 V shortcut to all layers, 18 learnable scalars, -0.015 BPB (arXiv:2410.17897)",
+    "Gated Attention: per-head sigmoid gate, ~37K params, -0.003 BPB (arXiv:2505.06708)",
+    "PPM-C context mixer: negative result, +0.002 BPB on SmearGate+BigramHash models"
+  ]
+}

--- a/records/track_non_record_16mb/2026-03-22_ValueResidual_GatedAttention_anantdgoel/train_gpt.py
+++ b/records/track_non_record_16mb/2026-03-22_ValueResidual_GatedAttention_anantdgoel/train_gpt.py
@@ -1,0 +1,1645 @@
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: `train_gpt.py` and `train_gpt_mlx.py` must never be longer than 1500 lines.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import json
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+try:
+    import zstandard
+except ImportError:
+    zstandard = None
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# HYPERPARAMETERS
+# 9 transformer blocks at width 512, 8 heads with 4 KV heads (GQA), vocab 1024, tied embeddings
+
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 2))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    weight_decay_muon = float(os.environ.get("WEIGHT_DECAY_MUON", 0.02))
+    weight_decay_adam = float(os.environ.get("WEIGHT_DECAY_ADAM", 0.01))
+
+
+    mtp_k = int(os.environ.get("MTP_K", 0))
+    mtp_alpha = float(os.environ.get("MTP_ALPHA", 0.3))
+
+
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 0))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 0))
+
+
+    # Full-model SGD TTT at eval (adapts all weights via SGD over val data).
+    sgd_ttt = bool(int(os.environ.get("SGD_TTT", "0")))
+    sgd_ttt_lr = float(os.environ.get("SGD_TTT_LR", 0.002))
+    sgd_ttt_momentum = float(os.environ.get("SGD_TTT_MOMENTUM", 0.9))
+    sgd_ttt_epochs = int(os.environ.get("SGD_TTT_EPOCHS", 2))
+    sgd_ttt_seq_len = int(os.environ.get("SGD_TTT_SEQ_LEN", 1024))
+    sgd_ttt_param_set = os.environ.get("SGD_TTT_PARAM_SET", "control")
+    # Attention pointer/copy: use last-layer attention as copy distribution.
+    pointer_copy = bool(int(os.environ.get("POINTER_COPY", "0")))
+    pointer_copy_lambda = float(os.environ.get("POINTER_COPY_LAMBDA", 0.05))
+    meta_ttt = bool(int(os.environ.get("META_TTT", "0")))
+    meta_ttt_param_set = os.environ.get("META_TTT_PARAM_SET", "control")
+    meta_ttt_start_frac = float(os.environ.get("META_TTT_START_FRAC", 0.5))
+    meta_ttt_every = int(os.environ.get("META_TTT_EVERY", 4))
+    meta_ttt_seq_len = int(os.environ.get("META_TTT_SEQ_LEN", 512))
+    meta_ttt_inner_lr = float(os.environ.get("META_TTT_INNER_LR", 0.03))
+    meta_ttt_inner_steps = int(os.environ.get("META_TTT_INNER_STEPS", 1))
+    meta_ttt_weight = float(os.environ.get("META_TTT_WEIGHT", 0.5))
+    # Eval-time adaptation: unigram cache mixture and online gradient descent on vocab bias.
+    cache_mixture = bool(int(os.environ.get("CACHE_MIXTURE", "0")))
+    cache_lambda = float(os.environ.get("CACHE_LAMBDA", 0.02))
+    cache_decay = float(os.environ.get("CACHE_DECAY", 0.995))
+    ogd_bias = bool(int(os.environ.get("OGD_BIAS", "0")))
+    ogd_lr = float(os.environ.get("OGD_LR", 0.1))
+    smear_gate = bool(int(os.environ.get("SMEAR_GATE", "0")))
+    bigram_hash = bool(int(os.environ.get("BIGRAM_HASH", "0")))
+    bigram_buckets = int(os.environ.get("BIGRAM_BUCKETS", 4096))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    ortho_init = bool(int(os.environ.get("ORTHO_INIT", "0")))
+    gated_attention = bool(int(os.environ.get("GATED_ATTENTION", "0")))
+    value_residual = bool(int(os.environ.get("VALUE_RESIDUAL", "0")))
+    xsa_layers = int(os.environ.get("XSA_LAYERS", 0))
+    ema_enabled = bool(int(os.environ.get("EMA_ENABLED", "0")))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+    partial_rope_dims = int(os.environ.get("PARTIAL_ROPE_DIMS", 0))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "0")))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "0")))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.2))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    train_only = bool(int(os.environ.get("TRAIN_ONLY", "0")))
+    artifact_filename = os.environ.get("ARTIFACT_FILENAME", "")
+    load_artifact = os.environ.get("LOAD_ARTIFACT", "")
+
+def get_artifact_compressor() -> str:
+    compressor = os.environ.get("ARTIFACT_COMPRESSOR", "zstd" if zstandard is not None else "zlib")
+    if compressor not in ("zlib", "zstd"):
+        raise ValueError(f"ARTIFACT_COMPRESSOR must be zlib or zstd, got {compressor}")
+    if compressor == "zstd" and zstandard is None:
+        raise RuntimeError("ARTIFACT_COMPRESSOR=zstd requires zstandard to be installed")
+    return compressor
+
+# MUON OPTIMIZER (from modded-nanogpt)
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, weight_decay=weight_decay),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Per-row normalization (NorMuon).
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    row_norms = g.norm(dim=-1, keepdim=True).clamp_min(1e-7)
+                    g = g / row_norms
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                if wd > 0:
+                    p.data.mul_(1.0 - lr * wd)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+# TOKENIZER-AGNOSTIC EVALUATION
+# BPB (bits-per-byte) instead of val loss, so we need per-token byte counts.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+def _count_token_bytes(
+    prev_ids: Tensor, tgt_ids: Tensor,
+    base_bytes_lut: Tensor, has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> float:
+    tb = base_bytes_lut[tgt_ids].to(torch.int16) + (
+        has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]
+    ).to(torch.int16)
+    return tb.to(torch.float64).sum().item()
+
+BOS_ID = 1
+
+def _build_sliding_windows(val_tokens: Tensor, seq_len: int, stride: int, doc_isolated: bool):
+    """Build sliding window start positions. If doc_isolated, reset at BOS boundaries."""
+    N = val_tokens.numel() - 1
+    if not doc_isolated:
+        return list(range(0, N - seq_len + 1, stride))
+    # Find document boundaries and build windows per document.
+    bos_positions = (val_tokens[:N] == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+    if not bos_positions or bos_positions[0] != 0:
+        bos_positions = [0] + bos_positions
+    bos_positions.append(N)
+    starts: list[int] = []
+    for di in range(len(bos_positions) - 1):
+        doc_start, doc_end = bos_positions[di], bos_positions[di + 1]
+        doc_len = doc_end - doc_start
+        if doc_len < 2:
+            continue
+        pos = doc_start
+        while pos + 1 <= doc_end:
+            starts.append(pos)
+            pos += stride
+            if pos + seq_len > doc_end:
+                # Last window aligned to document end.
+                if doc_end - seq_len > starts[-1]:
+                    starts.append(max(doc_start, doc_end - seq_len))
+                break
+    return starts
+
+def eval_val_sliding(
+    args: Hyperparameters, model: nn.Module, device: torch.device,
+    val_tokens: Tensor, base_bytes_lut: Tensor, has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float, int, float]:
+    """Sliding-window evaluation with optional document isolation."""
+    seq_len = args.eval_seq_len or args.train_seq_len
+    stride = args.eval_stride or seq_len
+    N = val_tokens.numel() - 1
+    batch_seqs = max(1, min(args.val_batch_size // seq_len, 64))
+    starts = _build_sliding_windows(val_tokens, seq_len, stride, False)
+    loss_sum, tok_count, byte_count = 0.0, 0, 0.0
+    model.eval()
+    with torch.inference_mode():
+        for bi in range(0, len(starts), batch_seqs):
+            bs = starts[bi : bi + batch_seqs]
+            bsz = len(bs)
+            x = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(bs):
+                end = min(ws + seq_len, N)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x[i, :wlen] = chunk[:-1]
+                y[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = model.get_logits(x)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(), y.reshape(-1), reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(bs):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum().item()
+                tok_count += wlen - s
+                byte_count += _count_token_bytes(
+                    x[i, s:wlen], y[i, s:wlen],
+                    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut)
+    model.train()
+    val_loss = loss_sum / tok_count
+    return val_loss, val_loss / math.log(2.0) * tok_count / byte_count, tok_count, byte_count
+
+# FULL-MODEL SGD TTT + ATTENTION POINTER/COPY
+
+def eval_val_sgd_ttt(
+    args: Hyperparameters, model: nn.Module, device: torch.device,
+    val_tokens: Tensor, base_bytes_lut: Tensor, has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float, int, float]:
+    """Two-phase SGD TTT: (1) adapt weights via SGD over val data, (2) score with sliding window.
+    Optionally mix with recency-weighted pointer/copy distribution during scoring."""
+    seq_len = args.sgd_ttt_seq_len or args.train_seq_len
+    stride = args.eval_stride or seq_len
+    N = val_tokens.numel() - 1
+    use_pointer = args.pointer_copy
+    ptr_lambda = args.pointer_copy_lambda
+    vocab_size = model.tok_emb.num_embeddings if hasattr(model, "tok_emb") else args.vocab_size
+    named_ttt_params = _named_ttt_params(model, args.sgd_ttt_param_set)
+    if not named_ttt_params:
+        raise ValueError(f"No parameters matched SGD_TTT_PARAM_SET={args.sgd_ttt_param_set}")
+    ttt_params = [param for _, param in named_ttt_params]
+    saved = {name: param.data.clone() for name, param in named_ttt_params}
+    for param in model.parameters():
+        param.requires_grad_(False)
+    for param in ttt_params:
+        param.requires_grad_(True)
+    opt = torch.optim.SGD(ttt_params, lr=args.sgd_ttt_lr, momentum=args.sgd_ttt_momentum)
+    _reset_rotary_caches(model)
+    # Phase 1: Adapt — SGD over val data with non-overlapping windows (fast)
+    model.eval()
+    adapt_starts = list(range(0, N - seq_len + 1, seq_len))
+    for epoch in range(args.sgd_ttt_epochs):
+        for s in adapt_starts:
+            chunk = val_tokens[s : s + seq_len + 1].to(device=device, dtype=torch.int64)
+            x, y = chunk[:-1].unsqueeze(0), chunk[1:].unsqueeze(0)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = model.get_logits(x)
+            loss = F.cross_entropy(logits.reshape(-1, logits.size(-1)).float(), y.reshape(-1), reduction="mean")
+            opt.zero_grad()
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            opt.step()
+    # Phase 2: Score — sliding window eval on adapted model (no gradients)
+    # Optional eval-time adaptation: cache_mixture (decayed unigram counts) and ogd_bias (online vocab bias).
+    for p in model.parameters():
+        p.requires_grad_(False)
+    use_cache = args.cache_mixture
+    use_ogd = args.ogd_bias
+    ogd_b = torch.zeros(vocab_size, device=device) if use_ogd else None
+    cache_counts = torch.zeros(vocab_size, device=device, dtype=torch.float64) if use_cache else None
+    cache_sum = 0.0
+    batch_seqs = max(1, min(args.val_batch_size // seq_len, 64))
+    starts = list(range(0, N - seq_len + 1, stride))
+    loss_sum, tok_count, byte_count = 0.0, 0, 0.0
+    with torch.inference_mode():
+        for bi in range(0, len(starts), batch_seqs):
+            bs = starts[bi : bi + batch_seqs]
+            bsz = len(bs)
+            x = torch.stack([val_tokens[s : s + seq_len] for s in bs]).to(device=device, dtype=torch.int64)
+            y = torch.stack([val_tokens[s + 1 : s + seq_len + 1] for s in bs]).to(device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = model.get_logits(x)
+            for i, s in enumerate(bs):
+                sc = seq_len - stride if s > 0 else 0
+                sl, st = logits[i, sc:, :].float(), y[i, sc:]
+                if use_ogd:
+                    sl = sl + ogd_b
+                if use_cache and cache_sum > 0:
+                    # Mix model softmax with decayed unigram cache distribution.
+                    log_pm = F.log_softmax(sl, dim=-1)
+                    lam = args.cache_lambda
+                    target_log_pm = log_pm.gather(1, st.unsqueeze(1)).squeeze(1).to(torch.float64)
+                    la = target_log_pm + math.log(1 - lam)
+                    lb = torch.log(lam * cache_counts[st] / cache_sum + 1e-30)
+                    loss_sum += (-torch.logaddexp(la, lb)).sum().item()
+                elif use_pointer and s > 0:
+                    log_pm = F.log_softmax(sl, dim=-1).gather(1, st.unsqueeze(1)).squeeze(1)
+                    ctx_ids = x[i, :sc]
+                    recency = torch.exp(0.01 * (torch.arange(sc, device=device, dtype=torch.float32) - sc))
+                    cdist = torch.zeros(vocab_size, device=device)
+                    cdist.scatter_add_(0, ctx_ids.long(), recency)
+                    cdist = cdist / cdist.sum().clamp(min=1)
+                    pc = cdist[st].to(torch.float64)
+                    la = log_pm.to(torch.float64) + math.log(1 - ptr_lambda)
+                    lb = torch.log(ptr_lambda * pc + 1e-30)
+                    loss_sum += (-torch.logaddexp(la, lb)).sum().item()
+                else:
+                    loss_sum += F.cross_entropy(sl, st, reduction="sum").item()
+                tok_count += st.numel()
+                byte_count += _count_token_bytes(x[i, sc:], st,
+                    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut)
+                # Update cache counts with scored tokens (decayed).
+                if use_cache:
+                    decay_factor = args.cache_decay ** st.numel()
+                    cache_counts *= decay_factor
+                    cache_sum = cache_sum * decay_factor + st.numel()
+                    cache_counts.scatter_add_(0, st.long(), torch.ones_like(st, dtype=torch.float64))
+                # Update OGD bias: gradient of CE w.r.t. bias = softmax - one_hot.
+                if use_ogd:
+                    probs = F.softmax(sl.detach(), dim=-1).mean(0)
+                    one_hot_mean = torch.zeros(vocab_size, device=device)
+                    one_hot_mean.scatter_add_(0, st.long(), torch.ones(st.numel(), device=device) / st.numel())
+                    ogd_b.sub_(args.ogd_lr * (probs - one_hot_mean))
+    # Restore original weights
+    with torch.no_grad():
+        for name, param in named_ttt_params:
+            param.data.copy_(saved[name])
+    model.train()
+    val_loss = loss_sum / tok_count
+    return val_loss, val_loss / math.log(2.0) * tok_count / byte_count, tok_count, byte_count
+
+# POST-TRAINING QUANTIZATION (int8 + zlib)
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,bigram.scale",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+FP16_KEEP_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get("FP16_KEEP_NAME_PATTERNS", "tok_emb").split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def quantize_int6_per_row(t: Tensor) -> tuple[Tensor, Tensor]:
+    """Quantize to int6 [-32, 31] with per-row scaling."""
+    t32 = t.float()
+    if t32.ndim == 2:
+        row_max = t32.abs().amax(dim=1)
+        scale = (row_max / 31.0).clamp_min(1e-12).to(torch.float16)
+        scale = scale.clamp_min(torch.finfo(torch.float16).tiny)
+        q = torch.clamp(torch.round(t32 / scale.float()[:, None]), -32, 31).to(torch.int8)
+        return q, scale
+    amax = t32.abs().max().item()
+    scale = torch.tensor(max(amax / 31.0, 1e-12), dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -32, 31).to(torch.int8)
+    return q, scale
+
+def quantize_int8_per_row(t: Tensor) -> tuple[Tensor, Tensor]:
+    """Quantize to int8 [-127, 127] with per-row scaling."""
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1) if t32.numel() else torch.empty((t32.shape[0],), dtype=torch.float32)
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+
+def mixed_quantize(state_dict: dict[str, Tensor], num_layers: int, quant_bits: int = 6):
+    """Mixed-precision quantization: fp16 passthrough for embeddings and last-2-layer c_k,
+    int6/int8 for MLP+attention weights, fp16 for small/control tensors."""
+    # Build fp16 keep patterns: tok_emb + last 2 layers' c_k
+    fp16_patterns = list(FP16_KEEP_NAME_PATTERNS)
+    for li in range(max(0, num_layers - 2), num_layers):
+        fp16_patterns.append(f"blocks.{li}.attn.c_k")
+    quantize_fn = quantize_int6_per_row if quant_bits == 6 else quantize_int8_per_row
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if any(p in name for p in fp16_patterns):
+            result[name] = t.to(dtype=torch.float16).contiguous()
+            meta[name] = "passthrough_fp16"
+            continue
+        cat = _classify_param(name)
+        if cat in ("mlp", "attn") and t.ndim >= 1:
+            q, s = quantize_fn(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": f"int{quant_bits}"}
+        else:
+            q, s = quantize_int8_per_row(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return {"w": result, "m": meta}
+
+def dequantize_mixed(obj: dict[str, object], template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    if obj.get("__quant_format__") == "int8_clean_per_row_v1":  # legacy format
+        out, qm, po = {}, obj.get("qmeta", {}), obj.get("passthrough_orig_dtypes", {})
+        for n, q in obj["quantized"].items():
+            dt, s = getattr(torch, obj["dtypes"][n]), obj["scales"][n]
+            out[n] = (q.float() * s.float().view(q.shape[0], *([1]*(q.ndim-1)))).to(dt) if (qm.get(n,{}).get("scheme")=="per_row" or s.ndim>0) else (q.float()*float(s.item())).to(dt)
+        for n, t in obj["passthrough"].items():
+            out[n] = t.to(dtype=getattr(torch, po[n])) if po.get(n) else t.detach().cpu()
+        return out
+    result, meta, out = obj["w"], obj["m"], {}
+    for name, orig in template_sd.items():
+        info = meta[name]
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            out[name] = t.to(orig.dtype) if (t.dtype == torch.float16 and orig.dtype in (torch.float32, torch.bfloat16)) else t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        out[name] = (q.float() * s.float().view(q.shape[0], *([1]*(q.ndim-1)))).to(orig.dtype) if s.ndim > 0 else (q.float()*float(s.item())).to(orig.dtype)
+    return out
+
+# DATA LOADING
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# TRANSFORMER MODULES
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+class CastedLinear(nn.Linear):
+    def forward(self, x: Tensor) -> Tensor:
+        return F.linear(x, self.weight.to(x.dtype), self.bias.to(x.dtype) if self.bias is not None else None)
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+def _reset_rotary_caches(module: nn.Module) -> None:
+    for submodule in module.modules():
+        if hasattr(submodule, "_seq_len_cached"):
+            submodule._seq_len_cached = 0
+
+def _named_ttt_params(model: nn.Module, param_set: str) -> list[tuple[str, nn.Parameter]]:
+    named_params = list(model.named_parameters())
+    if param_set == "all":
+        return named_params
+    if param_set not in ("control", "control_qk"):
+        raise ValueError(f"Unsupported TTT param set: {param_set}")
+    qk_names = {
+        f"blocks.{li}.attn.c_k.weight"
+        for li in range(max(0, len(model.blocks) - 2), len(model.blocks))
+    }
+    selected: list[tuple[str, nn.Parameter]] = []
+    for name, param in named_params:
+        is_control = any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        if is_control or (param_set == "control_qk" and name in qk_names):
+            selected.append((name, param))
+    return selected
+
+def _meta_ttt_step(
+    args: Hyperparameters,
+    train_model: nn.Module,
+    base_model: nn.Module,
+    x_support: Tensor,
+    y_support: Tensor,
+    x_query: Tensor,
+    y_query: Tensor,
+    grad_scale: float,
+) -> Tensor | None:
+    named_fast_params = _named_ttt_params(base_model, args.meta_ttt_param_set)
+    if not named_fast_params:
+        return None
+    fast_params = [param for _, param in named_fast_params]
+    saved = [param.detach().clone() for param in fast_params]
+    try:
+        for _ in range(args.meta_ttt_inner_steps):
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                support_loss = train_model(x_support, y_support)
+            grads = torch.autograd.grad(support_loss, fast_params, allow_unused=True)
+            with torch.no_grad():
+                for param, grad in zip(fast_params, grads, strict=True):
+                    if grad is not None:
+                        param.add_(grad, alpha=-args.meta_ttt_inner_lr)
+        with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+            query_loss = train_model(x_query, y_query)
+        (args.meta_ttt_weight * query_loss * grad_scale).backward()
+        return query_loss.detach()
+    finally:
+        with torch.no_grad():
+            for param, orig in zip(fast_params, saved, strict=True):
+                param.copy_(orig)
+        _reset_rotary_caches(base_model)
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0, rope_dims: int = 0):
+        super().__init__()
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        rd = self.rope_dims
+        inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, dtype=torch.float32) / rd))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    rd = cos.size(-1) * 2
+    if rd < x.size(-1):
+        x_rope, x_pass = x[..., :rd], x[..., rd:]
+        half = rd // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rot = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+        return torch.cat((x_rot, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+        partial_rope_dims: int = 0,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base, rope_dims=partial_rope_dims)
+        self.use_xsa = False
+        self.gated_attention = gated_attention
+        if gated_attention:
+            self.attn_gate = nn.Linear(dim, num_heads, bias=True)
+            nn.init.zeros_(self.attn_gate.weight)
+            nn.init.constant_(self.attn_gate.bias, 4.0)
+        self.value_residual = value_residual
+        if value_residual:
+            self.vr_lambda = nn.Parameter(torch.tensor([0.5, 0.5], dtype=torch.float32))
+
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        """Remove self-value projection via GQA-aware reshape."""
+        B, H, T, D = y.shape
+        Hkv = v.size(1)
+        group = H // Hkv
+        y_g = y.reshape(B, Hkv, group, T, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, H, T, D)
+
+    def forward(self, x: Tensor, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        raw_v = v if self.value_residual else None
+        if self.value_residual and v0 is not None:
+            lam = self.vr_lambda.to(dtype=v.dtype)
+            v = lam[0] * v0 + lam[1] * v
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        if self.gated_attention:
+            gate = torch.sigmoid(self.attn_gate(x))
+            y = y * gate.unsqueeze(-1).transpose(1, 2)
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y), raw_v
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: float):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+class SmearGate(nn.Module):
+    """Blend each token's embedding with the previous token's embedding."""
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+class BigramHashEmbedding(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: float,
+        rope_base: float,
+        qk_gain_init: float,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+        partial_rope_dims: int = 0,
+        layer_idx: int = 0,
+        ln_scale: bool = False,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+                                        gated_attention=gated_attention, value_residual=value_residual,
+                                        partial_rope_dims=partial_rope_dims)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+
+    def forward(self, x: Tensor, x0: Tensor, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        s = self.ln_scale_factor
+        attn_out, raw_v = self.attn(self.attn_norm(x) * s, v0=v0)
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x) * s)
+        return x, raw_v
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: float,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        mtp_k: int = 0,
+        mtp_alpha: float = 0.3,
+        smear_gate: bool = False,
+        bigram_buckets: int = 0,
+        bigram_dim: int = 128,
+        ortho_init: bool = False,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+        xsa_layers: int = 0,
+        partial_rope_dims: int = 0,
+        ln_scale: bool = False,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.value_residual = value_residual
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.smear = SmearGate(model_dim) if smear_gate else None
+        self.bigram = BigramHashEmbedding(bigram_buckets, bigram_dim, model_dim) if bigram_buckets > 0 else None
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList([
+            Block(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init,
+                  gated_attention=gated_attention, value_residual=value_residual,
+                  partial_rope_dims=partial_rope_dims, layer_idx=i, ln_scale=ln_scale)
+            for i in range(num_layers)
+        ])
+        if xsa_layers > 0:
+            for i in range(max(0, num_layers - xsa_layers), num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.mtp_k = mtp_k
+        self.mtp_alpha = mtp_alpha
+        self.mtp_head = CastedLinear(model_dim, vocab_size, bias=False) if mtp_k > 0 else None
+        if self.mtp_head is not None:
+            self.mtp_head._zero_init = True
+        self._ortho_init = ortho_init
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        num_layers = len(self.blocks)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif self._ortho_init and module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    # muP output scaling for projection layers.
+                    if ".proj." in name or name.endswith(".proj"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+
+    def _encode(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        if self.smear is not None:
+            x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        for i, block in enumerate(self.blocks):
+            if i < self.num_encoder_layers:
+                x, raw_v = block(x, x0, v0=v0)
+                if v0 is None and raw_v is not None:
+                    v0 = raw_v
+                skips.append(x)
+            else:
+                dec_idx = i - self.num_encoder_layers
+                if dec_idx < self.num_skip_weights and skips:
+                    x = x + self.skip_weights[dec_idx].to(dtype=x.dtype)[None, None, :] * skips.pop()
+                x, _ = block(x, x0, v0=v0)
+        return self.final_norm(x)
+
+    def _project_to_logits(self, hidden: Tensor) -> Tensor:
+        logits_proj = F.linear(hidden, self.tok_emb.weight) if self.tie_embeddings else self.lm_head(hidden)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def get_logits(self, input_ids: Tensor) -> Tensor:
+        return self._project_to_logits(self._encode(input_ids))
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        hidden = self._encode(input_ids)
+        logits = self._project_to_logits(hidden.reshape(-1, hidden.size(-1)))
+        loss = F.cross_entropy(logits.float(), target_ids.reshape(-1), reduction="mean")
+        if self.mtp_head is not None and self.training:
+            k = self.mtp_k
+            T = hidden.size(1)
+            mtp_logits = self.logit_softcap * torch.tanh(
+                self.mtp_head(hidden[:, : T - k + 1, :]) / self.logit_softcap
+            )
+            mtp_loss = F.cross_entropy(
+                mtp_logits.reshape(-1, mtp_logits.size(-1)).float(),
+                target_ids[:, k - 1 :].reshape(-1),
+                reduction="mean",
+            )
+            loss = loss + self.mtp_alpha * mtp_loss
+        return loss
+
+# TRAINING
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    artifact_compressor = get_artifact_compressor()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # DISTRIBUTED + CUDA SETUP
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # TOKENIZER + VALIDATION METRIC SETUP
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # MODEL + OPTIMIZER SETUP
+
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        mtp_k=args.mtp_k,
+        mtp_alpha=args.mtp_alpha,
+        smear_gate=args.smear_gate,
+        bigram_buckets=args.bigram_buckets if args.bigram_hash else 0,
+        bigram_dim=args.bigram_dim,
+        ortho_init=args.ortho_init,
+        gated_attention=args.gated_attention,
+        value_residual=args.value_residual,
+        xsa_layers=args.xsa_layers,
+        partial_rope_dims=args.partial_rope_dims,
+        ln_scale=args.ln_scale,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False, find_unused_parameters=(args.gated_attention or args.value_residual)) if distributed else compiled_model
+
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    if base_model.smear is not None:
+        scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_params.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None:
+            matrix_params.append(base_model.bigram.proj.weight)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params, betas=(args.beta1, args.beta2), eps=args.adam_eps,
+        weight_decay=args.weight_decay_adam, fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params, lr=args.matrix_lr, momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps, weight_decay=args.weight_decay_muon,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps,
+        weight_decay=args.weight_decay_adam, fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.AdamW(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2), eps=args.adam_eps,
+            weight_decay=args.weight_decay_adam, fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+    if base_model.mtp_head is not None:
+        optimizer_mtp = torch.optim.AdamW(
+            [{"params": [base_model.mtp_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2), eps=args.adam_eps,
+            weight_decay=args.weight_decay_adam, fused=True,
+        )
+        optimizers.append(optimizer_mtp)
+
+    # MTP params are excluded from the export artifact — don't count them.
+    export_param_names = {n for n, _ in base_model.named_parameters() if 'mtp_head' not in n}
+    n_params = sum(p.numel() for n, p in base_model.named_parameters() if n in export_param_names)
+    log0(f"model_params:{n_params}")
+    log0(f"layers:{len(base_model.blocks)}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(
+        f"sgd_ttt:param_set:{args.sgd_ttt_param_set} meta_ttt:{args.meta_ttt} "
+        f"meta_param_set:{args.meta_ttt_param_set} artifact_compressor:{artifact_compressor}"
+    )
+    log0(f"seed:{args.seed}")
+
+    # DATA LOADER & MODEL WARMUP
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    if args.load_artifact:
+        log0(f"load_artifact: loading pre-trained model from {args.load_artifact}")
+        with open(args.load_artifact, "rb") as f:
+            la_blob = f.read()
+        if artifact_compressor == "zstd":
+            la_dctx = zstandard.ZstdDecompressor()
+            la_raw = la_dctx.decompress(la_blob)
+        else:
+            import zlib
+            la_raw = zlib.decompress(la_blob)
+        la_state = torch.load(io.BytesIO(la_raw), map_location="cpu")
+        la_template = {k: v.detach().cpu() for k, v in base_model.state_dict().items() if 'mtp_head' not in k}
+        la_sd = dequantize_mixed(la_state, la_template)
+        base_model.load_state_dict(la_sd, strict=(args.mtp_k == 0))
+        log0("load_artifact: model loaded, skipping training, proceeding to eval")
+        quant_filename = args.load_artifact
+        sd_cpu = la_template
+        if args.eval_stride > 0:
+            lut_args = (base_bytes_lut, has_leading_space_lut, is_boundary_token_lut)
+            sw_loss, sw_bpb, sw_tokens, sw_bytes = eval_val_sliding(args, base_model, device, val_tokens, *lut_args)
+            log0(
+                f"sliding_window eval_stride:{args.eval_stride} val_loss:{sw_loss:.4f} val_bpb:{sw_bpb:.4f} "
+                f"scored_tokens:{sw_tokens} scored_bytes:{sw_bytes:.0f}"
+            )
+            log0(f"sliding_window_exact val_loss:{sw_loss:.8f} val_bpb:{sw_bpb:.8f}")
+        if distributed:
+            dist.destroy_process_group()
+        return
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # MAIN TRAINING LOOP
+
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    ema_state: dict[str, Tensor] | None = None
+    if args.ema_enabled:
+        ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    meta_global_tokens = max(args.meta_ttt_seq_len * world_size * grad_accum_steps, args.meta_ttt_seq_len)
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        run_meta_ttt = (
+            args.meta_ttt
+            and args.meta_ttt_every > 0
+            and step >= int(args.iterations * args.meta_ttt_start_frac)
+            and step % args.meta_ttt_every == 0
+        )
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        meta_query_loss = torch.zeros((), device=device) if run_meta_ttt else None
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+            if run_meta_ttt:
+                x_support, y_support = train_loader.next_batch(meta_global_tokens, args.meta_ttt_seq_len, grad_accum_steps)
+                x_query, y_query = train_loader.next_batch(meta_global_tokens, args.meta_ttt_seq_len, grad_accum_steps)
+                q_loss = _meta_ttt_step(args, model, base_model, x_support, y_support, x_query, y_query, grad_scale)
+                if q_loss is not None and meta_query_loss is not None:
+                    meta_query_loss += q_loss.detach()
+        train_loss /= grad_accum_steps
+        if meta_query_loss is not None:
+            meta_query_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+
+        # EMA: update shadow weights every step.
+        if ema_state is not None:
+            d = args.ema_decay
+            with torch.no_grad():
+                for name, t in base_model.state_dict().items():
+                    ema_state[name].mul_(d).add_(t.detach().float(), alpha=1.0 - d)
+
+        # SWA: collect checkpoints during warmdown phase (disabled when EMA is active).
+        if args.swa_enabled and not args.ema_enabled and scale < args.swa_start_frac and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().float() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu().float()
+                swa_count += 1
+
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            msg = (
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+            if meta_query_loss is not None:
+                msg += f" meta_query_loss:{meta_query_loss.item():.4f}"
+            log0(msg)
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # Apply EMA if enabled.
+    if ema_state is not None:
+        log0("ema:applying EMA weights")
+        avg_sd = {name: t.to(dtype=base_model.state_dict()[name].dtype) for name, t in ema_state.items()}
+        del ema_state
+        base_model.load_state_dict(avg_sd, strict=True)
+
+    # Apply SWA if collected (only when EMA is not used).
+    if args.swa_enabled and not args.ema_enabled and swa_state is not None and swa_count > 1:
+        log0(f"swa:applying averaged {swa_count} checkpoints")
+        current_state = base_model.state_dict()
+        avg_sd = {
+            name: (tensor / swa_count).to(dtype=current_state[name].dtype)
+            for name, tensor in swa_state.items()
+        }
+        base_model.load_state_dict(avg_sd, strict=True)
+
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # Exclude MTP head from export (training-only auxiliary head).
+    export_sd = {k: v for k, v in base_model.state_dict().items() if 'mtp_head' not in k}
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    if master_process:
+        torch.save(export_sd, "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_bits = int(os.environ.get("QUANT_BITS", "6"))
+    quant_label = f"int{quant_bits}+{artifact_compressor}"
+    quant_obj = mixed_quantize(sd_cpu, args.num_layers, quant_bits=quant_bits)
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    if artifact_compressor == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        import zlib
+        quant_blob = zlib.compress(quant_raw, level=9)
+    quant_filename = args.artifact_filename or f"final_model.{quant_label}.ptz"
+    if master_process:
+        with open(quant_filename, "wb") as f:
+            f.write(quant_blob)
+        with open("artifact_info.json", "w", encoding="utf-8") as f:
+            json.dump({
+                "artifact_filename": quant_filename,
+                "artifact_compressor": artifact_compressor,
+                "quant_bits": quant_bits,
+                "tokenizer_path": args.tokenizer_path,
+                "data_path": args.data_path,
+            }, f, indent=2)
+        quant_file_bytes = os.path.getsize(quant_filename)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model {quant_label}: {quant_file_bytes} bytes")
+        log0(f"Total submission size {quant_label}: {quant_file_bytes + code_bytes} bytes")
+        log0(f"artifact_filename:{quant_filename} artifact_compressor:{artifact_compressor}")
+
+    if args.train_only:
+        log0("train_only: skipping eval, model saved.")
+        if distributed:
+            dist.destroy_process_group()
+        return
+
+    if distributed:
+        dist.barrier()
+    with open(quant_filename, "rb") as f:
+        quant_blob_disk = f.read()
+    if artifact_compressor == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_disk = dctx.decompress(quant_blob_disk)
+    else:
+        import zlib
+        quant_raw_disk = zlib.decompress(quant_blob_disk)
+    quant_state = torch.load(io.BytesIO(quant_raw_disk), map_location="cpu")
+    base_model.load_state_dict(dequantize_mixed(quant_state, sd_cpu), strict=(args.mtp_k == 0))
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args, model, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_{quant_label}_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_quant_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    # Special eval modes (sliding window, SGD TTT)
+    lut_args = (base_bytes_lut, has_leading_space_lut, is_boundary_token_lut)
+    if args.eval_stride > 0:
+        sw_loss, sw_bpb, sw_tokens, sw_bytes = eval_val_sliding(args, base_model, device, val_tokens, *lut_args)
+        log0(
+            f"sliding_window eval_stride:{args.eval_stride} val_loss:{sw_loss:.4f} val_bpb:{sw_bpb:.4f} "
+            f"scored_tokens:{sw_tokens} scored_bytes:{sw_bytes:.0f}"
+        )
+        log0(f"sliding_window_exact val_loss:{sw_loss:.8f} val_bpb:{sw_bpb:.8f}")
+    if args.sgd_ttt:
+        original_param_set = args.sgd_ttt_param_set
+        eval_modes = [("sgd_ttt", original_param_set)]
+        if original_param_set != "all":
+            eval_modes.append(("sgd_ttt_full", "all"))
+        for label, param_set in eval_modes:
+            args.sgd_ttt_param_set = param_set
+            torch.cuda.synchronize()
+            t_ttt = time.perf_counter()
+            ttt_loss, ttt_bpb, ttt_tokens, ttt_bytes = eval_val_sgd_ttt(
+                args, base_model, device, val_tokens, *lut_args)
+            torch.cuda.synchronize()
+            log0(
+                f"{label} param_set:{param_set} lr:{args.sgd_ttt_lr} momentum:{args.sgd_ttt_momentum} "
+                f"epochs:{args.sgd_ttt_epochs} pointer:{args.pointer_copy} cache:{args.cache_mixture} "
+                f"ogd:{args.ogd_bias} val_loss:{ttt_loss:.4f} val_bpb:{ttt_bpb:.4f} "
+                f"scored_tokens:{ttt_tokens} scored_bytes:{ttt_bytes:.0f} "
+                f"time:{1000*(time.perf_counter()-t_ttt):.0f}ms"
+            )
+            log0(f"{label}_exact val_loss:{ttt_loss:.8f} val_bpb:{ttt_bpb:.8f}")
+        args.sgd_ttt_param_set = original_param_set
+
+    if distributed:
+        dist.destroy_process_group()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Non-record: Value Residual (-0.015 BPB) + Gated Attention (-0.003 BPB) with ablations

**val_bpb: 1.4525** (sliding window, stride=128, GA+VR combined) | **13.2 MB** | 1xRTX3090, 1000 steps, 131K batch

Two novel architecture modifications and one negative result. Sharing validated techniques with controlled ablation data.

### Contributions

1. **Value Residual (ResFormer)** -- -0.015 BPB. Cache V vectors from layer 0, mix into all subsequent layers via learnable scalars. 18 params total. arXiv:2410.17897 (ACL 2025). Enable: `VALUE_RESIDUAL=1`.

2. **Gated Attention** -- -0.003 BPB. Per-head sigmoid gate after SDPA output, eliminating attention sinks. ~37K params. arXiv:2505.06708 (NeurIPS 2025 Best Paper). Enable: `GATED_ATTENTION=1`.

3. **PPM-C Context Mixer** -- +0.0018 BPB (negative result). Classical compression blended with neural softmax. Dilutes predictions on SmearGate+BigramHash models.

The two positive techniques **stack additively** for **-0.017 BPB** combined.

### Ablation Results

v1024 9L 2xMLP, SmearGate + BigramHash + OrthoInit + WD 0.04, 131K batch, 1000 steps.

| Config | Sliding BPB | Delta vs Control |
|--------|-------------|------------------|
| Control | 1.4697 | -- |
| Gated Attention only | 1.4665 | -0.0032 |
| **Value Residual only** | **1.4546** | **-0.0151** |
| **GA + VR combined** | **1.4525** | **-0.0172** |
| PPM-C (eval-only) | 1.2900 | +0.0018 (worse) |

A production run (11L MLP3x + full community stack + VR + GA, 9500 steps) is in progress. Results in a follow-up submission if competitive.

### Files

- `README.md` -- Full writeup with technique details and reproducibility
- `submission.json` -- Metadata
- `train_gpt.py` -- Training script with Value Residual, Gated Attention, XSA, EMA, Partial RoPE, LN Scale