### PR TITLE
Add first non-record local smoke submission

### DIFF
--- a/records/track_non_record_16mb/2026-03-23_LocalSmoke_MLX_8Layer_ParamCut/README.md
+++ b/records/track_non_record_16mb/2026-03-23_LocalSmoke_MLX_8Layer_ParamCut/README.md
@@ -1,0 +1,78 @@
+## Non-record submission: Local smoke baseline + 8-layer param cut (MLX)
+
+This submission is a first end-to-end PR artifact for the challenge workflow:
+- run baseline
+- make one small, real model change
+- report results and include reproducible files
+
+Because this was executed on Apple Silicon MLX with a tiny local smoke shard, it is **not leaderboard-comparable** to the official 8xH100 full-validation track. It is intended as a reproducibility and iteration bootstrap.
+
+### What changed
+
+One architecture change:
+- `NUM_LAYERS: 9 -> 8` (all other model defaults unchanged)
+
+### Why this change
+
+Reducing depth is one of the simplest levers under strict artifact and runtime limits. This first attempt checks the speed/size trade-off before trying more advanced ideas.
+
+### Local setup used
+
+- Hardware: Apple Silicon (MLX backend)
+- Dataset: local smoke shard with valid challenge shard header format
+  - train tokens: 2,000,000
+  - val tokens: 1,000,000
+- Tokenizer: `data/tokenizers/fineweb_1024_bpe.model`
+
+### Commands
+
+Baseline:
+```bash
+RUN_ID=mlx_smoke_baseline_local \
+DATA_PATH=./data/datasets/fineweb10B_sp1024_smoke \
+TOKENIZER_PATH=./data/tokenizers/fineweb_1024_bpe.model \
+ITERATIONS=60 \
+TRAIN_BATCH_TOKENS=8192 \
+GRAD_ACCUM_STEPS=1 \
+VAL_LOSS_EVERY=0 \
+VAL_BATCH_SIZE=131072 \
+python3 train_gpt_mlx.py
+```
+
+Submission run (8 layers):
+```bash
+RUN_ID=mlx_smoke_layers8_local \
+DATA_PATH=./data/datasets/fineweb10B_sp1024_smoke \
+TOKENIZER_PATH=./data/tokenizers/fineweb_1024_bpe.model \
+ITERATIONS=60 \
+TRAIN_BATCH_TOKENS=8192 \
+GRAD_ACCUM_STEPS=1 \
+VAL_LOSS_EVERY=0 \
+VAL_BATCH_SIZE=131072 \
+NUM_LAYERS=8 \
+python3 train_gpt_mlx.py
+```
+
+### Results
+
+Baseline (`logs_baseline.txt`):
+- final `val_bpb`: `2.74767562`
+- int8+zlib model bytes: `9,283,342`
+- train time to step 60: `42,500ms`
+
+8-layer run (`train.log`):
+- final `val_bpb`: `2.75529448`
+- int8+zlib model bytes: `8,451,732`
+- train time to step 60: `35,198ms`
+
+Observed trade-off in this smoke setup:
+- faster training and smaller model artifact
+- slight regression in held-out bpb
+
+### Included files
+
+- `train.log`: full log for the 8-layer submission run
+- `logs_baseline.txt`: baseline comparison run log
+- `submission.json`: metadata for this non-record run
+- `train_gpt.py`: small launcher pinned to this run config
+

--- a/records/track_non_record_16mb/2026-03-23_LocalSmoke_MLX_8Layer_ParamCut/logs_baseline.txt
+++ b/records/track_non_record_16mb/2026-03-23_LocalSmoke_MLX_8Layer_ParamCut/logs_baseline.txt
@@ -1,0 +1,52 @@
+run_id:mlx_smoke_baseline_local
+mlx_version:0.31.1
+train_loader:shards pattern=./data/datasets/fineweb10B_sp1024_smoke/fineweb_train_*.bin
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024_smoke/fineweb_val_*.bin tokens:999424
+train_loader:dataset:fineweb10B_sp1024_smoke train_shards:1
+tokenizer_path:./data/tokenizers/fineweb_1024_bpe.model
+model_params:17059912 vocab_size:1024 layers:9 dim:512 heads:8 kv_heads:4 seq_len:1024 tie_embeddings:True
+iterations:60 train_batch_tokens:8192 grad_accum_steps:1 microbatch_tokens:8192 microbatch_batch_size:8 val_batch_size:131072 warmup_steps:20 max_wallclock_seconds:600.000
+mlx_max_microbatch_tokens:8192
+optimizer:muon+adam muon_matrix_params:54 scalar_params:37 embed_lr:0.05 matrix_lr:0.04 scalar_lr:0.04 muon_momentum:0.95 muon_steps:5
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+compute_dtype:mlx.core.bfloat16 compile:True
+dtypes tok_emb:mlx.core.bfloat16 linear_weight:mlx.core.float32 skip_weights:mlx.core.float32
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:1/60 train_loss:6.9429 train_time:546ms step_avg:546.39ms tok_s:14993
+step:2/60 train_loss:18.7882 train_time:1248ms step_avg:624.07ms tok_s:11679
+step:3/60 train_loss:14.5754 train_time:1965ms step_avg:655.10ms tok_s:11426
+step:4/60 train_loss:10.6208 train_time:2649ms step_avg:662.17ms tok_s:11991
+step:5/60 train_loss:8.1471 train_time:3341ms step_avg:668.24ms tok_s:11837
+step:6/60 train_loss:6.9890 train_time:4077ms step_avg:679.45ms tok_s:11143
+step:7/60 train_loss:6.5573 train_time:4774ms step_avg:682.06ms tok_s:11745
+step:8/60 train_loss:6.5266 train_time:5485ms step_avg:685.57ms tok_s:11543
+step:9/60 train_loss:6.3799 train_time:6198ms step_avg:688.64ms tok_s:11492
+step:10/60 train_loss:6.3084 train_time:6880ms step_avg:688.03ms tok_s:12009
+val_progress:1/8
+val_progress:8/8
+step:60/60 val_loss:4.5839 val_bpb:2.7475 train_time:42500ms step_avg:708.33ms
+saved_model:logs/mlx_smoke_baseline_local_mlx_model.npz bytes:67212188
+serialized_model_int8_zlib:9283342 bytes (payload:17178912 raw_pickle:17188361 payload_ratio:3.91x)
+val_progress:1/8
+val_progress:8/8
+final_int8_zlib_roundtrip val_loss:4.5843 val_bpb:2.7477 eval_time:12220ms
+final_int8_zlib_roundtrip_exact val_loss:4.58427349 val_bpb:2.74767562

--- a/records/track_non_record_16mb/2026-03-23_LocalSmoke_MLX_8Layer_ParamCut/submission.json
+++ b/records/track_non_record_16mb/2026-03-23_LocalSmoke_MLX_8Layer_ParamCut/submission.json
@@ -1,0 +1,18 @@
+{
+  "author": "",
+  "github_id": "",
+  "name": "Local smoke MLX 8-layer param cut",
+  "blurb": "First end-to-end non-record submission artifact from local Apple Silicon MLX smoke runs. Compares baseline 9-layer model to an 8-layer variant to test parameter/speed trade-offs under the 16MB artifact constraint workflow.",
+  "date": "2026-03-23T00:00:00Z",
+  "track": "non-record-16mb",
+  "val_loss": 4.59698495,
+  "val_bpb": 2.75529448,
+  "pre_quant_val_loss": 4.5954,
+  "pre_quant_val_bpb": 2.7543,
+  "step_stop": 60,
+  "wallclock_seconds": 35.198,
+  "bytes_total": 8451732,
+  "bytes_model_int8_zlib": 8451732,
+  "bytes_code": null,
+  "gpu": "Apple Silicon (MLX)"
+}

--- a/records/track_non_record_16mb/2026-03-23_LocalSmoke_MLX_8Layer_ParamCut/train.log
+++ b/records/track_non_record_16mb/2026-03-23_LocalSmoke_MLX_8Layer_ParamCut/train.log
@@ -1,0 +1,52 @@
+run_id:mlx_smoke_layers8_local
+mlx_version:0.31.1
+train_loader:shards pattern=./data/datasets/fineweb10B_sp1024_smoke/fineweb_train_*.bin
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024_smoke/fineweb_val_*.bin tokens:999424
+train_loader:dataset:fineweb10B_sp1024_smoke train_shards:1
+tokenizer_path:./data/tokenizers/fineweb_1024_bpe.model
+model_params:15222848 vocab_size:1024 layers:8 dim:512 heads:8 kv_heads:4 seq_len:1024 tie_embeddings:True
+iterations:60 train_batch_tokens:8192 grad_accum_steps:1 microbatch_tokens:8192 microbatch_batch_size:8 val_batch_size:131072 warmup_steps:20 max_wallclock_seconds:600.000
+mlx_max_microbatch_tokens:8192
+optimizer:muon+adam muon_matrix_params:48 scalar_params:33 embed_lr:0.05 matrix_lr:0.04 scalar_lr:0.04 muon_momentum:0.95 muon_steps:5
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+compute_dtype:mlx.core.bfloat16 compile:True
+dtypes tok_emb:mlx.core.bfloat16 linear_weight:mlx.core.float32 skip_weights:mlx.core.float32
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:1/60 train_loss:6.9425 train_time:536ms step_avg:536.10ms tok_s:15281
+step:2/60 train_loss:19.1216 train_time:1180ms step_avg:590.09ms tok_s:12724
+step:3/60 train_loss:15.0173 train_time:1921ms step_avg:640.19ms tok_s:11069
+step:4/60 train_loss:10.9795 train_time:2661ms step_avg:665.28ms tok_s:11067
+step:5/60 train_loss:8.3166 train_time:3323ms step_avg:664.65ms tok_s:12378
+step:6/60 train_loss:7.0917 train_time:4003ms step_avg:667.24ms tok_s:12049
+step:7/60 train_loss:6.6316 train_time:4685ms step_avg:669.26ms tok_s:12026
+step:8/60 train_loss:6.5769 train_time:5309ms step_avg:663.66ms tok_s:13126
+step:9/60 train_loss:6.3211 train_time:5921ms step_avg:657.89ms tok_s:13398
+step:10/60 train_loss:6.2817 train_time:6545ms step_avg:654.51ms tok_s:13133
+val_progress:1/8
+val_progress:8/8
+step:60/60 val_loss:4.5954 val_bpb:2.7543 train_time:35198ms step_avg:586.64ms
+saved_model:logs/mlx_smoke_layers8_local_mlx_model.npz bytes:59861636
+serialized_model_int8_zlib:8451732 bytes (payload:15329536 raw_pickle:15337933 payload_ratio:3.90x)
+val_progress:1/8
+val_progress:8/8
+final_int8_zlib_roundtrip val_loss:4.5970 val_bpb:2.7553 eval_time:9156ms
+final_int8_zlib_roundtrip_exact val_loss:4.59698495 val_bpb:2.75529448

--- a/records/track_non_record_16mb/2026-03-23_LocalSmoke_MLX_8Layer_ParamCut/train_gpt.py
+++ b/records/track_non_record_16mb/2026-03-23_LocalSmoke_MLX_8Layer_ParamCut/train_gpt.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+Small launcher for this local non-record MLX submission.
+
+This script pins the run configuration used for the 8-layer smoke run and
+delegates to the repository-level `train_gpt_mlx.py`.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def main() -> None:
+    here = Path(__file__).resolve().parent
+    repo_root = here.parents[2]
+    target = repo_root / "train_gpt_mlx.py"
+    if not target.exists():
+        raise FileNotFoundError(f"Could not find {target}")
+
+    env = os.environ.copy()
+    env.setdefault("RUN_ID", "mlx_smoke_layers8_local")
+    env.setdefault("DATA_PATH", str(repo_root / "data/datasets/fineweb10B_sp1024_smoke"))
+    env.setdefault("TOKENIZER_PATH", str(repo_root / "data/tokenizers/fineweb_1024_bpe.model"))
+    env.setdefault("ITERATIONS", "60")
+    env.setdefault("TRAIN_BATCH_TOKENS", "8192")
+    env.setdefault("GRAD_ACCUM_STEPS", "1")
+    env.setdefault("VAL_LOSS_EVERY", "0")
+    env.setdefault("VAL_BATCH_SIZE", "131072")
+    env.setdefault("NUM_LAYERS", "8")
+
+    subprocess.run(["python3", str(target)], check=True, env=env)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a first non-record submission folder under `records/track_non_record_16mb` with a complete local smoke workflow artifact.
- Document baseline vs 8-layer MLX smoke runs, including final `val_bpb`, artifact bytes, and runtime trade-offs.
- Include `submission.json`, run logs, and a small `train_gpt.py` launcher for reproducible reruns.

## Test plan
- [x] Create local smoke shards with valid challenge shard headers
- [x] Run baseline MLX smoke config end-to-end and record final metrics
- [x] Run 8-layer variant end-to-end and record final metrics
- [x] Verify files are committed only under new records folder