### PR TITLE
Non-record: 11L Depth Recurrence + High-Yield Legal TTT (1.14458 BPB)

### DIFF
--- a/records/track_non_record_16mb/2026-03-22_11L_VE128_PartialRoPE_LegalTTT/README.md
+++ b/records/track_non_record_16mb/2026-03-22_11L_VE128_PartialRoPE_LegalTTT/README.md
@@ -1,0 +1,196 @@
+# Depth Recurrence + Legal Score-First TTT with SGD Momentum
+
+**val_bpb = 1.14458** | Pre-TTT: 1.1611 | TTT gain: **−0.0165** | Artifact: 14.79 MB
+
+> Non-record unlimited-compute submission (trained on 4×A100-40GB, eval 1046s on 1×A100).
+
+---
+
+## Headline Result
+
+This submission demonstrates that **competition-legal test-time training (TTT) can deliver large gains** (−0.0165 BPB) when the TTT recipe is properly tuned.  The key insight is that SGD with momentum, applied for multiple epochs per chunk while freezing early layers, extracts **2.4× more TTT improvement** than single-epoch AdamW over the full network (−0.0068 in our prior submission, PR #456).
+
+The final 1.1446 BPB comes entirely from a legal score-first protocol: every validation token is **scored before any weight update** that could use it, enforced by `torch.inference_mode()` during the scoring phase.
+
+---
+
+## Novel & Creative Contributions
+
+### 1. High-Yield Legal TTT via Selective Freezing + SGD Momentum
+
+Most TTT approaches in the competition use AdamW over all parameters and train for a single epoch.  We find a much more effective recipe:
+
+- **SGD + momentum (0.9)** instead of AdamW — simpler optimizer with implicit regularization; lower memory footprint (no second-moment buffers) enables larger effective batch processing.
+- **3 epochs per chunk** instead of 1 — repeated passes over each 32K-token chunk let the model fully adapt, especially on domain-specific or rare constructions.
+- **Freeze the first 2 blocks** during TTT — early blocks learn general tokenization features (embeddings, basic syntax); adapting them hurts more than it helps. Freezing them regularizes TTT and keeps 19.9M of 24.6M parameters trainable on later, more "semantic" layers.
+
+This combination yields a TTT gain of **−0.0165 BPB** (1.1611 → 1.1446), compared to −0.0068 with our prior AdamW-1-epoch approach.
+
+### 2. Depth Recurrence (Weight-Efficient Deep Networks)
+
+The model uses 11 logical layers but only **10 unique BlockCores** — one core is reused at two different depths. Each Block wraps a shared core with its own per-layer LayerNorm buffers and scaling factors, so the reused core sees different normalization statistics at each depth.
+
+This delivers the representation capacity of an 11-layer network at the parameter cost of 10 layers — crucial in a size-constrained competition.  The technique is inspired by Universal Transformers but applied at the block level with independent normalization, avoiding the training instabilities of naive weight tying.
+
+### 3. Partial Rotary Position Embeddings (16 of 64 dims)
+
+Instead of applying RoPE to all head dimensions, we apply it to only the first 16 of 64 dimensions per head.  The remaining 48 dimensions are position-agnostic, acting as a "content-only" channel.
+
+This has two benefits:
+- **Better length generalization** — fewer dimensions are locked to absolute position, so the model degrades less gracefully on longer sequences during TTT.
+- **NTK-aware scaling** — the 16 RoPE dimensions use dynamic NTK base scaling (`base * scale^(d/(d-2))`) for extended contexts, concentrating position information in a compact subspace.
+
+### 4. Value Embeddings on Deep Layers Only
+
+Layers 9 and 10 receive **128-dim learned value embeddings** — a separate embedding table whose output is added to the value projection before attention.  This gives deep layers direct access to token identity information in the value stream, bypassing the information bottleneck of the residual stream.
+
+The embeddings are applied only to the deepest layers because:
+- Early layers benefit more from positional/syntactic features than raw token identity.
+- Adding VE everywhere wastes parameter budget (the 128-dim embedding table costs ~131K parameters).
+- Per-layer scale factors (initialized to 0.1) allow the model to smoothly learn how much value-embedding signal to mix in.
+
+### 5. Layer-Norm Depth Scaling
+
+Each block's attention and MLP outputs are scaled by `1/√(layer_idx + 1)`, so deeper layers contribute smaller residual updates.  This stabilizes training for deeper networks under depth recurrence, where the same core processes inputs at multiple depths with different effective scales.
+
+---
+
+## Architecture Summary
+
+| Component | Configuration |
+|---|---|
+| Layers | 11 logical (10 unique shared BlockCores) |
+| Embedding dim | 512 |
+| Heads | 8 (64 dim/head), 4 KV heads |
+| MLP | 3× expansion (1536) with ReLU²; SmearGate |
+| Vocab | 1024 (SentencePiece BPE) |
+| BigramHash | 2048 features |
+| RoPE | Partial: 16/64 dims, NTK-aware scaling |
+| Value Embeddings | 128d on layers 9–10, per-layer scale (init 0.1) |
+| LN Scale | `1/√(layer+1)` depth scaling |
+| XSA | Exclusive Self Attention on last 4 layers |
+| U-Net skips | Residual connections across layer pairs |
+| Parameters | 24,634,452 total |
+
+## Training Details
+
+| Setting | Value |
+|---|---|
+| Hardware | 4×A100-40GB (NVIDIA) |
+| Steps | 5,200 |
+| Training wallclock | 2,472s (~41 min) |
+| Optimizer | Muon (hidden/attn) + Adam (embeddings/scalars) |
+| SWA | 12 checkpoints from step 4,650 |
+| Late QAT | Enabled at step 4,901 (scale < 0.1) |
+| Quantization | Int6 + zstd-22 |
+
+## TTT Protocol (Legal Score-First)
+
+```
+for each 32K-token chunk:
+    1. model.eval() + torch.inference_mode()
+       → Forward pass on chunk, accumulate NLL    ← SCORE (graded)
+    2. model.train()
+       → SGD(lr=0.002, momentum=0.9), 3 epochs   ← TRAIN (adaptation)
+    3. Advance to next chunk with updated weights
+```
+
+Every target token is scored exactly once, strictly before any gradient update that could benefit from it.  The `torch.inference_mode()` context manager makes gradient leakage during scoring physically impossible.
+
+| TTT Setting | Value |
+|---|---|
+| Optimizer | SGD, momentum=0.9 |
+| Learning rate | 0.002 |
+| Epochs per chunk | 3 |
+| Chunk size | 32,768 tokens |
+| Stride | 64 |
+| Frozen blocks | First 2 (of 11) |
+| Trainable params | 19,911,748 / 24,634,452 |
+| Eval time | 1,046s (1×A100) |
+
+## Quantization & Size
+
+| Component | Bytes |
+|---|---|
+| Model (int6 + zstd) | 14,717,713 |
+| Code (train_gpt.py) | 71,706 |
+| **Total** | **14,789,419** |
+| Limit | 16,000,000 |
+| Headroom | 1,210,581 (7.6%) |
+
+## Training Curve
+
+| Step | Val BPB | Notes |
+|---|---|---|
+| 0 | 4.1037 | |
+| 500 | 1.4046 | |
+| 1000 | 1.3226 | |
+| 1500 | 1.2947 | |
+| 2000 | 1.2626 | |
+| 2500 | 1.2425 | |
+| 3000 | 1.2265 | |
+| 3500 | 1.2123 | |
+| 4000 | 1.1982 | |
+| 4500 | 1.1821 | |
+| 5000 | 1.1654 | SWA started at 4650, Late QAT at 4901 |
+| **5200** | **1.1611** | Pre-TTT baseline |
+| **TTT** | **1.14458** | −0.0165 from legal score-first TTT |
+
+## Comparison to Prior Submission (PR #456)
+
+| Metric | PR #456 (10L) | This (11L) | Δ |
+|---|---|---|---|
+| **val_bpb** | 1.15321 | **1.14458** | **−0.00863** |
+| Pre-TTT BPB | 1.1600 | 1.1611 | +0.0011 |
+| TTT gain | −0.0068 | **−0.0165** | **2.4× larger** |
+| Layers | 10 | 11 (10 unique) | +1 |
+| BigramHash | 10240 | 2048 | −8192 |
+| Artifact size | 15.98 MB | 14.79 MB | −1.19 MB |
+
+The pre-TTT baselines are nearly identical (1.1600 vs 1.1611).  The entire improvement comes from better TTT — validating that the SGD+momentum + freeze + multi-epoch recipe is the key advance.
+
+## Reproducibility
+
+```bash
+# Environment: Python 3.10+, PyTorch 2.x with CUDA
+# From the repo root:
+RUN_ID=i15_11L_ve128 \
+NUM_LAYERS=11 \
+UNIQUE_LAYERS=10 \
+DATA_PATH=./data/datasets/fineweb10B_sp1024/ \
+TOKENIZER_PATH=./data/tokenizers/fineweb_1024_bpe.model \
+VOCAB_SIZE=1024 \
+MAX_WALLCLOCK_SECONDS=0 \
+ITERATIONS=5200 \
+VAL_LOSS_EVERY=500 \
+VE_ENABLED=1 VE_DIM=128 VE_LAYERS=9,10 \
+ROPE_DIMS=16 LN_SCALE=1 \
+BIGRAM_VOCAB_SIZE=2048 \
+XSA_LAST_N=4 EVAL_STRIDE=64 \
+TTT_ENABLED=1 TTT_LR=0.002 TTT_EPOCHS=3 \
+TTT_FREEZE_BLOCKS=2 TTT_BATCH_SEQS=32 TTT_MOMENTUM=0.9 \
+torchrun --standalone --nproc_per_node=4 \
+   records/track_non_record_16mb/2026-03-22_11L_VE128_PartialRoPE_LegalTTT/train_gpt.py
+```
+
+## Credits
+
+This submission builds on work from many contributors to the parameter-golf competition:
+
+- **Muon optimizer** — Baseline (`modded-nanogpt`); Newton-Schulz orthogonal preconditioning
+- **BigramHash embeddings** — PR #65 (aquariouseworkman): hash consecutive token pairs for cheap bigram context
+- **SmearGate** — PR #65 (aquariouseworkman): per-dim sigmoid gate blending adjacent token embeddings
+- **XSA (Exclusive Self Attention)** — PR #187 (Idan3011): removes self-value bias via orthogonal projection; GQA-aware variant in PR #265 (unnir)
+- **U-Net skip connections** — PR #65 (aquariouseworkman), PR #69 (TevBenji): encoder-decoder layer pairing with learned skip weights
+- **Mixed int5/int6 quantization** — PR #76 (unixmadtoonslab / Will DePue): int5 for MLP, int6 for attention
+- **SWA (Stochastic Weight Averaging)** — PR #69 (TevBenji): checkpoint averaging during warmdown
+- **Late QAT** — PR #315 (jfprincz), working implementation in PR #374 (unnir): STE fake-quantization in final training phase
+- **Sliding window evaluation** — PR #50 (mattqlf / Matthew Li): stride-64 overlapping windows
+- **Value Embeddings (VE128)** — PR #374 (unnir): learned embeddings added to value projections on deep layers
+- **Partial RoPE (16/64 dims)** — PR #315 (jfprincz), PR #374 (unnir): rotary embeddings on 25% of head dims
+- **LN Scale (depth scaling)** — PR #315 (jfprincz), PR #374 (unnir): `1/√(layer+1)` output scaling
+- **Depth recurrence** — PR #8 (iranzithierry): earliest depth-recurrence infrastructure
+- **Legal TTT framework** — PR #77 (samacqua): first legal score-first TTT (LoRA); full-model variant in our PR #456
+- **ReLU² activation, GQA** — Baseline (`modded-nanogpt`)
+
+Built on the [parameter-golf](https://github.com/openai/parameter-golf) starter code by Beren Millidge & Keller Jordan.

--- a/records/track_non_record_16mb/2026-03-22_11L_VE128_PartialRoPE_LegalTTT/submission.json
+++ b/records/track_non_record_16mb/2026-03-22_11L_VE128_PartialRoPE_LegalTTT/submission.json
@@ -1,0 +1,19 @@
+{
+  "author": "Chris McClendon",
+  "github_id": "Christopher-Lee-McClendon",
+  "name": "11L VE128 PartialRoPE LNScale Legal TTT",
+  "blurb": "11-layer depth-recurrence GPT with Value Embeddings (128d on layers 9-10), Partial RoPE (16/64), Layer-Norm Scale, XSA last 4, BigramHash(2048), legal score-first TTT (3-epoch SGD momentum=0.9), int6+zstd quantization, SWA, and Late QAT. Key techniques integrated from PR #455 and #442. Trained on 4xA100.",
+  "date": "2026-03-22",
+  "track": "non-record-unlimited-compute-16mb",
+  "val_loss": 1.93257718,
+  "val_bpb": 1.14458409,
+  "pre_ttt_val_loss": 1.9605,
+  "pre_ttt_val_bpb": 1.1611,
+  "step_stop": 5200,
+  "wallclock_seconds": 2472,
+  "eval_time_seconds": 1046,
+  "bytes_total": 14789419,
+  "bytes_model_int6_zstd": 14717713,
+  "bytes_code": 71706,
+  "gpu": "4xA100-40GB"
+}

--- a/records/track_non_record_16mb/2026-03-22_11L_VE128_PartialRoPE_LegalTTT/train.log
+++ b/records/track_non_record_16mb/2026-03-22_11L_VE128_PartialRoPE_LegalTTT/train.log
@@ -1,0 +1,1779 @@
+"""
+Parameter Golf: 11L Depth Recurrence + VE128 + Partial RoPE + LN Scale + Legal TTT
+11-layer GPT with BigramHash, SmearGate, XSA, U-Net skips, SWA, VE128,
+partial RoPE (16/64), LN scale, mixed int5/int6 quantization, and legal TTT.
+Depth recurrence (shared BlockCores) enabled via UNIQUE_LAYERS env var.
+
+Key improvements from PRs #455, #442, #374:
+- 11 layers (vs 10) for more capacity
+- Partial RoPE: only 16/64 head dims get rotary embedding
+- LN Scale: 1/sqrt(layer_idx+1) scaling on normalized inputs
+- ValueEmbedding (VE128): shared embedding added to value projections on deep layers
+- XSA on last 4 layers, BigramHash(2048)
+- Legal TTT: SGD 3 epochs, freeze first 2 blocks
+"""
+from __future__ import annotations
+import copy, glob, io, math, os, random, subprocess, sys, time, uuid, zlib
+from pathlib import Path
+try:
+    import zstandard; _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+_IS_AMPERE_PLUS = torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 8
+_HALF_DTYPE = torch.bfloat16 if _IS_AMPERE_PLUS else torch.float16
+
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 42))
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 500))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 100))
+    iterations = int(os.environ.get("ITERATIONS", 5200))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 3.0))
+    mlp_activation = os.environ.get("MLP_ACTIVATION", "relu_sq").lower()
+    unique_layers = int(os.environ.get("UNIQUE_LAYERS", 10))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.035))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.025))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.025))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    weight_decay = float(os.environ.get("WEIGHT_DECAY", 0.04))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.01))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 64))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 2048))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.2))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 4))
+    late_qat = bool(int(os.environ.get("LATE_QAT", "1")))
+    qat_threshold = float(os.environ.get("QAT_THRESHOLD", 0.1))
+    all_int5 = bool(int(os.environ.get("ALL_INT5", "0")))
+    prune_frac = float(os.environ.get("PRUNE_FRAC", "0.03"))
+    gptq_lite = bool(int(os.environ.get("GPTQ_LITE", "0")))
+    quant_eval_every = int(os.environ.get("QUANT_EVAL_EVERY", "0"))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.002))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 3))
+    ttt_freeze_blocks = int(os.environ.get("TTT_FREEZE_BLOCKS", 2))
+    ttt_grad_clip = float(os.environ.get("TTT_GRAD_CLIP", 1.0))
+    ttt_batch_seqs = int(os.environ.get("TTT_BATCH_SEQS", 32))
+    ttt_chunk_tokens = int(os.environ.get("TTT_CHUNK_TOKENS", 32768))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+    ve_enabled = bool(int(os.environ.get("VE_ENABLED", "1")))
+    ve_dim = int(os.environ.get("VE_DIM", 128))
+    ve_layers = os.environ.get("VE_LAYERS", "9,10")
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.to(torch.bfloat16 if _IS_AMPERE_PLUS else torch.float32)
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(params, dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                                      nesterov=nesterov, weight_decay=weight_decay))
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr, momentum = group["lr"], group["momentum"]
+            backend_steps, nesterov = group["backend_steps"], group["nesterov"]
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=_HALF_DTYPE)
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                if wd > 0:
+                    p.data.mul_(1.0 - lr * wd)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+        return loss
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+def eval_val(
+    args: Hyperparameters, model: nn.Module, rank: int, world_size: int,
+    device: torch.device, grad_accum_steps: int, val_tokens: Tensor,
+    base_bytes_lut: Tensor, has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError("VAL_BATCH_SIZE too small")
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=_HALF_DTYPE, enabled=True):
+                batch_loss = model(x, y).detach()
+            val_loss_sum += batch_loss.to(torch.float64) * float(y.numel())
+            val_token_count += float(y.numel())
+            prev_ids, tgt_ids = x.reshape(-1), y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    p for p in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,"
+        "q_gain,skip_weight,skip_weights,smear,bigram.scale,ve_layer_scales,ve_shared.scale",
+    ).split(",") if p
+)
+FP16_KEEP_NAME_PATTERNS = tuple(
+    p for p in os.environ.get(
+        "FP16_KEEP_NAME_PATTERNS", "tok_emb,cores.2.attn.c_k"
+    ).split(",") if p
+)
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_Q = float(os.environ.get("INT8_CLIP_PERCENTILE", "99.99984")) / 100.0
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+                    if t32.numel() else torch.empty((t32.shape[0],), dtype=torch.float32))
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name: return "embed"
+    if ".mlp." in name: return "mlp"
+    if "bigram" in name: return "bigram"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name): return "attn"
+    return "other"
+
+def quantize_intN_per_row(t: Tensor, clip_range: int = 31,
+                          gptq_lite: bool = False) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        if gptq_lite:
+            n_cols = t32.shape[1]
+            sorted_abs, _ = t32.abs().sort(dim=1)
+            best_q = best_scale = None
+            best_mse = torch.full((t32.shape[0],), float('inf'), device=t32.device)
+            for p in (0.95, 0.975, 0.99, 0.995, 1.0):
+                idx = min(int(p * (n_cols - 1)), n_cols - 1)
+                row_clip = sorted_abs[:, idx]
+                sc = (row_clip / clip_range).clamp_min(1e-12).to(torch.float16)
+                sc = sc.clamp_min(torch.finfo(torch.float16).tiny)
+                q = torch.clamp(torch.round(t32 / sc.float()[:, None]),
+                                -(clip_range + 1), clip_range).to(torch.int8)
+                deq = q.float() * sc.float()[:, None]
+                mse = (t32 - deq).pow(2).mean(dim=1)
+                if best_q is None:
+                    best_q, best_scale, best_mse = q, sc, mse
+                else:
+                    better = mse < best_mse
+                    best_q[better] = q[better]
+                    best_scale[better] = sc[better]
+                    best_mse[better] = mse[better]
+            return best_q, best_scale
+        row_max = t32.abs().amax(dim=1)
+        scale = (row_max / clip_range).clamp_min(1e-12).to(torch.float16)
+        scale = scale.clamp_min(torch.finfo(torch.float16).tiny)
+        q = torch.clamp(torch.round(t32 / scale.float()[:, None]), -(clip_range + 1), clip_range).to(torch.int8)
+        return q, scale
+    amax = t32.abs().max().item()
+    scale = torch.tensor(max(amax / clip_range, 1e-12), dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -(clip_range + 1), clip_range).to(torch.int8)
+    return q, scale
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str],
+                        gptq_lite: bool = False, force_int5: bool = False):
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 8192:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if any(p in name for p in FP16_KEEP_NAME_PATTERNS):
+            result[name] = t.to(dtype=torch.float16).contiguous()
+            meta[name] = "passthrough_fp16"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            clip = 15 if force_int5 else (15 if cat == "mlp" else 31)
+            q, s = quantize_intN_per_row(t, clip_range=clip, gptq_lite=gptq_lite)
+            bits = {15: 5, 31: 6, 63: 7}.get(clip, 6)
+            result[name + ".q"] = q; result[name + ".scale"] = s
+            meta[name] = {"type": f"int{bits}"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q; result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta[name]
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    if file.stat().st_size != header_bytes + num_tokens * token_bytes:
+        raise ValueError(f"Shard size mismatch for {file}")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank, self.world_size, self.device = rank, world_size, device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+    _qat_clip_range: int = 31
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            cr = CastedLinear._qat_clip_range
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                scale_q = (row_max / float(cr)).clamp_min(1.0 / float(cr))
+                w_q = (torch.clamp(torch.round(w32 / scale_q[:, None]), -(cr + 1), cr) * scale_q[:, None]).to(x.dtype)
+            w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS)) \
+                    and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024,
+                 rope_dims: int = 0):
+        super().__init__()
+        self.dim, self.base = dim, base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        rd = self.rope_dims
+        inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, dtype=torch.float32) / rd))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (self._cos_cached is None or self._sin_cached is None
+                or self._seq_len_cached != seq_len or self._cos_cached.device != device):
+            rd = self.rope_dims
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (rd / (rd - 2)))
+                inv_freq = 1.0 / (new_base ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd))
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int = 0) -> Tensor:
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int,
+                 rope_base: float, qk_gain_init: float, xsa_enabled: bool = False,
+                 rope_dims: int = 0):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads, self.num_kv_heads = num_heads, num_kv_heads
+        self.head_dim = dim // num_heads
+        self.xsa_enabled = xsa_enabled
+        self.rope_dims = rope_dims
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024,
+                             rope_dims=rope_dims)
+
+    def forward(self, x: Tensor, v_embed: Tensor | None = None) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = self.c_v(x)
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        # Transpose to [B, H, T, D] for SDPA
+        q = q.transpose(1, 2)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
+        if _IS_AMPERE_PLUS and self.num_kv_heads != self.num_heads:
+            y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True, enable_gqa=True)
+        else:
+            if self.num_kv_heads != self.num_heads:
+                repeats = self.num_heads // self.num_kv_heads
+                k = k.repeat_interleave(repeats, dim=1)
+                v_for_sdpa = v.repeat_interleave(repeats, dim=1)
+            else:
+                v_for_sdpa = v
+            y = F.scaled_dot_product_attention(q, k, v_for_sdpa, attn_mask=None, is_causal=True)
+        if self.xsa_enabled:
+            group_size = self.num_heads // self.num_kv_heads
+            y_t = y.transpose(1, 2)
+            y_grouped = y_t.reshape(bsz, seqlen, self.num_kv_heads, group_size, self.head_dim)
+            vn = F.normalize(v.transpose(1, 2).unsqueeze(3), dim=-1)
+            dot_prod = (y_grouped * vn).sum(dim=-1, keepdim=True)
+            y = (y_grouped - dot_prod * vn).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: float, activation: str = "relu_sq"):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+        self.activation = activation
+
+    def forward(self, x: Tensor) -> Tensor:
+        if self.activation == "leaky_relu_sq":
+            x = F.leaky_relu(self.fc(x), negative_slope=0.5)
+        else:
+            x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class ValueEmbedding(nn.Module):
+    def __init__(self, vocab_size: int, ve_dim: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, ve_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(ve_dim, model_dim, bias=False) if ve_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(token_ids)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class BlockCore(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: float,
+                 rope_base: float, qk_gain_init: float,
+                 xsa_enabled: bool = False, mlp_activation: str = "relu_sq",
+                 rope_dims: int = 0):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+                                        xsa_enabled=xsa_enabled, rope_dims=rope_dims)
+        self.mlp = MLP(dim, mlp_mult, activation=mlp_activation)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, layer_idx: int = 0, ln_scale: bool = False):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+
+    def forward(self, x: Tensor, x0: Tensor, core: BlockCore,
+                v_embed: Tensor | None = None) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * core.attn(
+            self.attn_norm(x) * self.ln_scale_factor, v_embed=v_embed)
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * core.mlp(
+            self.mlp_norm(x) * self.ln_scale_factor)
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int, num_heads: int,
+                 num_kv_heads: int, mlp_mult: float, tie_embeddings: bool,
+                 tied_embed_init_std: float, logit_softcap: float, rope_base: float,
+                 qk_gain_init: float, bigram_vocab_size: int = 0, bigram_dim: int = 128,
+                 unique_layers: int = 0, xsa_last_n: int = 0, mlp_activation: str = "relu_sq",
+                 rope_dims: int = 0, ln_scale: bool = False,
+                 ve_enabled: bool = False, ve_dim: int = 128, ve_layers: str = "9,10"):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) \
+            if bigram_vocab_size > 0 else None
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.smear = SmearGate(model_dim)
+        n_cores = unique_layers if (0 < unique_layers < num_layers) else num_layers
+        xsa_start = max(0, n_cores - xsa_last_n) if xsa_last_n > 0 else n_cores
+        self.cores = nn.ModuleList([
+            BlockCore(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base,
+                      qk_gain_init, xsa_enabled=(i >= xsa_start),
+                      mlp_activation=mlp_activation, rope_dims=rope_dims)
+            for i in range(n_cores)
+        ])
+        self.blocks = nn.ModuleList([
+            Block(model_dim, layer_idx=i, ln_scale=ln_scale)
+            for i in range(num_layers)
+        ])
+        self._core_indices = [i % n_cores for i in range(num_layers)]
+        if n_cores < num_layers:
+            from collections import Counter
+            uses = Counter(self._core_indices)
+            for core_idx, core in enumerate(self.cores):
+                n_uses = uses[core_idx]
+                if n_uses > 1:
+                    scale = 1.0 / n_uses
+                    for p in core.parameters():
+                        p.register_hook(lambda grad, s=scale: grad * s)
+        # Value Embedding (VE128)
+        self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+        kv_dim = num_kv_heads * (model_dim // num_heads)
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim)
+            self.ve_layer_scales = nn.ParameterList(
+                [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices])
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        num_layers = len(self.blocks)
+        for name, module in self.named_modules():
+            if isinstance(module, CastedLinear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj." in name or name.endswith(".proj"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+
+    def _get_ve(self, layer_idx: int, input_ids: Tensor,
+                ve_cache: dict | None = None) -> Tensor | None:
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if ve_cache is not None and 've' not in ve_cache:
+            ve_cache['ve'] = self.ve_shared(input_ids)
+        ve_base = ve_cache['ve'] if ve_cache is not None else self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_base * self.ve_layer_scales[ve_idx].to(dtype=ve_base.dtype)
+
+    def _forward_body(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x = self.blocks[i](x, x0, self.cores[self._core_indices[i]], v_embed=ve)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            idx = self.num_encoder_layers + i
+            ve = self._get_ve(idx, input_ids, ve_cache)
+            x = self.blocks[idx](x, x0, self.cores[self._core_indices[idx]], v_embed=ve)
+        return self.final_norm(x)
+
+    def _logits(self, x: Tensor) -> Tensor:
+        if self.tie_embeddings:
+            raw = F.linear(x, self.tok_emb.weight)
+        else:
+            raw = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(raw / self.logit_softcap)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self._forward_body(input_ids)
+        x = x.reshape(-1, x.size(-1))
+        logits = self._logits(x)
+        return F.cross_entropy(logits.float(), target_ids.reshape(-1), reduction="mean")
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        return self._logits(self._forward_body(input_ids))
+
+def eval_val_sliding(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    stride: int, batch_seqs: int = 32,
+) -> tuple[float, float]:
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    base_model.eval()
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=_HALF_DTYPE):
+                logits = base_model.forward_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1), reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt, prev = y_batch[i, s:wlen], x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+            if rank == 0 and (bi // batch_seqs) % 50 == 0:
+                done = min(bi + batch_seqs, len(my_windows))
+                pct = done / len(my_windows) * 100
+                rl = (loss_sum / token_count).item() if token_count.item() > 0 else 0.0
+                rbpb = rl / math.log(2.0) * (token_count.item() / byte_count.item()) if token_count.item() > 0 else 0.0
+                print(f"  sliding_eval [{pct:5.1f}%] {done}/{len(my_windows)} "
+                      f"windows running_bpb={rbpb:.6f}", flush=True)
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (loss_sum / token_count).item()
+    base_model.train()
+    return val_loss, val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+def eval_val_sliding_ttt(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    stride: int, batch_seqs: int = 32, log0=print,
+) -> tuple[float, float]:
+    """Legal score-first TTT: score each chunk with sliding windows, then train on it."""
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = args.ttt_chunk_tokens
+
+    # Pre-compute all window starts (same as eval_val_sliding)
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+
+    # Assign each window to a chunk based on the first token it scores
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    chunk_windows: list[list[int]] = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        end = min(ws + seq_len, total_tokens)
+        wlen = end - ws
+        s = 0 if ws == 0 else max(wlen - stride, 0)
+        scored_start = ws + s
+        ci = min(scored_start // ttt_chunk, num_chunks - 1)
+        chunk_windows[ci].append(ws)
+
+    log0(f"ttt_sliding:start chunks={num_chunks} chunk_tokens={ttt_chunk} "
+         f"total_windows={len(window_starts)} stride={stride} "
+         f"ttt_lr={args.ttt_lr} ttt_epochs={args.ttt_epochs} "
+         f"freeze_blocks={args.ttt_freeze_blocks}")
+
+    # BPB accumulators
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Setup TTT optimizer (AdamW per PR #442)
+    n_blocks = len(base_model.blocks)
+    frozen_block_ids = set(range(min(args.ttt_freeze_blocks, n_blocks)))
+    frozen_core_ids = set(base_model._core_indices[i] for i in frozen_block_ids) if frozen_block_ids else set()
+
+    ttt_params = []
+    for name, p in base_model.named_parameters():
+        freeze = False
+        for bi in frozen_block_ids:
+            if f"blocks.{bi}." in name:
+                freeze = True; break
+        if not freeze:
+            for ci_core in frozen_core_ids:
+                if f"cores.{ci_core}." in name:
+                    freeze = True; break
+        if freeze:
+            p.requires_grad_(False)
+        else:
+            p.requires_grad_(True)
+            ttt_params.append(p)
+
+    log0(f"ttt_sliding:params unfrozen={sum(p.numel() for p in ttt_params)} "
+         f"frozen={sum(p.numel() for p in base_model.parameters() if not p.requires_grad)}")
+
+    optimizer = torch.optim.SGD(ttt_params, lr=args.ttt_lr, momentum=args.ttt_momentum)
+
+    t0 = time.perf_counter()
+
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows:
+            continue
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+
+        # --- Phase 1: SCORE this chunk's windows (sliding window eval) ---
+        my_s = (len(windows) * rank) // world_size
+        my_e = (len(windows) * (rank + 1)) // world_size
+        my_windows = windows[my_s:my_e]
+
+        base_model.eval()
+        with torch.inference_mode():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi:bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens: list[int] = []
+                for i, ws in enumerate(batch_ws):
+                    end = min(ws + seq_len, total_tokens)
+                    wlen = end - ws
+                    wlens.append(wlen)
+                    chunk_tok = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                    x_batch[i, :wlen] = chunk_tok[:-1]
+                    y_batch[i, :wlen] = chunk_tok[1:]
+                with torch.autocast(device_type="cuda", dtype=_HALF_DTYPE):
+                    logits = base_model.forward_logits(x_batch)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y_batch.reshape(-1), reduction="none",
+                ).reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]
+                    s = 0 if ws == 0 else max(wlen - stride, 0)
+                    scored_nll = nll[i, s:wlen].to(torch.float64)
+                    loss_sum += scored_nll.sum()
+                    token_count += float(wlen - s)
+                    tgt, prev = y_batch[i, s:wlen], x_batch[i, s:wlen]
+                    tb = base_bytes_lut[tgt].to(torch.float64)
+                    tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                    byte_count += tb.sum()
+
+        # --- Phase 2: TRAIN on this chunk's tokens (already scored = legal) ---
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and args.ttt_epochs > 0:
+            base_model.train()
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if chunk_seqs > 0:
+                # Cosine decay across chunks
+                cos_lr = args.ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                for pg in optimizer.param_groups:
+                    pg['lr'] = cos_lr
+
+                # Partition training seqs across ranks
+                my_seq_s = (chunk_seqs * rank) // world_size
+                my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+                my_chunk_seqs = my_seq_e - my_seq_s
+
+                for _ep in range(args.ttt_epochs):
+                    for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                        be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                        actual_bs = my_seq_s + bs
+                        actual_be = my_seq_s + be
+                        start_tok = chunk_start + actual_bs * seq_len
+                        end_tok = chunk_start + actual_be * seq_len + 1
+                        if end_tok > val_tokens.numel():
+                            continue
+                        local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                        x = local[:-1].reshape(-1, seq_len)
+                        y = local[1:].reshape(-1, seq_len)
+                        optimizer.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            loss = base_model(x, y)
+                        loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        if args.ttt_grad_clip > 0:
+                            torch.nn.utils.clip_grad_norm_(ttt_params, args.ttt_grad_clip)
+                        optimizer.step()
+
+        # Progress log
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            log0(f"  ttt_chunk [{ci+1}/{num_chunks}] bpb={rbpb:.6f} time={elapsed:.1f}s")
+
+    # Final all-reduce
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+    # Restore state
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+    log0(f"ttt_sliding:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+         f"elapsed={time.perf_counter() - t0:.1f}s")
+    return val_loss, val_bpb
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    if _IS_AMPERE_PLUS:
+        zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    if _IS_AMPERE_PLUS:
+        enable_cudnn_sdp(False); enable_flash_sdp(True)
+        enable_mem_efficient_sdp(False); enable_math_sdp(False)
+    else:
+        enable_cudnn_sdp(False); enable_flash_sdp(False)
+        enable_mem_efficient_sdp(True); enable_math_sdp(True)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process: return
+        if console: print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                        text=True, check=False).stdout, console=False)
+    log0("=" * 100, console=False)
+    random.seed(args.seed); np.random.seed(args.seed)
+    torch.manual_seed(args.seed); torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(f"VOCAB_SIZE={args.vocab_size} != tokenizer vocab_size={int(sp.vocab_size())}")
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device)
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    base_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init, bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim, unique_layers=args.unique_layers,
+        xsa_last_n=args.xsa_last_n, mlp_activation=args.mlp_activation,
+        rope_dims=args.rope_dims, ln_scale=args.ln_scale,
+        ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+    ).to(device).to(_HALF_DTYPE)
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    if _IS_AMPERE_PLUS:
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    else:
+        log0("skipping torch.compile on non-Ampere GPU")
+        compiled_model = base_model
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank],
+                           broadcast_buffers=False) if distributed else compiled_model
+
+    matrix_params, scalar_params = [], []
+    for name, p in base_model.cores.named_parameters():
+        if p.ndim == 2 and not any(pat in name for pat in CONTROL_TENSOR_NAME_PATTERNS):
+            matrix_params.append(p)
+        else:
+            scalar_params.append(p)
+    for name, p in base_model.blocks.named_parameters():
+        if p.ndim < 2 or any(pat in name for pat in CONTROL_TENSOR_NAME_PATTERNS):
+            scalar_params.append(p)
+        elif p.ndim == 2 and not any(pat in name for pat in CONTROL_TENSOR_NAME_PATTERNS):
+            matrix_params.append(p)
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_params.append({"params": [base_model.bigram.embed.weight],
+                           "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None:
+            matrix_params.append(base_model.bigram.proj.weight)
+    if base_model.ve_shared is not None:
+        tok_params.append({"params": [base_model.ve_shared.embed.weight],
+                           "lr": token_lr, "base_lr": token_lr})
+        if base_model.ve_shared.proj is not None:
+            matrix_params.append(base_model.ve_shared.proj.weight)
+        scalar_params.append(base_model.ve_shared.scale)
+        for s in base_model.ve_layer_scales:
+            scalar_params.append(s)
+
+    optimizer_tok = torch.optim.AdamW(
+        tok_params, betas=(args.beta1, args.beta2), eps=args.adam_eps,
+        weight_decay=args.adam_wd, fused=True)
+    optimizer_muon = Muon(
+        matrix_params, lr=args.matrix_lr, momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps, weight_decay=0.04)
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps,
+        weight_decay=args.adam_wd, fused=True)
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True)
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params} unique_cores:{len(base_model.cores)}")
+    log0(f"unique_layers:{args.unique_layers} mlp_mult:{args.mlp_mult}")
+    log0(f"matrix_params:{sum(p.numel() for p in matrix_params)} "
+         f"scalar_params:{sum(p.numel() for p in scalar_params)}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+         f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}")
+    log0(f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+         f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+         f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}")
+    log0(f"seed:{args.seed}")
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0: return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            if warmdown_start <= step < args.iterations:
+                return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0)
+            return 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    if args.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=_HALF_DTYPE, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+
+    while True:
+        last_step = step == args.iterations or (
+            stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut)
+            log0(f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                 f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms")
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            if (args.quant_eval_every > 0 and should_validate
+                    and lr_mul(step, training_time_ms) < args.swa_start_frac
+                    and step % args.quant_eval_every == 0 and master_process):
+                with torch.no_grad():
+                    sd_snap = {k: v.detach().cpu().clone() for k, v in base_model.state_dict().items()}
+                    qr, qm = mixed_quantize_int6(sd_snap, {"mlp", "attn", "bigram"})
+                    deq = dequantize_mixed_int6(qr, qm, sd_snap)
+                    orig_sd = base_model.state_dict()
+                    base_model.load_state_dict(
+                        {k: v.to(dtype=orig_sd[k].dtype, device=orig_sd[k].device) for k, v in deq.items()},
+                        strict=True)
+                    _, q_bpb = eval_val(
+                        args, model, rank, world_size, device, grad_accum_steps,
+                        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut)
+                    log0(f"quant_gap step:{step} float_bpb:{val_bpb:.4f} int6_bpb:{q_bpb:.4f} gap:{q_bpb - val_bpb:.4f}")
+                    base_model.load_state_dict(orig_sd, strict=True)
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms step:{step}/{args.iterations}")
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=_HALF_DTYPE, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        if args.late_qat and scale < args.qat_threshold and not CastedLinear._qat_enabled:
+            CastedLinear._qat_enabled = True
+            CastedLinear._qat_clip_range = 15 if args.all_int5 else 31
+            log0(f"late_qat:enabled step:{step} scale:{scale:.4f} clip_range:{CastedLinear._qat_clip_range}")
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+
+        if args.swa_enabled and scale < args.swa_start_frac and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+
+        should_log_train = (args.train_log_every > 0 and
+            (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None))
+        if should_log_train:
+            log0(f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                 f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms")
+
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+         f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB")
+
+    if args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"swa:applying averaged {swa_count} checkpoints")
+        current_state = base_model.state_dict()
+        avg_state = {name: (tensor / swa_count).to(dtype=current_state[name].dtype)
+                     for name, tensor in swa_state.items()}
+        base_model.load_state_dict(avg_state, strict=True)
+
+    _model_pt = f"final_model_{args.run_id}.pt"
+    _model_ptz = f"final_model_{args.run_id}.int8.ptz"
+    if master_process:
+        torch.save(base_model.state_dict(), _model_pt)
+        model_bytes = os.path.getsize(_model_pt)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    with torch.no_grad():
+        for name, param in base_model.named_parameters():
+            if param.ndim == 2 and param.numel() > 65536:
+                threshold = torch.quantile(param.abs().float().flatten(), args.prune_frac)
+                param.masked_fill_(param.abs() < threshold, 0.0)
+        log0(f"magnitude_pruning: frac={args.prune_frac}")
+
+    if master_process:
+        log0("=== Weight distribution diagnostics ===")
+        for name, param in base_model.named_parameters():
+            if param.ndim == 2 and param.numel() > 8192:
+                t = param.detach().float()
+                absmax = t.abs().max().item()
+                absmean = t.abs().mean().item()
+                kurtosis = ((t - t.mean()) / t.std()).pow(4).mean().item() - 3.0
+                if kurtosis > 5.0 or absmax / absmean > 20.0:
+                    log0(f"  OUTLIER {name}: max={absmax:.4f} mean={absmean:.4f} "
+                         f"ratio={absmax/absmean:.1f} kurtosis={kurtosis:.1f}")
+
+    CastedLinear._qat_enabled = False
+    sd_cpu = {k: v.detach().cpu() for k, v in base_model.state_dict().items()}
+    quant_result, quant_meta = mixed_quantize_int6(sd_cpu, {"mlp", "attn", "bigram"},
+                                                   gptq_lite=args.gptq_lite,
+                                                   force_int5=args.all_int5)
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    if _COMPRESSOR == "zstd":
+        quant_blob = zstandard.ZstdCompressor(level=22).compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, 9)
+    if master_process:
+        with open(_model_ptz, "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize(_model_ptz)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+{_COMPRESSOR}: {quant_file_bytes} bytes")
+        log0(f"Total submission size int6+{_COMPRESSOR}: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open(_model_ptz, "rb") as f:
+        quant_blob_disk = f.read()
+    if _COMPRESSOR == "zstd":
+        decompressed = zstandard.ZstdDecompressor().decompress(quant_blob_disk)
+    else:
+        decompressed = zlib.decompress(quant_blob_disk)
+    quant_state = torch.load(io.BytesIO(decompressed), map_location="cpu")
+    deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], sd_cpu)
+    base_model.load_state_dict(deq_state, strict=True)
+
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    if args.ttt_enabled and args.eval_stride > 0 and args.eval_stride < args.train_seq_len:
+        log0(f"final_eval_mode:sliding_window_ttt stride:{args.eval_stride} "
+             f"chunk_tokens:{args.ttt_chunk_tokens}")
+        q_val_loss, q_val_bpb = eval_val_sliding_ttt(
+            args, base_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, batch_seqs=args.eval_batch_seqs, log0=log0)
+    elif args.eval_stride > 0 and args.eval_stride < args.train_seq_len:
+        log0(f"final_eval_mode:sliding_window stride:{args.eval_stride} batch_seqs:{args.eval_batch_seqs}")
+        q_val_loss, q_val_bpb = eval_val_sliding(
+            args, base_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, batch_seqs=args.eval_batch_seqs)
+    else:
+        log0("final_eval_mode:standard")
+        q_val_loss, q_val_bpb = eval_val(
+            args, model, rank, world_size, device, grad_accum_steps,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut)
+    torch.cuda.synchronize()
+    log0(f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+         f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms")
+    log0(f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
+Running Python 3.12.7 | packaged by conda-forge | (main, Oct  4 2024, 16:05:46) [GCC 13.3.0]
+Running PyTorch 2.10.0+cu128
+Sun Mar 22 16:14:36 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.172.08             Driver Version: 570.172.08     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA A100-PCIE-40GB          On  |   00000000:17:00.0 Off |                    0 |
+| N/A   34C    P0             47W /  250W |     667MiB /  40960MiB |      9%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA A100-PCIE-40GB          On  |   00000000:65:00.0 Off |                    0 |
+| N/A   34C    P0             46W /  250W |     667MiB /  40960MiB |     10%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA A100-PCIE-40GB          On  |   00000000:CA:00.0 Off |                    0 |
+| N/A   34C    P0             49W /  250W |     667MiB /  40960MiB |     10%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA A100-PCIE-40GB          On  |   00000000:E3:00.0 Off |                    0 |
+| N/A   34C    P0             46W /  250W |     667MiB /  40960MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A         3957905      C   ...ameter_golf/.venv/bin/python3        658MiB |
+|    1   N/A  N/A         3957906      C   ...ameter_golf/.venv/bin/python3        658MiB |
+|    2   N/A  N/A         3957907      C   ...ameter_golf/.venv/bin/python3        658MiB |
+|    3   N/A  N/A         3957908      C   ...ameter_golf/.venv/bin/python3        658MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/hpfs/scratch/gpfs/mcclec07/code/parameter_golf/repo/data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=/hpfs/scratch/gpfs/mcclec07/code/parameter_golf/repo/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:24634452 unique_cores:10
+unique_layers:10 mlp_mult:3.0
+matrix_params:23691264 scalar_params:25684
+world_size:4 grad_accum_steps:2
+tie_embeddings:True embed_lr:0.035 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:5200 warmup_steps:20 max_wallclock_seconds:0.000
+seed:42
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/5200 val_loss:6.9290 val_bpb:4.1037 train_time:0ms step_avg:0.01ms
+step:1/5200 train_loss:6.9304 train_time:472ms step_avg:472.06ms
+step:2/5200 train_loss:8.6917 train_time:955ms step_avg:477.61ms
+step:3/5200 train_loss:7.6835 train_time:1437ms step_avg:478.99ms
+step:4/5200 train_loss:7.3547 train_time:1926ms step_avg:481.39ms
+step:5/5200 train_loss:7.0843 train_time:2409ms step_avg:481.79ms
+step:6/5200 train_loss:6.8967 train_time:2893ms step_avg:482.09ms
+step:7/5200 train_loss:6.8889 train_time:3375ms step_avg:482.15ms
+step:8/5200 train_loss:6.6909 train_time:3860ms step_avg:482.54ms
+step:9/5200 train_loss:6.4068 train_time:4352ms step_avg:483.56ms
+step:10/5200 train_loss:6.1330 train_time:4836ms step_avg:483.61ms
+step:100/5200 train_loss:3.2494 train_time:47194ms step_avg:471.94ms
+step:200/5200 train_loss:2.5401 train_time:94757ms step_avg:473.78ms
+step:300/5200 train_loss:2.5540 train_time:142226ms step_avg:474.09ms
+step:400/5200 train_loss:2.4311 train_time:189621ms step_avg:474.05ms
+step:500/5200 train_loss:2.3784 train_time:236733ms step_avg:473.47ms
+step:500/5200 val_loss:2.3716 val_bpb:1.4046 train_time:236744ms step_avg:473.49ms
+step:600/5200 train_loss:2.3572 train_time:283792ms step_avg:472.99ms
+step:700/5200 train_loss:2.3954 train_time:330760ms step_avg:472.51ms
+step:800/5200 train_loss:2.2479 train_time:377783ms step_avg:472.23ms
+step:900/5200 train_loss:2.1285 train_time:424959ms step_avg:472.18ms
+step:1000/5200 train_loss:2.2833 train_time:471996ms step_avg:472.00ms
+step:1000/5200 val_loss:2.2331 val_bpb:1.3226 train_time:472007ms step_avg:472.01ms
+step:1100/5200 train_loss:2.2579 train_time:519105ms step_avg:471.91ms
+step:1200/5200 train_loss:2.2765 train_time:566228ms step_avg:471.86ms
+step:1300/5200 train_loss:2.2194 train_time:613198ms step_avg:471.69ms
+step:1400/5200 train_loss:2.2392 train_time:660120ms step_avg:471.51ms
+step:1500/5200 train_loss:2.2006 train_time:707093ms step_avg:471.40ms
+step:1500/5200 val_loss:2.1861 val_bpb:1.2947 train_time:707104ms step_avg:471.40ms
+step:1600/5200 train_loss:2.1361 train_time:754051ms step_avg:471.28ms
+step:1700/5200 train_loss:2.1696 train_time:801171ms step_avg:471.28ms
+step:1800/5200 train_loss:2.1385 train_time:848376ms step_avg:471.32ms
+step:1900/5200 train_loss:2.1275 train_time:895349ms step_avg:471.24ms
+step:2000/5200 train_loss:2.0286 train_time:942513ms step_avg:471.26ms
+step:2000/5200 val_loss:2.1319 val_bpb:1.2626 train_time:942524ms step_avg:471.26ms
+step:2100/5200 train_loss:2.0199 train_time:989616ms step_avg:471.25ms
+step:2200/5200 train_loss:2.1415 train_time:1036629ms step_avg:471.20ms
+step:2300/5200 train_loss:2.0524 train_time:1083659ms step_avg:471.16ms
+step:2400/5200 train_loss:2.0759 train_time:1130725ms step_avg:471.14ms
+step:2500/5200 train_loss:2.1375 train_time:1177716ms step_avg:471.09ms
+step:2500/5200 val_loss:2.0979 val_bpb:1.2425 train_time:1177730ms step_avg:471.09ms
+step:2600/5200 train_loss:2.1323 train_time:1224861ms step_avg:471.10ms
+step:2700/5200 train_loss:2.0272 train_time:1272000ms step_avg:471.11ms
+step:2800/5200 train_loss:2.1640 train_time:1319161ms step_avg:471.13ms
+step:2900/5200 train_loss:2.0566 train_time:1366175ms step_avg:471.09ms
+step:3000/5200 train_loss:2.0879 train_time:1413134ms step_avg:471.04ms
+step:3000/5200 val_loss:2.0710 val_bpb:1.2265 train_time:1413146ms step_avg:471.05ms
+step:3100/5200 train_loss:2.0888 train_time:1460114ms step_avg:471.00ms
+step:3200/5200 train_loss:2.1179 train_time:1507163ms step_avg:470.99ms
+step:3300/5200 train_loss:2.0754 train_time:1554158ms step_avg:470.96ms
+step:3400/5200 train_loss:2.0600 train_time:1601246ms step_avg:470.95ms
+step:3500/5200 train_loss:2.1392 train_time:1648367ms step_avg:470.96ms
+step:3500/5200 val_loss:2.0470 val_bpb:1.2123 train_time:1648379ms step_avg:470.97ms
+step:3600/5200 train_loss:2.0519 train_time:1695451ms step_avg:470.96ms
+step:3700/5200 train_loss:2.0482 train_time:1742384ms step_avg:470.91ms
+step:3800/5200 train_loss:2.0346 train_time:1789273ms step_avg:470.86ms
+step:3900/5200 train_loss:2.0492 train_time:1836185ms step_avg:470.82ms
+step:4000/5200 train_loss:2.0897 train_time:1883173ms step_avg:470.79ms
+step:4000/5200 val_loss:2.0231 val_bpb:1.1982 train_time:1883184ms step_avg:470.80ms
+step:4100/5200 train_loss:2.0120 train_time:1930114ms step_avg:470.76ms
+step:4200/5200 train_loss:2.0283 train_time:1977239ms step_avg:470.77ms
+step:4300/5200 train_loss:2.0068 train_time:2024240ms step_avg:470.75ms
+step:4400/5200 train_loss:1.9465 train_time:2071331ms step_avg:470.76ms
+step:4500/5200 train_loss:2.0457 train_time:2118419ms step_avg:470.76ms
+step:4500/5200 val_loss:1.9960 val_bpb:1.1821 train_time:2118430ms step_avg:470.76ms
+step:4600/5200 train_loss:1.8914 train_time:2165414ms step_avg:470.74ms
+swa:start step:4650
+step:4700/5200 train_loss:2.0822 train_time:2214479ms step_avg:471.17ms
+step:4800/5200 train_loss:2.1901 train_time:2265631ms step_avg:472.01ms
+step:4900/5200 train_loss:1.9562 train_time:2316653ms step_avg:472.79ms
+late_qat:enabled step:4901 scale:0.0997 clip_range:31
+step:5000/5200 train_loss:1.9870 train_time:2367990ms step_avg:473.60ms
+step:5000/5200 val_loss:1.9677 val_bpb:1.1654 train_time:2370029ms step_avg:474.01ms
+step:5100/5200 train_loss:1.9916 train_time:2419256ms step_avg:474.36ms
+step:5200/5200 train_loss:1.9949 train_time:2470415ms step_avg:475.08ms
+step:5200/5200 val_loss:1.9605 val_bpb:1.1611 train_time:2472414ms step_avg:475.46ms
+peak memory allocated: 20223 MiB reserved: 20350 MiB
+swa:applying averaged 12 checkpoints
+Serialized model: 96747459 bytes
+Code size: 71706 bytes
+Total submission size: 96819165 bytes
+magnitude_pruning: frac=0.03
+=== Weight distribution diagnostics ===
+  OUTLIER cores.0.attn.c_k.weight: max=2.7084 mean=0.1390 ratio=19.5 kurtosis=8.6
+Serialized model int6+zstd: 14717713 bytes
+Total submission size int6+zstd: 14789419 bytes
+final_eval_mode:sliding_window_ttt stride:64 chunk_tokens:32768
+ttt_sliding:start chunks=1893 chunk_tokens=32768 total_windows=969088 stride=64 ttt_lr=0.002 ttt_epochs=3 freeze_blocks=2
+ttt_sliding:params unfrozen=19911748 frozen=4722704
+  ttt_chunk [1/1893] bpb=1.189547 time=0.7s
+  ttt_chunk [11/1893] bpb=1.147780 time=6.2s
+  ttt_chunk [21/1893] bpb=1.151905 time=11.7s
+  ttt_chunk [31/1893] bpb=1.156021 time=17.1s
+  ttt_chunk [41/1893] bpb=1.144279 time=22.6s
+  ttt_chunk [51/1893] bpb=1.141479 time=28.1s
+  ttt_chunk [61/1893] bpb=1.147215 time=33.7s
+  ttt_chunk [71/1893] bpb=1.143907 time=39.2s
+  ttt_chunk [81/1893] bpb=1.143903 time=44.7s
+  ttt_chunk [91/1893] bpb=1.143291 time=50.2s
+  ttt_chunk [101/1893] bpb=1.146425 time=55.8s
+  ttt_chunk [111/1893] bpb=1.147836 time=61.3s
+  ttt_chunk [121/1893] bpb=1.144709 time=66.8s
+  ttt_chunk [131/1893] bpb=1.144962 time=72.4s
+  ttt_chunk [141/1893] bpb=1.144614 time=77.9s
+  ttt_chunk [151/1893] bpb=1.147944 time=83.5s
+  ttt_chunk [161/1893] bpb=1.149935 time=89.0s
+  ttt_chunk [171/1893] bpb=1.150824 time=94.6s
+  ttt_chunk [181/1893] bpb=1.150934 time=100.1s
+  ttt_chunk [191/1893] bpb=1.154394 time=105.6s
+  ttt_chunk [201/1893] bpb=1.154806 time=111.2s
+  ttt_chunk [211/1893] bpb=1.152567 time=116.7s
+  ttt_chunk [221/1893] bpb=1.154601 time=122.3s
+  ttt_chunk [231/1893] bpb=1.154082 time=127.8s
+  ttt_chunk [241/1893] bpb=1.153900 time=133.4s
+  ttt_chunk [251/1893] bpb=1.152332 time=138.9s
+  ttt_chunk [261/1893] bpb=1.150776 time=144.4s
+  ttt_chunk [271/1893] bpb=1.149483 time=150.0s
+  ttt_chunk [281/1893] bpb=1.151923 time=155.5s
+  ttt_chunk [291/1893] bpb=1.152747 time=161.0s
+  ttt_chunk [301/1893] bpb=1.153346 time=166.6s
+  ttt_chunk [311/1893] bpb=1.154952 time=172.1s
+  ttt_chunk [321/1893] bpb=1.156408 time=177.6s
+  ttt_chunk [331/1893] bpb=1.156275 time=183.2s
+  ttt_chunk [341/1893] bpb=1.156647 time=188.7s
+  ttt_chunk [351/1893] bpb=1.158008 time=194.2s
+  ttt_chunk [361/1893] bpb=1.159391 time=199.8s
+  ttt_chunk [371/1893] bpb=1.158904 time=205.3s
+  ttt_chunk [381/1893] bpb=1.158723 time=210.8s
+  ttt_chunk [391/1893] bpb=1.158319 time=216.4s
+  ttt_chunk [401/1893] bpb=1.156985 time=221.9s
+  ttt_chunk [411/1893] bpb=1.155931 time=227.4s
+  ttt_chunk [421/1893] bpb=1.155373 time=232.9s
+  ttt_chunk [431/1893] bpb=1.156103 time=238.5s
+  ttt_chunk [441/1893] bpb=1.155971 time=244.0s
+  ttt_chunk [451/1893] bpb=1.155680 time=249.5s
+  ttt_chunk [461/1893] bpb=1.154944 time=255.1s
+  ttt_chunk [471/1893] bpb=1.154515 time=260.6s
+  ttt_chunk [481/1893] bpb=1.154283 time=266.1s
+  ttt_chunk [491/1893] bpb=1.153921 time=271.6s
+  ttt_chunk [501/1893] bpb=1.153421 time=277.2s
+  ttt_chunk [511/1893] bpb=1.152866 time=282.7s
+  ttt_chunk [521/1893] bpb=1.152062 time=288.2s
+  ttt_chunk [531/1893] bpb=1.152131 time=293.7s
+  ttt_chunk [541/1893] bpb=1.152052 time=299.3s
+  ttt_chunk [551/1893] bpb=1.150838 time=304.8s
+  ttt_chunk [561/1893] bpb=1.151343 time=310.3s
+  ttt_chunk [571/1893] bpb=1.150590 time=315.8s
+  ttt_chunk [581/1893] bpb=1.150054 time=321.4s
+  ttt_chunk [591/1893] bpb=1.149398 time=326.9s
+  ttt_chunk [601/1893] bpb=1.150048 time=332.4s
+  ttt_chunk [611/1893] bpb=1.149620 time=337.9s
+  ttt_chunk [621/1893] bpb=1.149550 time=343.5s
+  ttt_chunk [631/1893] bpb=1.149940 time=349.0s
+  ttt_chunk [641/1893] bpb=1.149705 time=354.5s
+  ttt_chunk [651/1893] bpb=1.149703 time=360.0s
+  ttt_chunk [661/1893] bpb=1.149580 time=365.6s
+  ttt_chunk [671/1893] bpb=1.149204 time=371.1s
+  ttt_chunk [681/1893] bpb=1.149490 time=376.6s
+  ttt_chunk [691/1893] bpb=1.150179 time=382.1s
+  ttt_chunk [701/1893] bpb=1.149390 time=387.7s
+  ttt_chunk [711/1893] bpb=1.149946 time=393.2s
+  ttt_chunk [721/1893] bpb=1.149576 time=398.7s
+  ttt_chunk [731/1893] bpb=1.149988 time=404.2s
+  ttt_chunk [741/1893] bpb=1.149961 time=409.8s
+  ttt_chunk [751/1893] bpb=1.149552 time=415.3s
+  ttt_chunk [761/1893] bpb=1.149411 time=420.8s
+  ttt_chunk [771/1893] bpb=1.149198 time=426.3s
+  ttt_chunk [781/1893] bpb=1.149763 time=431.9s
+  ttt_chunk [791/1893] bpb=1.149432 time=437.4s
+  ttt_chunk [801/1893] bpb=1.149495 time=442.9s
+  ttt_chunk [811/1893] bpb=1.149037 time=448.4s
+  ttt_chunk [821/1893] bpb=1.148848 time=454.0s
+  ttt_chunk [831/1893] bpb=1.148420 time=459.5s
+  ttt_chunk [841/1893] bpb=1.147843 time=465.0s
+  ttt_chunk [851/1893] bpb=1.147798 time=470.5s
+  ttt_chunk [861/1893] bpb=1.147932 time=476.1s
+  ttt_chunk [871/1893] bpb=1.147995 time=481.6s
+  ttt_chunk [881/1893] bpb=1.148054 time=487.1s
+  ttt_chunk [891/1893] bpb=1.147875 time=492.6s
+  ttt_chunk [901/1893] bpb=1.147861 time=498.2s
+  ttt_chunk [911/1893] bpb=1.147878 time=503.7s
+  ttt_chunk [921/1893] bpb=1.148241 time=509.2s
+  ttt_chunk [931/1893] bpb=1.148070 time=514.7s
+  ttt_chunk [941/1893] bpb=1.147976 time=520.3s
+  ttt_chunk [951/1893] bpb=1.148012 time=525.8s
+  ttt_chunk [961/1893] bpb=1.147783 time=531.3s
+  ttt_chunk [971/1893] bpb=1.148538 time=536.8s
+  ttt_chunk [981/1893] bpb=1.148690 time=542.4s
+  ttt_chunk [991/1893] bpb=1.148580 time=547.9s
+  ttt_chunk [1001/1893] bpb=1.148738 time=553.4s
+  ttt_chunk [1011/1893] bpb=1.149018 time=558.9s
+  ttt_chunk [1021/1893] bpb=1.149178 time=564.5s
+  ttt_chunk [1031/1893] bpb=1.149710 time=570.0s
+  ttt_chunk [1041/1893] bpb=1.149358 time=575.5s
+  ttt_chunk [1051/1893] bpb=1.149076 time=581.1s
+  ttt_chunk [1061/1893] bpb=1.149353 time=586.6s
+  ttt_chunk [1071/1893] bpb=1.149850 time=592.1s
+  ttt_chunk [1081/1893] bpb=1.149876 time=597.6s
+  ttt_chunk [1091/1893] bpb=1.150285 time=603.2s
+  ttt_chunk [1101/1893] bpb=1.150433 time=608.7s
+  ttt_chunk [1111/1893] bpb=1.150174 time=614.2s
+  ttt_chunk [1121/1893] bpb=1.150105 time=619.8s
+  ttt_chunk [1131/1893] bpb=1.149986 time=625.3s
+  ttt_chunk [1141/1893] bpb=1.149838 time=630.8s
+  ttt_chunk [1151/1893] bpb=1.149884 time=636.3s
+  ttt_chunk [1161/1893] bpb=1.149301 time=641.9s
+  ttt_chunk [1171/1893] bpb=1.149846 time=647.4s
+  ttt_chunk [1181/1893] bpb=1.149323 time=652.9s
+  ttt_chunk [1191/1893] bpb=1.149030 time=658.4s
+  ttt_chunk [1201/1893] bpb=1.149606 time=664.0s
+  ttt_chunk [1211/1893] bpb=1.149035 time=669.5s
+  ttt_chunk [1221/1893] bpb=1.148728 time=675.0s
+  ttt_chunk [1231/1893] bpb=1.148615 time=680.5s
+  ttt_chunk [1241/1893] bpb=1.148432 time=686.1s
+  ttt_chunk [1251/1893] bpb=1.148182 time=691.6s
+  ttt_chunk [1261/1893] bpb=1.148104 time=697.1s
+  ttt_chunk [1271/1893] bpb=1.147913 time=702.7s
+  ttt_chunk [1281/1893] bpb=1.147728 time=708.2s
+  ttt_chunk [1291/1893] bpb=1.147559 time=713.7s
+  ttt_chunk [1301/1893] bpb=1.147175 time=719.2s
+  ttt_chunk [1311/1893] bpb=1.146843 time=724.8s
+  ttt_chunk [1321/1893] bpb=1.146668 time=730.3s
+  ttt_chunk [1331/1893] bpb=1.146589 time=735.8s
+  ttt_chunk [1341/1893] bpb=1.146482 time=741.3s
+  ttt_chunk [1351/1893] bpb=1.146434 time=746.9s
+  ttt_chunk [1361/1893] bpb=1.146630 time=752.4s
+  ttt_chunk [1371/1893] bpb=1.146482 time=757.9s
+  ttt_chunk [1381/1893] bpb=1.146405 time=763.4s
+  ttt_chunk [1391/1893] bpb=1.145869 time=769.0s
+  ttt_chunk [1401/1893] bpb=1.145905 time=774.5s
+  ttt_chunk [1411/1893] bpb=1.145919 time=780.0s
+  ttt_chunk [1421/1893] bpb=1.146185 time=785.5s
+  ttt_chunk [1431/1893] bpb=1.146040 time=791.1s
+  ttt_chunk [1441/1893] bpb=1.146715 time=796.6s
+  ttt_chunk [1451/1893] bpb=1.146813 time=802.1s
+  ttt_chunk [1461/1893] bpb=1.146553 time=807.6s
+  ttt_chunk [1471/1893] bpb=1.147458 time=813.2s
+  ttt_chunk [1481/1893] bpb=1.147246 time=818.7s
+  ttt_chunk [1491/1893] bpb=1.147257 time=824.2s
+  ttt_chunk [1501/1893] bpb=1.147444 time=829.7s
+  ttt_chunk [1511/1893] bpb=1.147546 time=835.3s
+  ttt_chunk [1521/1893] bpb=1.147565 time=840.8s
+  ttt_chunk [1531/1893] bpb=1.147382 time=846.3s
+  ttt_chunk [1541/1893] bpb=1.147351 time=851.8s
+  ttt_chunk [1551/1893] bpb=1.147700 time=857.4s
+  ttt_chunk [1561/1893] bpb=1.147841 time=862.9s
+  ttt_chunk [1571/1893] bpb=1.147972 time=868.4s
+  ttt_chunk [1581/1893] bpb=1.148090 time=873.9s
+  ttt_chunk [1591/1893] bpb=1.148033 time=879.5s
+  ttt_chunk [1601/1893] bpb=1.148202 time=885.0s
+  ttt_chunk [1611/1893] bpb=1.148275 time=890.5s
+  ttt_chunk [1621/1893] bpb=1.148127 time=896.0s
+  ttt_chunk [1631/1893] bpb=1.148296 time=901.6s
+  ttt_chunk [1641/1893] bpb=1.148170 time=907.1s
+  ttt_chunk [1651/1893] bpb=1.148102 time=912.6s
+  ttt_chunk [1661/1893] bpb=1.147992 time=918.1s
+  ttt_chunk [1671/1893] bpb=1.148347 time=923.7s
+  ttt_chunk [1681/1893] bpb=1.148614 time=929.2s
+  ttt_chunk [1691/1893] bpb=1.148576 time=934.7s
+  ttt_chunk [1701/1893] bpb=1.148556 time=940.2s
+  ttt_chunk [1711/1893] bpb=1.148404 time=945.8s
+  ttt_chunk [1721/1893] bpb=1.148252 time=951.3s
+  ttt_chunk [1731/1893] bpb=1.148205 time=956.8s
+  ttt_chunk [1741/1893] bpb=1.147995 time=962.3s
+  ttt_chunk [1751/1893] bpb=1.147834 time=967.9s
+  ttt_chunk [1761/1893] bpb=1.147917 time=973.4s
+  ttt_chunk [1771/1893] bpb=1.147850 time=978.9s
+  ttt_chunk [1781/1893] bpb=1.147808 time=984.4s
+  ttt_chunk [1791/1893] bpb=1.147395 time=990.0s
+  ttt_chunk [1801/1893] bpb=1.147394 time=995.5s
+  ttt_chunk [1811/1893] bpb=1.147219 time=1001.0s
+  ttt_chunk [1821/1893] bpb=1.147244 time=1006.5s
+  ttt_chunk [1831/1893] bpb=1.146858 time=1012.0s
+  ttt_chunk [1841/1893] bpb=1.146904 time=1017.6s
+  ttt_chunk [1851/1893] bpb=1.146696 time=1023.1s
+  ttt_chunk [1861/1893] bpb=1.146210 time=1028.6s
+  ttt_chunk [1871/1893] bpb=1.146061 time=1034.1s
+  ttt_chunk [1881/1893] bpb=1.145667 time=1039.7s
+  ttt_chunk [1891/1893] bpb=1.145506 time=1045.2s
+  ttt_chunk [1893/1893] bpb=1.145521 time=1046.0s
+ttt_sliding:done val_loss=1.932577 val_bpb=1.144584 elapsed=1046.1s
+final_int6_roundtrip val_loss:1.9326 val_bpb:1.1446 eval_time:1046591ms
+final_int6_roundtrip_exact val_loss:1.93257718 val_bpb:1.14458409

--- a/records/track_non_record_16mb/2026-03-22_11L_VE128_PartialRoPE_LegalTTT/train_gpt.py
+++ b/records/track_non_record_16mb/2026-03-22_11L_VE128_PartialRoPE_LegalTTT/train_gpt.py
@@ -1,0 +1,1425 @@
+"""
+Parameter Golf: 11L Depth Recurrence + VE128 + Partial RoPE + LN Scale + Legal TTT
+11-layer GPT with BigramHash, SmearGate, XSA, U-Net skips, SWA, VE128,
+partial RoPE (16/64), LN scale, mixed int5/int6 quantization, and legal TTT.
+Depth recurrence (shared BlockCores) enabled via UNIQUE_LAYERS env var.
+
+Key improvements from PRs #455, #442, #374:
+- 11 layers (vs 10) for more capacity
+- Partial RoPE: only 16/64 head dims get rotary embedding
+- LN Scale: 1/sqrt(layer_idx+1) scaling on normalized inputs
+- ValueEmbedding (VE128): shared embedding added to value projections on deep layers
+- XSA on last 4 layers, BigramHash(2048)
+- Legal TTT: SGD 3 epochs, freeze first 2 blocks
+"""
+from __future__ import annotations
+import copy, glob, io, math, os, random, subprocess, sys, time, uuid, zlib
+from pathlib import Path
+try:
+    import zstandard; _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+_IS_AMPERE_PLUS = torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 8
+_HALF_DTYPE = torch.bfloat16 if _IS_AMPERE_PLUS else torch.float16
+
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 42))
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 500))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 100))
+    iterations = int(os.environ.get("ITERATIONS", 5200))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 3.0))
+    mlp_activation = os.environ.get("MLP_ACTIVATION", "relu_sq").lower()
+    unique_layers = int(os.environ.get("UNIQUE_LAYERS", 10))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.035))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.025))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.025))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    weight_decay = float(os.environ.get("WEIGHT_DECAY", 0.04))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.01))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 64))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 2048))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.2))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 4))
+    late_qat = bool(int(os.environ.get("LATE_QAT", "1")))
+    qat_threshold = float(os.environ.get("QAT_THRESHOLD", 0.1))
+    all_int5 = bool(int(os.environ.get("ALL_INT5", "0")))
+    prune_frac = float(os.environ.get("PRUNE_FRAC", "0.03"))
+    gptq_lite = bool(int(os.environ.get("GPTQ_LITE", "0")))
+    quant_eval_every = int(os.environ.get("QUANT_EVAL_EVERY", "0"))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.002))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 3))
+    ttt_freeze_blocks = int(os.environ.get("TTT_FREEZE_BLOCKS", 2))
+    ttt_grad_clip = float(os.environ.get("TTT_GRAD_CLIP", 1.0))
+    ttt_batch_seqs = int(os.environ.get("TTT_BATCH_SEQS", 32))
+    ttt_chunk_tokens = int(os.environ.get("TTT_CHUNK_TOKENS", 32768))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+    ve_enabled = bool(int(os.environ.get("VE_ENABLED", "1")))
+    ve_dim = int(os.environ.get("VE_DIM", 128))
+    ve_layers = os.environ.get("VE_LAYERS", "9,10")
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.to(torch.bfloat16 if _IS_AMPERE_PLUS else torch.float32)
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(params, dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                                      nesterov=nesterov, weight_decay=weight_decay))
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr, momentum = group["lr"], group["momentum"]
+            backend_steps, nesterov = group["backend_steps"], group["nesterov"]
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=_HALF_DTYPE)
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                if wd > 0:
+                    p.data.mul_(1.0 - lr * wd)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+        return loss
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+def eval_val(
+    args: Hyperparameters, model: nn.Module, rank: int, world_size: int,
+    device: torch.device, grad_accum_steps: int, val_tokens: Tensor,
+    base_bytes_lut: Tensor, has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError("VAL_BATCH_SIZE too small")
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=_HALF_DTYPE, enabled=True):
+                batch_loss = model(x, y).detach()
+            val_loss_sum += batch_loss.to(torch.float64) * float(y.numel())
+            val_token_count += float(y.numel())
+            prev_ids, tgt_ids = x.reshape(-1), y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    p for p in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,"
+        "q_gain,skip_weight,skip_weights,smear,bigram.scale,ve_layer_scales,ve_shared.scale",
+    ).split(",") if p
+)
+FP16_KEEP_NAME_PATTERNS = tuple(
+    p for p in os.environ.get(
+        "FP16_KEEP_NAME_PATTERNS", "tok_emb,cores.2.attn.c_k"
+    ).split(",") if p
+)
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_Q = float(os.environ.get("INT8_CLIP_PERCENTILE", "99.99984")) / 100.0
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+                    if t32.numel() else torch.empty((t32.shape[0],), dtype=torch.float32))
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name: return "embed"
+    if ".mlp." in name: return "mlp"
+    if "bigram" in name: return "bigram"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name): return "attn"
+    return "other"
+
+def quantize_intN_per_row(t: Tensor, clip_range: int = 31,
+                          gptq_lite: bool = False) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        if gptq_lite:
+            n_cols = t32.shape[1]
+            sorted_abs, _ = t32.abs().sort(dim=1)
+            best_q = best_scale = None
+            best_mse = torch.full((t32.shape[0],), float('inf'), device=t32.device)
+            for p in (0.95, 0.975, 0.99, 0.995, 1.0):
+                idx = min(int(p * (n_cols - 1)), n_cols - 1)
+                row_clip = sorted_abs[:, idx]
+                sc = (row_clip / clip_range).clamp_min(1e-12).to(torch.float16)
+                sc = sc.clamp_min(torch.finfo(torch.float16).tiny)
+                q = torch.clamp(torch.round(t32 / sc.float()[:, None]),
+                                -(clip_range + 1), clip_range).to(torch.int8)
+                deq = q.float() * sc.float()[:, None]
+                mse = (t32 - deq).pow(2).mean(dim=1)
+                if best_q is None:
+                    best_q, best_scale, best_mse = q, sc, mse
+                else:
+                    better = mse < best_mse
+                    best_q[better] = q[better]
+                    best_scale[better] = sc[better]
+                    best_mse[better] = mse[better]
+            return best_q, best_scale
+        row_max = t32.abs().amax(dim=1)
+        scale = (row_max / clip_range).clamp_min(1e-12).to(torch.float16)
+        scale = scale.clamp_min(torch.finfo(torch.float16).tiny)
+        q = torch.clamp(torch.round(t32 / scale.float()[:, None]), -(clip_range + 1), clip_range).to(torch.int8)
+        return q, scale
+    amax = t32.abs().max().item()
+    scale = torch.tensor(max(amax / clip_range, 1e-12), dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -(clip_range + 1), clip_range).to(torch.int8)
+    return q, scale
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str],
+                        gptq_lite: bool = False, force_int5: bool = False):
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 8192:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if any(p in name for p in FP16_KEEP_NAME_PATTERNS):
+            result[name] = t.to(dtype=torch.float16).contiguous()
+            meta[name] = "passthrough_fp16"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            clip = 15 if force_int5 else (15 if cat == "mlp" else 31)
+            q, s = quantize_intN_per_row(t, clip_range=clip, gptq_lite=gptq_lite)
+            bits = {15: 5, 31: 6, 63: 7}.get(clip, 6)
+            result[name + ".q"] = q; result[name + ".scale"] = s
+            meta[name] = {"type": f"int{bits}"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q; result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta[name]
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    if file.stat().st_size != header_bytes + num_tokens * token_bytes:
+        raise ValueError(f"Shard size mismatch for {file}")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank, self.world_size, self.device = rank, world_size, device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+    _qat_clip_range: int = 31
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            cr = CastedLinear._qat_clip_range
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                scale_q = (row_max / float(cr)).clamp_min(1.0 / float(cr))
+                w_q = (torch.clamp(torch.round(w32 / scale_q[:, None]), -(cr + 1), cr) * scale_q[:, None]).to(x.dtype)
+            w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS)) \
+                    and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024,
+                 rope_dims: int = 0):
+        super().__init__()
+        self.dim, self.base = dim, base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        rd = self.rope_dims
+        inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, dtype=torch.float32) / rd))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (self._cos_cached is None or self._sin_cached is None
+                or self._seq_len_cached != seq_len or self._cos_cached.device != device):
+            rd = self.rope_dims
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (rd / (rd - 2)))
+                inv_freq = 1.0 / (new_base ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd))
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int = 0) -> Tensor:
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int,
+                 rope_base: float, qk_gain_init: float, xsa_enabled: bool = False,
+                 rope_dims: int = 0):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads, self.num_kv_heads = num_heads, num_kv_heads
+        self.head_dim = dim // num_heads
+        self.xsa_enabled = xsa_enabled
+        self.rope_dims = rope_dims
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024,
+                             rope_dims=rope_dims)
+
+    def forward(self, x: Tensor, v_embed: Tensor | None = None) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = self.c_v(x)
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        # Transpose to [B, H, T, D] for SDPA
+        q = q.transpose(1, 2)
+        k = k.transpose(1, 2)
+        v = v.transpose(1, 2)
+        if _IS_AMPERE_PLUS and self.num_kv_heads != self.num_heads:
+            y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True, enable_gqa=True)
+        else:
+            if self.num_kv_heads != self.num_heads:
+                repeats = self.num_heads // self.num_kv_heads
+                k = k.repeat_interleave(repeats, dim=1)
+                v_for_sdpa = v.repeat_interleave(repeats, dim=1)
+            else:
+                v_for_sdpa = v
+            y = F.scaled_dot_product_attention(q, k, v_for_sdpa, attn_mask=None, is_causal=True)
+        if self.xsa_enabled:
+            group_size = self.num_heads // self.num_kv_heads
+            y_t = y.transpose(1, 2)
+            y_grouped = y_t.reshape(bsz, seqlen, self.num_kv_heads, group_size, self.head_dim)
+            vn = F.normalize(v.transpose(1, 2).unsqueeze(3), dim=-1)
+            dot_prod = (y_grouped * vn).sum(dim=-1, keepdim=True)
+            y = (y_grouped - dot_prod * vn).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: float, activation: str = "relu_sq"):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+        self.activation = activation
+
+    def forward(self, x: Tensor) -> Tensor:
+        if self.activation == "leaky_relu_sq":
+            x = F.leaky_relu(self.fc(x), negative_slope=0.5)
+        else:
+            x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class ValueEmbedding(nn.Module):
+    def __init__(self, vocab_size: int, ve_dim: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, ve_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(ve_dim, model_dim, bias=False) if ve_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(token_ids)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class BlockCore(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: float,
+                 rope_base: float, qk_gain_init: float,
+                 xsa_enabled: bool = False, mlp_activation: str = "relu_sq",
+                 rope_dims: int = 0):
+        super().__init__()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+                                        xsa_enabled=xsa_enabled, rope_dims=rope_dims)
+        self.mlp = MLP(dim, mlp_mult, activation=mlp_activation)
+
+class Block(nn.Module):
+    def __init__(self, dim: int, layer_idx: int = 0, ln_scale: bool = False):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+
+    def forward(self, x: Tensor, x0: Tensor, core: BlockCore,
+                v_embed: Tensor | None = None) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * core.attn(
+            self.attn_norm(x) * self.ln_scale_factor, v_embed=v_embed)
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * core.mlp(
+            self.mlp_norm(x) * self.ln_scale_factor)
+        return x
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int, num_heads: int,
+                 num_kv_heads: int, mlp_mult: float, tie_embeddings: bool,
+                 tied_embed_init_std: float, logit_softcap: float, rope_base: float,
+                 qk_gain_init: float, bigram_vocab_size: int = 0, bigram_dim: int = 128,
+                 unique_layers: int = 0, xsa_last_n: int = 0, mlp_activation: str = "relu_sq",
+                 rope_dims: int = 0, ln_scale: bool = False,
+                 ve_enabled: bool = False, ve_dim: int = 128, ve_layers: str = "9,10"):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) \
+            if bigram_vocab_size > 0 else None
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.smear = SmearGate(model_dim)
+        n_cores = unique_layers if (0 < unique_layers < num_layers) else num_layers
+        xsa_start = max(0, n_cores - xsa_last_n) if xsa_last_n > 0 else n_cores
+        self.cores = nn.ModuleList([
+            BlockCore(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base,
+                      qk_gain_init, xsa_enabled=(i >= xsa_start),
+                      mlp_activation=mlp_activation, rope_dims=rope_dims)
+            for i in range(n_cores)
+        ])
+        self.blocks = nn.ModuleList([
+            Block(model_dim, layer_idx=i, ln_scale=ln_scale)
+            for i in range(num_layers)
+        ])
+        self._core_indices = [i % n_cores for i in range(num_layers)]
+        if n_cores < num_layers:
+            from collections import Counter
+            uses = Counter(self._core_indices)
+            for core_idx, core in enumerate(self.cores):
+                n_uses = uses[core_idx]
+                if n_uses > 1:
+                    scale = 1.0 / n_uses
+                    for p in core.parameters():
+                        p.register_hook(lambda grad, s=scale: grad * s)
+        # Value Embedding (VE128)
+        self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+        kv_dim = num_kv_heads * (model_dim // num_heads)
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim)
+            self.ve_layer_scales = nn.ParameterList(
+                [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices])
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        num_layers = len(self.blocks)
+        for name, module in self.named_modules():
+            if isinstance(module, CastedLinear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj." in name or name.endswith(".proj"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+
+    def _get_ve(self, layer_idx: int, input_ids: Tensor,
+                ve_cache: dict | None = None) -> Tensor | None:
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if ve_cache is not None and 've' not in ve_cache:
+            ve_cache['ve'] = self.ve_shared(input_ids)
+        ve_base = ve_cache['ve'] if ve_cache is not None else self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_base * self.ve_layer_scales[ve_idx].to(dtype=ve_base.dtype)
+
+    def _forward_body(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x = self.blocks[i](x, x0, self.cores[self._core_indices[i]], v_embed=ve)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            idx = self.num_encoder_layers + i
+            ve = self._get_ve(idx, input_ids, ve_cache)
+            x = self.blocks[idx](x, x0, self.cores[self._core_indices[idx]], v_embed=ve)
+        return self.final_norm(x)
+
+    def _logits(self, x: Tensor) -> Tensor:
+        if self.tie_embeddings:
+            raw = F.linear(x, self.tok_emb.weight)
+        else:
+            raw = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(raw / self.logit_softcap)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self._forward_body(input_ids)
+        x = x.reshape(-1, x.size(-1))
+        logits = self._logits(x)
+        return F.cross_entropy(logits.float(), target_ids.reshape(-1), reduction="mean")
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        return self._logits(self._forward_body(input_ids))
+
+def eval_val_sliding(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    stride: int, batch_seqs: int = 32,
+) -> tuple[float, float]:
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    base_model.eval()
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=_HALF_DTYPE):
+                logits = base_model.forward_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1), reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt, prev = y_batch[i, s:wlen], x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+            if rank == 0 and (bi // batch_seqs) % 50 == 0:
+                done = min(bi + batch_seqs, len(my_windows))
+                pct = done / len(my_windows) * 100
+                rl = (loss_sum / token_count).item() if token_count.item() > 0 else 0.0
+                rbpb = rl / math.log(2.0) * (token_count.item() / byte_count.item()) if token_count.item() > 0 else 0.0
+                print(f"  sliding_eval [{pct:5.1f}%] {done}/{len(my_windows)} "
+                      f"windows running_bpb={rbpb:.6f}", flush=True)
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (loss_sum / token_count).item()
+    base_model.train()
+    return val_loss, val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+def eval_val_sliding_ttt(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    stride: int, batch_seqs: int = 32, log0=print,
+) -> tuple[float, float]:
+    """Legal score-first TTT: score each chunk with sliding windows, then train on it."""
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = args.ttt_chunk_tokens
+
+    # Pre-compute all window starts (same as eval_val_sliding)
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+
+    # Assign each window to a chunk based on the first token it scores
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    chunk_windows: list[list[int]] = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        end = min(ws + seq_len, total_tokens)
+        wlen = end - ws
+        s = 0 if ws == 0 else max(wlen - stride, 0)
+        scored_start = ws + s
+        ci = min(scored_start // ttt_chunk, num_chunks - 1)
+        chunk_windows[ci].append(ws)
+
+    log0(f"ttt_sliding:start chunks={num_chunks} chunk_tokens={ttt_chunk} "
+         f"total_windows={len(window_starts)} stride={stride} "
+         f"ttt_lr={args.ttt_lr} ttt_epochs={args.ttt_epochs} "
+         f"freeze_blocks={args.ttt_freeze_blocks}")
+
+    # BPB accumulators
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Setup TTT optimizer (SGD + momentum for the legal score-first TTT pass)
+    n_blocks = len(base_model.blocks)
+    frozen_block_ids = set(range(min(args.ttt_freeze_blocks, n_blocks)))
+    frozen_core_ids = set(base_model._core_indices[i] for i in frozen_block_ids) if frozen_block_ids else set()
+
+    ttt_params = []
+    for name, p in base_model.named_parameters():
+        freeze = False
+        for bi in frozen_block_ids:
+            if f"blocks.{bi}." in name:
+                freeze = True; break
+        if not freeze:
+            for ci_core in frozen_core_ids:
+                if f"cores.{ci_core}." in name:
+                    freeze = True; break
+        if freeze:
+            p.requires_grad_(False)
+        else:
+            p.requires_grad_(True)
+            ttt_params.append(p)
+
+    log0(f"ttt_sliding:params unfrozen={sum(p.numel() for p in ttt_params)} "
+         f"frozen={sum(p.numel() for p in base_model.parameters() if not p.requires_grad)}")
+
+    optimizer = torch.optim.SGD(ttt_params, lr=args.ttt_lr, momentum=args.ttt_momentum)
+
+    t0 = time.perf_counter()
+
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows:
+            continue
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+
+        # --- Phase 1: SCORE this chunk's windows (sliding window eval) ---
+        my_s = (len(windows) * rank) // world_size
+        my_e = (len(windows) * (rank + 1)) // world_size
+        my_windows = windows[my_s:my_e]
+
+        base_model.eval()
+        with torch.inference_mode():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi:bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens: list[int] = []
+                for i, ws in enumerate(batch_ws):
+                    end = min(ws + seq_len, total_tokens)
+                    wlen = end - ws
+                    wlens.append(wlen)
+                    chunk_tok = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                    x_batch[i, :wlen] = chunk_tok[:-1]
+                    y_batch[i, :wlen] = chunk_tok[1:]
+                with torch.autocast(device_type="cuda", dtype=_HALF_DTYPE):
+                    logits = base_model.forward_logits(x_batch)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y_batch.reshape(-1), reduction="none",
+                ).reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]
+                    s = 0 if ws == 0 else max(wlen - stride, 0)
+                    scored_nll = nll[i, s:wlen].to(torch.float64)
+                    loss_sum += scored_nll.sum()
+                    token_count += float(wlen - s)
+                    tgt, prev = y_batch[i, s:wlen], x_batch[i, s:wlen]
+                    tb = base_bytes_lut[tgt].to(torch.float64)
+                    tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                    byte_count += tb.sum()
+
+        # --- Phase 2: TRAIN on this chunk's tokens (already scored = legal) ---
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and args.ttt_epochs > 0:
+            base_model.train()
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if chunk_seqs > 0:
+                # Cosine decay across chunks
+                cos_lr = args.ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                for pg in optimizer.param_groups:
+                    pg['lr'] = cos_lr
+
+                # Partition training seqs across ranks
+                my_seq_s = (chunk_seqs * rank) // world_size
+                my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+                my_chunk_seqs = my_seq_e - my_seq_s
+
+                for _ep in range(args.ttt_epochs):
+                    for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                        be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                        actual_bs = my_seq_s + bs
+                        actual_be = my_seq_s + be
+                        start_tok = chunk_start + actual_bs * seq_len
+                        end_tok = chunk_start + actual_be * seq_len + 1
+                        if end_tok > val_tokens.numel():
+                            continue
+                        local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                        x = local[:-1].reshape(-1, seq_len)
+                        y = local[1:].reshape(-1, seq_len)
+                        optimizer.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            loss = base_model(x, y)
+                        loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        if args.ttt_grad_clip > 0:
+                            torch.nn.utils.clip_grad_norm_(ttt_params, args.ttt_grad_clip)
+                        optimizer.step()
+
+        # Progress log
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            log0(f"  ttt_chunk [{ci+1}/{num_chunks}] bpb={rbpb:.6f} time={elapsed:.1f}s")
+
+    # Final all-reduce
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+    # Restore state
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+    log0(f"ttt_sliding:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+         f"elapsed={time.perf_counter() - t0:.1f}s")
+    return val_loss, val_bpb
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    if _IS_AMPERE_PLUS:
+        zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    if _IS_AMPERE_PLUS:
+        enable_cudnn_sdp(False); enable_flash_sdp(True)
+        enable_mem_efficient_sdp(False); enable_math_sdp(False)
+    else:
+        enable_cudnn_sdp(False); enable_flash_sdp(False)
+        enable_mem_efficient_sdp(True); enable_math_sdp(True)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process: return
+        if console: print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                        text=True, check=False).stdout, console=False)
+    log0("=" * 100, console=False)
+    random.seed(args.seed); np.random.seed(args.seed)
+    torch.manual_seed(args.seed); torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(f"VOCAB_SIZE={args.vocab_size} != tokenizer vocab_size={int(sp.vocab_size())}")
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device)
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    base_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init, bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim, unique_layers=args.unique_layers,
+        xsa_last_n=args.xsa_last_n, mlp_activation=args.mlp_activation,
+        rope_dims=args.rope_dims, ln_scale=args.ln_scale,
+        ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+    ).to(device).to(_HALF_DTYPE)
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    if _IS_AMPERE_PLUS:
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    else:
+        log0("skipping torch.compile on non-Ampere GPU")
+        compiled_model = base_model
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank],
+                           broadcast_buffers=False) if distributed else compiled_model
+
+    matrix_params, scalar_params = [], []
+    for name, p in base_model.cores.named_parameters():
+        if p.ndim == 2 and not any(pat in name for pat in CONTROL_TENSOR_NAME_PATTERNS):
+            matrix_params.append(p)
+        else:
+            scalar_params.append(p)
+    for name, p in base_model.blocks.named_parameters():
+        if p.ndim < 2 or any(pat in name for pat in CONTROL_TENSOR_NAME_PATTERNS):
+            scalar_params.append(p)
+        elif p.ndim == 2 and not any(pat in name for pat in CONTROL_TENSOR_NAME_PATTERNS):
+            matrix_params.append(p)
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_params.append({"params": [base_model.bigram.embed.weight],
+                           "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None:
+            matrix_params.append(base_model.bigram.proj.weight)
+    if base_model.ve_shared is not None:
+        tok_params.append({"params": [base_model.ve_shared.embed.weight],
+                           "lr": token_lr, "base_lr": token_lr})
+        if base_model.ve_shared.proj is not None:
+            matrix_params.append(base_model.ve_shared.proj.weight)
+        scalar_params.append(base_model.ve_shared.scale)
+        for s in base_model.ve_layer_scales:
+            scalar_params.append(s)
+
+    optimizer_tok = torch.optim.AdamW(
+        tok_params, betas=(args.beta1, args.beta2), eps=args.adam_eps,
+        weight_decay=args.adam_wd, fused=True)
+    optimizer_muon = Muon(
+        matrix_params, lr=args.matrix_lr, momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps, weight_decay=0.04)
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps,
+        weight_decay=args.adam_wd, fused=True)
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True)
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params} unique_cores:{len(base_model.cores)}")
+    log0(f"unique_layers:{args.unique_layers} mlp_mult:{args.mlp_mult}")
+    log0(f"matrix_params:{sum(p.numel() for p in matrix_params)} "
+         f"scalar_params:{sum(p.numel() for p in scalar_params)}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+         f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}")
+    log0(f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+         f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+         f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}")
+    log0(f"seed:{args.seed}")
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0: return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            if warmdown_start <= step < args.iterations:
+                return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0)
+            return 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    if args.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=_HALF_DTYPE, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+
+    while True:
+        last_step = step == args.iterations or (
+            stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut)
+            log0(f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                 f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms")
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+            if (args.quant_eval_every > 0 and should_validate
+                    and lr_mul(step, training_time_ms) < args.swa_start_frac
+                    and step % args.quant_eval_every == 0 and master_process):
+                with torch.no_grad():
+                    sd_snap = {k: v.detach().cpu().clone() for k, v in base_model.state_dict().items()}
+                    qr, qm = mixed_quantize_int6(sd_snap, {"mlp", "attn", "bigram"})
+                    deq = dequantize_mixed_int6(qr, qm, sd_snap)
+                    orig_sd = base_model.state_dict()
+                    base_model.load_state_dict(
+                        {k: v.to(dtype=orig_sd[k].dtype, device=orig_sd[k].device) for k, v in deq.items()},
+                        strict=True)
+                    _, q_bpb = eval_val(
+                        args, model, rank, world_size, device, grad_accum_steps,
+                        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut)
+                    log0(f"quant_gap step:{step} float_bpb:{val_bpb:.4f} int6_bpb:{q_bpb:.4f} gap:{q_bpb - val_bpb:.4f}")
+                    base_model.load_state_dict(orig_sd, strict=True)
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms step:{step}/{args.iterations}")
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=_HALF_DTYPE, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        if args.late_qat and scale < args.qat_threshold and not CastedLinear._qat_enabled:
+            CastedLinear._qat_enabled = True
+            CastedLinear._qat_clip_range = 15 if args.all_int5 else 31
+            log0(f"late_qat:enabled step:{step} scale:{scale:.4f} clip_range:{CastedLinear._qat_clip_range}")
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+
+        if args.swa_enabled and scale < args.swa_start_frac and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+
+        should_log_train = (args.train_log_every > 0 and
+            (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None))
+        if should_log_train:
+            log0(f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                 f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms")
+
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+         f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB")
+
+    if args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"swa:applying averaged {swa_count} checkpoints")
+        current_state = base_model.state_dict()
+        avg_state = {name: (tensor / swa_count).to(dtype=current_state[name].dtype)
+                     for name, tensor in swa_state.items()}
+        base_model.load_state_dict(avg_state, strict=True)
+
+    _model_pt = f"final_model_{args.run_id}.pt"
+    _model_ptz = f"final_model_{args.run_id}.int8.ptz"
+    if master_process:
+        torch.save(base_model.state_dict(), _model_pt)
+        model_bytes = os.path.getsize(_model_pt)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    with torch.no_grad():
+        for name, param in base_model.named_parameters():
+            if param.ndim == 2 and param.numel() > 65536:
+                threshold = torch.quantile(param.abs().float().flatten(), args.prune_frac)
+                param.masked_fill_(param.abs() < threshold, 0.0)
+        log0(f"magnitude_pruning: frac={args.prune_frac}")
+
+    if master_process:
+        log0("=== Weight distribution diagnostics ===")
+        for name, param in base_model.named_parameters():
+            if param.ndim == 2 and param.numel() > 8192:
+                t = param.detach().float()
+                absmax = t.abs().max().item()
+                absmean = t.abs().mean().item()
+                kurtosis = ((t - t.mean()) / t.std()).pow(4).mean().item() - 3.0
+                if kurtosis > 5.0 or absmax / absmean > 20.0:
+                    log0(f"  OUTLIER {name}: max={absmax:.4f} mean={absmean:.4f} "
+                         f"ratio={absmax/absmean:.1f} kurtosis={kurtosis:.1f}")
+
+    CastedLinear._qat_enabled = False
+    sd_cpu = {k: v.detach().cpu() for k, v in base_model.state_dict().items()}
+    quant_result, quant_meta = mixed_quantize_int6(sd_cpu, {"mlp", "attn", "bigram"},
+                                                   gptq_lite=args.gptq_lite,
+                                                   force_int5=args.all_int5)
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    if _COMPRESSOR == "zstd":
+        quant_blob = zstandard.ZstdCompressor(level=22).compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, 9)
+    if master_process:
+        with open(_model_ptz, "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize(_model_ptz)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+{_COMPRESSOR}: {quant_file_bytes} bytes")
+        log0(f"Total submission size int6+{_COMPRESSOR}: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open(_model_ptz, "rb") as f:
+        quant_blob_disk = f.read()
+    if _COMPRESSOR == "zstd":
+        decompressed = zstandard.ZstdDecompressor().decompress(quant_blob_disk)
+    else:
+        decompressed = zlib.decompress(quant_blob_disk)
+    quant_state = torch.load(io.BytesIO(decompressed), map_location="cpu")
+    deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], sd_cpu)
+    base_model.load_state_dict(deq_state, strict=True)
+
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    if args.ttt_enabled and args.eval_stride > 0 and args.eval_stride < args.train_seq_len:
+        log0(f"final_eval_mode:sliding_window_ttt stride:{args.eval_stride} "
+             f"chunk_tokens:{args.ttt_chunk_tokens}")
+        q_val_loss, q_val_bpb = eval_val_sliding_ttt(
+            args, base_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, batch_seqs=args.eval_batch_seqs, log0=log0)
+    elif args.eval_stride > 0 and args.eval_stride < args.train_seq_len:
+        log0(f"final_eval_mode:sliding_window stride:{args.eval_stride} batch_seqs:{args.eval_batch_seqs}")
+        q_val_loss, q_val_bpb = eval_val_sliding(
+            args, base_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, batch_seqs=args.eval_batch_seqs)
+    else:
+        log0("final_eval_mode:standard")
+        q_val_loss, q_val_bpb = eval_val(
+            args, model, rank, world_size, device, grad_accum_steps,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut)
+    torch.cuda.synchronize()
+    log0(f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+         f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms")
+    log0(f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Non-Record Submission: 11L Depth Recurrence + Legal Score-First TTT

**val_bpb = 1.14458** | Pre-TTT: 1.1611 | TTT gain: **−0.0165** | Artifact: 14.79 MB

> Non-record unlimited-compute submission (trained on 4×A100-40GB).

---

### Headline

This submission demonstrates that **competition-legal test-time training can deliver large gains** when properly tuned. The key finding is a TTT recipe — SGD with momentum, multiple epochs per chunk, freezing early blocks — that extracts **2.4× more improvement** (−0.0165 BPB) than single-epoch AdamW over the full network (−0.0068 in our prior PR #456).

Every validation token is **scored before any weight update** that could use it, enforced by `torch.inference_mode()` during scoring.

### Novel & Creative Contributions

1. **High-yield legal TTT via selective freezing + SGD momentum** — Most TTT approaches use AdamW for 1 epoch over all parameters. We use SGD+momentum(0.9) for 3 epochs per 32K chunk while freezing the first 2 blocks. This is simpler, uses less memory, and gets 2.4× better TTT gains.

2. **Depth recurrence** — 11 logical layers from 10 unique BlockCores (one core reused at two depths with independent normalization). Delivers 11-layer capacity at 10-layer parameter cost.

3. **Partial RoPE (16/64 dims)** — Only 16 of 64 head dimensions use rotary embeddings, with NTK-aware scaling. The remaining 48 act as position-agnostic content channels, improving length generalization during TTT.

4. **Value Embeddings on deep layers only** — 128-dim learned embeddings added to value projections on layers 9–10, giving deep layers direct token-identity access in the value stream.

5. **Layer-Norm depth scaling** — `1/√(layer+1)` scaling stabilizes training under depth recurrence.

### Architecture

| Component | Setting |
|---|---|
| Layers | 11 logical (10 shared BlockCores) |
| Dim/Heads | 512 / 8 (4 KV heads) |
| MLP | 3× (1536), ReLU²; SmearGate |
| BigramHash | 2048 |
| RoPE | 16/64 dims, NTK scaling |
| Value Embed | 128d on layers 9–10 |
| XSA | Last 4 layers |
| Quant | Int6 + zstd |

### TTT Protocol

```
for each 32K chunk:
    1. model.eval() + inference_mode → score chunk (NLL recorded)
    2. model.train() → SGD(lr=0.002, mom=0.9), 3 epochs, freeze blocks 0-1
```

### Size Budget

| Component | Bytes |
|---|---|
| Model (int6+zstd) | 14,717,713 |
| Code | 71,706 |
| **Total** | **14,789,419** (< 16,000,000) |

### vs. Prior Submission (PR #456)

| | PR #456 | This PR | Δ |
|---|---|---|---|
| val_bpb | 1.15321 | **1.14458** | **−0.00863** |
| Pre-TTT | 1.1600 | 1.1611 | +0.0011 |
| TTT gain | −0.0068 | **−0.0165** | **2.4×** |

Pre-TTT baselines are nearly identical — the entire improvement comes from better TTT, validating the recipe.

### Credits

This submission builds on work from many contributors to the parameter-golf competition:

- **Muon optimizer** — Baseline (modded-nanogpt); Newton-Schulz orthogonal preconditioning
- **BigramHash embeddings** — PR #65 (aquariouseworkman)
- **SmearGate** — PR #65 (aquariouseworkman)
- **XSA** — PR #187 (Idan3011); GQA-aware variant in PR #265 (unnir)
- **U-Net skip connections** — PR #65 (aquariouseworkman), PR #69 (TevBenji)
- **Mixed int5/int6 quantization** — PR #76 (unixmadtoonslab / Will DePue)
- **SWA** — PR #69 (TevBenji)
- **Late QAT** — PR #315 (jfprincz), PR #374 (unnir)
- **Sliding window evaluation** — PR #50 (mattqlf / Matthew Li)
- **Value Embeddings** — PR #374 (unnir)
- **Partial RoPE** — PR #315 (jfprincz), PR #374 (unnir)
- **LN Scale** — PR #315 (jfprincz), PR #374 (unnir)
- **Depth recurrence** — PR #8 (iranzithierry)
- **Legal TTT framework** — PR #77 (samacqua); full-model variant in our PR #456
- **ReLU², GQA** — Baseline (modded-nanogpt)

Built on the [parameter-golf](https://github.com/openai/parameter-golf) starter code by Beren Millidge & Keller Jordan.