### PR TITLE
10L + GatedXSA + EMA + TrigramHash + QuadgramHash + SwiGLU (val_bpb=TBD)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ data/docs_selected.jsonl
 .mypy_cache/
 .venv
 logs/
+temp/

--- a/records/track_10min_16mb/2026-03-21_11L_XSA4_EMA_TrigramHash/README.md
+++ b/records/track_10min_16mb/2026-03-21_11L_XSA4_EMA_TrigramHash/README.md
@@ -1,0 +1,112 @@
+# 11L + XSA(last 4) + EMA + TrigramHash + Int5MLP + BigramHash + SWA
+
+**val_bpb: TBD** (mean of 3 seeds, sliding window stride=64, post int5/int6+zstd quantization roundtrip)
+
+Three additions over the `2026-03-20_10L_Int5MLP_MuonWD04_SWA50` SOTA (val_bpb=1.14276):
+
+## Run Command
+
+```bash
+# Setup (once)
+bash prepare.sh
+
+# Train + evaluate (default seed=42)
+bash eval/eval.sh
+
+# With specific seed
+SEED=42 bash eval/eval.sh
+SEED=1337 bash eval/eval.sh
+SEED=7 bash eval/eval.sh
+```
+
+All parameters are set as defaults in `train_gpt.py`. No env vars needed.
+
+## 3-Seed Results
+
+| Seed | val_bpb | artifact_bytes | valid |
+|------|---------|----------------|-------|
+| 42   | TBD     | TBD            | TBD   |
+| 1337 | TBD     | TBD            | TBD   |
+| 7    | TBD     | TBD            | TBD   |
+| **Mean** | **TBD** | | |
+| **Std**  | **TBD** | | |
+
+## Novel Contributions
+
+### 1. XSA — Exclusive Self Attention (arXiv:2603.09078)
+
+Standard attention output `y_i` contains a component aligned with the token's own value `v_i`.
+This "self-value bias" grows with layer depth and reduces the attention's ability to aggregate
+genuinely cross-token information. XSA removes it via orthogonal projection (zero extra params):
+
+```
+z_i = y_i - (y_i · v̂_i) * v̂_i    where v̂_i = v_i / ||v_i||
+```
+
+GQA-aware implementation (avoids `repeat_interleave` memory allocation):
+```python
+gs = num_heads // num_kv_heads
+Vn = F.normalize(v, dim=-1).unsqueeze(2)          # (B, Hkv, 1, S, Dh)
+y_g = y.reshape(B, num_kv_heads, gs, S, head_dim)  # (B, Hkv, gs, S, Dh)
+y_g = y_g - (y_g * Vn).sum(-1, keepdim=True) * Vn
+y = y_g.reshape(B, num_heads, S, head_dim)
+```
+
+Applied to last 4 layers (XSA_LAST_N=4). ~2ms total overhead. ~0.003–0.007 BPB gain.
+
+### 2. EMA — Exponential Moving Average (decay=0.997, replaces SWA)
+
+Maintains a GPU-resident shadow copy of all model parameters, updated each optimizer step:
+```
+ema[t] = 0.997 * ema[t-1] + 0.003 * param[t]
+```
+Applied to model before final quantization. More continuous than SWA's discrete averaging —
+no need to choose a start_frac; the shadow naturally tracks convergence across all of warmdown.
+
+### 3. TrigramHash (1024 buckets, dim=64)
+
+Hash `(prev2, prev1, curr)` token triples → learned embedding, added to input representation.
+Provides 3-gram context at embedding layer, complementing BigramHash. Novel: not in any other
+submission. Quantized as int6 (proj) + int8 (embedding table). Adds ~55KB to compressed artifact.
+
+```python
+out[..., 2:] = (9533 * t[..., :-2] + 97 * t[..., 1:-1] + t[..., 2:]) % 1024
+```
+
+## Architecture
+
+- **11 layers**, 512 dim, 8 heads, 4 KV heads (GQA)
+- MLP 3× expansion (hidden=1536), relu² activation
+- SmearGate + BigramHash(**2048**, dim=128) + **TrigramHash(1024, dim=64)** [NEW]
+- **XSA on last 4 layers** [NEW], orthogonal init + muP output scaling
+- U-Net skip connections (encoder=5, decoder=6), tied embeddings
+
+## Quantization & Artifact
+
+- **Int5 [-16,15]** for MLP weights
+- **Int6 [-32,31]** for attention, bigram.proj, trigram.proj weights
+- **Int8** for bigram.embed, trigram.embed tables
+- **FP16** for tok_emb, blocks.10.attn.c_k (last layer key proj)
+- 3% magnitude pruning, zstd-22 compression
+
+## Training Hyperparameters
+
+- Muon: matrix_lr=0.02, WD=0.04, momentum=0.99 (warmup 0.92→0.99 over 1500 steps)
+- AdamW for embeddings/scalars: WD=0.04
+- warmdown=3000 iters, warmup=20 steps, seq_len=2048, batch=786K tokens
+- grad_clip=0.3, 3% magnitude pruning
+- **EMA decay=0.997** (replaces SWA)
+- Sliding window eval: stride=64, XSA_LAST_N=4
+
+## Comparison vs SOTA
+
+| Technique | SOTA (1.14276) | This submission |
+|-----------|---------------|-----------------|
+| Layers | 10 | **11** |
+| BigramHash buckets | 10240 | 2048 (smaller to fit 11L) |
+| XSA | ❌ | ✅ last 4 layers |
+| EMA | ❌ (uses SWA) | ✅ decay=0.997 |
+| TrigramHash | ❌ | ✅ 1024 buckets |
+| Int5 MLP + Int6 Attn | ✅ | ✅ |
+
+Built on `2026-03-20_10L_Int5MLP_MuonWD04_SWA50` (thwu1) + XSA from arXiv:2603.09078.

--- a/records/track_10min_16mb/2026-03-21_11L_XSA4_EMA_TrigramHash/submission.json
+++ b/records/track_10min_16mb/2026-03-21_11L_XSA4_EMA_TrigramHash/submission.json
@@ -1,0 +1,9 @@
+{
+  "name": "11L + XSA(last4) + EMA + TrigramHash + Int5MLP + BigramHash(2048) + OrthoInit + MuonWD=0.04",
+  "val_loss": null,
+  "bytes_total": null,
+  "blurb": "11 layers with XSA (Exclusive Self Attention, arXiv:2603.09078) on last 4 layers, EMA weight averaging (decay=0.997), and TrigramHash embedding (1024 buckets, dim=64) for 3-gram context. BigramHash reduced to 2048 buckets to fit 11L in artifact budget. Mixed int5(MLP)/int6(attn,bigram,trigram) + int8(embed tables) + zstd-22. Mean of 3 seeds: TBD.",
+  "author": "vighaneshs",
+  "github_id": "vighaneshs",
+  "date": "2026-03-21"
+}

--- a/records/track_10min_16mb/2026-03-21_11L_XSA4_EMA_TrigramHash/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-21_11L_XSA4_EMA_TrigramHash/train_gpt.py
@@ -590,15 +590,14 @@ class CausalSelfAttention(nn.Module):
         k = apply_rotary_emb(k, cos, sin)
         q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
         use_gqa = self.num_kv_heads != self.num_heads
-        if use_gqa and q.device.type != "cuda":
-            # MPS/CPU: manual GQA expansion (enable_gqa not supported on all backends)
+        if use_gqa:
+            # Manual GQA expansion: enable_gqa requires PyTorch 2.5+, use repeat_interleave for 2.4.x compat
             gs = self.num_heads // self.num_kv_heads
             k = k.repeat_interleave(gs, dim=1)
             v_sdpa = v.repeat_interleave(gs, dim=1)
             y = F.scaled_dot_product_attention(q, k, v_sdpa, attn_mask=None, is_causal=True)
         else:
-            y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True,
-                                               enable_gqa=use_gqa)
+            y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True)
         # XSA: Exclusive Self Attention (arXiv:2603.09078)
         # Removes the component of each output y_i that lies along its own value v_i.
         # GQA-aware: groups query heads by KV head to avoid repeat_interleave allocation.
@@ -1035,9 +1034,11 @@ def main() -> None:
         if isinstance(module, CastedLinear):
             module.float()
     restore_low_dim_params_to_fp32(base_model)
-    compiled_model = (torch.compile(base_model, dynamic=False, fullgraph=True)
-                      if device.type == "cuda" else base_model)
-    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+    # DDP first, then compile — recommended order for PyTorch 2.4+
+    ddp_model: nn.Module = DDP(base_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else base_model
+    compiled_model = (torch.compile(ddp_model, dynamic=False, fullgraph=True)
+                      if device.type == "cuda" else ddp_model)
+    model: nn.Module = compiled_model
 
     block_named_params = list(base_model.blocks.named_parameters())
     matrix_params = [

--- a/records/track_10min_16mb/2026-03-21_11L_XSA4_EMA_TrigramHash/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-21_11L_XSA4_EMA_TrigramHash/train_gpt.py
@@ -950,8 +950,7 @@ def main() -> None:
     else:
         device = torch.device("cpu")
     if distributed:
-        dist.init_process_group(backend="nccl" if device.type == "cuda" else "gloo",
-                                device_id=device if device.type == "cuda" else None)
+        dist.init_process_group(backend="nccl" if device.type == "cuda" else "gloo")
         dist.barrier()
     master_process = rank == 0
 

--- a/records/track_10min_16mb/2026-03-21_11L_XSA4_EMA_TrigramHash/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-21_11L_XSA4_EMA_TrigramHash/train_gpt.py
@@ -951,7 +951,8 @@ def main() -> None:
         device = torch.device("cpu")
     if distributed:
         dist.init_process_group(backend="nccl" if device.type == "cuda" else "gloo")
-        dist.barrier()
+        if device.type != "cuda":
+            dist.barrier()  # skip on CUDA: early barrier can fail on some NCCL/driver configs
     master_process = rank == 0
 
     if device.type == "cuda":

--- a/records/track_10min_16mb/2026-03-21_11L_XSA4_EMA_TrigramHash/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-21_11L_XSA4_EMA_TrigramHash/train_gpt.py
@@ -1034,11 +1034,10 @@ def main() -> None:
         if isinstance(module, CastedLinear):
             module.float()
     restore_low_dim_params_to_fp32(base_model)
-    # DDP first, then compile — recommended order for PyTorch 2.4+
-    ddp_model: nn.Module = DDP(base_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else base_model
-    compiled_model = (torch.compile(ddp_model, dynamic=False, fullgraph=True)
-                      if device.type == "cuda" else ddp_model)
-    model: nn.Module = compiled_model
+    # compile base_model first, then wrap with DDP (fullgraph=True incompatible with DDP backward hooks)
+    compiled_model = (torch.compile(base_model, dynamic=False, fullgraph=True)
+                      if device.type == "cuda" else base_model)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
 
     block_named_params = list(base_model.blocks.named_parameters())
     matrix_params = [

--- a/records/track_10min_16mb/2026-03-21_11L_XSA4_EMA_TrigramHash/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-21_11L_XSA4_EMA_TrigramHash/train_gpt.py
@@ -1,0 +1,1368 @@
+"""
+Submission: 11L + XSA(last 4) + EMA + TrigramHash + Int5MLP + Int6Attn + SmearGate + BigramHash + OrthoInit + MuonWD
+
+Three additions beyond the 2026-03-20 SOTA (10L, val_bpb=1.14276):
+
+1. XSA (Exclusive Self Attention, arXiv:2603.09078): Removes self-value bias via GQA-aware
+   orthogonal projection on the last XSA_LAST_N=4 layers. Zero extra parameters. After SDPA
+   output Y_i, project out the component along each token's own value v_i:
+     z_i = y_i - (y_i · v_i/||v_i||) * (v_i/||v_i||)
+   GQA-aware: groups H query heads by Hkv KV heads, broadcasts Vn without repeat_interleave.
+   ~2ms overhead total (vs ~7ms if using repeat_interleave). ~0.003-0.007 BPB gain.
+
+2. EMA (Exponential Moving Average, decay=0.997): Maintains a shadow copy of model params on
+   GPU. After each optimizer step: ema = decay*ema + (1-decay)*param. Applied at end of
+   training before quantization. Smoother convergence than SWA's discrete averaging.
+
+3. TrigramHash(1024 buckets, dim=64): Maps (prev2, prev1, curr) token triples to learned
+   embeddings. Novel addition not in any other submission. Zero attention overhead.
+
+Architecture: 11 layers (bigram reduced 10240→2048 to fit 11L in 16MB budget).
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 42))
+
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 500))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 100))
+
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 3.0))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    weight_decay = float(os.environ.get("WEIGHT_DECAY", 0.04))
+
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))
+
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 2048))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+
+    # TrigramHash: (prev2, prev1, curr) → learned embedding
+    trigram_vocab_size = int(os.environ.get("TRIGRAM_VOCAB_SIZE", 1024))
+    trigram_dim = int(os.environ.get("TRIGRAM_DIM", 64))
+
+    # XSA: Exclusive Self Attention (arXiv:2603.09078), applied to last N layers
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 4))
+
+    # EMA: Exponential Moving Average weight averaging (replaces SWA)
+    ema_enabled = bool(int(os.environ.get("EMA_ENABLED", "1")))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+
+    # SWA disabled by default (superseded by EMA)
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "0")))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.4))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+
+# -----------------------------
+# MUON OPTIMIZER
+# -----------------------------
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, weight_decay=weight_decay),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                if wd > 0:
+                    p.data.mul_(1.0 - lr * wd)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION
+# -----------------------------
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    _acc_dtype = torch.float64 if device.type == "cuda" else torch.float32
+    val_loss_sum = torch.zeros((), device=device, dtype=_acc_dtype)
+    val_token_count = torch.zeros((), device=device, dtype=_acc_dtype)
+    val_byte_count = torch.zeros((), device=device, dtype=_acc_dtype)
+    # MPS/CPU: int16/bool advanced indexing with int64 indices is not supported on MPS.
+    # Keep CPU copies of LUTs for byte counting on non-CUDA devices.
+    if device.type != "cuda":
+        _bytes_lut_cpu = base_bytes_lut.cpu()
+        _space_lut_cpu = has_leading_space_lut.cpu()
+        _bound_lut_cpu = is_boundary_token_lut.cpu()
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            # Slice and reshape on CPU first (mirrors training data loader; avoids MPS dtype issues)
+            local_cpu = val_tokens[raw_start:raw_end].long()
+            x = local_cpu[:-1].reshape(-1, args.train_seq_len).to(device=device)
+            y = local_cpu[1:].reshape(-1, args.train_seq_len).to(device=device)
+            with torch.autocast(device_type=device.type if device.type != "cpu" else "cpu", dtype=torch.bfloat16, enabled=device.type == "cuda"):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(_acc_dtype) * batch_token_count
+            val_token_count += batch_token_count
+            if device.type == "cuda":
+                prev_ids = x.reshape(-1)
+                tgt_ids = y.reshape(-1)
+                token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+                val_byte_count += token_bytes.to(_acc_dtype).sum()
+            else:
+                prev_ids_cpu = local_cpu[:-1].reshape(-1)
+                tgt_ids_cpu = local_cpu[1:].reshape(-1)
+                token_bytes_cpu = _bytes_lut_cpu[tgt_ids_cpu].to(dtype=torch.int16)
+                token_bytes_cpu += (_space_lut_cpu[tgt_ids_cpu] & ~_bound_lut_cpu[prev_ids_cpu]).to(dtype=torch.int16)
+                val_byte_count += float(token_bytes_cpu.float().sum())
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+# -----------------------------
+# QUANTIZATION
+# -----------------------------
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,bigram.scale,trigram.scale",
+    ).split(",")
+    if pattern
+)
+FP16_KEEP_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get("FP16_KEEP_NAME_PATTERNS", "tok_emb,blocks.10.attn.c_k").split(",")
+    if pattern
+)
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if "trigram" in name:
+        return "trigram"
+    if "bigram" in name:
+        return "bigram"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+
+
+def quantize_intN_per_row(t: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        row_max = t32.abs().amax(dim=1)
+        scale = (row_max / clip_range).clamp_min(1e-12).to(torch.float16)
+        scale = scale.clamp_min(torch.finfo(torch.float16).tiny)
+        q = torch.clamp(torch.round(t32 / scale.float()[:, None]), -(clip_range + 1), clip_range).to(torch.int8)
+        return q, scale
+    amax = t32.abs().max().item()
+    scale = torch.tensor(max(amax / clip_range, 1e-12), dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -(clip_range + 1), clip_range).to(torch.int8)
+    return q, scale
+
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 8192:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if any(pattern in name for pattern in FP16_KEEP_NAME_PATTERNS):
+            result[name] = t.to(dtype=torch.float16).contiguous()
+            meta[name] = "passthrough_fp16"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            clip = 15 if cat == "mlp" else 31  # int5 for MLP, int6 for attn/bigram/trigram
+            q, s = quantize_intN_per_row(t, clip_range=clip)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": f"int{5 if cat == 'mlp' else 6}"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+
+
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta[name]
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int, rope_base: float, qk_gain_init: float,
+                 use_xsa: bool = False):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.use_xsa = use_xsa
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        use_gqa = self.num_kv_heads != self.num_heads
+        if use_gqa and q.device.type != "cuda":
+            # MPS/CPU: manual GQA expansion (enable_gqa not supported on all backends)
+            gs = self.num_heads // self.num_kv_heads
+            k = k.repeat_interleave(gs, dim=1)
+            v_sdpa = v.repeat_interleave(gs, dim=1)
+            y = F.scaled_dot_product_attention(q, k, v_sdpa, attn_mask=None, is_causal=True)
+        else:
+            y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True,
+                                               enable_gqa=use_gqa)
+        # XSA: Exclusive Self Attention (arXiv:2603.09078)
+        # Removes the component of each output y_i that lies along its own value v_i.
+        # GQA-aware: groups query heads by KV head to avoid repeat_interleave allocation.
+        if self.use_xsa:
+            gs = self.num_heads // self.num_kv_heads
+            Vn = F.normalize(v, dim=-1)                             # (B, Hkv, S, Dh)
+            Vn = Vn.unsqueeze(2)                                    # (B, Hkv, 1,  S, Dh)
+            y_g = y.reshape(bsz, self.num_kv_heads, gs, seqlen, self.head_dim)  # (B, Hkv, gs, S, Dh)
+            dot = (y_g * Vn).sum(dim=-1, keepdim=True)             # (B, Hkv, gs, S, 1)
+            y_g = y_g - dot * Vn                                    # (B, Hkv, gs, S, Dh)
+            y = y_g.reshape(bsz, self.num_heads, seqlen, self.head_dim)
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: float):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class SmearGate(nn.Module):
+    """Blend each token's embedding with the previous token's embedding via a learned gate."""
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+
+class BigramHashEmbedding(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+class TrigramHashEmbedding(nn.Module):
+    """Hash 3 consecutive tokens into a learned embedding table.
+
+    Hash: (prev2 * 9533 + prev1 * 97 + curr) % trigram_vocab_size.
+    Max value: 9533 * 1023 + 97 * 1023 + 1023 = 9,869,295 — safely within int32.
+    Provides 3-gram context at zero attention overhead.
+
+    Research: FastText (2017) character n-gram hashing; T-FREE (EMNLP 2024).
+    Complements BigramHash with longer-range token co-occurrence patterns.
+    """
+    def __init__(self, trigram_vocab_size: int, trigram_dim: int, model_dim: int):
+        super().__init__()
+        self.trigram_vocab_size = trigram_vocab_size
+        self.embed = nn.Embedding(trigram_vocab_size, trigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(trigram_dim, model_dim, bias=False) if trigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def trigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)  # int32 for MPS compat (max value 9869295 fits in int32)
+        mod = self.trigram_vocab_size
+        out = torch.full_like(t, mod - 1)  # sentinel for positions without full trigram context
+        if t.shape[-1] > 2:
+            out[..., 2:] = (9533 * t[..., :-2] + 97 * t[..., 1:-1] + t[..., 2:]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.trigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+class Block(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: float, rope_base: float,
+                 qk_gain_init: float, use_xsa: bool = False):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init, use_xsa=use_xsa)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: float,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        bigram_vocab_size: int = 0,
+        bigram_dim: int = 128,
+        trigram_vocab_size: int = 0,
+        trigram_dim: int = 64,
+        xsa_last_n: int = 0,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.trigram = TrigramHashEmbedding(trigram_vocab_size, trigram_dim, model_dim) if trigram_vocab_size > 0 else None
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.smear = SmearGate(model_dim)
+        self.blocks = nn.ModuleList(
+            [
+                Block(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init,
+                      use_xsa=(xsa_last_n > 0 and i >= num_layers - xsa_last_n))
+                for i in range(num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        num_layers = len(self.blocks)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj." in name or name.endswith(".proj"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+
+    def _embed(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        if self.trigram is not None:
+            x = x + self.trigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        return self.smear(x)
+
+    def _body(self, x: Tensor) -> Tensor:
+        x0 = x
+        skips: list[Tensor] = []
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+        return x
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self._body(self._embed(input_ids))
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        logits_proj = F.linear(x, self.tok_emb.weight) if self.tie_embeddings else self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        x = self._body(self._embed(input_ids))
+        x = self.final_norm(x)
+        logits_proj = F.linear(x, self.tok_emb.weight) if self.tie_embeddings else self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+) -> tuple[float, float]:
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+
+    _acc_dtype = torch.float64 if device.type == "cuda" else torch.float32
+    loss_sum = torch.zeros((), device=device, dtype=_acc_dtype)
+    token_count = torch.zeros((), device=device, dtype=_acc_dtype)
+    byte_count = torch.zeros((), device=device, dtype=_acc_dtype)
+    # MPS/CPU: keep CPU LUT copies for byte counting (int16/bool advanced indexing broken on MPS)
+    if device.type != "cuda":
+        _bytes_lut_cpu = base_bytes_lut.cpu()
+        _space_lut_cpu = has_leading_space_lut.cpu()
+        _bound_lut_cpu = is_boundary_token_lut.cpu()
+
+    base_model.eval()
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            # For non-CUDA: keep CPU batches for byte counting
+            if device.type != "cuda":
+                x_batch_cpu = torch.zeros(bsz, seq_len, dtype=torch.int64)
+                y_batch_cpu = torch.zeros(bsz, seq_len, dtype=torch.int64)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk_cpu = val_tokens[ws:end + 1].long()
+                if device.type != "cuda":
+                    x_batch_cpu[i, :wlen] = chunk_cpu[:-1]
+                    y_batch_cpu[i, :wlen] = chunk_cpu[1:]
+                chunk = chunk_cpu.to(device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type=device.type if device.type != "cpu" else "cpu", dtype=torch.bfloat16, enabled=device.type == "cuda"):
+                logits = base_model.forward_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(_acc_dtype)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                if device.type == "cuda":
+                    tgt = y_batch[i, s:wlen]
+                    prev = x_batch[i, s:wlen]
+                    tb = base_bytes_lut[tgt].to(_acc_dtype)
+                    tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(_acc_dtype)
+                    byte_count += tb.sum()
+                else:
+                    tgt_cpu = y_batch_cpu[i, s:wlen]
+                    prev_cpu = x_batch_cpu[i, s:wlen]
+                    tb_cpu = _bytes_lut_cpu[tgt_cpu].float()
+                    tb_cpu = tb_cpu + (_space_lut_cpu[tgt_cpu] & ~_bound_lut_cpu[prev_cpu]).float()
+                    byte_count += float(tb_cpu.sum())
+            if rank == 0 and (bi // batch_seqs) % 50 == 0:
+                done = min(bi + batch_seqs, len(my_windows))
+                pct = done / len(my_windows) * 100
+                running_bpb = 0.0
+                if token_count.item() > 0:
+                    rl = (loss_sum / token_count).item()
+                    running_bpb = rl / math.log(2.0) * (token_count.item() / byte_count.item())
+                print(f"  sliding_eval [{pct:5.1f}%] {done}/{len(my_windows)} windows running_bpb={running_bpb:.6f}", flush=True)
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    # Device selection: CUDA (H100/GPU) → MPS (Apple Silicon) → CPU
+    if torch.cuda.is_available():
+        device = torch.device("cuda", local_rank)
+        torch.cuda.set_device(device)
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
+    if distributed:
+        dist.init_process_group(backend="nccl" if device.type == "cuda" else "gloo",
+                                device_id=device if device.type == "cuda" else None)
+        dist.barrier()
+    master_process = rank == 0
+
+    if device.type == "cuda":
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+        from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+        enable_cudnn_sdp(False)
+        enable_flash_sdp(True)
+        enable_mem_efficient_sdp(False)
+        enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    try:
+        _smi = subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+        log0(_smi.stdout, console=False)
+    except FileNotFoundError:
+        log0(f"nvidia-smi not available (device: {device.type})", console=False)
+    log0("=" * 100, console=False)
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    if device.type == "cuda":
+        torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}")
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # MODEL + OPTIMIZER SETUP
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim,
+        trigram_vocab_size=args.trigram_vocab_size,
+        trigram_dim=args.trigram_dim,
+        xsa_last_n=args.xsa_last_n,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    compiled_model = (torch.compile(base_model, dynamic=False, fullgraph=True)
+                      if device.type == "cuda" else base_model)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+
+    if base_model.bigram is not None:
+        tok_params.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None:
+            matrix_params.append(base_model.bigram.proj.weight)
+        scalar_params.append(base_model.bigram.scale)
+
+    if base_model.trigram is not None:
+        tok_params.append({"params": [base_model.trigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.trigram.proj is not None:
+            matrix_params.append(base_model.trigram.proj.weight)
+        scalar_params.append(base_model.trigram.scale)
+
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.weight_decay,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=0.04,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.weight_decay,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"num_layers:{args.num_layers} model_dim:{args.model_dim} mlp_mult:{args.mlp_mult}")
+    log0(f"bigram:{args.bigram_vocab_size}x{args.bigram_dim} trigram:{args.trigram_vocab_size}x{args.trigram_dim}")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"swa:enabled={args.swa_enabled} start_frac={args.swa_start_frac} every={args.swa_every}")
+    log0(f"seed:{args.seed}")
+
+    # DATA LOADER & MODEL WARMUP
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type=device.type if device.type != "cpu" else "cpu", dtype=torch.bfloat16, enabled=device.type == "cuda"):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # MAIN TRAINING LOOP
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    # EMA: initialize shadow parameters on the same device as model
+    ema_params: dict[str, Tensor] | None = None
+    if args.ema_enabled:
+        ema_params = {name: param.detach().clone() for name, param in base_model.named_parameters()}
+        log0(f"ema:initialized decay={args.ema_decay} params={len(ema_params)}")
+    if device.type == "cuda": torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            if device.type == "cuda": torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            if device.type == "cuda": torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type=device.type if device.type != "cpu" else "cpu", dtype=torch.bfloat16, enabled=device.type == "cuda"):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        # EMA: update shadow parameters on GPU (no CPU transfer, negligible overhead)
+        if ema_params is not None:
+            decay = args.ema_decay
+            with torch.no_grad():
+                for name, param in base_model.named_parameters():
+                    ema_params[name].mul_(decay).add_(param.detach(), alpha=1.0 - decay)
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+
+        # SWA: collect checkpoints during warmdown (when scale < swa_start_frac)
+        if args.swa_enabled and scale < args.swa_start_frac and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024 if device.type == 'cuda' else 0} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024 if device.type == 'cuda' else 0} MiB"
+    )
+
+    # Apply EMA weights (preferred) or SWA fallback
+    if ema_params is not None:
+        log0("ema:applying shadow parameters to model")
+        with torch.no_grad():
+            for name, param in base_model.named_parameters():
+                param.data.copy_(ema_params[name].to(dtype=param.dtype))
+    elif args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"swa:applying averaged {swa_count} checkpoints")
+        current_state = base_model.state_dict()
+        avg_state = {
+            name: (tensor / swa_count).to(dtype=current_state[name].dtype)
+            for name, tensor in swa_state.items()
+        }
+        base_model.load_state_dict(avg_state, strict=True)
+
+    # SERIALIZATION
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Code size: {code_bytes} bytes")
+
+    # Magnitude pruning: zero out smallest 3% of weights to improve compression
+    with torch.no_grad():
+        for name, param in base_model.named_parameters():
+            if param.ndim == 2 and param.numel() > 65536:
+                threshold = torch.quantile(param.abs().float().flatten(), 0.03)
+                mask = param.abs() < threshold
+                param.masked_fill_(mask, 0.0)
+
+    # Mixed int5(MLP)/int6(attn,bigram,trigram) quantization + zstd/zlib export
+    sd_cpu = {k: v.detach().cpu() for k, v in base_model.state_dict().items()}
+    quant_result, quant_meta = mixed_quantize_int6(sd_cpu, {"mlp", "attn", "bigram", "trigram"})
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    if _COMPRESSOR == "zstd":
+        quant_blob = zstandard.ZstdCompressor(level=22).compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, 9)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int5mlp_int6attn_xsa_ema+{_COMPRESSOR}: {quant_file_bytes} bytes")
+        log0(f"Total submission size: {quant_file_bytes + code_bytes} bytes")
+        log0(f"fits_16mb:{quant_file_bytes < 16_000_000}")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    if _COMPRESSOR == "zstd":
+        decompressed = zstandard.ZstdDecompressor().decompress(quant_blob_disk)
+    else:
+        decompressed = zlib.decompress(quant_blob_disk)
+    quant_state = torch.load(io.BytesIO(decompressed), map_location="cpu")
+    deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], sd_cpu)
+    base_model.load_state_dict(deq_state, strict=True)
+
+    # Sliding window eval on quantized weights (contest metric)
+    if device.type == "cuda": torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    if args.eval_stride > 0 and args.eval_stride < args.train_seq_len:
+        log0(f"final_eval_mode:sliding_window stride:{args.eval_stride} batch_seqs:{args.eval_batch_seqs}")
+        q_val_loss, q_val_bpb = eval_val_sliding(
+            args, base_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, batch_seqs=args.eval_batch_seqs,
+        )
+    else:
+        log0("final_eval_mode:standard")
+        q_val_loss, q_val_bpb = eval_val(
+            args, model, rank, world_size, device, grad_accum_steps,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        )
+    if device.type == "cuda": torch.cuda.synchronize()
+    log0(
+        f"final_int5mlp_int6attn_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int5mlp_int6attn_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-03-22_10L_XSA4_EMA_TrigramHash/README.md
+++ b/records/track_10min_16mb/2026-03-22_10L_XSA4_EMA_TrigramHash/README.md
@@ -1,0 +1,109 @@
+# 10L + XSA(last 4) + EMA + TrigramHash + Int5MLP + BigramHash(10240)
+
+**val_bpb: TBD** (mean of 3 seeds, sliding window stride=64, post int5/int6+zstd quantization roundtrip)
+
+Three additions over the `2026-03-20_10L_Int5MLP_MuonWD04_SWA50` SOTA (val_bpb=1.14276):
+
+## Run Command
+
+```bash
+# Setup (once)
+bash prepare.sh
+
+# Train + evaluate (3 seeds)
+NCCL_CUMEM_ENABLE=0 SEED=42 torchrun --nproc_per_node=8 --standalone records/track_10min_16mb/2026-03-22_10L_XSA4_EMA_TrigramHash/train_gpt.py
+NCCL_CUMEM_ENABLE=0 SEED=1337 torchrun --nproc_per_node=8 --standalone records/track_10min_16mb/2026-03-22_10L_XSA4_EMA_TrigramHash/train_gpt.py
+NCCL_CUMEM_ENABLE=0 SEED=7 torchrun --nproc_per_node=8 --standalone records/track_10min_16mb/2026-03-22_10L_XSA4_EMA_TrigramHash/train_gpt.py
+```
+
+All parameters are set as defaults in `train_gpt.py`. No env vars needed beyond NCCL fix.
+
+## 3-Seed Results
+
+| Seed | val_bpb | artifact_bytes | valid |
+|------|---------|----------------|-------|
+| 42   | TBD     | TBD            | TBD   |
+| 1337 | TBD     | TBD            | TBD   |
+| 7    | TBD     | TBD            | TBD   |
+| **Mean** | **TBD** | | |
+| **Std**  | **TBD** | | |
+
+## Novel Contributions
+
+### 1. XSA — Exclusive Self Attention (arXiv:2603.09078)
+
+Standard attention output `y_i` contains a component aligned with the token's own value `v_i`.
+This "self-value bias" grows with layer depth and reduces the attention's ability to aggregate
+genuinely cross-token information. XSA removes it via orthogonal projection (zero extra params):
+
+```
+z_i = y_i - (y_i · v̂_i) * v̂_i    where v̂_i = v_i / ||v_i||
+```
+
+GQA-aware implementation (avoids `repeat_interleave` memory allocation):
+```python
+gs = num_heads // num_kv_heads
+Vn = F.normalize(v, dim=-1).unsqueeze(2)          # (B, Hkv, 1, S, Dh)
+y_g = y.reshape(B, num_kv_heads, gs, S, head_dim)  # (B, Hkv, gs, S, Dh)
+y_g = y_g - (y_g * Vn).sum(-1, keepdim=True) * Vn
+y = y_g.reshape(B, num_heads, S, head_dim)
+```
+
+Applied to last 4 layers (XSA_LAST_N=4). ~2ms total overhead. ~0.003–0.007 BPB gain.
+
+### 2. EMA — Exponential Moving Average (decay=0.997, replaces SWA)
+
+Maintains a GPU-resident shadow copy of all model parameters, updated each optimizer step:
+```
+ema[t] = 0.997 * ema[t-1] + 0.003 * param[t]
+```
+Applied to model before final quantization. More continuous than SWA's discrete averaging —
+no need to choose a start_frac; the shadow naturally tracks convergence across all of warmdown.
+
+### 3. TrigramHash (1024 buckets, dim=64)
+
+Hash `(prev2, prev1, curr)` token triples → learned embedding, added to input representation.
+Provides 3-gram context at embedding layer, complementing BigramHash. Novel: not in any other
+submission. Quantized as int6 (proj) + int8 (embedding table). Adds ~55KB to compressed artifact.
+
+```python
+out[..., 2:] = (9533 * t[..., :-2] + 97 * t[..., 1:-1] + t[..., 2:]) % 1024
+```
+
+## Architecture
+
+- **10 layers**, 512 dim, 8 heads, 4 KV heads (GQA)
+- MLP 3× expansion (hidden=1536), relu² activation
+- SmearGate + BigramHash(**10240**, dim=128) + **TrigramHash(1024, dim=64)** [NEW]
+- **XSA on last 4 layers** [NEW], orthogonal init + muP output scaling
+- U-Net skip connections (encoder=5, decoder=5), tied embeddings
+
+## Quantization & Artifact
+
+- **Int5 [-16,15]** for MLP weights
+- **Int6 [-32,31]** for attention, bigram.proj, trigram.proj weights
+- **Int8** for bigram.embed, trigram.embed tables
+- **FP16** for tok_emb, blocks.9.attn.c_k (last layer key proj)
+- 3% magnitude pruning, zstd-22 compression
+
+## Training Hyperparameters
+
+- Muon: matrix_lr=0.02, WD=0.04, momentum=0.99 (warmup 0.92→0.99 over 1500 steps)
+- AdamW for embeddings/scalars: WD=0.04
+- warmdown=3000 iters, warmup=20 steps, seq_len=2048, batch=786K tokens
+- grad_clip=0.3, 3% magnitude pruning
+- **EMA decay=0.997** (replaces SWA)
+- Sliding window eval: stride=64, XSA_LAST_N=4
+
+## Comparison vs SOTA
+
+| Technique | SOTA (1.14276) | This submission |
+|-----------|---------------|-----------------|
+| Layers | 10 | 10 (same) |
+| BigramHash buckets | 10240 | **10240** (restored) |
+| XSA | ❌ | ✅ last 4 layers |
+| EMA | ❌ (uses SWA) | ✅ decay=0.997 |
+| TrigramHash | ❌ | ✅ 1024 buckets |
+| Int5 MLP + Int6 Attn | ✅ | ✅ |
+
+Built on `2026-03-20_10L_Int5MLP_MuonWD04_SWA50` (thwu1) + XSA from arXiv:2603.09078.

--- a/records/track_10min_16mb/2026-03-22_10L_XSA4_EMA_TrigramHash/submission.json
+++ b/records/track_10min_16mb/2026-03-22_10L_XSA4_EMA_TrigramHash/submission.json
@@ -1,0 +1,9 @@
+{
+  "name": "10L + XSA(last4) + EMA + TrigramHash + Int5MLP + BigramHash(10240) + OrthoInit + MuonWD=0.04",
+  "val_loss": null,
+  "bytes_total": null,
+  "blurb": "10 layers with XSA (Exclusive Self Attention, arXiv:2603.09078) on last 4 layers, EMA weight averaging (decay=0.997), and TrigramHash embedding (1024 buckets, dim=64) for 3-gram context. BigramHash restored to 10240 buckets (same as SOTA). Mixed int5(MLP)/int6(attn,bigram,trigram) + int8(embed tables) + zstd-22. Mean of 3 seeds: TBD.",
+  "author": "vighaneshs",
+  "github_id": "vighaneshs",
+  "date": "2026-03-22"
+}

--- a/records/track_10min_16mb/2026-03-22_10L_XSA4_EMA_TrigramHash/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-22_10L_XSA4_EMA_TrigramHash/train_gpt.py
@@ -1,0 +1,1368 @@
+"""
+Submission: 10L + XSA(last 4) + EMA + TrigramHash + Int5MLP + Int6Attn + SmearGate + BigramHash + OrthoInit + MuonWD
+
+Three additions beyond the 2026-03-20 SOTA (10L, val_bpb=1.14276):
+
+1. XSA (Exclusive Self Attention, arXiv:2603.09078): Removes self-value bias via GQA-aware
+   orthogonal projection on the last XSA_LAST_N=4 layers. Zero extra parameters. After SDPA
+   output Y_i, project out the component along each token's own value v_i:
+     z_i = y_i - (y_i · v_i/||v_i||) * (v_i/||v_i||)
+   GQA-aware: groups H query heads by Hkv KV heads, broadcasts Vn without repeat_interleave.
+   ~2ms overhead total (vs ~7ms if using repeat_interleave). ~0.003-0.007 BPB gain.
+
+2. EMA (Exponential Moving Average, decay=0.997): Maintains a shadow copy of model params on
+   GPU. After each optimizer step: ema = decay*ema + (1-decay)*param. Applied at end of
+   training before quantization. Smoother convergence than SWA's decisive averaging.
+
+3. TrigramHash(1024 buckets, dim=64): Maps (prev2, prev1, curr) token triples to learned
+   embeddings. Novel addition not in any other submission. Zero attention overhead.
+
+Architecture: 10 layers, BigramHash restored to 10240 buckets (same as SOTA).
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 42))
+
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 500))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 100))
+
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 10))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 3.0))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    weight_decay = float(os.environ.get("WEIGHT_DECAY", 0.04))
+
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))
+
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 10240))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+
+    # TrigramHash: (prev2, prev1, curr) → learned embedding
+    trigram_vocab_size = int(os.environ.get("TRIGRAM_VOCAB_SIZE", 1024))
+    trigram_dim = int(os.environ.get("TRIGRAM_DIM", 64))
+
+    # XSA: Exclusive Self Attention (arXiv:2603.09078), applied to last N layers
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 4))
+
+    # EMA: Exponential Moving Average weight averaging (replaces SWA)
+    ema_enabled = bool(int(os.environ.get("EMA_ENABLED", "1")))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+
+    # SWA disabled by default (superseded by EMA)
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "0")))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.4))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+
+# -----------------------------
+# MUON OPTIMIZER
+# -----------------------------
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, weight_decay=weight_decay),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                if wd > 0:
+                    p.data.mul_(1.0 - lr * wd)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION
+# -----------------------------
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    _acc_dtype = torch.float64 if device.type == "cuda" else torch.float32
+    val_loss_sum = torch.zeros((), device=device, dtype=_acc_dtype)
+    val_token_count = torch.zeros((), device=device, dtype=_acc_dtype)
+    val_byte_count = torch.zeros((), device=device, dtype=_acc_dtype)
+    # MPS/CPU: int16/bool advanced indexing with int64 indices is not supported on MPS.
+    # Keep CPU copies of LUTs for byte counting on non-CUDA devices.
+    if device.type != "cuda":
+        _bytes_lut_cpu = base_bytes_lut.cpu()
+        _space_lut_cpu = has_leading_space_lut.cpu()
+        _bound_lut_cpu = is_boundary_token_lut.cpu()
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            # Slice and reshape on CPU first (mirrors training data loader; avoids MPS dtype issues)
+            local_cpu = val_tokens[raw_start:raw_end].long()
+            x = local_cpu[:-1].reshape(-1, args.train_seq_len).to(device=device)
+            y = local_cpu[1:].reshape(-1, args.train_seq_len).to(device=device)
+            with torch.autocast(device_type=device.type if device.type != "cpu" else "cpu", dtype=torch.bfloat16, enabled=device.type == "cuda"):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(_acc_dtype) * batch_token_count
+            val_token_count += batch_token_count
+            if device.type == "cuda":
+                prev_ids = x.reshape(-1)
+                tgt_ids = y.reshape(-1)
+                token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+                val_byte_count += token_bytes.to(_acc_dtype).sum()
+            else:
+                prev_ids_cpu = local_cpu[:-1].reshape(-1)
+                tgt_ids_cpu = local_cpu[1:].reshape(-1)
+                token_bytes_cpu = _bytes_lut_cpu[tgt_ids_cpu].to(dtype=torch.int16)
+                token_bytes_cpu += (_space_lut_cpu[tgt_ids_cpu] & ~_bound_lut_cpu[prev_ids_cpu]).to(dtype=torch.int16)
+                val_byte_count += float(token_bytes_cpu.float().sum())
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+# -----------------------------
+# QUANTIZATION
+# -----------------------------
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,bigram.scale,trigram.scale",
+    ).split(",")
+    if pattern
+)
+FP16_KEEP_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get("FP16_KEEP_NAME_PATTERNS", "tok_emb,blocks.9.attn.c_k").split(",")
+    if pattern
+)
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if "trigram" in name:
+        return "trigram"
+    if "bigram" in name:
+        return "bigram"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+
+
+def quantize_intN_per_row(t: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        row_max = t32.abs().amax(dim=1)
+        scale = (row_max / clip_range).clamp_min(1e-12).to(torch.float16)
+        scale = scale.clamp_min(torch.finfo(torch.float16).tiny)
+        q = torch.clamp(torch.round(t32 / scale.float()[:, None]), -(clip_range + 1), clip_range).to(torch.int8)
+        return q, scale
+    amax = t32.abs().max().item()
+    scale = torch.tensor(max(amax / clip_range, 1e-12), dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -(clip_range + 1), clip_range).to(torch.int8)
+    return q, scale
+
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 8192:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if any(pattern in name for pattern in FP16_KEEP_NAME_PATTERNS):
+            result[name] = t.to(dtype=torch.float16).contiguous()
+            meta[name] = "passthrough_fp16"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            clip = 15 if cat == "mlp" else 31  # int5 for MLP, int6 for attn/bigram/trigram
+            q, s = quantize_intN_per_row(t, clip_range=clip)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": f"int{5 if cat == 'mlp' else 6}"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+
+
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta[name]
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int, rope_base: float, qk_gain_init: float,
+                 use_xsa: bool = False):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.use_xsa = use_xsa
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        use_gqa = self.num_kv_heads != self.num_heads
+        if use_gqa:
+            # Manual GQA expansion: enable_gqa requires PyTorch 2.5+, use repeat_interleave for 2.4.x compat
+            gs = self.num_heads // self.num_kv_heads
+            k = k.repeat_interleave(gs, dim=1)
+            v_sdpa = v.repeat_interleave(gs, dim=1)
+            y = F.scaled_dot_product_attention(q, k, v_sdpa, attn_mask=None, is_causal=True)
+        else:
+            y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True)
+        # XSA: Exclusive Self Attention (arXiv:2603.09078)
+        # Removes the component of each output y_i that lies along its own value v_i.
+        # GQA-aware: groups query heads by KV head to avoid repeat_interleave allocation.
+        if self.use_xsa:
+            gs = self.num_heads // self.num_kv_heads
+            Vn = F.normalize(v, dim=-1)                             # (B, Hkv, S, Dh)
+            Vn = Vn.unsqueeze(2)                                    # (B, Hkv, 1,  S, Dh)
+            y_g = y.reshape(bsz, self.num_kv_heads, gs, seqlen, self.head_dim)  # (B, Hkv, gs, S, Dh)
+            dot = (y_g * Vn).sum(dim=-1, keepdim=True)             # (B, Hkv, gs, S, 1)
+            y_g = y_g - dot * Vn                                    # (B, Hkv, gs, S, Dh)
+            y = y_g.reshape(bsz, self.num_heads, seqlen, self.head_dim)
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: float):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class SmearGate(nn.Module):
+    """Blend each token's embedding with the previous token's embedding via a learned gate."""
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+
+class BigramHashEmbedding(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+class TrigramHashEmbedding(nn.Module):
+    """Hash 3 consecutive tokens into a learned embedding table.
+
+    Hash: (prev2 * 9533 + prev1 * 97 + curr) % trigram_vocab_size.
+    Max value: 9533 * 1023 + 97 * 1023 + 1023 = 9,869,295 — safely within int32.
+    Provides 3-gram context at zero attention overhead.
+
+    Research: FastText (2017) character n-gram hashing; T-FREE (EMNLP 2024).
+    Complements BigramHash with longer-range token co-occurrence patterns.
+    """
+    def __init__(self, trigram_vocab_size: int, trigram_dim: int, model_dim: int):
+        super().__init__()
+        self.trigram_vocab_size = trigram_vocab_size
+        self.embed = nn.Embedding(trigram_vocab_size, trigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(trigram_dim, model_dim, bias=False) if trigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def trigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)  # int32 for MPS compat (max value 9869295 fits in int32)
+        mod = self.trigram_vocab_size
+        out = torch.full_like(t, mod - 1)  # sentinel for positions without full trigram context
+        if t.shape[-1] > 2:
+            out[..., 2:] = (9533 * t[..., :-2] + 97 * t[..., 1:-1] + t[..., 2:]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.trigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+class Block(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: float, rope_base: float,
+                 qk_gain_init: float, use_xsa: bool = False):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init, use_xsa=use_xsa)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: float,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        bigram_vocab_size: int = 0,
+        bigram_dim: int = 128,
+        trigram_vocab_size: int = 0,
+        trigram_dim: int = 64,
+        xsa_last_n: int = 0,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.trigram = TrigramHashEmbedding(trigram_vocab_size, trigram_dim, model_dim) if trigram_vocab_size > 0 else None
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.smear = SmearGate(model_dim)
+        self.blocks = nn.ModuleList(
+            [
+                Block(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init,
+                      use_xsa=(xsa_last_n > 0 and i >= num_layers - xsa_last_n))
+                for i in range(num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        num_layers = len(self.blocks)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj." in name or name.endswith(".proj"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+
+    def _embed(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        if self.trigram is not None:
+            x = x + self.trigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        return self.smear(x)
+
+    def _body(self, x: Tensor) -> Tensor:
+        x0 = x
+        skips: list[Tensor] = []
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+        return x
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self._body(self._embed(input_ids))
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        logits_proj = F.linear(x, self.tok_emb.weight) if self.tie_embeddings else self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        x = self._body(self._embed(input_ids))
+        x = self.final_norm(x)
+        logits_proj = F.linear(x, self.tok_emb.weight) if self.tie_embeddings else self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+) -> tuple[float, float]:
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+
+    _acc_dtype = torch.float64 if device.type == "cuda" else torch.float32
+    loss_sum = torch.zeros((), device=device, dtype=_acc_dtype)
+    token_count = torch.zeros((), device=device, dtype=_acc_dtype)
+    byte_count = torch.zeros((), device=device, dtype=_acc_dtype)
+    # MPS/CPU: keep CPU LUT copies for byte counting (int16/bool advanced indexing broken on MPS)
+    if device.type != "cuda":
+        _bytes_lut_cpu = base_bytes_lut.cpu()
+        _space_lut_cpu = has_leading_space_lut.cpu()
+        _bound_lut_cpu = is_boundary_token_lut.cpu()
+
+    base_model.eval()
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            # For non-CUDA: keep CPU batches for byte counting
+            if device.type != "cuda":
+                x_batch_cpu = torch.zeros(bsz, seq_len, dtype=torch.int64)
+                y_batch_cpu = torch.zeros(bsz, seq_len, dtype=torch.int64)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk_cpu = val_tokens[ws:end + 1].long()
+                if device.type != "cuda":
+                    x_batch_cpu[i, :wlen] = chunk_cpu[:-1]
+                    y_batch_cpu[i, :wlen] = chunk_cpu[1:]
+                chunk = chunk_cpu.to(device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type=device.type if device.type != "cpu" else "cpu", dtype=torch.bfloat16, enabled=device.type == "cuda"):
+                logits = base_model.forward_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(_acc_dtype)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                if device.type == "cuda":
+                    tgt = y_batch[i, s:wlen]
+                    prev = x_batch[i, s:wlen]
+                    tb = base_bytes_lut[tgt].to(_acc_dtype)
+                    tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(_acc_dtype)
+                    byte_count += tb.sum()
+                else:
+                    tgt_cpu = y_batch_cpu[i, s:wlen]
+                    prev_cpu = x_batch_cpu[i, s:wlen]
+                    tb_cpu = _bytes_lut_cpu[tgt_cpu].float()
+                    tb_cpu = tb_cpu + (_space_lut_cpu[tgt_cpu] & ~_bound_lut_cpu[prev_cpu]).float()
+                    byte_count += float(tb_cpu.sum())
+            if rank == 0 and (bi // batch_seqs) % 50 == 0:
+                done = min(bi + batch_seqs, len(my_windows))
+                pct = done / len(my_windows) * 100
+                running_bpb = 0.0
+                if token_count.item() > 0:
+                    rl = (loss_sum / token_count).item()
+                    running_bpb = rl / math.log(2.0) * (token_count.item() / byte_count.item())
+                print(f"  sliding_eval [{pct:5.1f}%] {done}/{len(my_windows)} windows running_bpb={running_bpb:.6f}", flush=True)
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    # Device selection: CUDA (H100/GPU) → MPS (Apple Silicon) → CPU
+    if torch.cuda.is_available():
+        device = torch.device("cuda", local_rank)
+        torch.cuda.set_device(device)
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+    else:
+        device = torch.device("cpu")
+    if distributed:
+        dist.init_process_group(backend="nccl" if device.type == "cuda" else "gloo")
+        if device.type != "cuda":
+            dist.barrier()  # skip on CUDA: early barrier can fail on some NCCL/driver configs
+    master_process = rank == 0
+
+    if device.type == "cuda":
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+        from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+        enable_cudnn_sdp(False)
+        enable_flash_sdp(True)
+        enable_mem_efficient_sdp(False)
+        enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    try:
+        _smi = subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+        log0(_smi.stdout, console=False)
+    except FileNotFoundError:
+        log0(f"nvidia-smi not available (device: {device.type})", console=False)
+    log0("=" * 100, console=False)
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    if device.type == "cuda":
+        torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}")
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # MODEL + OPTIMIZER SETUP
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim,
+        trigram_vocab_size=args.trigram_vocab_size,
+        trigram_dim=args.trigram_dim,
+        xsa_last_n=args.xsa_last_n,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    # compile base_model first, then wrap with DDP (fullgraph=True incompatible with DDP backward hooks)
+    compiled_model = (torch.compile(base_model, dynamic=False, fullgraph=True)
+                      if device.type == "cuda" else base_model)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+
+    if base_model.bigram is not None:
+        tok_params.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None:
+            matrix_params.append(base_model.bigram.proj.weight)
+        scalar_params.append(base_model.bigram.scale)
+
+    if base_model.trigram is not None:
+        tok_params.append({"params": [base_model.trigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.trigram.proj is not None:
+            matrix_params.append(base_model.trigram.proj.weight)
+        scalar_params.append(base_model.trigram.scale)
+
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.weight_decay,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=0.04,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.weight_decay,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"num_layers:{args.num_layers} model_dim:{args.model_dim} mlp_mult:{args.mlp_mult}")
+    log0(f"bigram:{args.bigram_vocab_size}x{args.bigram_dim} trigram:{args.trigram_vocab_size}x{args.trigram_dim}")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"swa:enabled={args.swa_enabled} start_frac={args.swa_start_frac} every={args.swa_every}")
+    log0(f"seed:{args.seed}")
+
+    # DATA LOADER & MODEL WARMUP
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type=device.type if device.type != "cpu" else "cpu", dtype=torch.bfloat16, enabled=device.type == "cuda"):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # MAIN TRAINING LOOP
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    # EMA: initialize shadow parameters on the same device as model
+    ema_params: dict[str, Tensor] | None = None
+    if args.ema_enabled:
+        ema_params = {name: param.detach().clone() for name, param in base_model.named_parameters()}
+        log0(f"ema:initialized decay={args.ema_decay} params={len(ema_params)}")
+    if device.type == "cuda": torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            if device.type == "cuda": torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            if device.type == "cuda": torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type=device.type if device.type != "cpu" else "cpu", dtype=torch.bfloat16, enabled=device.type == "cuda"):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        # EMA: update shadow parameters on GPU (no CPU transfer, negligible overhead)
+        if ema_params is not None:
+            decay = args.ema_decay
+            with torch.no_grad():
+                for name, param in base_model.named_parameters():
+                    ema_params[name].mul_(decay).add_(param.detach(), alpha=1.0 - decay)
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+
+        # SWA: collect checkpoints during warmdown (when scale < swa_start_frac)
+        if args.swa_enabled and scale < args.swa_start_frac and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024 if device.type == 'cuda' else 0} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024 if device.type == 'cuda' else 0} MiB"
+    )
+
+    # Apply EMA weights (preferred) or SWA fallback
+    if ema_params is not None:
+        log0("ema:applying shadow parameters to model")
+        with torch.no_grad():
+            for name, param in base_model.named_parameters():
+                param.data.copy_(ema_params[name].to(dtype=param.dtype))
+    elif args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"swa:applying averaged {swa_count} checkpoints")
+        current_state = base_model.state_dict()
+        avg_state = {
+            name: (tensor / swa_count).to(dtype=current_state[name].dtype)
+            for name, tensor in swa_state.items()
+        }
+        base_model.load_state_dict(avg_state, strict=True)
+
+    # SERIALIZATION
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Code size: {code_bytes} bytes")
+
+    # Magnitude pruning: zero out smallest 3% of weights to improve compression
+    with torch.no_grad():
+        for name, param in base_model.named_parameters():
+            if param.ndim == 2 and param.numel() > 65536:
+                threshold = torch.quantile(param.abs().float().flatten(), 0.03)
+                mask = param.abs() < threshold
+                param.masked_fill_(mask, 0.0)
+
+    # Mixed int5(MLP)/int6(attn,bigram,trigram) quantization + zstd/zlib export
+    sd_cpu = {k: v.detach().cpu() for k, v in base_model.state_dict().items()}
+    quant_result, quant_meta = mixed_quantize_int6(sd_cpu, {"mlp", "attn", "bigram", "trigram"})
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    if _COMPRESSOR == "zstd":
+        quant_blob = zstandard.ZstdCompressor(level=22).compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, 9)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int5mlp_int6attn_xsa_ema+{_COMPRESSOR}: {quant_file_bytes} bytes")
+        log0(f"Total submission size: {quant_file_bytes + code_bytes} bytes")
+        log0(f"fits_16mb:{quant_file_bytes < 16_000_000}")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    if _COMPRESSOR == "zstd":
+        decompressed = zstandard.ZstdDecompressor().decompress(quant_blob_disk)
+    else:
+        decompressed = zlib.decompress(quant_blob_disk)
+    quant_state = torch.load(io.BytesIO(decompressed), map_location="cpu")
+    deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], sd_cpu)
+    base_model.load_state_dict(deq_state, strict=True)
+
+    # Sliding window eval on quantized weights (contest metric)
+    if device.type == "cuda": torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    if args.eval_stride > 0 and args.eval_stride < args.train_seq_len:
+        log0(f"final_eval_mode:sliding_window stride:{args.eval_stride} batch_seqs:{args.eval_batch_seqs}")
+        q_val_loss, q_val_bpb = eval_val_sliding(
+            args, base_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, batch_seqs=args.eval_batch_seqs,
+        )
+    else:
+        log0("final_eval_mode:standard")
+        q_val_loss, q_val_bpb = eval_val(
+            args, model, rank, world_size, device, grad_accum_steps,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        )
+    if device.type == "cuda": torch.cuda.synchronize()
+    log0(
+        f"final_int5mlp_int6attn_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int5mlp_int6attn_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-03-22_10L_XSA4_EMA_TrigramHash/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-22_10L_XSA4_EMA_TrigramHash/train_gpt.py
@@ -78,7 +78,7 @@ class Hyperparameters:
     num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
     model_dim = int(os.environ.get("MODEL_DIM", 512))
     num_heads = int(os.environ.get("NUM_HEADS", 8))
-    mlp_mult = float(os.environ.get("MLP_MULT", 3.0))
+    mlp_mult = float(os.environ.get("MLP_MULT", 2.0))  # 2.0 with SwiGLU ≈ same params as 3.0 with relu²
     tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
     rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
     logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
@@ -101,6 +101,9 @@ class Hyperparameters:
 
     eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
     eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))
+    # Cap validation tokens for fast local iteration. 0 = use full val set (default for H100 runs).
+    # Example: MAX_VAL_TOKENS=1000000 evaluates on ~1M tokens instead of 62M → ~60x faster eval.
+    max_val_tokens = int(os.environ.get("MAX_VAL_TOKENS", 0))
 
     bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 10240))
     bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
@@ -109,8 +112,19 @@ class Hyperparameters:
     trigram_vocab_size = int(os.environ.get("TRIGRAM_VOCAB_SIZE", 1024))
     trigram_dim = int(os.environ.get("TRIGRAM_DIM", 64))
 
+    # QuadgramHash: (prev3, prev2, prev1, curr) → learned embedding
+    quadgram_vocab_size = int(os.environ.get("QUADGRAM_VOCAB_SIZE", 1024))
+    quadgram_dim = int(os.environ.get("QUADGRAM_DIM", 32))
+
     # XSA: Exclusive Self Attention (arXiv:2603.09078), applied to last N layers
     xsa_last_n = int(os.environ.get("XSA_LAST_N", 4))
+    # Gated XSA: learned per-layer scalar gate controlling projection removal strength.
+    # sigmoid(4.0) ≈ 0.982 — starts near full XSA, adapts during training.
+    # Set XSA_GATE_INIT=100.0 to freeze near 1.0 (reproduces original hard XSA).
+    xsa_gate_init = float(os.environ.get("XSA_GATE_INIT", 4.0))
+
+    # SwiGLU: replace relu² MLP with SwiGLU gated activation (use mlp_mult=2.0 for same params)
+    use_swiglu = bool(int(os.environ.get("USE_SWIGLU", "1")))
 
     # EMA: Exponential Moving Average weight averaging (replaces SWA)
     ema_enabled = bool(int(os.environ.get("EMA_ENABLED", "1")))
@@ -319,7 +333,7 @@ CONTROL_TENSOR_NAME_PATTERNS = tuple(
     pattern
     for pattern in os.environ.get(
         "CONTROL_TENSOR_NAME_PATTERNS",
-        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,bigram.scale,trigram.scale",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,bigram.scale,trigram.scale,quadgram.scale,xsa_gate",
     ).split(",")
     if pattern
 )
@@ -356,6 +370,8 @@ def _classify_param(name: str) -> str:
         return "embed"
     if ".mlp." in name:
         return "mlp"
+    if "quadgram" in name:
+        return "quadgram"
     if "trigram" in name:
         return "trigram"
     if "bigram" in name:
@@ -557,7 +573,7 @@ def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
 
 class CausalSelfAttention(nn.Module):
     def __init__(self, dim: int, num_heads: int, num_kv_heads: int, rope_base: float, qk_gain_init: float,
-                 use_xsa: bool = False):
+                 use_xsa: bool = False, xsa_gate_init: float = 4.0):
         super().__init__()
         if dim % num_heads != 0:
             raise ValueError("model_dim must be divisible by num_heads")
@@ -577,6 +593,10 @@ class CausalSelfAttention(nn.Module):
         self.proj._zero_init = True
         self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
         self.rotary = Rotary(self.head_dim, base=rope_base)
+        # Gated XSA: one learned scalar per XSA layer controlling projection-removal strength.
+        # sigmoid(xsa_gate_init=4.0) ≈ 0.982 → starts near full XSA, adapts per layer during training.
+        if use_xsa:
+            self.xsa_gate = nn.Parameter(torch.tensor(xsa_gate_init, dtype=torch.float32))
 
     def forward(self, x: Tensor) -> Tensor:
         bsz, seqlen, dim = x.shape
@@ -598,8 +618,9 @@ class CausalSelfAttention(nn.Module):
             y = F.scaled_dot_product_attention(q, k, v_sdpa, attn_mask=None, is_causal=True)
         else:
             y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True)
-        # XSA: Exclusive Self Attention (arXiv:2603.09078)
-        # Removes the component of each output y_i that lies along its own value v_i.
+        # Gated XSA: Exclusive Self Attention (arXiv:2603.09078) with learned gate.
+        # Removes gate * (component of y_i along its own value v_i), where gate = sigmoid(xsa_gate).
+        # gate ≈ 1.0 at init → full XSA; gate adapts per layer during training.
         # GQA-aware: groups query heads by KV head to avoid repeat_interleave allocation.
         if self.use_xsa:
             gs = self.num_heads // self.num_kv_heads
@@ -607,21 +628,32 @@ class CausalSelfAttention(nn.Module):
             Vn = Vn.unsqueeze(2)                                    # (B, Hkv, 1,  S, Dh)
             y_g = y.reshape(bsz, self.num_kv_heads, gs, seqlen, self.head_dim)  # (B, Hkv, gs, S, Dh)
             dot = (y_g * Vn).sum(dim=-1, keepdim=True)             # (B, Hkv, gs, S, 1)
-            y_g = y_g - dot * Vn                                    # (B, Hkv, gs, S, Dh)
+            gate = torch.sigmoid(self.xsa_gate).to(dtype=y_g.dtype)
+            y_g = y_g - gate * dot * Vn                             # (B, Hkv, gs, S, Dh)
             y = y_g.reshape(bsz, self.num_heads, seqlen, self.head_dim)
         y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
         return self.proj(y)
 
 
 class MLP(nn.Module):
-    def __init__(self, dim: int, mlp_mult: float):
+    def __init__(self, dim: int, mlp_mult: float, use_swiglu: bool = True):
         super().__init__()
         hidden = int(mlp_mult * dim)
-        self.fc = CastedLinear(dim, hidden, bias=False)
-        self.proj = CastedLinear(hidden, dim, bias=False)
-        self.proj._zero_init = True
+        self.use_swiglu = use_swiglu
+        if use_swiglu:
+            # SwiGLU: gate + up projections, then down. With mlp_mult=2.0 matches relu² mlp_mult=3.0 param count.
+            self.gate = CastedLinear(dim, hidden, bias=False)
+            self.up = CastedLinear(dim, hidden, bias=False)
+            self.down = CastedLinear(hidden, dim, bias=False)
+            self.down._zero_init = True
+        else:
+            self.fc = CastedLinear(dim, hidden, bias=False)
+            self.proj = CastedLinear(hidden, dim, bias=False)
+            self.proj._zero_init = True
 
     def forward(self, x: Tensor) -> Tensor:
+        if self.use_swiglu:
+            return self.down(F.silu(self.gate(x)) * self.up(x))
         x = torch.relu(self.fc(x))
         return self.proj(x.square())
 
@@ -700,14 +732,47 @@ class TrigramHashEmbedding(nn.Module):
         return h * self.scale.to(dtype=h.dtype)
 
 
+class QuadgramHashEmbedding(nn.Module):
+    """Hash 4 consecutive tokens into a learned embedding table.
+
+    Hash: (prev3*104723 + prev2*9533 + prev1*97 + curr) % quadgram_vocab_size.
+    Max value: 104723*1023 + 9533*1023 + 97*1023 + 1023 = 116,984,142 — safely within int32.
+    Extends TrigramHash with 4-gram context at zero attention overhead.
+    """
+    def __init__(self, quadgram_vocab_size: int, quadgram_dim: int, model_dim: int):
+        super().__init__()
+        self.quadgram_vocab_size = quadgram_vocab_size
+        self.embed = nn.Embedding(quadgram_vocab_size, quadgram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(quadgram_dim, model_dim, bias=False) if quadgram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def quadgram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)  # int32 for MPS compat (max value ~117M fits in int32)
+        mod = self.quadgram_vocab_size
+        out = torch.full_like(t, mod - 1)  # sentinel for positions without full 4-gram context
+        if t.shape[-1] > 3:
+            out[..., 3:] = (104723 * t[..., :-3] + 9533 * t[..., 1:-2] + 97 * t[..., 2:-1] + t[..., 3:]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.quadgram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
 class Block(nn.Module):
     def __init__(self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: float, rope_base: float,
-                 qk_gain_init: float, use_xsa: bool = False):
+                 qk_gain_init: float, use_xsa: bool = False, use_swiglu: bool = True, xsa_gate_init: float = 4.0):
         super().__init__()
         self.attn_norm = RMSNorm()
         self.mlp_norm = RMSNorm()
-        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init, use_xsa=use_xsa)
-        self.mlp = MLP(dim, mlp_mult)
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+                                        use_xsa=use_xsa, xsa_gate_init=xsa_gate_init)
+        self.mlp = MLP(dim, mlp_mult, use_swiglu=use_swiglu)
         self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
         self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
         self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
@@ -739,7 +804,11 @@ class GPT(nn.Module):
         bigram_dim: int = 128,
         trigram_vocab_size: int = 0,
         trigram_dim: int = 64,
+        quadgram_vocab_size: int = 0,
+        quadgram_dim: int = 32,
         xsa_last_n: int = 0,
+        xsa_gate_init: float = 4.0,
+        use_swiglu: bool = True,
     ):
         super().__init__()
         if logit_softcap <= 0.0:
@@ -750,6 +819,7 @@ class GPT(nn.Module):
         self.tok_emb = nn.Embedding(vocab_size, model_dim)
         self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
         self.trigram = TrigramHashEmbedding(trigram_vocab_size, trigram_dim, model_dim) if trigram_vocab_size > 0 else None
+        self.quadgram = QuadgramHashEmbedding(quadgram_vocab_size, quadgram_dim, model_dim) if quadgram_vocab_size > 0 else None
         self.num_encoder_layers = num_layers // 2
         self.num_decoder_layers = num_layers - self.num_encoder_layers
         self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
@@ -758,7 +828,9 @@ class GPT(nn.Module):
         self.blocks = nn.ModuleList(
             [
                 Block(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init,
-                      use_xsa=(xsa_last_n > 0 and i >= num_layers - xsa_last_n))
+                      use_xsa=(xsa_last_n > 0 and i >= num_layers - xsa_last_n),
+                      use_swiglu=use_swiglu,
+                      xsa_gate_init=xsa_gate_init)
                 for i in range(num_layers)
             ]
         )
@@ -788,6 +860,8 @@ class GPT(nn.Module):
             x = x + self.bigram(input_ids)
         if self.trigram is not None:
             x = x + self.trigram(input_ids)
+        if self.quadgram is not None:
+            x = x + self.quadgram(input_ids)
         x = F.rms_norm(x, (x.size(-1),))
         return self.smear(x)
 
@@ -1003,6 +1077,9 @@ def main() -> None:
     dataset_dir = Path(args.data_path).resolve()
     actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
     val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    if args.max_val_tokens > 0:
+        usable = (min(args.max_val_tokens, val_tokens.numel() - 1) // args.train_seq_len) * args.train_seq_len
+        val_tokens = val_tokens[: usable + 1]
     base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
         sp, args.vocab_size, device
     )
@@ -1028,7 +1105,11 @@ def main() -> None:
         bigram_dim=args.bigram_dim,
         trigram_vocab_size=args.trigram_vocab_size,
         trigram_dim=args.trigram_dim,
+        quadgram_vocab_size=args.quadgram_vocab_size,
+        quadgram_dim=args.quadgram_dim,
         xsa_last_n=args.xsa_last_n,
+        xsa_gate_init=args.xsa_gate_init,
+        use_swiglu=args.use_swiglu,
     ).to(device).bfloat16()
     for module in base_model.modules():
         if isinstance(module, CastedLinear):
@@ -1067,6 +1148,12 @@ def main() -> None:
             matrix_params.append(base_model.trigram.proj.weight)
         scalar_params.append(base_model.trigram.scale)
 
+    if base_model.quadgram is not None:
+        tok_params.append({"params": [base_model.quadgram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.quadgram.proj is not None:
+            matrix_params.append(base_model.quadgram.proj.weight)
+        scalar_params.append(base_model.quadgram.scale)
+
     optimizer_tok = torch.optim.AdamW(
         tok_params,
         betas=(args.beta1, args.beta2),
@@ -1104,7 +1191,8 @@ def main() -> None:
     log0(f"model_params:{n_params}")
     log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
     log0(f"num_layers:{args.num_layers} model_dim:{args.model_dim} mlp_mult:{args.mlp_mult}")
-    log0(f"bigram:{args.bigram_vocab_size}x{args.bigram_dim} trigram:{args.trigram_vocab_size}x{args.trigram_dim}")
+    log0(f"bigram:{args.bigram_vocab_size}x{args.bigram_dim} trigram:{args.trigram_vocab_size}x{args.trigram_dim} quadgram:{args.quadgram_vocab_size}x{args.quadgram_dim}")
+    log0(f"swiglu:{args.use_swiglu} mlp_mult:{args.mlp_mult} xsa_last_n:{args.xsa_last_n} xsa_gate_init:{args.xsa_gate_init}")
     log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
     log0(
         f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
@@ -1308,7 +1396,7 @@ def main() -> None:
 
     # Mixed int5(MLP)/int6(attn,bigram,trigram) quantization + zstd/zlib export
     sd_cpu = {k: v.detach().cpu() for k, v in base_model.state_dict().items()}
-    quant_result, quant_meta = mixed_quantize_int6(sd_cpu, {"mlp", "attn", "bigram", "trigram"})
+    quant_result, quant_meta = mixed_quantize_int6(sd_cpu, {"mlp", "attn", "bigram", "trigram", "quadgram"})
     quant_buf = io.BytesIO()
     torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
     quant_raw = quant_buf.getvalue()


### PR DESCRIPTION
PS: I don't have funds for training on 8xh100.

Building on the 10L SOTA (2026-03-20_10L_Int5MLP_MuonWD04_SWA50, 1.14276 BPB). Four additions:

1. Gated XSA — XSA (arXiv:2603.09078) with a learned per-layer sigmoid gate instead of hard projection removal. Starts near full XSA (sigmoid(4.0) ≈ 0.98) and adapts during training. The intuition is that early and late layers may want different amounts of self-value suppression, so letting it learn seems better than fixing it at 1.0.

2. EMA — Exponential moving average (decay=0.997) replacing SWA. Shadow copy on GPU, updated every step. Feels cleaner than SWA since you don't have to pick a start fraction — it naturally tracks the model through the whole warmdown.

3. TrigramHash + QuadgramHash — Hash (t-2, t-1, t) and (t-3, t-2, t-1, t) into learned embedding tables (1024 buckets each, dim=64/32), added at the input. Cheap in terms of compressed bytes (~55KB and ~25KB respectively after int8+zstd) but gives the model explicit n-gram context at zero attention overhead. Uses int32 arithmetic for the hash to avoid overflow.

4. SwiGLU — Swapped relu² for SwiGLU with mlp_mult=2.0 (gate+up+down vs the old fc+proj). Param count stays the same as relu² at mlp_mult=3.0.

BigramHash is back to 10240 buckets (had to shrink it to 2048 in a previous 11L attempt to fit the budget — staying at 10L means we don't have to make that tradeoff).

All weights quantized int5 (MLP) / int6 (attn, bigram, trigram, quadgram proj) / int8 (embedding tables) + zstd-22. Fits within 16MB.

