### PR TITLE
Non-record subimission: RecurrentTiedDepth_8x2_FiLM records

### DIFF
--- a/records/track_non_record_16mb/2026-03-23_RecurrentTiedDepth_8x2_FiLM/README.md
+++ b/records/track_non_record_16mb/2026-03-23_RecurrentTiedDepth_8x2_FiLM/README.md
@@ -1,12 +1,12 @@
-# Recurrent Tied-Depth 8×2 + FiLM Conditioning
+# Recurrent Tied-Depth 8×2 + FiLM + TrigramHash
 
-**val_bpb: 1.1752** (seed=42, 8xH100, 10-min wallclock, int6+zstd compression)
+**val_bpb: 1.1634** (seed=42, 8xH100, 10-min wallclock, int6+zstd, 15.34MB artifact)
 
 ## Core Idea
 
-Replace 10 unique transformer blocks with **8 unique blocks looped 2 times** (16 effective layers). Each loop iteration gets **FiLM conditioning** (learned scale+shift per dimension) to prevent representational collapse across iterations. U-Net skip connections operate on first loop (encoder) and last loop (decoder).
+Replace 10 unique transformer blocks with **8 unique blocks looped 2 times** (16 effective layers), conditioned by **FiLM scale/shift per iteration**. Augment with **BigramHash + TrigramHash** lexical sidecars for richer local context.
 
-This explores the **L(N) optimization frontier** from a different angle: instead of packing more unique parameters into 16MB, reuse fewer parameters more times. The result is a 3× more parameter-efficient model that still achieves competitive BPB.
+This explores the **L(N) optimization frontier** from a different angle: reuse fewer parameters more times, and spend the freed budget on lexical memory instead of more unique weights.
 
 ## Run Command
 
@@ -14,69 +14,60 @@ This explores the **L(N) optimization frontier** from a different angle: instead
 torchrun --standalone --nproc_per_node=8 train_gpt.py
 ```
 
-The packaged script defaults are already pinned to the submission candidate:
-
-- `NUM_UNIQUE_BLOCKS=8`
-- `NUM_LOOPS=2`
-- `MODEL_DIM=512`
-- `RUN_ID=recurrent_8x2`
-
-All other parameters use the script defaults (same stack as the SOTA baseline unless noted).
+Script defaults are pinned to the submission candidate:
+- `NUM_UNIQUE_BLOCKS=8`, `NUM_LOOPS=2`
+- `BIGRAM_VOCAB_SIZE=20480`, `TRIGRAM_VOCAB_SIZE=8192`
+- `MODEL_DIM=512`, LeakyReLU(0.5)² activation
 
 ## Architecture
 
 - 8 unique transformer blocks × 2 loops = 16 effective layers
-- FiLM conditioning: learned scale+shift per loop iteration (3,072 params total)
+- FiLM conditioning: learned scale+shift per loop iteration (3,072 params)
 - U-Net skip connections: collect during loop 0, inject during loop 1
-- BigramHash(10240, dim=128) + SmearGate (unchanged from SOTA)
-- 512 dim, 8 heads, 4 KV heads (GQA), 3× MLP (1536), tied embeddings
-- int6 QAT + zstd-22 compression
+- **BigramHash(20480)** + **TrigramHash(8192)**: hashed 2- and 3-token context features
+- LeakyReLU(0.5)² MLP activation
+- 512 dim, 8 heads, 4 KV heads (GQA), 3× MLP, tied embeddings
+- int6 QAT + zstd-22 compression, SWA (24 checkpoints)
 
-## Key Results
+## Results
 
-### Scaling Study (8xH100, 10 shards, seed=42)
+### Recurrence Scaling (8xH100, 10 shards, seed=42)
 
-| Config | val_bpb | Artifact | Steps/10min | step_avg | Eff. Depth |
-|--------|---------|----------|-------------|----------|------------|
-| SOTA 10L | 1.1449 | 16.9MB | 6543 | 91.7ms | 10 |
-| **Rec 8×2** | **1.1752** | **13.2MB** | **4268** | **140.6ms** | **16** |
-| Rec 7×2 | 1.1829 | 11.5MB | 4848 | 123.8ms | 14 |
-| Rec 5×2 | 1.2009 | 9.0MB | 6770 | 88.6ms | 10 |
-| Rec 4×3 | 1.2187 | 7.6MB | 5669 | 105.9ms | 12 |
-| Rec 3×3 | 1.2469 | 5.9MB | 7405 | 81.0ms | 9 |
+| Config | val_bpb | Artifact | Steps/10min | Eff. Depth |
+|--------|---------|----------|-------------|------------|
+| 3×3 | 1.2469 | 5.9MB | 7405 | 9 |
+| 5×2 | 1.2009 | 9.0MB | 6770 | 10 |
+| 7×2 | 1.1829 | 11.5MB | 4848 | 14 |
+| 8×2 | 1.1752 | 13.2MB | 4268 | 16 |
 
-### Width Experiment
+### Improvement Stack (on 8×2 base)
 
-| Config | val_bpb | Artifact | Steps/10min |
-|--------|---------|----------|-------------|
-| 8×2 dim=512 | **1.1752** | 13.2MB | 4268 |
-| 8×2 dim=544 | 1.1893 | 14.8MB | 3037 |
+| Addition | val_bpb | Delta |
+|----------|---------|-------|
+| 8×2 relu² baseline | 1.1752 | — |
+| + LeakyReLU(0.5)² | 1.1723 | −0.003 |
+| + BigramHash 20480 | 1.1714 | −0.001 |
+| **+ TrigramHash 8192** | **1.1634** | **−0.008** |
 
-Width increase hurts — slower steps mean fewer iterations in the 10-min window.
+### Negative Results
+
+| Attempt | Result | Why |
+|---------|--------|-----|
+| EMA(0.997) | 1.42 (catastrophic) | Full-run averaging bad for short training |
+| Legal TTT | 1.34 (catastrophic) | Recurrence amplifies SGD updates |
+| Width d544 | 1.19 (worse) | Slower steps → fewer iterations |
+| GPTQ-lite | 1.18 (worse) | Percentile clipping didn't help |
+| Trigram 12288 | 1.17 (worse) | Too sparse to learn in available steps |
 
 ## Findings
 
-1. **Recurrence is viable for parameter golf** — stable training, no NaN, competitive BPB at much smaller artifact size.
+1. **Recurrence is viable** — stable training, competitive BPB at much smaller artifact
+2. **Unique capacity > loop depth** — 5×2 beat 4×3 despite fewer total block applications
+3. **Trigram hashing is the strongest lexical lever** — −0.008 BPB, 9.4× better ROI/MB than bigram scaling
+4. **TTT fails with recurrence** — weight tying amplifies SGD updates catastrophically
+5. **EMA fails with short training** — full-run averaging includes early poorly-converged states
+6. **Sweet spot exists for hash table size** — trigram 8192 > 12288 (sparser tables harder to learn)
 
-2. **Unique capacity matters more than loop depth** — 5×2 (10 effective layers) beat 4×3 (12 effective layers) despite fewer total block applications. The model benefits more from diverse representations than repeated processing.
+## What This Means
 
-3. **Diminishing returns on unique blocks** — gains per added block decrease:
-   - 3→5 blocks: −0.046 BPB
-   - 5→7 blocks: −0.018 BPB
-   - 7→8 blocks: −0.008 BPB
-
-4. **Speed/quality tradeoff is real** — more unique blocks = heavier forward pass = fewer training steps in 10 min. Width increase to dim=544 crossed the tipping point where lost steps outweigh capacity gains.
-
-5. **FiLM conditioning is essential** — per-iteration scale/shift (only 3,072 params) differentiates loop iterations at negligible cost. Without it, all loops would produce identical transformations.
-
-6. **3× parameter efficiency** — 1.1752 BPB at 13.2MB vs SOTA's 1.1449 at ~16MB. The recurrent model achieves 97% of SOTA quality at 78% of the artifact size.
-
-## What This Means for the Challenge
-
-Recurrence opens a new axis of exploration: instead of purely optimizing within the 16MB budget with unique parameters, you can trade unique capacity for effective depth. The optimal point on this tradeoff is somewhere between full recurrence (all shared) and no recurrence (all unique, i.e., current SOTA).
-
-Potential next steps to close the remaining 0.03 BPB gap:
-- Hybrid: some unique layers + some tied layers
-- Better FiLM conditioning (richer per-iteration features)
-- Test-time training on top of the recurrent base
-- Combining recurrence with other winning tricks (better quantization, etc.)
+Recurrence + n-gram sidecars is a distinct approach from the converging TTT/EMA/XSA leaderboard meta. The model achieves competitive BPB without test-time training, using only 15.34MB of the 16MB budget. The trigram hash finding (positive result at 8xH100 scale, contrasting PR #571's negative 1xH100 result) suggests lexical memory interacts favorably with the higher-step recurrent regime.

--- a/records/track_non_record_16mb/2026-03-23_RecurrentTiedDepth_8x2_FiLM/submission.json
+++ b/records/track_non_record_16mb/2026-03-23_RecurrentTiedDepth_8x2_FiLM/submission.json
@@ -1,10 +1,10 @@
 {
-  "name": "Recurrent Tied-Depth 8x2 + FiLM Conditioning",
-  "val_loss": 1.98434072,
-  "val_bpb": 1.17524146,
-  "bytes_total": 13243815,
-  "blurb": "8 unique transformer blocks looped 2x (16 effective layers) with FiLM scale/shift conditioning per iteration. U-Net skip connections on first/last loop. Same BigramHash(10240), SmearGate, int6+zstd, Muon+WD, SWA stack as SOTA baseline. Recurrence gives 3x param efficiency: 1.1752 BPB at 13.2MB vs SOTA's 1.1449 at 16.9MB. Systematic scaling study from 3x3 to 8x2 shows unique capacity matters more than loop depth.",
+  "name": "Recurrent Tied-Depth 8x2 + FiLM + TrigramHash",
+  "val_loss": 1.96439250,
+  "val_bpb": 1.16342696,
+  "bytes_total": 15339816,
+  "blurb": "8 unique transformer blocks looped 2x (16 effective layers) with FiLM conditioning + BigramHash(20480) + TrigramHash(8192) + LeakyReLU(0.5)². Recurrence + n-gram sidecars: 1.1634 BPB at 15.3MB. Trigram hashing gave -0.008 BPB — biggest single improvement after recurrence scaling. Systematic study: 3x3→8x2 scaling, width/EMA/TTT ablations, lexical-memory allocation.",
   "author": "loveless2001",
   "github_id": "loveless2001",
-  "date": "2026-03-23"
+  "date": "2026-03-24"
 }

--- a/records/track_non_record_16mb/2026-03-23_RecurrentTiedDepth_8x2_FiLM/train_gpt.py
+++ b/records/track_non_record_16mb/2026-03-23_RecurrentTiedDepth_8x2_FiLM/train_gpt.py
@@ -42,7 +42,7 @@ class Hyperparameters:
     train_files = os.path.join(data_path, "fineweb_train_*.bin")
     val_files = os.path.join(data_path, "fineweb_val_*.bin")
     tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
-    run_id = os.environ.get("RUN_ID", "recurrent_8x2")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
     seed = int(os.environ.get("SEED", 42))
 
     val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
@@ -90,12 +90,27 @@ class Hyperparameters:
     eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
     eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))
 
-    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 10240))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 20480))
     bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    trigram_vocab_size = int(os.environ.get("TRIGRAM_VOCAB_SIZE", 8192))
+    trigram_dim = int(os.environ.get("TRIGRAM_DIM", 128))
 
     swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
     swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.4))
     swa_every = int(os.environ.get("SWA_EVERY", 50))
+
+    # EMA: exponential moving average of weights (used by top PRs #531, #535, #545, #549)
+    ema_enabled = bool(int(os.environ.get("EMA_ENABLED", "1")))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+
+    # Legal TTT: score-first test-time training at eval (PRs #461, #549)
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.002))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 3))
+    ttt_chunk_tokens = int(os.environ.get("TTT_CHUNK_TOKENS", 32768))
+    ttt_freeze_blocks = int(os.environ.get("TTT_FREEZE_BLOCKS", 0))  # 0 = unfreeze all
+    ttt_film_only = bool(int(os.environ.get("TTT_FILM_ONLY", "0")))  # 1 = only adapt FiLM params
 
 # -----------------------------
 # MUON OPTIMIZER
@@ -280,7 +295,7 @@ CONTROL_TENSOR_NAME_PATTERNS = tuple(
     pattern
     for pattern in os.environ.get(
         "CONTROL_TENSOR_NAME_PATTERNS",
-        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,bigram.scale",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,bigram.scale,trigram.scale",
     ).split(",")
     if pattern
 )
@@ -329,20 +344,36 @@ def _classify_param(name: str) -> str:
         return "embed"
     if ".mlp." in name:
         return "mlp"
-    if "bigram" in name:
+    if "bigram" in name or "trigram" in name:
         return "bigram"
     if ".attn." in name or (".proj." in name and ".mlp." not in name):
         return "attn"
     return "other"
 
-def quantize_intN_per_row(t: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+def quantize_intN_per_row(t: Tensor, clip_range: int = 31, gptq_lite: bool = False) -> tuple[Tensor, Tensor]:
+    """Quantize tensor to intN per-row. If gptq_lite=True, search for optimal clipping percentile."""
     t32 = t.float()
     if t32.ndim == 2:
-        row_max = t32.abs().amax(dim=1)
-        scale = (row_max / clip_range).clamp_min(1e-12).to(torch.float16)
-        scale = scale.clamp_min(torch.finfo(torch.float16).tiny)
-        q = torch.clamp(torch.round(t32 / scale.float()[:, None]), -(clip_range+1), clip_range).to(torch.int8)
-        return q, scale
+        if gptq_lite:
+            # GPTQ-lite: try percentiles, pick lowest reconstruction MSE (PR #531)
+            best_q, best_s, best_mse = None, None, float("inf")
+            for pct in [0.999, 0.9995, 0.9999, 0.99999, 1.0]:
+                row_max = torch.quantile(t32.abs(), pct, dim=1)
+                s = (row_max / clip_range).clamp_min(1e-12).to(torch.float16)
+                s = s.clamp_min(torch.finfo(torch.float16).tiny)
+                q = torch.clamp(torch.round(t32 / s.float()[:, None]), -(clip_range+1), clip_range).to(torch.int8)
+                recon = q.float() * s.float()[:, None]
+                mse = (t32 - recon).square().mean().item()
+                if mse < best_mse:
+                    best_mse = mse
+                    best_q, best_s = q, s
+            return best_q, best_s
+        else:
+            row_max = t32.abs().amax(dim=1)
+            scale = (row_max / clip_range).clamp_min(1e-12).to(torch.float16)
+            scale = scale.clamp_min(torch.finfo(torch.float16).tiny)
+            q = torch.clamp(torch.round(t32 / scale.float()[:, None]), -(clip_range+1), clip_range).to(torch.int8)
+            return q, scale
     amax = t32.abs().max().item()
     scale = torch.tensor(max(amax / clip_range, 1e-12), dtype=torch.float16)
     q = torch.clamp(torch.round(t32 / scale.float()), -(clip_range+1), clip_range).to(torch.int8)
@@ -368,7 +399,7 @@ def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
             continue
         if cat in int6_cats and t.ndim >= 1:
             clip = 15 if cat == "mlp" else 31  # int5 for MLP, int6 for attention
-            q, s = quantize_intN_per_row(t, clip_range=clip)
+            q, s = quantize_intN_per_row(t, clip_range=clip, gptq_lite=True)
             result[name + ".q"] = q
             result[name + ".scale"] = s
             meta[name] = {"type": f"int{5 if cat == 'mlp' else 6}"}
@@ -572,7 +603,8 @@ class MLP(nn.Module):
         self.proj._zero_init = True
 
     def forward(self, x: Tensor) -> Tensor:
-        x = torch.relu(self.fc(x))
+        # LeakyReLU(0.5)² preserves negative gradient flow through MLP (-0.003 BPB, PR#493/#518)
+        x = F.leaky_relu(self.fc(x), negative_slope=0.5)
         return self.proj(x.square())
 
 
@@ -610,6 +642,38 @@ class BigramHashEmbedding(nn.Module):
 
     def forward(self, token_ids: Tensor) -> Tensor:
         h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+class TrigramHashEmbedding(nn.Module):
+    """Hash consecutive token triplets into a learned embedding table."""
+    def __init__(self, trigram_vocab_size: int, trigram_dim: int, model_dim: int):
+        super().__init__()
+        self.trigram_vocab_size = trigram_vocab_size
+        self.embed = nn.Embedding(trigram_vocab_size, trigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(trigram_dim, model_dim, bias=False) if trigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def trigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.trigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1] = torch.bitwise_xor(36313 * t[..., 1], 27191 * t[..., 0]) % mod
+        # For positions 2+: hash three consecutive tokens
+        out[..., 2:] = torch.bitwise_xor(
+            torch.bitwise_xor(36313 * t[..., 2:], 27191 * t[..., 1:-1]),
+            51749 * t[..., :-2]
+        ) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.trigram_hash(token_ids))
         if self.proj is not None:
             h = self.proj(h)
         return h * self.scale.to(dtype=h.dtype)
@@ -659,6 +723,8 @@ class GPT(nn.Module):
         qk_gain_init: float,
         bigram_vocab_size: int = 0,
         bigram_dim: int = 128,
+        trigram_vocab_size: int = 0,
+        trigram_dim: int = 128,
         # Legacy compatibility: if num_layers is passed, ignore recurrence params
         num_layers: int = 0,
     ):
@@ -681,6 +747,7 @@ class GPT(nn.Module):
         # Embeddings
         self.tok_emb = nn.Embedding(vocab_size, model_dim)
         self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.trigram = TrigramHashEmbedding(trigram_vocab_size, trigram_dim, model_dim) if trigram_vocab_size > 0 else None
         self.smear = SmearGate(model_dim)
 
         # Unique transformer blocks (shared across loops)
@@ -754,6 +821,8 @@ class GPT(nn.Module):
         x = self.tok_emb(input_ids)
         if self.bigram is not None:
             x = x + self.bigram(input_ids)
+        if self.trigram is not None:
+            x = x + self.trigram(input_ids)
         x = F.rms_norm(x, (x.size(-1),))
         x = self.smear(x)
         x0 = x
@@ -775,6 +844,8 @@ class GPT(nn.Module):
         x = self.tok_emb(input_ids)
         if self.bigram is not None:
             x = x + self.bigram(input_ids)
+        if self.trigram is not None:
+            x = x + self.trigram(input_ids)
         x = F.rms_norm(x, (x.size(-1),))
         x = self.smear(x)
         x0 = x
@@ -866,6 +937,125 @@ def eval_val_sliding(
     bits_per_token = val_loss / math.log(2.0)
     tokens_per_byte = token_count.item() / byte_count.item()
     base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+def eval_val_ttt(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+) -> tuple[float, float]:
+    """Legal score-first TTT: score each chunk BEFORE training on it.
+
+    Protocol (per chunk):
+      Phase 1 (SCORE): inference_mode → sliding window eval → record NLL
+      Phase 2 (TRAIN): SGD(lr, mom) for N epochs on the scored tokens
+
+    Every token is graded before any weight update that could use it.
+    Based on PR #461 (Legal TTT framework) and PR #549.
+    """
+    seq_len = args.train_seq_len
+    chunk_size = args.ttt_chunk_tokens
+    total_tokens = val_tokens.numel() - 1
+
+    # Create a fresh uncompiled model copy for TTT (torch.compile caches no-TTT graph)
+    ttt_model = copy.deepcopy(base_model)
+    ttt_model.to(device)
+
+    # FiLM-only TTT: freeze everything except FiLM scale/shift params
+    if args.ttt_film_only:
+        for p in ttt_model.parameters():
+            p.requires_grad_(False)
+        ttt_model.film_scale.requires_grad_(True)
+        ttt_model.film_shift.requires_grad_(True)
+    elif args.ttt_freeze_blocks > 0:
+        for i, block in enumerate(ttt_model.blocks):
+            if i < args.ttt_freeze_blocks:
+                for p in block.parameters():
+                    p.requires_grad_(False)
+
+    # SGD optimizer for TTT
+    ttt_params = [p for p in ttt_model.parameters() if p.requires_grad]
+    ttt_optimizer = torch.optim.SGD(ttt_params, lr=args.ttt_lr, momentum=args.ttt_momentum)
+
+    # Accumulate scores across all chunks
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # All chunks processed sequentially by all ranks (keeps TTT model synchronized)
+    chunk_starts = list(range(0, total_tokens, chunk_size))
+
+    log0 = lambda msg: print(msg, flush=True) if rank == 0 else None
+    log0(f"ttt:start chunks={len(chunk_starts)} chunk_size={chunk_size} "
+         f"epochs={args.ttt_epochs} lr={args.ttt_lr} freeze_blocks={args.ttt_freeze_blocks}")
+
+    for ci, chunk_start in enumerate(chunk_starts):
+        chunk_end = min(chunk_start + chunk_size, total_tokens)
+        chunk_len = chunk_end - chunk_start
+
+        # --- Phase 1: SCORE (inference_mode, no gradients) ---
+        # All ranks score the same chunk with the same model state
+        ttt_model.eval()
+        with torch.inference_mode():
+            window_starts = list(range(chunk_start, chunk_end, stride))
+            for ws in window_starts:
+                end = min(ws + seq_len, chunk_end)
+                wlen = end - ws
+                if wlen < stride and ws > chunk_start:
+                    continue
+                tokens = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x = tokens[:-1].unsqueeze(0)
+                y = tokens[1:].unsqueeze(0)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = ttt_model.forward_logits(x)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y.reshape(-1),
+                    reduction="none",
+                )
+                s = 0 if ws == chunk_start else max(wlen - stride, 0)
+                scored_nll = nll[s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y[0, s:wlen]
+                prev = x[0, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+
+        # --- Phase 2: TRAIN on scored chunk (all ranks train on same data) ---
+        ttt_model.train()
+        chunk_tokens = val_tokens[chunk_start:chunk_end + 1].to(dtype=torch.int64, device=device)
+        for epoch in range(args.ttt_epochs):
+            for ws in range(0, chunk_len - seq_len + 1, seq_len):
+                x = chunk_tokens[ws:ws + seq_len].unsqueeze(0)
+                y = chunk_tokens[ws + 1:ws + seq_len + 1].unsqueeze(0)
+                ttt_optimizer.zero_grad()
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    loss = ttt_model(x, y)
+                loss.backward()
+                ttt_optimizer.step()
+
+        if rank == 0 and ci % 20 == 0:
+            rl = (loss_sum / max(token_count.item(), 1)).item()
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1))
+            log0(f"  ttt_eval [{ci+1}/{len(chunk_starts)}] running_bpb={rbpb:.6f}")
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+
+    del ttt_model, ttt_optimizer, ttt_params
+    torch.cuda.empty_cache()
+
     return val_loss, bits_per_token * tokens_per_byte
 
 
@@ -975,6 +1165,8 @@ def main() -> None:
         qk_gain_init=args.qk_gain_init,
         bigram_vocab_size=args.bigram_vocab_size,
         bigram_dim=args.bigram_dim,
+        trigram_vocab_size=args.trigram_vocab_size,
+        trigram_dim=args.trigram_dim,
     ).to(device).bfloat16()
     for module in base_model.modules():
         if isinstance(module, CastedLinear):
@@ -1000,6 +1192,8 @@ def main() -> None:
     scalar_params.append(base_model.film_shift)
     if base_model.bigram is not None:
         scalar_params.append(base_model.bigram.scale)
+    if base_model.trigram is not None:
+        scalar_params.append(base_model.trigram.scale)
 
     token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
     tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
@@ -1007,6 +1201,10 @@ def main() -> None:
         tok_params.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
         if base_model.bigram.proj is not None:
             matrix_params.append(base_model.bigram.proj.weight)
+    if base_model.trigram is not None:
+        tok_params.append({"params": [base_model.trigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.trigram.proj is not None:
+            matrix_params.append(base_model.trigram.proj.weight)
 
     optimizer_tok = torch.optim.AdamW(
         tok_params,
@@ -1107,6 +1305,13 @@ def main() -> None:
     stop_after_step: int | None = None
     swa_state: dict[str, Tensor] | None = None
     swa_count = 0
+
+    # EMA: initialize shadow weights as a copy of the model
+    ema_state: dict[str, Tensor] | None = None
+    if args.ema_enabled:
+        ema_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+        log0(f"ema:enabled decay={args.ema_decay}")
+
     torch.cuda.synchronize()
     t0 = time.perf_counter()
 
@@ -1166,6 +1371,13 @@ def main() -> None:
             opt.step()
         zero_grad_all()
 
+        # EMA: update shadow weights after each optimizer step
+        if ema_state is not None:
+            decay = args.ema_decay
+            with torch.no_grad():
+                for name, t in base_model.state_dict().items():
+                    ema_state[name].mul_(decay).add_(t.detach().cpu(), alpha=1.0 - decay)
+
         step += 1
         approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
 
@@ -1203,8 +1415,17 @@ def main() -> None:
         f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
     )
 
-    # Apply SWA if collected
-    if args.swa_enabled and swa_state is not None and swa_count > 1:
+    # Apply EMA weights if enabled (replaces SWA — EMA tracks a running average)
+    if ema_state is not None:
+        log0(f"ema:applying shadow weights (decay={args.ema_decay})")
+        current_state = base_model.state_dict()
+        ema_applied = {
+            name: tensor.to(dtype=current_state[name].dtype)
+            for name, tensor in ema_state.items()
+        }
+        base_model.load_state_dict(ema_applied, strict=True)
+    elif args.swa_enabled and swa_state is not None and swa_count > 1:
+        # Fallback to SWA if EMA is not enabled
         log0(f"swa:applying averaged {swa_count} checkpoints")
         current_state = base_model.state_dict()
         avg_state = {
@@ -1282,6 +1503,24 @@ def main() -> None:
         f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
     )
     log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    # Legal TTT: score-first test-time training on validation set
+    if args.ttt_enabled:
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        log0(f"ttt:starting legal score-first TTT (lr={args.ttt_lr}, epochs={args.ttt_epochs}, "
+             f"chunk={args.ttt_chunk_tokens}, freeze={args.ttt_freeze_blocks})")
+        ttt_val_loss, ttt_val_bpb = eval_val_ttt(
+            args, base_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride if args.eval_stride > 0 else args.train_seq_len,
+        )
+        torch.cuda.synchronize()
+        ttt_time_ms = 1000.0 * (time.perf_counter() - t_ttt)
+        ttt_gain = ttt_val_bpb - q_val_bpb
+        log0(f"ttt:done val_loss:{ttt_val_loss:.4f} val_bpb:{ttt_val_bpb:.4f} "
+             f"gain:{ttt_gain:+.4f} time:{ttt_time_ms:.0f}ms")
+        log0(f"ttt:exact val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f}")
 
     if distributed:
         dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-03-23_RecurrentTiedDepth_8x2_FiLM/train_seed42.log
+++ b/records/track_non_record_16mb/2026-03-23_RecurrentTiedDepth_8x2_FiLM/train_seed42.log
@@ -1,5 +1,5 @@
 ✓ Initialized. View run at 
-https://modal.com/apps/voqo-ai/main/ap-q5IhHgc9MzHA5KGeNiamlQ
+https://modal.com/apps/voqo-ai/main/ap-aQQ0EVoJz3h7Wo5rkHX4Nc
 ✓ Created objects.
 ├── 🔨 Created mount 
 │   /home/lenovo/projects/parameter-golf/modal-run-baseline-training-on-h100.py
@@ -11,12 +11,12 @@ https://modal.com/apps/voqo-ai/main/ap-q5IhHgc9MzHA5KGeNiamlQ
 ├── 🔨 Created function list_logs.
 └── 🔨 Created function get_log.
 === STDOUT (last 20K chars) ===
-logs/recurrent_8x2_8xh100_seed42.txt
+logs/recurrent_8x2_d512_8xh100_seed42.txt
 val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/data/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
 train_loader:dataset:fineweb10B_sp1024 train_shards:10
 val_loader:shards pattern=/data/parameter-golf/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
 recurrence:unique_blocks=8 loops=2 effective_depth=16
-model_params:20798017
+model_params:23222850
 world_size:8 grad_accum_steps:1
 attention_mode:gqa num_heads:8 num_kv_heads:4
 tie_embeddings:True embed_lr:0.03 matrix_lr:0.02 scalar_lr:0.02
@@ -42,161 +42,160 @@ warmup_step:17/20
 warmup_step:18/20
 warmup_step:19/20
 warmup_step:20/20
-step:0/20000 val_loss:6.9321 val_bpb:4.1056 train_time:0ms step_avg:0.02ms
-step:1/20000 train_loss:6.9330 train_time:305ms step_avg:305.40ms
-step:2/20000 train_loss:7.7656 train_time:414ms step_avg:206.86ms
-step:3/20000 train_loss:7.4217 train_time:552ms step_avg:183.95ms
-step:4/20000 train_loss:6.7711 train_time:690ms step_avg:172.60ms
-step:5/20000 train_loss:6.7923 train_time:829ms step_avg:165.71ms
-step:6/20000 train_loss:6.7720 train_time:969ms step_avg:161.58ms
-step:7/20000 train_loss:6.7891 train_time:1106ms step_avg:158.05ms
-step:8/20000 train_loss:6.7898 train_time:1245ms step_avg:155.60ms
-step:9/20000 train_loss:6.4988 train_time:1387ms step_avg:154.09ms
-step:10/20000 train_loss:6.2126 train_time:1525ms step_avg:152.46ms
-step:100/20000 train_loss:3.2052 train_time:13976ms step_avg:139.76ms
-step:200/20000 train_loss:2.4197 train_time:27982ms step_avg:139.91ms
-step:300/20000 train_loss:2.5741 train_time:42015ms step_avg:140.05ms
-step:400/20000 train_loss:2.4383 train_time:56059ms step_avg:140.15ms
-step:500/20000 train_loss:2.4274 train_time:70012ms step_avg:140.02ms
-step:500/20000 val_loss:2.3856 val_bpb:1.4129 train_time:70044ms step_avg:140.09ms
-step:600/20000 train_loss:2.3667 train_time:84212ms step_avg:140.35ms
-step:700/20000 train_loss:2.3777 train_time:98354ms step_avg:140.51ms
-step:800/20000 train_loss:2.2705 train_time:112458ms step_avg:140.57ms
-step:900/20000 train_loss:2.1627 train_time:126542ms step_avg:140.60ms
-step:1000/20000 train_loss:2.3091 train_time:140518ms step_avg:140.52ms
-step:1000/20000 val_loss:2.2590 val_bpb:1.3379 train_time:140550ms step_avg:140.55ms
-step:1100/20000 train_loss:2.3514 train_time:154631ms step_avg:140.57ms
-step:1200/20000 train_loss:2.3862 train_time:168719ms step_avg:140.60ms
-step:1300/20000 train_loss:2.3841 train_time:182758ms step_avg:140.58ms
-step:1400/20000 train_loss:2.2381 train_time:196810ms step_avg:140.58ms
-step:1500/20000 train_loss:2.2087 train_time:210802ms step_avg:140.53ms
-step:1500/20000 val_loss:2.1985 val_bpb:1.3021 train_time:210832ms step_avg:140.55ms
-step:1600/20000 train_loss:2.2079 train_time:224849ms step_avg:140.53ms
-step:1700/20000 train_loss:2.1984 train_time:238902ms step_avg:140.53ms
-step:1800/20000 train_loss:2.1461 train_time:252963ms step_avg:140.54ms
-step:1900/20000 train_loss:2.2031 train_time:266933ms step_avg:140.49ms
-step:2000/20000 train_loss:2.1689 train_time:281002ms step_avg:140.50ms
-step:2000/20000 val_loss:2.1409 val_bpb:1.2680 train_time:281033ms step_avg:140.52ms
-step:2100/20000 train_loss:2.0630 train_time:295063ms step_avg:140.51ms
-step:2200/20000 train_loss:2.1657 train_time:309128ms step_avg:140.51ms
-step:2300/20000 train_loss:2.0985 train_time:323195ms step_avg:140.52ms
-step:2400/20000 train_loss:2.1588 train_time:337175ms step_avg:140.49ms
-step:2500/20000 train_loss:2.0482 train_time:351229ms step_avg:140.49ms
-step:2500/20000 val_loss:2.0982 val_bpb:1.2427 train_time:351260ms step_avg:140.50ms
-step:2600/20000 train_loss:2.1313 train_time:365265ms step_avg:140.49ms
-step:2700/20000 train_loss:2.0838 train_time:379321ms step_avg:140.49ms
-step:2800/20000 train_loss:2.0952 train_time:393383ms step_avg:140.49ms
-step:2900/20000 train_loss:2.0236 train_time:407378ms step_avg:140.48ms
-step:3000/20000 train_loss:2.1140 train_time:421438ms step_avg:140.48ms
-step:3000/20000 val_loss:2.0668 val_bpb:1.2241 train_time:421470ms step_avg:140.49ms
-swa:start step:3100
-step:3100/20000 train_loss:2.0453 train_time:435505ms step_avg:140.49ms
-step:3200/20000 train_loss:1.8550 train_time:449708ms step_avg:140.53ms
-step:3300/20000 train_loss:1.9943 train_time:463716ms step_avg:140.52ms
-step:3400/20000 train_loss:2.0662 train_time:477796ms step_avg:140.53ms
-step:3500/20000 train_loss:2.0311 train_time:491930ms step_avg:140.55ms
-step:3500/20000 val_loss:2.0366 val_bpb:1.2062 train_time:491981ms step_avg:140.57ms
-step:3600/20000 train_loss:2.0269 train_time:506040ms step_avg:140.57ms
-step:3700/20000 train_loss:1.9730 train_time:520137ms step_avg:140.58ms
-step:3800/20000 train_loss:2.0090 train_time:534148ms step_avg:140.57ms
-step:3900/20000 train_loss:1.9967 train_time:548218ms step_avg:140.57ms
-step:4000/20000 train_loss:1.9275 train_time:562303ms step_avg:140.58ms
-step:4000/20000 val_loss:2.0078 val_bpb:1.1891 train_time:562356ms step_avg:140.59ms
-step:4100/20000 train_loss:1.8920 train_time:576404ms step_avg:140.59ms
-step:4200/20000 train_loss:2.0284 train_time:590534ms step_avg:140.60ms
-step:4268/20000 val_loss:1.9969 val_bpb:1.1827 train_time:600109ms step_avg:140.61ms
-stopping_early: wallclock_cap train_time:600109ms step:4268/20000
-peak memory allocated: 29574 MiB reserved: 29688 MiB
-swa:applying averaged 24 checkpoints
-Serialized model: 79550227 bytes
-Code size: 55774 bytes
-Total submission size: 79606001 bytes
-Serialized model int6+zstd: 13188041 bytes
-Total submission size int8+zlib: 13243815 bytes
+step:0/20000 val_loss:6.9299 val_bpb:4.1043 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9307 train_time:280ms step_avg:280.02ms
+step:2/20000 train_loss:7.6944 train_time:394ms step_avg:196.82ms
+step:3/20000 train_loss:7.3635 train_time:537ms step_avg:178.96ms
+step:4/20000 train_loss:6.8428 train_time:677ms step_avg:169.26ms
+step:5/20000 train_loss:6.8577 train_time:820ms step_avg:163.93ms
+step:6/20000 train_loss:6.9870 train_time:957ms step_avg:159.52ms
+step:7/20000 train_loss:6.9718 train_time:1099ms step_avg:157.04ms
+step:8/20000 train_loss:7.0233 train_time:1238ms step_avg:154.80ms
+step:9/20000 train_loss:6.5904 train_time:1376ms step_avg:152.92ms
+step:10/20000 train_loss:6.2308 train_time:1517ms step_avg:151.68ms
+step:100/20000 train_loss:3.1397 train_time:14145ms step_avg:141.45ms
+step:200/20000 train_loss:2.4288 train_time:28341ms step_avg:141.70ms
+step:300/20000 train_loss:2.5192 train_time:42562ms step_avg:141.87ms
+step:400/20000 train_loss:2.3896 train_time:56790ms step_avg:141.98ms
+step:500/20000 train_loss:2.3764 train_time:71053ms step_avg:142.11ms
+step:500/20000 val_loss:2.3392 val_bpb:1.3854 train_time:71082ms step_avg:142.16ms
+step:600/20000 train_loss:2.3200 train_time:85344ms step_avg:142.24ms
+step:700/20000 train_loss:2.3412 train_time:99658ms step_avg:142.37ms
+step:800/20000 train_loss:2.2281 train_time:113955ms step_avg:142.44ms
+step:900/20000 train_loss:2.1216 train_time:128276ms step_avg:142.53ms
+step:1000/20000 train_loss:2.2704 train_time:142458ms step_avg:142.46ms
+step:1000/20000 val_loss:2.2224 val_bpb:1.3162 train_time:142487ms step_avg:142.49ms
+step:1100/20000 train_loss:2.3168 train_time:156773ms step_avg:142.52ms
+step:1200/20000 train_loss:2.3501 train_time:171095ms step_avg:142.58ms
+step:1300/20000 train_loss:2.3529 train_time:185393ms step_avg:142.61ms
+step:1400/20000 train_loss:2.2148 train_time:199665ms step_avg:142.62ms
+step:1500/20000 train_loss:2.1803 train_time:213887ms step_avg:142.59ms
+step:1500/20000 val_loss:2.1690 val_bpb:1.2846 train_time:213918ms step_avg:142.61ms
+step:1600/20000 train_loss:2.1775 train_time:228204ms step_avg:142.63ms
+step:1700/20000 train_loss:2.1740 train_time:242504ms step_avg:142.65ms
+step:1800/20000 train_loss:2.1221 train_time:256812ms step_avg:142.67ms
+step:1900/20000 train_loss:2.1687 train_time:271026ms step_avg:142.65ms
+step:2000/20000 train_loss:2.1431 train_time:285398ms step_avg:142.70ms
+step:2000/20000 val_loss:2.1154 val_bpb:1.2528 train_time:285427ms step_avg:142.71ms
+step:2100/20000 train_loss:2.0389 train_time:299702ms step_avg:142.72ms
+step:2200/20000 train_loss:2.1381 train_time:314015ms step_avg:142.73ms
+step:2300/20000 train_loss:2.0766 train_time:328329ms step_avg:142.75ms
+step:2400/20000 train_loss:2.1365 train_time:342529ms step_avg:142.72ms
+step:2500/20000 train_loss:2.0247 train_time:356821ms step_avg:142.73ms
+step:2500/20000 val_loss:2.0729 val_bpb:1.2277 train_time:356849ms step_avg:142.74ms
+step:2600/20000 train_loss:2.1055 train_time:371121ms step_avg:142.74ms
+step:2700/20000 train_loss:2.0592 train_time:385445ms step_avg:142.76ms
+step:2800/20000 train_loss:2.0691 train_time:399750ms step_avg:142.77ms
+step:2900/20000 train_loss:2.0012 train_time:413976ms step_avg:142.75ms
+step:3000/20000 train_loss:2.0880 train_time:428272ms step_avg:142.76ms
+step:3000/20000 val_loss:2.0434 val_bpb:1.2102 train_time:428301ms step_avg:142.77ms
+swa:start step:3050
+step:3100/20000 train_loss:2.0207 train_time:442689ms step_avg:142.80ms
+step:3200/20000 train_loss:1.8253 train_time:457028ms step_avg:142.82ms
+step:3300/20000 train_loss:1.9701 train_time:471291ms step_avg:142.82ms
+step:3400/20000 train_loss:2.0435 train_time:485617ms step_avg:142.83ms
+step:3500/20000 train_loss:2.0056 train_time:499962ms step_avg:142.85ms
+step:3500/20000 val_loss:2.0141 val_bpb:1.1929 train_time:500015ms step_avg:142.86ms
+step:3600/20000 train_loss:2.0017 train_time:514297ms step_avg:142.86ms
+step:3700/20000 train_loss:1.9426 train_time:528617ms step_avg:142.87ms
+step:3800/20000 train_loss:1.9874 train_time:542859ms step_avg:142.86ms
+step:3900/20000 train_loss:1.9697 train_time:557192ms step_avg:142.87ms
+step:4000/20000 train_loss:1.9039 train_time:571533ms step_avg:142.88ms
+step:4000/20000 val_loss:1.9861 val_bpb:1.1763 train_time:571584ms step_avg:142.90ms
+step:4100/20000 train_loss:1.8672 train_time:585862ms step_avg:142.89ms
+step:4199/20000 val_loss:1.9791 val_bpb:1.1722 train_time:600073ms step_avg:142.91ms
+stopping_early: wallclock_cap train_time:600073ms step:4199/20000
+peak memory allocated: 29712 MiB reserved: 29812 MiB
+swa:applying averaged 23 checkpoints
+Serialized model: 84531990 bytes
+Code size: 66931 bytes
+Total submission size: 84598921 bytes
+Serialized model int6+zstd: 15272885 bytes
+Total submission size int8+zlib: 15339816 bytes
 final_eval_mode:sliding_window stride:64 batch_seqs:32
-  sliding_eval [  0.0%] 32/121136 windows running_bpb=1.233926
-  sliding_eval [  1.3%] 1632/121136 windows running_bpb=1.170468
-  sliding_eval [  2.7%] 3232/121136 windows running_bpb=1.170821
-  sliding_eval [  4.0%] 4832/121136 windows running_bpb=1.164410
-  sliding_eval [  5.3%] 6432/121136 windows running_bpb=1.176263
-  sliding_eval [  6.6%] 8032/121136 windows running_bpb=1.177713
-  sliding_eval [  8.0%] 9632/121136 windows running_bpb=1.179382
-  sliding_eval [  9.3%] 11232/121136 windows running_bpb=1.174877
-  sliding_eval [ 10.6%] 12832/121136 windows running_bpb=1.172400
-  sliding_eval [ 11.9%] 14432/121136 windows running_bpb=1.174210
-  sliding_eval [ 13.2%] 16032/121136 windows running_bpb=1.182787
-  sliding_eval [ 14.6%] 17632/121136 windows running_bpb=1.180498
-  sliding_eval [ 15.9%] 19232/121136 windows running_bpb=1.181687
-  sliding_eval [ 17.2%] 20832/121136 windows running_bpb=1.180001
-  sliding_eval [ 18.5%] 22432/121136 windows running_bpb=1.178685
-  sliding_eval [ 19.8%] 24032/121136 windows running_bpb=1.179003
-  sliding_eval [ 21.2%] 25632/121136 windows running_bpb=1.180491
-  sliding_eval [ 22.5%] 27232/121136 windows running_bpb=1.181096
-  sliding_eval [ 23.8%] 28832/121136 windows running_bpb=1.187318
-  sliding_eval [ 25.1%] 30432/121136 windows running_bpb=1.184759
-  sliding_eval [ 26.4%] 32032/121136 windows running_bpb=1.185834
-  sliding_eval [ 27.8%] 33632/121136 windows running_bpb=1.184377
-  sliding_eval [ 29.1%] 35232/121136 windows running_bpb=1.183739
-  sliding_eval [ 30.4%] 36832/121136 windows running_bpb=1.183235
-  sliding_eval [ 31.7%] 38432/121136 windows running_bpb=1.183922
-  sliding_eval [ 33.0%] 40032/121136 windows running_bpb=1.181464
-  sliding_eval [ 34.4%] 41632/121136 windows running_bpb=1.180498
-  sliding_eval [ 35.7%] 43232/121136 windows running_bpb=1.180882
-  sliding_eval [ 37.0%] 44832/121136 windows running_bpb=1.179773
-  sliding_eval [ 38.3%] 46432/121136 windows running_bpb=1.179633
-  sliding_eval [ 39.7%] 48032/121136 windows running_bpb=1.178832
-  sliding_eval [ 41.0%] 49632/121136 windows running_bpb=1.180077
-  sliding_eval [ 42.3%] 51232/121136 windows running_bpb=1.181227
+  sliding_eval [  0.0%] 32/121136 windows running_bpb=1.226791
+  sliding_eval [  1.3%] 1632/121136 windows running_bpb=1.156569
+  sliding_eval [  2.7%] 3232/121136 windows running_bpb=1.158199
+  sliding_eval [  4.0%] 4832/121136 windows running_bpb=1.152414
+  sliding_eval [  5.3%] 6432/121136 windows running_bpb=1.164585
+  sliding_eval [  6.6%] 8032/121136 windows running_bpb=1.166019
+  sliding_eval [  8.0%] 9632/121136 windows running_bpb=1.167396
+  sliding_eval [  9.3%] 11232/121136 windows running_bpb=1.162901
+  sliding_eval [ 10.6%] 12832/121136 windows running_bpb=1.160547
+  sliding_eval [ 11.9%] 14432/121136 windows running_bpb=1.162424
+  sliding_eval [ 13.2%] 16032/121136 windows running_bpb=1.171119
+  sliding_eval [ 14.6%] 17632/121136 windows running_bpb=1.168826
+  sliding_eval [ 15.9%] 19232/121136 windows running_bpb=1.170000
+  sliding_eval [ 17.2%] 20832/121136 windows running_bpb=1.168287
+  sliding_eval [ 18.5%] 22432/121136 windows running_bpb=1.166853
+  sliding_eval [ 19.8%] 24032/121136 windows running_bpb=1.167272
+  sliding_eval [ 21.2%] 25632/121136 windows running_bpb=1.168726
+  sliding_eval [ 22.5%] 27232/121136 windows running_bpb=1.169250
+  sliding_eval [ 23.8%] 28832/121136 windows running_bpb=1.175430
+  sliding_eval [ 25.1%] 30432/121136 windows running_bpb=1.172873
+  sliding_eval [ 26.4%] 32032/121136 windows running_bpb=1.173874
+  sliding_eval [ 27.8%] 33632/121136 windows running_bpb=1.172533
+  sliding_eval [ 29.1%] 35232/121136 windows running_bpb=1.171899
+  sliding_eval [ 30.4%] 36832/121136 windows running_bpb=1.171462
+  sliding_eval [ 31.7%] 38432/121136 windows running_bpb=1.172203
+  sliding_eval [ 33.0%] 40032/121136 windows running_bpb=1.169775
+  sliding_eval [ 34.4%] 41632/121136 windows running_bpb=1.168754
+  sliding_eval [ 35.7%] 43232/121136 windows running_bpb=1.169118
+  sliding_eval [ 37.0%] 44832/121136 windows running_bpb=1.168038
+  sliding_eval [ 38.3%] 46432/121136 windows running_bpb=1.167918
+  sliding_eval [ 39.7%] 48032/121136 windows running_bpb=1.167116
+  sliding_eval [ 41.0%] 49632/121136 windows running_bpb=1.168313
+  sliding_eval [ 42.3%] 51232/121136 windows running_bpb=1.169383
+  sliding_eval [ 43.6%] 52832/121136 windows running_bpb=1.169883
 
 Exit code: 0
-  sliding_eval [ 43.6%] 52832/121136 windows running_bpb=1.181748
-  sliding_eval [ 44.9%] 54432/121136 windows running_bpb=1.181228
-  sliding_eval [ 46.3%] 56032/121136 windows running_bpb=1.181619
-  sliding_eval [ 47.6%] 57632/121136 windows running_bpb=1.180735
-  sliding_eval [ 48.9%] 59232/121136 windows running_bpb=1.176830
-  sliding_eval [ 50.2%] 60832/121136 windows running_bpb=1.176955
-  sliding_eval [ 51.5%] 62432/121136 windows running_bpb=1.177811
-  sliding_eval [ 52.9%] 64032/121136 windows running_bpb=1.178006
-  sliding_eval [ 54.2%] 65632/121136 windows running_bpb=1.177894
-  sliding_eval [ 55.5%] 67232/121136 windows running_bpb=1.176670
-  sliding_eval [ 56.8%] 68832/121136 windows running_bpb=1.176382
-  sliding_eval [ 58.1%] 70432/121136 windows running_bpb=1.175616
-  sliding_eval [ 59.5%] 72032/121136 windows running_bpb=1.175695
-  sliding_eval [ 60.8%] 73632/121136 windows running_bpb=1.175717
-  sliding_eval [ 62.1%] 75232/121136 windows running_bpb=1.175914
-  sliding_eval [ 63.4%] 76832/121136 windows running_bpb=1.175633
-  sliding_eval [ 64.7%] 78432/121136 windows running_bpb=1.176211
-  sliding_eval [ 66.1%] 80032/121136 windows running_bpb=1.176540
-  sliding_eval [ 67.4%] 81632/121136 windows running_bpb=1.176266
-  sliding_eval [ 68.7%] 83232/121136 windows running_bpb=1.177396
-  sliding_eval [ 70.0%] 84832/121136 windows running_bpb=1.179322
-  sliding_eval [ 71.4%] 86432/121136 windows running_bpb=1.178586
-  sliding_eval [ 72.7%] 88032/121136 windows running_bpb=1.179321
-  sliding_eval [ 74.0%] 89632/121136 windows running_bpb=1.179674
-  sliding_eval [ 75.3%] 91232/121136 windows running_bpb=1.179655
-  sliding_eval [ 76.6%] 92832/121136 windows running_bpb=1.179220
-  sliding_eval [ 78.0%] 94432/121136 windows running_bpb=1.179462
-  sliding_eval [ 79.3%] 96032/121136 windows running_bpb=1.178887
-  sliding_eval [ 80.6%] 97632/121136 windows running_bpb=1.181737
-  sliding_eval [ 81.9%] 99232/121136 windows running_bpb=1.181751
-  sliding_eval [ 83.2%] 100832/121136 windows running_bpb=1.181772
-  sliding_eval [ 84.6%] 102432/121136 windows running_bpb=1.181413
-  sliding_eval [ 85.9%] 104032/121136 windows running_bpb=1.180916
-  sliding_eval [ 87.2%] 105632/121136 windows running_bpb=1.180174
-  sliding_eval [ 88.5%] 107232/121136 windows running_bpb=1.180185
-  sliding_eval [ 89.8%] 108832/121136 windows running_bpb=1.180829
-  sliding_eval [ 91.2%] 110432/121136 windows running_bpb=1.180869
-  sliding_eval [ 92.5%] 112032/121136 windows running_bpb=1.180859
-  sliding_eval [ 93.8%] 113632/121136 windows running_bpb=1.181322
-  sliding_eval [ 95.1%] 115232/121136 windows running_bpb=1.181112
-  sliding_eval [ 96.4%] 116832/121136 windows running_bpb=1.180735
-  sliding_eval [ 97.8%] 118432/121136 windows running_bpb=1.181048
-  sliding_eval [ 99.1%] 120032/121136 windows running_bpb=1.181143
-final_int8_zlib_roundtrip val_loss:1.9843 val_bpb:1.1752 eval_time:262886ms
-final_int8_zlib_roundtrip_exact val_loss:1.98434072 val_bpb:1.17524146
+  sliding_eval [ 44.9%] 54432/121136 windows running_bpb=1.169352
+  sliding_eval [ 46.3%] 56032/121136 windows running_bpb=1.169672
+  sliding_eval [ 47.6%] 57632/121136 windows running_bpb=1.168803
+  sliding_eval [ 48.9%] 59232/121136 windows running_bpb=1.164899
+  sliding_eval [ 50.2%] 60832/121136 windows running_bpb=1.164997
+  sliding_eval [ 51.5%] 62432/121136 windows running_bpb=1.165827
+  sliding_eval [ 52.9%] 64032/121136 windows running_bpb=1.166021
+  sliding_eval [ 54.2%] 65632/121136 windows running_bpb=1.165855
+  sliding_eval [ 55.5%] 67232/121136 windows running_bpb=1.164613
+  sliding_eval [ 56.8%] 68832/121136 windows running_bpb=1.164353
+  sliding_eval [ 58.1%] 70432/121136 windows running_bpb=1.163583
+  sliding_eval [ 59.5%] 72032/121136 windows running_bpb=1.163676
+  sliding_eval [ 60.8%] 73632/121136 windows running_bpb=1.163695
+  sliding_eval [ 62.1%] 75232/121136 windows running_bpb=1.163903
+  sliding_eval [ 63.4%] 76832/121136 windows running_bpb=1.163632
+  sliding_eval [ 64.7%] 78432/121136 windows running_bpb=1.164236
+  sliding_eval [ 66.1%] 80032/121136 windows running_bpb=1.164551
+  sliding_eval [ 67.4%] 81632/121136 windows running_bpb=1.164260
+  sliding_eval [ 68.7%] 83232/121136 windows running_bpb=1.165311
+  sliding_eval [ 70.0%] 84832/121136 windows running_bpb=1.167239
+  sliding_eval [ 71.4%] 86432/121136 windows running_bpb=1.166521
+  sliding_eval [ 72.7%] 88032/121136 windows running_bpb=1.167288
+  sliding_eval [ 74.0%] 89632/121136 windows running_bpb=1.167677
+  sliding_eval [ 75.3%] 91232/121136 windows running_bpb=1.167639
+  sliding_eval [ 76.6%] 92832/121136 windows running_bpb=1.167202
+  sliding_eval [ 78.0%] 94432/121136 windows running_bpb=1.167455
+  sliding_eval [ 79.3%] 96032/121136 windows running_bpb=1.166868
+  sliding_eval [ 80.6%] 97632/121136 windows running_bpb=1.169694
+  sliding_eval [ 81.9%] 99232/121136 windows running_bpb=1.169686
+  sliding_eval [ 83.2%] 100832/121136 windows running_bpb=1.169720
+  sliding_eval [ 84.6%] 102432/121136 windows running_bpb=1.169347
+  sliding_eval [ 85.9%] 104032/121136 windows running_bpb=1.168854
+  sliding_eval [ 87.2%] 105632/121136 windows running_bpb=1.168105
+  sliding_eval [ 88.5%] 107232/121136 windows running_bpb=1.168083
+  sliding_eval [ 89.8%] 108832/121136 windows running_bpb=1.168761
+  sliding_eval [ 91.2%] 110432/121136 windows running_bpb=1.168797
+  sliding_eval [ 92.5%] 112032/121136 windows running_bpb=1.168793
+  sliding_eval [ 93.8%] 113632/121136 windows running_bpb=1.169254
+  sliding_eval [ 95.1%] 115232/121136 windows running_bpb=1.169036
+  sliding_eval [ 96.4%] 116832/121136 windows running_bpb=1.168664
+  sliding_eval [ 97.8%] 118432/121136 windows running_bpb=1.168973
+  sliding_eval [ 99.1%] 120032/121136 windows running_bpb=1.169068
+final_int8_zlib_roundtrip val_loss:1.9644 val_bpb:1.1634 eval_time:264454ms
+final_int8_zlib_roundtrip_exact val_loss:1.96439250 val_bpb:1.16342696
 
 
 === Full logs saved to /data/logs/ ===
 Stopping app - local entrypoint completed.
 ✓ App completed. View run at 
-https://modal.com/apps/voqo-ai/main/ap-q5IhHgc9MzHA5KGeNiamlQ
+https://modal.com/apps/voqo-ai/main/ap-aQQ0EVoJz3h7Wo5rkHX4Nc


### PR DESCRIPTION
recurrent tied-depth 8x2, 1.1752 val_bpb, 13.24MB, 8xH100, single-seed exploratory/non-record result