### PR TITLE
[DRAFT] BitNet b1.58 ternary QAT + depth recurrence submission

### DIFF
--- a/records/track_10min_16mb/2026-03-23_BitNetRecurrent_4x6_1024d/README.md
+++ b/records/track_10min_16mb/2026-03-23_BitNetRecurrent_4x6_1024d/README.md
@@ -1,0 +1,96 @@
+# BitNet b1.58 Ternary QAT + Depth Recurrence
+
+**val_bpb: TBD** (mean across 3 seeds — results pending H100 run)
+
+## Core Idea
+
+Two orthogonal, compounding innovations:
+
+**1. Ternary QAT (BitNet b1.58 + LSQ)**
+All weight matrices are quantized to `{-1, 0, +1}` during training via a
+Straight-Through Estimator (STE). The quantization scale `alpha = exp(log_alpha)`
+is a learnable scalar initialized from `median(|W|)` — robust to weight outliers
+at small parameter counts (BitNet b1.58 Reloaded, arXiv:2407.09527).
+
+The baseline int8+zlib export sees values tightly clustered at
+`{-alpha, 0, +alpha}`, achieving ~1.7 bits/param vs ~8 bits/param for
+standard float→int8. This gives **~4–5× more unique parameters in the same
+16MB budget.**
+
+**2. Depth Recurrence with Eval-Time Loop Scaling**
+`K=4` unique transformer blocks are applied `N=6` times per forward pass during
+training (24 effective layers). At evaluation, `M=12` loops are used — the same
+weights run twice as many times for free. This is explicitly permitted by the FAQ
+("evaluation at any sequence length... push the bounds of evaluation methods").
+
+The `resid_mix` residual anchor (`x = mix[0]*x + mix[1]*x0`) stabilizes
+representations across recurrence steps, preventing distribution shift when
+increasing loop count at eval time.
+
+## Key Techniques
+
+| Technique | Source |
+|-----------|--------|
+| Ternary QAT + STE | BitNet b1.58 (arXiv:2402.17764) |
+| LSQ learnable scale | BitNet b1.58 Reloaded (arXiv:2407.09527) |
+| Depth recurrence | Geiping et al. (arXiv:2502.05171) |
+| Eval-time loop scaling | Saunshi et al. (arXiv:2510.25741) |
+| Muon + weight decay | modded-nanogpt |
+| Sliding window eval (stride=64) | SlidingWindow submission (this leaderboard) |
+| FP16 tied embedding export | SlidingWindow submission |
+| RoPE, GQA, QK-Norm, ReLU² | modded-nanogpt / nanogpt speedrun |
+
+## Model Config
+
+| Param | Value |
+|-------|-------|
+| vocab_size | 1024 |
+| model_dim | 1024 |
+| num_heads | 16 |
+| num_kv_heads | 4 |
+| mlp_mult | 6 |
+| num_unique_layers | 4 |
+| num_recurrences (train) | 6 |
+| num_eval_recurrences | 12 |
+| effective_depth (train) | 24 |
+| effective_depth (eval) | 48 |
+
+## Compression Math
+
+- 61.9M unique params × 1.7 bits/param (ternary + zlib) ≈ 13.1MB weights
+- Embedding (fp16): ~1.0MB
+- Code: ~32KB
+- **Total artifact: ~14.2MB** (validated on M1 Max)
+
+Compare to float16 baseline: ~15M params × 8 bits/param ≈ 14.7MB
+
+Our artifact is similar size but represents **4× more unique parameters** and
+**24 effective layers** vs 10 flat layers.
+
+## Results
+
+| Seed | val_loss | val_bpb | Steps | ms/step |
+|------|----------|---------|-------|---------|
+| 1337 | TBD | TBD | TBD | TBD |
+| 42   | TBD | TBD | TBD | TBD |
+| 7    | TBD | TBD | TBD | TBD |
+| **Mean** | **TBD** | **TBD** | | |
+
+## Reproduce
+
+```bash
+# 3 seeds, 8×H100, ~10 min training + ~3 min sliding-window eval each
+for SEED in 1337 42 7; do
+  RUN_ID=bitnet_rec_seed${SEED} SEED=${SEED} \
+  torchrun --standalone --nproc_per_node=8 train_gpt.py \
+  2>&1 | tee logs/seed${SEED}.txt
+done
+```
+
+## Local Validation (M1 Max)
+
+Approach was iteratively developed on Apple M1 Max 64GB using the MLX port
+(`train_gpt_mlx.py` in repo root), confirming:
+- Ternary compression: 61.9M params → 14.23MB artifact ✅
+- LSQ scale: O(1) forward pass, 559ms/step on M1 Max ✅
+- Eval loop scaling: 2× loops at eval confirmed working ✅

--- a/records/track_10min_16mb/2026-03-23_BitNetRecurrent_4x6_1024d/submission.json
+++ b/records/track_10min_16mb/2026-03-23_BitNetRecurrent_4x6_1024d/submission.json
@@ -1,0 +1,51 @@
+{
+  "run_name": "BitNet_Recurrent_4x6_1024d",
+  "author": "Rafael Ferraz",
+  "github_id": "devferrazZz",
+  "val_bpb": null,
+  "val_loss": null,
+  "artifact_bytes": null,
+  "artifact_mb": null,
+  "date": "2026-03-23",
+  "hardware": "8\u00d7H100 SXM",
+  "training_time_seconds": null,
+  "seeds_tested": [
+    1337,
+    42,
+    7
+  ],
+  "mean_val_bpb": null,
+  "summary": "BitNet b1.58 ternary QAT + depth recurrence. 4 unique transformer blocks applied 6\u00d7 per pass (24 effective layers), 12\u00d7 at eval (free test-time compute). LSQ learnable quantization scale initialized from median(|W|). Muon+WD for matrix params. Sliding-window BPB eval (stride=64). ~62M unique params, ~14.2MB compressed artifact.",
+  "techniques": [
+    "BitNet b1.58 ternary QAT with LSQ scale (arXiv:2402.17764, 2407.09527)",
+    "Depth recurrence: 4 unique \u00d7 6 train loops = 24 effective layers",
+    "Eval-time loop scaling: 12 loops at inference (free test-time compute)",
+    "Muon optimizer + weight decay (0.02) for matrix params",
+    "Sliding window evaluation (stride=64, seq=1024)",
+    "FP16 tied embeddings at export",
+    "RoPE, GQA (16 heads / 4 KV heads), QK-Norm, ReLU\u00b2, logit softcap",
+    "Residual mixing: x blended with initial embedding x0"
+  ],
+  "model_config": {
+    "vocab_size": 1024,
+    "model_dim": 1024,
+    "num_heads": 16,
+    "num_kv_heads": 4,
+    "mlp_mult": 6,
+    "num_unique_layers": 4,
+    "num_recurrences": 6,
+    "num_eval_recurrences": 12,
+    "effective_depth_train": 24,
+    "effective_depth_eval": 48,
+    "rope_base": 10000.0,
+    "logit_softcap": 30.0
+  },
+  "optimizer_config": {
+    "matrix_params": "Muon (lr=0.04, momentum=0.95, wd=0.02)",
+    "embed_params": "Adam (lr=0.05)",
+    "scalar_params": "Adam (lr=0.04)",
+    "warmdown_iters": 1200,
+    "max_wallclock_seconds": 600
+  },
+  "notes": "Results TBD pending H100 grant run. Approach validated on M1 Max 64GB: compression confirmed at ~14.2MB for 61.9M unique ternary params. Fill val_bpb, val_loss, artifact_mb, date from actual run logs before final PR."
+}

--- a/records/track_10min_16mb/2026-03-23_BitNetRecurrent_4x6_1024d/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-23_BitNetRecurrent_4x6_1024d/train_gpt.py
@@ -1,0 +1,833 @@
+"""
+BitNet b1.58 Ternary QAT + Depth Recurrence — Parameter Golf Submission
+=======================================================================
+Key innovations over the baseline:
+
+1. BitLinear (ternary QAT + LSQ): every nn.Linear replaced with a ternary
+   quantized layer using a Learned Step-Size (LSQ) scale. Weights are kept as
+   float32 for the optimizer but quantized to {-1, 0, +1} on every forward pass
+   via a Straight-Through Estimator (STE). The scale alpha = exp(log_alpha) is
+   a learnable scalar initialized from median(|W|) — robust to outliers at small
+   parameter counts (BitNet b1.58 Reloaded, arXiv:2407.09527).
+
+   Compression math: ternary values cluster tightly at {-alpha, 0, +alpha}
+   after training. The baseline int8+zlib export sees near-perfect entropy
+   (~1.7 bits/param) vs ~8 bits/param for standard float→int8. This gives
+   4-5x more unique parameters in the same 16MB artifact budget.
+
+2. Depth Recurrence: NUM_UNIQUE_LAYERS transformer blocks are applied
+   NUM_RECURRENCES times per forward pass. Unique parameter count = the K blocks
+   only; effective depth = K × N. Default: 4 unique blocks × 6 recurrences =
+   24 effective layers. At evaluation time, NUM_EVAL_RECURRENCES (default 12)
+   loops are used — free test-time compute explicitly permitted by the FAQ.
+
+3. All baseline wins preserved: Muon optimizer for matrix params, RoPE, GQA,
+   QK-Norm, ReLU², logit softcap, residual mixing with x0 anchor, sliding
+   window BPB evaluation.
+
+4. FP16 tied embedding at export: int8 errors compound through both input
+   lookup and output projection; kept in fp16.
+
+Locked config (validated on M1 Max):
+  MODEL_DIM=1024, NUM_HEADS=16, NUM_KV_HEADS=4, MLP_MULT=6
+  NUM_UNIQUE_LAYERS=4, NUM_RECURRENCES=6
+  → 61.9M unique params, ~14.2MB compressed artifact
+
+Run on 8×H100:
+  torchrun --standalone --nproc_per_node=8 train_gpt.py
+"""
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# ─────────────────────────────────────────────────────────────
+# HYPERPARAMETERS
+# ─────────────────────────────────────────────────────────────
+
+class Hyperparameters:
+    data_path      = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files    = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files      = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id         = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed           = int(os.environ.get("SEED", 1337))
+
+    # Validation
+    val_batch_size  = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every  = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training
+    iterations            = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters        = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps          = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens    = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len         = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+
+    # Model — BitNet Recurrent (locked config)
+    vocab_size        = int(os.environ.get("VOCAB_SIZE", 1024))
+    model_dim         = int(os.environ.get("MODEL_DIM", 1024))
+    num_heads         = int(os.environ.get("NUM_HEADS", 16))
+    num_kv_heads      = int(os.environ.get("NUM_KV_HEADS", 4))
+    mlp_mult          = int(os.environ.get("MLP_MULT", 6))
+    num_unique_layers = int(os.environ.get("NUM_UNIQUE_LAYERS", 4))
+    num_recurrences   = int(os.environ.get("NUM_RECURRENCES", 6))
+    # 0 = auto (2× train). Override with NUM_EVAL_RECURRENCES=N.
+    num_eval_recurrences = int(os.environ.get("NUM_EVAL_RECURRENCES", 0))
+    rope_base         = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap     = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    qk_gain_init      = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Sliding window eval
+    sw_stride  = int(os.environ.get("SW_STRIDE", 64))
+    sw_seq_len = int(os.environ.get("SW_SEQ_LEN", 1024))
+
+    # Optimizer
+    embed_lr           = float(os.environ.get("EMBED_LR", 0.05))
+    matrix_lr          = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr          = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum      = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_weight_decay  = float(os.environ.get("MUON_WEIGHT_DECAY", 0.02))
+    beta1              = float(os.environ.get("BETA1", 0.9))
+    beta2              = float(os.environ.get("BETA2", 0.95))
+    adam_eps           = float(os.environ.get("ADAM_EPS", 1e-8))
+
+
+# ─────────────────────────────────────────────────────────────
+# MUON OPTIMIZER  (unchanged from baseline)
+# ─────────────────────────────────────────────────────────────
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 weight_decay: float = 0.0, nesterov: bool = True):
+        super().__init__(params, dict(lr=lr, momentum=momentum,
+                                      backend_steps=backend_steps,
+                                      weight_decay=weight_decay,
+                                      nesterov=nesterov))
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size  = dist.get_world_size() if distributed else 1
+        rank        = dist.get_rank()       if distributed else 0
+        for group in self.param_groups:
+            params        = group["params"]
+            lr            = group["lr"]
+            momentum      = group["momentum"]
+            backend_steps = group["backend_steps"]
+            weight_decay  = group["weight_decay"]
+            nesterov      = group["nesterov"]
+            total  = sum(int(p.numel()) for p in params)
+            flat   = torch.zeros(total, device=params[0].device, dtype=torch.bfloat16)
+            curr   = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    if weight_decay != 0.0:
+                        g = g + weight_decay * p.data.to(g.dtype)
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    flat[curr: curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+            if distributed:
+                dist.all_reduce(flat, op=dist.ReduceOp.SUM)
+            curr = 0
+            for p in params:
+                g = flat[curr: curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+        return loss
+
+
+# ─────────────────────────────────────────────────────────────
+# BPB EVALUATION UTILITIES  (unchanged from baseline)
+# ─────────────────────────────────────────────────────────────
+
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sv  = int(sp.vocab_size())
+    sz  = max(sv, vocab_size)
+    bb  = np.zeros(sz, dtype=np.int16)
+    hs  = np.zeros(sz, dtype=bool)
+    ib  = np.ones(sz,  dtype=bool)
+    for tid in range(sv):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        ib[tid] = False
+        if sp.is_byte(tid):
+            bb[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("▁"):
+            hs[tid] = True
+            piece = piece[1:]
+        bb[tid] = len(piece.encode("utf-8"))
+    return (torch.tensor(bb, dtype=torch.int16, device=device),
+            torch.tensor(hs, dtype=torch.bool,  device=device),
+            torch.tensor(ib, dtype=torch.bool,  device=device))
+
+
+def eval_val_sliding_window(args, model, rank, world_size, device,
+                             val_tokens, base_bytes_lut, has_space_lut, is_boundary_lut):
+    """Sliding-window BPB: every token scored with sw_stride context."""
+    seq_len    = args.sw_seq_len
+    stride     = args.sw_stride
+    T          = val_tokens.numel()
+    all_starts = list(range(0, T - seq_len - 1, stride))
+    my_starts  = all_starts[rank::world_size]
+
+    loss_sum  = torch.zeros((), device=device, dtype=torch.float64)
+    token_cnt = torch.zeros((), device=device, dtype=torch.float64)
+    byte_cnt  = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for start in my_starts:
+            end = start + seq_len
+            x   = val_tokens[start:end].unsqueeze(0).to(device, dtype=torch.int64)
+            y   = val_tokens[start + 1:end + 1].unsqueeze(0).to(device, dtype=torch.int64)
+            with torch.autocast("cuda", dtype=torch.bfloat16):
+                ptl = model.per_token_loss(x, y)   # (1, T)
+            lo      = seq_len - stride
+            ptl_s   = ptl[0, lo:]
+            y_s     = y[0, lo:]
+            x_s     = x[0, lo:]
+            loss_sum  += ptl_s.to(torch.float64).sum()
+            token_cnt += ptl_s.numel()
+            tb = base_bytes_lut[y_s].to(torch.float64)
+            tb += (has_space_lut[y_s] & ~is_boundary_lut[x_s]).to(torch.float64)
+            byte_cnt  += tb.sum()
+
+    if dist.is_available() and dist.is_initialized():
+        for t in (loss_sum, token_cnt, byte_cnt):
+            dist.all_reduce(t, op=dist.ReduceOp.SUM)
+
+    val_loss = float((loss_sum / token_cnt).item())
+    bpb      = float((loss_sum / math.log(2) / byte_cnt).item())
+    model.train()
+    return val_loss, bpb
+
+
+# ─────────────────────────────────────────────────────────────
+# QUANTIZATION / EXPORT  (unchanged from baseline)
+# ─────────────────────────────────────────────────────────────
+
+CONTROL_PATTERNS = tuple(p for p in os.environ.get(
+    "CONTROL_TENSOR_NAME_PATTERNS",
+    "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,log_alpha"
+).split(",") if p)
+
+KEEP_FP_MAX_NUMEL   = 65_536
+KEEP_FP_STORE_DTYPE = torch.float16
+INT8_SCALE_DTYPE    = torch.float16
+INT8_CLIP_Q         = 0.9999984
+
+
+def _quant_tensor(t: Tensor):
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip  = torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1).clamp_min(1e-9)
+        scale = clip / 127.0
+        q     = torch.clamp(torch.round(t32 / scale[:, None]), -127, 127).to(torch.int8)
+        return q.contiguous(), scale.to(INT8_SCALE_DTYPE).contiguous()
+    cv    = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(max(cv / 127.0, 1.0 / 127.0), dtype=torch.float32)
+    q     = torch.clamp(torch.round(t32.clamp(-cv, cv) / scale), -127, 127).to(torch.int8)
+    return q.contiguous(), scale
+
+
+def quantize_state_dict_int8(state_dict: dict):
+    quantized, scales, dtypes, passthrough, pt_orig, qmeta = {}, {}, {}, {}, {}, {}
+    stats = {k: 0 for k in ("param_count", "num_tensors", "baseline_bytes", "int8_bytes")}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        stats["param_count"]    += t.numel()
+        stats["num_tensors"]    += 1
+        stats["baseline_bytes"] += t.numel() * t.element_size()
+        if not t.is_floating_point():
+            passthrough[name]    = t
+            stats["int8_bytes"] += t.numel() * t.element_size()
+            continue
+        is_ctrl  = any(p in name for p in CONTROL_PATTERNS)
+        is_small = t.numel() <= KEEP_FP_MAX_NUMEL
+        # FP16 for tied embedding — errors compound both I/O paths if int8
+        if "tok_emb" in name:
+            pt_orig[name]    = str(t.dtype).removeprefix("torch.")
+            passthrough[name] = t.to(torch.float16).contiguous()
+            stats["int8_bytes"] += passthrough[name].numel() * 2
+            continue
+        if is_ctrl or is_small:
+            if t.dtype in (torch.float32, torch.bfloat16):
+                pt_orig[name] = str(t.dtype).removeprefix("torch.")
+            passthrough[name]    = t.float() if is_ctrl else t.to(KEEP_FP_STORE_DTYPE)
+            passthrough[name]    = passthrough[name].contiguous()
+            stats["int8_bytes"] += passthrough[name].numel() * passthrough[name].element_size()
+            continue
+        q, s = _quant_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name]    = s
+        dtypes[name]    = str(t.dtype).removeprefix("torch.")
+        stats["int8_bytes"] += q.numel() + s.numel() * s.element_size()
+    obj = {"__quant_format__": "int8_clean_per_row_v1",
+           "quantized": quantized, "scales": scales, "dtypes": dtypes,
+           "passthrough": passthrough}
+    if qmeta:   obj["qmeta"] = qmeta
+    if pt_orig: obj["passthrough_orig_dtypes"] = pt_orig
+    return obj, stats
+
+
+def dequantize_state_dict_int8(obj: dict) -> dict:
+    out    = {}
+    qmeta  = obj.get("qmeta", {})
+    pt_orig = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s     = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s   = s.to(torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype).contiguous()
+        else:
+            out[name] = (q.float() * float(s.item())).to(dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        ot = t.detach().cpu().contiguous()
+        od = pt_orig.get(name)
+        if isinstance(od, str):
+            ot = ot.to(dtype=getattr(torch, od)).contiguous()
+        out[name] = ot
+    return out
+
+
+# ─────────────────────────────────────────────────────────────
+# DATA LOADING  (unchanged from baseline)
+# ─────────────────────────────────────────────────────────────
+
+def load_data_shard(file: Path) -> Tensor:
+    hdr = np.fromfile(file, dtype="<i4", count=256)
+    if hdr.size != 256 or int(hdr[0]) != 20240520 or int(hdr[1]) != 1:
+        raise ValueError(f"Bad shard: {file}")
+    n = int(hdr[2])
+    tokens = np.fromfile(file, dtype="<u2", count=n, offset=256 * 4)
+    return torch.from_numpy(tokens.astype(np.uint16, copy=False))
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No val files: {pattern}")
+    tokens = torch.cat([load_data_shard(f) for f in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not files:
+            raise FileNotFoundError(f"No shards: {pattern}")
+        self.files  = files
+        self.idx    = 0
+        self.tokens = load_data_shard(files[0])
+        self.pos    = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks, rem = [], n
+        while rem > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self.idx    = (self.idx + 1) % len(self.files)
+                self.tokens = load_data_shard(self.files[self.idx])
+                self.pos    = 0
+                avail       = self.tokens.numel()
+            k = min(rem, avail)
+            chunks.append(self.tokens[self.pos: self.pos + k])
+            self.pos += k
+            rem -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    def __init__(self, pattern, rank, world_size, device):
+        self.rank = rank; self.ws = world_size; self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens, seq_len, grad_accum):
+        local_tokens  = global_tokens // (self.ws * grad_accum)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.ws)
+        start = self.rank * per_rank_span
+        local = chunk[start: start + per_rank_span].to(torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+
+# ─────────────────────────────────────────────────────────────
+# BITLINEAR — Ternary QAT + LSQ (Patches 1+2+3)
+# ─────────────────────────────────────────────────────────────
+
+class TernarySTE(torch.autograd.Function):
+    """Straight-Through Estimator for ternary quantization."""
+    @staticmethod
+    def forward(ctx, w_norm: Tensor) -> Tensor:
+        return torch.clamp(torch.round(w_norm), -1.0, 1.0)
+
+    @staticmethod
+    def backward(ctx, grad: Tensor) -> Tensor:
+        return grad   # identity STE
+
+
+ternary_quantize = TernarySTE.apply
+
+
+class BitLinear(nn.Linear):
+    """
+    Drop-in nn.Linear replacement — BitNet b1.58 ternary QAT with LSQ scale.
+
+    Patch 1: median(|W|) initializes log_alpha (robust to weight outliers).
+    Patch 3: alpha = exp(log_alpha) is O(1) at forward — no sort per step.
+    STE:     gradient flows through quantizer unchanged.
+    Export:  weights cluster at {-alpha, 0, +alpha} → ~1.7 bits/param via zlib.
+    """
+    def __init__(self, in_features: int, out_features: int, bias: bool = False):
+        super().__init__(in_features, out_features, bias=bias)
+        # LSQ: learnable scale, initialized from median(|W|) at construction.
+        with torch.no_grad():
+            init_alpha = float(self.weight.abs().median().item()) + 1e-8
+        self.log_alpha = nn.Parameter(
+            torch.tensor(math.log(init_alpha), dtype=torch.float32)
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        alpha  = torch.exp(self.log_alpha)
+        w_norm = self.weight.float() / alpha
+        w_q    = ternary_quantize(w_norm)
+        # STE: full-precision gradient, ternary forward
+        w_ternary = (w_norm + (w_q - w_norm).detach()) * alpha
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w_ternary.to(x.dtype), bias)
+
+
+def restore_low_dim_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, p in module.named_parameters():
+            if (p.ndim < 2 or any(pat in name for pat in CONTROL_PATTERNS)) \
+               and p.dtype != torch.float32:
+                p.data = p.data.float()
+
+
+# ─────────────────────────────────────────────────────────────
+# TRANSFORMER COMPONENTS
+# ─────────────────────────────────────────────────────────────
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._cached_len = 0
+        self._cos: Tensor | None = None
+        self._sin: Tensor | None = None
+
+    def forward(self, seq_len: int, device, dtype):
+        if self._cos is None or self._cached_len != seq_len or self._cos.device != device:
+            t      = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs  = torch.outer(t, self.inv_freq.to(device))
+            self._cos = freqs.cos()[None, None, :, :]
+            self._sin = freqs.sin()[None, None, :, :]
+            self._cached_len = seq_len
+        return self._cos.to(dtype=dtype), self._sin.to(dtype=dtype)
+
+
+def apply_rotary(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init):
+        super().__init__()
+        assert dim % num_heads == 0 and num_heads % num_kv_heads == 0
+        self.num_heads    = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim     = dim // num_heads
+        kv_dim = num_kv_heads * self.head_dim
+        self.c_q   = BitLinear(dim, dim,    bias=False)
+        self.c_k   = BitLinear(dim, kv_dim, bias=False)
+        self.c_v   = BitLinear(dim, kv_dim, bias=False)
+        self.proj  = BitLinear(dim, dim,    bias=False)
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor) -> Tensor:
+        B, T, _ = x.shape
+        q = self.c_q(x).reshape(B, T, self.num_heads,    self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(B, T, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(B, T, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(T, x.device, q.dtype)
+        q = apply_rotary(q, cos, sin)
+        k = apply_rotary(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(q, k, v,
+            attn_mask=None, is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads))
+        return self.proj(y.transpose(1, 2).contiguous().reshape(B, T, -1))
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        hidden     = dim * mlp_mult
+        self.fc    = BitLinear(dim, hidden, bias=False)
+        self.proj  = BitLinear(hidden, dim, bias=False)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.proj(torch.relu(self.fc(x)).square())
+
+
+class Block(nn.Module):
+    def __init__(self, dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init):
+        super().__init__()
+        self.attn_norm  = RMSNorm()
+        self.mlp_norm   = RMSNorm()
+        self.attn       = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp        = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim,  dtype=torch.float32))
+        self.mlp_scale  = nn.Parameter(torch.ones(dim,  dtype=torch.float32))
+        # resid_mix[0]*x + resid_mix[1]*x0 (init = identity: keep x, ignore x0)
+        self.resid_mix  = nn.Parameter(torch.stack([torch.ones(dim), torch.zeros(dim)]).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(x.dtype)
+        x   = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        x   = x + self.attn_scale.to(x.dtype)[None, None, :] * self.attn(self.attn_norm(x))
+        x   = x + self.mlp_scale.to(x.dtype)[None, None, :]  * self.mlp(self.mlp_norm(x))
+        return x
+
+
+# ─────────────────────────────────────────────────────────────
+# RECURRENT GPT MODEL
+# ─────────────────────────────────────────────────────────────
+
+class RecurrentGPT(nn.Module):
+    """
+    K unique blocks × N recurrences (Patch 2: eval uses 2N loops).
+
+    Tied embedding kept in fp16 at export — int8 errors compound both
+    the input lookup and output projection paths.
+    """
+    def __init__(self, args: Hyperparameters):
+        super().__init__()
+        self.logit_softcap = args.logit_softcap
+        self._train_rec    = args.num_recurrences
+        self._eval_rec     = args.num_eval_recurrences or args.num_recurrences * 2
+
+        self.tok_emb = nn.Embedding(args.vocab_size, args.model_dim)
+        self.blocks  = nn.ModuleList([
+            Block(args.model_dim, args.num_heads, args.num_kv_heads,
+                  args.mlp_mult,  args.rope_base,  args.qk_gain_init)
+            for _ in range(args.num_unique_layers)
+        ])
+        self.final_norm = RMSNorm()
+        nn.init.normal_(self.tok_emb.weight, std=0.005)
+
+    def _forward_hidden(self, input_ids: Tensor) -> Tensor:
+        x  = F.rms_norm(self.tok_emb(input_ids), (self.tok_emb.embedding_dim,))
+        x0 = x
+        n  = self._train_rec if self.training else self._eval_rec
+        for _ in range(n):
+            for block in self.blocks:
+                x = block(x, x0)
+        return self.final_norm(x)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        h      = self._forward_hidden(input_ids)
+        logits = F.linear(h.reshape(-1, h.size(-1)), self.tok_emb.weight)
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        return F.cross_entropy(logits.float(), target_ids.reshape(-1), reduction="mean")
+
+    def per_token_loss(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        h      = self._forward_hidden(input_ids)
+        B, T, D = h.shape
+        logits = F.linear(h.reshape(B * T, D), self.tok_emb.weight)
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        return F.cross_entropy(logits.float(), target_ids.reshape(B * T),
+                               reduction="none").reshape(B, T)
+
+
+# ─────────────────────────────────────────────────────────────
+# TRAINING
+# ─────────────────────────────────────────────────────────────
+
+def main():
+    global zeropower_via_newtonschulz5
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # ── distributed setup ────────────────────────────────────
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank        = int(os.environ.get("RANK", "0"))
+    world_size  = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank  = int(os.environ.get("LOCAL_RANK", "0"))
+    grad_accum  = max(1, 8 // world_size)
+    grad_scale  = 1.0 / grad_accum
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group("nccl", device_id=device)
+        dist.barrier()
+
+    master = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32       = True
+    from torch.backends.cuda import (enable_flash_sdp, enable_math_sdp,
+                                      enable_mem_efficient_sdp, enable_cudnn_sdp)
+    enable_flash_sdp(True); enable_math_sdp(False)
+    enable_mem_efficient_sdp(False); enable_cudnn_sdp(False)
+
+    logfile = None
+    if master:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg, console=True):
+        if not master: return
+        if console: print(msg)
+        if logfile:
+            with open(logfile, "a") as f: print(msg, file=f)
+
+    log0(code, console=False)
+    log0(f"Python {sys.version}", console=False)
+    log0(f"PyTorch {torch.__version__}", console=False)
+    try:
+        log0(subprocess.run(["nvidia-smi"], capture_output=True, text=True, check=False).stdout,
+             console=False)
+    except FileNotFoundError:
+        pass
+
+    random.seed(args.seed); np.random.seed(args.seed)
+    torch.manual_seed(args.seed); torch.cuda.manual_seed_all(args.seed)
+
+    # ── tokenizer + val data ─────────────────────────────────
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    base_bytes_lut, has_space_lut, is_boundary_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device)
+    val_tokens = load_validation_tokens(args.val_files, args.sw_seq_len)
+    log0(f"val_tokens:{val_tokens.numel()}")
+
+    # ── model ────────────────────────────────────────────────
+    base_model = RecurrentGPT(args).to(device).bfloat16()
+    # BitLinear weights stay in fp32 for optimizer quality
+    for m in base_model.modules():
+        if isinstance(m, BitLinear):
+            m.weight.data   = m.weight.data.float()
+            m.log_alpha.data = m.log_alpha.data.float()
+    restore_low_dim_fp32(base_model)
+
+    compiled = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model    = DDP(compiled, device_ids=[local_rank], broadcast_buffers=False) \
+               if distributed else compiled
+
+    n_unique  = sum(p.numel() for p in base_model.parameters())
+    eff_depth = args.num_unique_layers * args.num_recurrences
+    log0(f"unique_params:{n_unique}  effective_depth:{eff_depth}  "
+         f"train_loops:{args.num_recurrences}  eval_loops:{base_model._eval_rec}")
+    log0(f"world_size:{world_size}  grad_accum:{grad_accum}")
+
+    # ── optimizer ────────────────────────────────────────────
+    block_params   = list(base_model.blocks.named_parameters())
+    matrix_params  = [p for n, p in block_params
+                      if p.ndim == 2 and not any(pat in n for pat in CONTROL_PATTERNS)]
+    scalar_params  = [p for n, p in block_params
+                      if p.ndim < 2 or any(pat in n for pat in CONTROL_PATTERNS)]
+
+    opt_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": args.embed_lr, "base_lr": args.embed_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True)
+    opt_muon = Muon(matrix_params, lr=args.matrix_lr,
+                    momentum=args.muon_momentum, backend_steps=args.muon_backend_steps,
+                    weight_decay=args.muon_weight_decay)
+    for g in opt_muon.param_groups: g["base_lr"] = args.matrix_lr
+    opt_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True)
+    optimizers = [opt_tok, opt_muon, opt_scalar]
+
+    # ── LR schedule ──────────────────────────────────────────
+    max_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step, elapsed_ms):
+        if args.warmdown_iters <= 0: return 1.0
+        if max_ms is None:
+            ws = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) \
+                   if ws <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        remain  = max(max_ms - elapsed_ms, 0.0)
+        wd_ms   = args.warmdown_iters * step_ms
+        return remain / max(wd_ms, 1e-9) if remain <= wd_ms else 1.0
+
+    def zero_all(): [o.zero_grad(set_to_none=True) for o in optimizers]
+
+    # ── warmup ───────────────────────────────────────────────
+    if args.warmup_steps > 0:
+        init_model = {n: t.detach().cpu().clone() for n, t in base_model.state_dict().items()}
+        init_opts  = [copy.deepcopy(o.state_dict()) for o in optimizers]
+        model.train()
+        train_loader_w = DistributedTokenLoader(args.train_files, rank, world_size, device)
+        for ws_i in range(args.warmup_steps):
+            zero_all()
+            for ms_i in range(grad_accum):
+                if distributed:
+                    model.require_backward_grad_sync = (ms_i == grad_accum - 1)
+                x, y = train_loader_w.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum)
+                with torch.autocast("cuda", torch.bfloat16):
+                    (model(x, y) * grad_scale).backward()
+            for o in optimizers: o.step()
+            zero_all()
+        base_model.load_state_dict(init_model, strict=True)
+        for o, s in zip(optimizers, init_opts): o.load_state_dict(s)
+        zero_all()
+        if distributed: model.require_backward_grad_sync = True
+
+    # ── data + training loop ─────────────────────────────────
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    training_ms  = 0.0
+    stop_step: int | None = None
+    torch.cuda.synchronize()
+    t0   = time.perf_counter()
+    step = 0
+
+    while True:
+        last_step = step == args.iterations or (stop_step is not None and step >= stop_step)
+        do_val    = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+
+        if do_val:
+            torch.cuda.synchronize()
+            training_ms += 1000.0 * (time.perf_counter() - t0)
+            vl, vbpb = eval_val_sliding_window(
+                args, model, rank, world_size, device,
+                val_tokens, base_bytes_lut, has_space_lut, is_boundary_lut)
+            log0(f"step:{step}/{args.iterations} val_loss:{vl:.4f} val_bpb:{vbpb:.4f} "
+                 f"train_ms:{training_ms:.0f} step_avg:{training_ms/max(step,1):.2f}ms")
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if master:
+                sd          = base_model.state_dict()
+                obj, stats  = quantize_state_dict_int8(sd)
+                buf         = io.BytesIO()
+                torch.save(obj, buf)
+                compressed  = zlib.compress(buf.getvalue(), level=9)
+                code_bytes  = len(code.encode())
+                model_bytes = len(compressed)
+                total_bytes = code_bytes + model_bytes
+                log0(f"final_int8_zlib_roundtrip "
+                     f"code_bytes:{code_bytes} "
+                     f"model_compressed_bytes:{model_bytes} "
+                     f"total_artifact_bytes:{total_bytes} "
+                     f"total_artifact_mb:{total_bytes/1e6:.3f} "
+                     f"param_count:{stats['param_count']}")
+                # round-trip verify
+                sd2 = dequantize_state_dict_int8(obj)
+                base_model.load_state_dict(sd2, strict=True)
+                vl2, vbpb2 = eval_val_sliding_window(
+                    args, base_model, rank, world_size, device,
+                    val_tokens, base_bytes_lut, has_space_lut, is_boundary_lut)
+                log0(f"quantized_model val_loss:{vl2:.4f} val_bpb:{vbpb2:.4f}")
+            break
+
+        if stop_step is None and max_ms is not None:
+            torch.cuda.synchronize()
+            elapsed = 1000.0 * (time.perf_counter() - t0) + training_ms
+            if elapsed >= max_ms:
+                stop_step = step + 1
+
+        zero_all()
+        for ms_i in range(grad_accum):
+            if distributed:
+                model.require_backward_grad_sync = (ms_i == grad_accum - 1)
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum)
+            with torch.autocast("cuda", torch.bfloat16):
+                (model(x, y) * grad_scale).backward()
+
+        torch.cuda.synchronize()
+        elapsed_ms = 1000.0 * (time.perf_counter() - t0) + training_ms
+        m = lr_mul(step, elapsed_ms)
+        for o in optimizers:
+            for g in o.param_groups: g["lr"] = g["base_lr"] * m
+        for o in optimizers: o.step()
+
+        if step % args.train_log_every == 0 and master:
+            log0(f"step:{step} lr_mul:{m:.4f}")
+
+        step += 1
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Results TBD pending H100 grant run. Approach validated on M1 Max 64GB: compression confirmed at ~14.2MB for 61.9M unique ternary params. Fill val_bpb, val_loss, artifact_mb, date from actual run logs before final PR.