### PR TITLE
Add 10min/16MB record: skinny RLM seq2048 (int8+zlib val_bpb 1.1750)

### DIFF
--- a/records/track_10min_16mb/2026-03-23_repro_submit_2048_lr02/README.md
+++ b/records/track_10min_16mb/2026-03-23_repro_submit_2048_lr02/README.md
@@ -1,0 +1,53 @@
+# Skinny looped RLM — 512d / 6L / loop 2×3 / seq2048 / Muon LR 0.02
+
+## Architecture
+
+**Looped Transformer (RLM):** prefix and suffix are **6 distinct** transformer blocks; the **middle** uses **2 weight-tied blocks** applied **3 times** (`LOOP_BLOCKS=2`, `LOOP_ITERS=3`). Standard **GQA + RoPE**, **ReLU² MLP** with **3×** expansion.
+
+## Techniques
+
+| Item | Setting |
+|------|---------|
+| Sequence length | `TRAIN_SEQ_LEN=2048` |
+| Optimizer | Muon (matrix) + Adam (scalars), `MATRIX_LR=0.02`, `SCALAR_LR=0.02` |
+| Weight decay | `MUON_WD=0.04` (decoupled, compression headroom) |
+| Embeddings | `TIE_EMBEDDINGS=1`, `EMBED_BITS=8` (STE fake-quant) |
+| Loss | `LOSS_POS_WARMUP=256` (position ramp) |
+| Clock | `MAX_WALLCLOCK_SECONDS=590` |
+
+## Reproduction
+
+```bash
+MODEL_DIM=512 NUM_LAYERS=6 LOOP_BLOCKS=2 LOOP_ITERS=3 \
+MATRIX_LR=0.02 SCALAR_LR=0.02 TIED_EMBED_LR=0.05 \
+NUM_HEADS=8 NUM_KV_HEADS=8 TIE_EMBEDDINGS=1 \
+MLP_MULT=3 MUON_WD=0.04 EMBED_BITS=8 LOSS_POS_WARMUP=256 \
+TRAIN_SEQ_LEN=2048 TRAIN_BATCH_TOKENS=524288 \
+ITERATIONS=100000 WARMUP_STEPS=200 WARMDOWN_ITERS=3000 \
+MAX_WALLCLOCK_SECONDS=590 VAL_LOSS_EVERY=0 TRAIN_LOG_EVERY=200 \
+DATA_PATH=./data/datasets/fineweb10B_sp1024 \
+TOKENIZER_PATH=./data/tokenizers/fineweb_1024_bpe.model \
+VOCAB_SIZE=1024 SEED=1337 RUN_ID=repro_submit_2048_lr02 \
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+## Metrics (this run)
+
+| Metric | Value |
+|--------|--------|
+| Wallclock | `590080 ms` |
+| Steps | `6106` |
+| `step_avg` | `96.64 ms` (at final val line) |
+| Pre-quant `val_bpb` | `1.1683` |
+| **`final_int8_zlib_roundtrip_exact val_bpb`** | **`1.17503786`** |
+| `Total submission size int8+zlib` | **`14903768`** bytes (≤ 16_000_000) |
+| `Code size` | `66048` bytes |
+| Peak VRAM | `19506 MiB` allocated |
+
+## Included files
+
+- `train_gpt.py` — snapshot used for training  
+- `train.log` — full master log (includes embedded source + `nvidia-smi` + training)  
+- `submission.json` — leaderboard metadata  
+
+If the upstream PR template expects the weight blob, add **`final_model.int8.ptz`** from the same run next to these files (same directory as `train_gpt.py`).

--- a/records/track_10min_16mb/2026-03-23_repro_submit_2048_lr02/submission.json
+++ b/records/track_10min_16mb/2026-03-23_repro_submit_2048_lr02/submission.json
@@ -1,0 +1,12 @@
+{
+  "author": "Kevin O'Connor",
+  "github_id": "k-oconnor",
+  "name": "Skinny RLM 512×6, loop 2×3, seq2048, Muon LR 0.02",
+  "blurb": "Looped RLM: 6 layers with 2-block weight-tied core × 3 iterations. GQA, ReLU² MLP 3×, tied embeddings, EMBED_BITS=8 STE, LOSS_POS_WARMUP=256, MUON_WD=0.04, MATRIX_LR=0.02. Trained 6106 steps / 590s on 8×H100.",
+  "date": "2026-03-23T00:00:00Z",
+  "val_loss": 1.9840022,
+  "val_bpb": 1.17503786,
+  "bytes_total": 14903768,
+  "bytes_code": 66048,
+  "run_id": "repro_submit_2048_lr02"
+}

--- a/records/track_10min_16mb/2026-03-23_repro_submit_2048_lr02/train.log
+++ b/records/track_10min_16mb/2026-03-23_repro_submit_2048_lr02/train.log
@@ -1,0 +1,3087 @@
+W0323 20:24:05.562000 135202818409600 torch/distributed/run.py:779] 
+W0323 20:24:05.562000 135202818409600 torch/distributed/run.py:779] *****************************************
+W0323 20:24:05.562000 135202818409600 torch/distributed/run.py:779] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0323 20:24:05.562000 135202818409600 torch/distributed/run.py:779] *****************************************
+logs/repro_submit_2048_lr02.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:35
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:21512256 unique_params:21512256
+loop_mode:blocks=2 iters=3 prefix=3 suffix=3
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:8
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:524288 train_seq_len:2048 iterations:100000 warmup_steps:200 max_wallclock_seconds:590.000
+seed:1337
+mlp_activation:relu2 embed_bits:8 ortho_init:False loss_pos_warmup:256 muon_wd:0.04 tfw:False shard_order:False
+[rank3]:W0323 20:24:48.603000 129100027380864 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] r1 is not in var_ranges, defaulting to unknown range.
+[rank3]:W0323 20:24:48.607000 129100027380864 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] rindex is not in var_ranges, defaulting to unknown range.
+[rank3]:W0323 20:24:48.619000 129100027380864 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] xindex is not in var_ranges, defaulting to unknown range.
+[rank6]:W0323 20:24:49.267000 128803462395008 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] r1 is not in var_ranges, defaulting to unknown range.
+[rank6]:W0323 20:24:49.269000 128803462395008 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] rindex is not in var_ranges, defaulting to unknown range.
+[rank6]:W0323 20:24:49.281000 128803462395008 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] xindex is not in var_ranges, defaulting to unknown range.
+[rank1]:W0323 20:24:50.068000 123527461987456 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] r1 is not in var_ranges, defaulting to unknown range.
+[rank1]:W0323 20:24:50.070000 123527461987456 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] rindex is not in var_ranges, defaulting to unknown range.
+[rank1]:W0323 20:24:50.082000 123527461987456 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] xindex is not in var_ranges, defaulting to unknown range.
+[rank7]:W0323 20:24:50.122000 132258617439360 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] r1 is not in var_ranges, defaulting to unknown range.
+[rank7]:W0323 20:24:50.124000 132258617439360 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] rindex is not in var_ranges, defaulting to unknown range.
+[rank7]:W0323 20:24:50.136000 132258617439360 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] xindex is not in var_ranges, defaulting to unknown range.
+[rank5]:W0323 20:24:50.226000 138471358968960 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] r1 is not in var_ranges, defaulting to unknown range.
+[rank5]:W0323 20:24:50.228000 138471358968960 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] rindex is not in var_ranges, defaulting to unknown range.
+[rank5]:W0323 20:24:50.240000 138471358968960 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] xindex is not in var_ranges, defaulting to unknown range.
+[rank0]:W0323 20:24:50.359000 130746180686976 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] r1 is not in var_ranges, defaulting to unknown range.
+[rank0]:W0323 20:24:50.361000 130746180686976 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] rindex is not in var_ranges, defaulting to unknown range.
+[rank0]:W0323 20:24:50.373000 130746180686976 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] xindex is not in var_ranges, defaulting to unknown range.
+[rank2]:W0323 20:24:50.496000 137947689669760 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] r1 is not in var_ranges, defaulting to unknown range.
+[rank2]:W0323 20:24:50.501000 137947689669760 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] rindex is not in var_ranges, defaulting to unknown range.
+[rank2]:W0323 20:24:50.513000 137947689669760 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] xindex is not in var_ranges, defaulting to unknown range.
+[rank4]:W0323 20:24:50.564000 140063205905536 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] r1 is not in var_ranges, defaulting to unknown range.
+[rank4]:W0323 20:24:50.566000 140063205905536 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] rindex is not in var_ranges, defaulting to unknown range.
+[rank4]:W0323 20:24:50.578000 140063205905536 torch/fx/experimental/symbolic_shapes.py:4449] [0/0_1] xindex is not in var_ranges, defaulting to unknown range.
+ied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+    muon_wd = float(os.environ.get("MUON_WD", "0.0"))
+
+    # Curriculum / data ordering: path to a text file with one shard path per line.
+    shard_order_file = os.environ.get("SHARD_ORDER_FILE", "")
+    # Token-frequency weighted loss: path to .npy file with per-token weights (shape: vocab_size).
+    tfw_weight_file = os.environ.get("TFW_WEIGHT_FILE", "")
+    tfw_alpha = float(os.environ.get("TFW_ALPHA", "0.5"))
+    # Sequence-position weighted loss: ramp loss from 0→1 over the first N positions.
+    loss_pos_warmup = int(os.environ.get("LOSS_POS_WARMUP", "0"))
+    # Embedding fake-quantization bits (16 = default bf16, 8 = INT8 STE fake-quant).
+    embed_bits = int(os.environ.get("EMBED_BITS", "16"))
+    # MLP activation: "relu2" (default relu²) or "swiglu".
+    mlp_activation = os.environ.get("MLP_ACTIVATION", "relu2").lower()
+    # Orthogonal weight initialization for all non-zero-init Linear layers.
+    ortho_init = bool(int(os.environ.get("ORTHO_INIT", "0")))
+
+# -----------------------------
+# MUON OPTIMIZER 
+# -----------------------------
+# 
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, wd: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, wd=wd),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            wd = group.get("wd", 0.0)
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                if wd > 0.0:
+                    p.data.mul_(1.0 - lr * wd)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING 
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str, shard_order_file: str = ""):
+        if shard_order_file and Path(shard_order_file).exists():
+            lines = Path(shard_order_file).read_text(encoding="utf-8").splitlines()
+            self.files = [Path(p.strip()) for p in lines if p.strip()]
+        else:
+            self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device, shard_order_file: str = ""):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern, shard_order_file=shard_order_file)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, self.weight.to(x.dtype), bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        predicate_k: int,       # unused in LTLf mode, kept for API compat
+        attention_as_ltl: bool,
+        head_formulas: str,
+        head_alpha_idxs: str,   # unused in LTLf mode, kept for API compat
+        head_beta_idxs: str,    # unused in LTLf mode, kept for API compat
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.attention_as_ltl = attention_as_ltl
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+
+        if not attention_as_ltl:
+            # ── Baseline: standard GQA + RoPE + flash attention ──────────── #
+            kv_dim = self.num_kv_heads * self.head_dim
+            self.c_q = CastedLinear(dim, dim, bias=False)
+            self.c_k = CastedLinear(dim, kv_dim, bias=False)
+            self.c_v = CastedLinear(dim, kv_dim, bias=False)
+            self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+            self.rotary = Rotary(self.head_dim, base=rope_base)
+            return
+
+        # ── Pure LTLf attention ──────────────────────────────────────────── #
+        # Each head IS a temporal operator — the formula defines the attention
+        # weight pattern exactly; V is the content being temporally aggregated.
+        #
+        #   F (Eventually):  w[t,u] = softmax_u( q_F · k[u] / √d )
+        #                    Fixed per-head query vector; content-based spike.
+        #   G (Globally):    w[t,u] = 1 / (t+1)
+        #                    Uniform causal average; zero extra params.
+        #   Y (Yesterday):   w[t,u] = δ(u = t-1)
+        #                    Hard copy of the previous token; zero extra params.
+        #   S (Since):       w[t,u] ∝ σ( κ · (q_S · k[u] − τ) )  for u ≤ t
+        #                    Sigmoid-gated window anchored by boundary detection.
+        #
+        # No predicates, no KV grouping, no separate bias scale.
+        # G and Y are computed in O(T) via cumsum / shift — no T×T matrix.
+
+        def _parse_formulas(s: str) -> list[str]:
+            s = s.strip() or "FGYS"
+            toks = [t.strip().upper() for t in s.split(",")] if "," in s else [c.upper() for c in s if c.strip()]
+            return toks or ["F", "G", "Y", "S"]
+
+        formula_toks = _parse_formulas(head_formulas)
+        code_map = {"F": 0, "G": 1, "Y": 2, "S": 3}
+        formula_codes: list[int] = []
+        for h in range(num_heads):
+            t = formula_toks[h % len(formula_toks)]
+            if t not in code_map:
+                raise ValueError(f"Unknown formula '{t}'. Use F, G, Y, S.")
+            formula_codes.append(code_map[t])
+
+        self.has_F: bool = any(c == 0 for c in formula_codes)
+        self.has_G: bool = any(c == 1 for c in formula_codes)
+        self.has_Y: bool = any(c == 2 for c in formula_codes)
+        self.has_S: bool = any(c == 3 for c in formula_codes)
+
+        # Head-index buffers — fixed shape, safe for torch.compile.
+        F_list = [h for h, c in enumerate(formula_codes) if c == 0]
+        G_list = [h for h, c in enumerate(formula_codes) if c == 1]
+        Y_list = [h for h, c in enumerate(formula_codes) if c == 2]
+        S_list = [h for h, c in enumerate(formula_codes) if c == 3]
+        if self.has_F:
+            self.register_buffer("F_idx", torch.tensor(F_list, dtype=torch.long), persistent=False)
+        if self.has_G:
+            self.register_buffer("G_idx", torch.tensor(G_list, dtype=torch.long), persistent=False)
+        if self.has_Y:
+            self.register_buffer("Y_idx", torch.tensor(Y_list, dtype=torch.long), persistent=False)
+        if self.has_S:
+            self.register_buffer("S_idx", torch.tensor(S_list, dtype=torch.long), persistent=False)
+
+        n_F, n_S = len(F_list), len(S_list)
+
+        # Shared V projection for all H heads (full model_dim).
+        self.c_v_ltl = CastedLinear(dim, num_heads * self.head_dim, bias=False)
+
+        # F heads: token-dependent query + content keys → standard causal softmax attention.
+        # The formula constraint is the dedicated key projection (separate from other heads).
+        # "Eventually": attend softly to whichever past position is most relevant NOW.
+        if self.has_F:
+            self.c_q_F = CastedLinear(dim, n_F * self.head_dim, bias=False)
+            self.c_k_F = CastedLinear(dim, n_F * self.head_dim, bias=False)
+
+        # S heads: token-dependent query + boundary keys → sigmoid-gated window.
+        # "Since": attend uniformly to positions since the last detected boundary event.
+        if self.has_S:
+            self.c_q_S = CastedLinear(dim, n_S * self.head_dim, bias=False)
+            self.c_k_S = CastedLinear(dim, n_S * self.head_dim, bias=False)
+            self.s_tau   = nn.Parameter(torch.zeros(n_S, dtype=torch.float32))
+            self.s_kappa = nn.Parameter(torch.ones(n_S,  dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+
+        if not self.attention_as_ltl:
+            # ── Baseline: flash attention via SDPA ───────────────────────── #
+            q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+            k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+            v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+            q = F.rms_norm(q, (q.size(-1),))
+            k = F.rms_norm(k, (k.size(-1),))
+            cos, sin = self.rotary(seqlen, x.device, q.dtype)
+            q = apply_rotary_emb(q, cos, sin)
+            k = apply_rotary_emb(k, cos, sin)
+            q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+            if self.num_kv_heads != self.num_heads:
+                group = self.num_heads // self.num_kv_heads
+                k = k.repeat_interleave(group, dim=1)
+                v = v.repeat_interleave(group, dim=1)
+            y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True)
+            y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+            return self.proj(y)
+
+        # ── Pure LTLf path ──────────────────────────────────────────────── #
+        device = x.device
+        scale  = self.head_dim ** -0.5
+
+        # Shared V for all H heads; RMS-normed for stable aggregation.
+        v = self.c_v_ltl(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        v = F.rms_norm(v, (v.size(-1),))                               # (B, H, T, d)
+
+        y_out = torch.zeros_like(v)                                    # (B, H, T, d)
+
+        # ── G: uniform causal mean — O(T), no T×T matrix ────────────────── #
+        if self.has_G:
+            v_G     = v[:, self.G_idx]                                 # (B, n_G, T, d)
+            cs_G    = v_G.cumsum(dim=2)                                # (B, n_G, T, d)
+            counts  = torch.arange(1, seqlen + 1, device=device, dtype=v.dtype)
+            y_out[:, self.G_idx] = cs_G / counts[None, None, :, None]
+
+        # ── Y: previous-token copy — O(T), no T×T matrix ─────────────────── #
+        if self.has_Y:
+            v_Y              = v[:, self.Y_idx]                        # (B, n_Y, T, d)
+            y_Y              = v_Y.new_zeros(v_Y.shape)
+            y_Y[:, :, 1:]   = v_Y[:, :, :-1]                         # shift right by 1
+            y_out[:, self.Y_idx] = y_Y
+
+        # ── Shared causal bias for F / S ─────────────────────────────────── #
+        if self.has_F or self.has_S:
+            # causal_bias[t, u] = 0 if u ≤ t, −1e9 if u > t
+            causal_bias = torch.zeros(seqlen, seqlen, device=device, dtype=v.dtype)
+            causal_bias = causal_bias.masked_fill(
+                torch.ones(seqlen, seqlen, device=device, dtype=torch.bool).triu(1), -1e9
+            )                                                          # (T, T)
+
+        # ── F: Eventually — token-dependent QK softmax attention ────────── #
+        if self.has_F:
+            q_F = self.c_q_F(x).reshape(bsz, seqlen, -1, self.head_dim).transpose(1, 2)
+            k_F = self.c_k_F(x).reshape(bsz, seqlen, -1, self.head_dim).transpose(1, 2)
+            q_F = F.rms_norm(q_F, (q_F.size(-1),))                    # (B, n_F, T, d)
+            k_F = F.rms_norm(k_F, (k_F.size(-1),))                    # (B, n_F, T, d)
+            logits_F = torch.matmul(q_F, k_F.transpose(-2, -1)) * scale  # (B, n_F, T, T)
+            logits_F = logits_F + causal_bias[None, None]
+            w_F      = torch.softmax(logits_F.float(), dim=-1).to(v.dtype)
+            y_out[:, self.F_idx] = torch.matmul(w_F, v[:, self.F_idx])
+
+        # ── S: Since — token-dependent boundary gate, normalized window ───── #
+        if self.has_S:
+            q_S = self.c_q_S(x).reshape(bsz, seqlen, -1, self.head_dim).transpose(1, 2)
+            k_S = self.c_k_S(x).reshape(bsz, seqlen, -1, self.head_dim).transpose(1, 2)
+            q_S = F.rms_norm(q_S, (q_S.size(-1),))                    # (B, n_S, T, d)
+            k_S = F.rms_norm(k_S, (k_S.size(-1),))                    # (B, n_S, T, d)
+            # score[b, h, t, u] = q_S[t] · k_S[u] — boundary relevance
+            score_S = torch.matmul(q_S, k_S.transpose(-2, -1)) * scale   # (B, n_S, T, T)
+            kappa   = F.softplus(self.s_kappa) + 1e-3                  # (n_S,)
+            tau     = self.s_tau.to(v.dtype)                           # (n_S,)
+            gate    = torch.sigmoid(
+                kappa[None, :, None, None] * score_S - tau[None, :, None, None]
+            )                                                          # (B, n_S, T, T)
+            # Apply causal mask: zero out future positions
+            causal_mask = (causal_bias == 0).to(v.dtype)               # (T, T) — 1 if u ≤ t
+            gate_causal = gate * causal_mask[None, None]
+            w_S  = gate_causal / (gate_causal.sum(dim=-1, keepdim=True) + 1e-9)
+            y_out[:, self.S_idx] = torch.matmul(w_S, v[:, self.S_idx])
+
+        y = y_out.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int, activation: str = "relu2"):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.activation = activation
+        # SwiGLU doubles the fc width since the output is split gate+up before projection.
+        fc_out = hidden * 2 if activation == "swiglu" else hidden
+        self.fc = CastedLinear(dim, fc_out, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        if self.activation == "swiglu":
+            gate, up = self.fc(x).chunk(2, dim=-1)
+            return self.proj(F.silu(gate) * up)
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        predicate_k: int,
+        attention_as_ltl: bool,
+        head_formulas: str,
+        head_alpha_idxs: str,
+        head_beta_idxs: str,
+        mlp_activation: str = "relu2",
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim,
+            num_heads,
+            num_kv_heads,
+            rope_base,
+            qk_gain_init,
+            predicate_k=predicate_k,
+            attention_as_ltl=attention_as_ltl,
+            head_formulas=head_formulas,
+            head_alpha_idxs=head_alpha_idxs,
+            head_beta_idxs=head_beta_idxs,
+        )
+        self.mlp = MLP(dim, mlp_mult, activation=mlp_activation)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        predicate_k: int,
+        attention_as_ltl: bool,
+        g_aux_lambda: float,
+        head_formulas: str,
+        head_alpha_idxs: str,
+        head_beta_idxs: str,
+        loop_blocks: int = 0,
+        loop_iters: int = 1,
+        embed_bits: int = 16,
+        ortho_init: bool = False,
+        loss_pos_warmup: int = 0,
+        mlp_activation: str = "relu2",
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.attention_as_ltl = attention_as_ltl
+        self.g_aux_lambda = g_aux_lambda
+        self.loop_blocks = loop_blocks
+        self.loop_iters  = loop_iters
+        self.embed_bits = embed_bits
+        self.ortho_init = ortho_init
+        self.loss_pos_warmup = loss_pos_warmup
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        # token_weights buffer: all-ones by default; replaced in main() for TFW experiments.
+        # persistent=False so it is never saved to the state dict.
+        self.register_buffer("token_weights", torch.ones(vocab_size, dtype=torch.float32), persistent=False)
+
+        def _make_block() -> Block:
+            return Block(
+                model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init,
+                predicate_k=predicate_k, attention_as_ltl=attention_as_ltl,
+                head_formulas=head_formulas, head_alpha_idxs=head_alpha_idxs,
+                head_beta_idxs=head_beta_idxs, mlp_activation=mlp_activation,
+            )
+
+        self.blocks = nn.ModuleList([_make_block() for _ in range(num_layers)])
+
+        if loop_blocks > 0:
+            # Looped path: num_layers standard blocks split into prefix / suffix,
+            # with loop_blocks weight-tied blocks repeated loop_iters times in between.
+            # skip_weights are not used in this path (no U-Net).
+            self.num_prefix = num_layers // 2
+            self.loop_block_list = nn.ModuleList([_make_block() for _ in range(loop_blocks)])
+        else:
+            # Original U-Net path with skip connections.
+            self.num_encoder_layers = num_layers // 2
+            self.num_decoder_layers = num_layers - self.num_encoder_layers
+            self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+            self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+        if self.ortho_init:
+            for module in self.modules():
+                if isinstance(module, nn.Linear) and not getattr(module, "_zero_init", False):
+                    nn.init.orthogonal_(module.weight)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        bsz, seqlen = input_ids.shape
+        if self.embed_bits < 16:
+            # INT-N fake-quant with straight-through estimator (STE).
+            w = self.tok_emb.weight.float()
+            qmax = 2 ** (self.embed_bits - 1) - 1
+            scale = w.abs().max() / qmax
+            w_q = (w / scale).round().clamp(-qmax - 1, qmax) * scale
+            # STE: use quantized values in forward, true gradients in backward.
+            w_ste = self.tok_emb.weight + (w_q.to(self.tok_emb.weight.dtype) - self.tok_emb.weight).detach()
+            x = F.embedding(input_ids, w_ste)
+        else:
+            x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+
+        if self.loop_blocks > 0:
+            # ── Looped path ──────────────────────────────────────────────── #
+            # prefix standard blocks
+            for i in range(self.num_prefix):
+                x = self.blocks[i](x, x0)
+            # weight-tied core, repeated loop_iters times
+            for _ in range(self.loop_iters):
+                for block in self.loop_block_list:
+                    x = block(x, x0)
+            # suffix standard blocks
+            for i in range(self.num_prefix, len(self.blocks)):
+                x = self.blocks[i](x, x0)
+        else:
+            # ── Original U-Net path ───────────────────────────────────────── #
+            skips: list[Tensor] = []
+            for i in range(self.num_encoder_layers):
+                x = self.blocks[i](x, x0)
+                skips.append(x)
+            for i in range(self.num_decoder_layers):
+                if skips:
+                    x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+                x = self.blocks[self.num_encoder_layers + i](x, x0)
+
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+        # Per-token loss weighting: token-frequency weights (TFW) and/or position ramp.
+        ce = F.cross_entropy(logits.float(), targets, reduction="none")       # (B*T,)
+        tw = self.token_weights[targets].to(dtype=ce.dtype)                   # (B*T,)
+        tw = tw / (tw.mean() + 1e-9)
+        if self.loss_pos_warmup > 0:
+            pos = torch.arange(seqlen, device=ce.device, dtype=ce.dtype).repeat(bsz)
+            tw = tw * (pos / self.loss_pos_warmup).clamp(0.0, 1.0)
+        ce_loss = (ce * tw).sum() / (tw.sum() + 1e-9)
+
+        return ce_loss
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    if not args.disable_torch_compile:
+        zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        predicate_k=args.predicate_k,
+        attention_as_ltl=args.attention_as_ltl,
+        g_aux_lambda=args.g_aux_lambda,
+        head_formulas=args.head_formulas,
+        head_alpha_idxs=args.head_alpha_idxs,
+        head_beta_idxs=args.head_beta_idxs,
+        loop_blocks=args.loop_blocks,
+        loop_iters=args.loop_iters,
+        embed_bits=args.embed_bits,
+        ortho_init=args.ortho_init,
+        loss_pos_warmup=args.loss_pos_warmup,
+        mlp_activation=args.mlp_activation,
+    ).to(device).bfloat16()
+    # TFW: load pre-computed inverse-frequency weights and register as float32 buffer.
+    if args.tfw_weight_file and Path(args.tfw_weight_file).exists():
+        tfw_np = np.load(args.tfw_weight_file).astype(np.float32)
+        base_model.token_weights.data = torch.from_numpy(tfw_np).to(device)
+        log0(f"tfw:loaded {args.tfw_weight_file} alpha={args.tfw_alpha}")
+    else:
+        # Keep all-ones (neutral weighting); ensure float32 after bfloat16() cast.
+        base_model.token_weights.data = base_model.token_weights.data.float()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    if args.disable_torch_compile:
+        compiled_model = base_model
+    else:
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model: nn.Module = (
+        DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False, find_unused_parameters=False)
+        if distributed else compiled_model
+    )
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    if base_model.loop_blocks > 0:
+        block_named_params += list(base_model.loop_block_list.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if hasattr(base_model, 'skip_weights') and base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=args.adam_fused,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        wd=args.muon_wd,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=args.adam_fused,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=args.adam_fused,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    n_unique = sum(p.numel() for p in set(base_model.parameters()))
+    log0(f"model_params:{n_params} unique_params:{n_unique}")
+    if args.loop_blocks > 0:
+        log0(f"loop_mode:blocks={args.loop_blocks} iters={args.loop_iters} prefix={base_model.num_prefix} suffix={len(base_model.blocks)-base_model.num_prefix}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+    log0(
+        f"mlp_activation:{args.mlp_activation} embed_bits:{args.embed_bits} "
+        f"ortho_init:{args.ortho_init} loss_pos_warmup:{args.loss_pos_warmup} "
+        f"muon_wd:{args.muon_wd} tfw:{bool(args.tfw_weight_file)} "
+        f"shard_order:{bool(args.shard_order_file)}"
+    )
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device, shard_order_file=args.shard_order_file)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device, shard_order_file=args.shard_order_file)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed int8+zlib artifact and validate the round-tripped weights.
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
+Running Python 3.11.10 (main, Sep  7 2024, 18:35:41) [GCC 11.4.0]
+Running PyTorch 2.4.1+cu124
+Mon Mar 23 20:24:23 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 565.57.01              Driver Version: 565.57.01      CUDA Version: 12.7     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   40C    P0            151W /  700W |   28461MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   35C    P0            153W /  700W |   28557MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   32C    P0            143W /  700W |   28553MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   36C    P0            136W /  700W |   28553MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   37C    P0            153W /  700W |   28557MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   32C    P0            150W /  700W |   28739MiB /  81559MiB |      3%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   36C    P0            152W /  700W |   28557MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   31C    P0            146W /  700W |   28259MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:35
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:21512256 unique_params:21512256
+loop_mode:blocks=2 iters=3 prefix=3 suffix=3
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:8
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:524288 train_seq_len:2048 iterations:100000 warmup_steps:200 max_wallclock_seconds:590.000
+seed:1337
+mlp_activation:relu2 embed_bits:8 ortho_init:False loss_pos_warmup:256 muon_wd:0.04 tfw:False shard_order:False
+warmup_step:10/200
+warmup_step:20/200
+warmup_step:30/200
+warmup_step:40/200
+warmup_step:50/200
+warmup_step:60/200
+warmup_step:70/200
+warmup_step:80/200
+warmup_step:90/200
+warmup_step:100/200
+warmup_step:110/200
+warmup_step:120/200
+warmup_step:130/200
+warmup_step:140/200
+warmup_step:150/200
+warmup_step:160/200
+warmup_step:170/200
+warmup_step:180/200
+warmup_step:190/200
+warmup_step:200/200
+step:1/100000 train_loss:6.9365 train_time:45ms step_avg:44.58ms
+step:2/100000 train_loss:15.9118 train_time:190ms step_avg:94.88ms
+step:3/100000 train_loss:7.4120 train_time:378ms step_avg:126.06ms
+step:4/100000 train_loss:7.2689 train_time:563ms step_avg:140.75ms
+step:5/100000 train_loss:7.4024 train_time:714ms step_avg:142.82ms
+step:6/100000 train_loss:7.6729 train_time:918ms step_avg:152.99ms
+step:7/100000 train_loss:6.5562 train_time:1127ms step_avg:161.04ms
+step:8/100000 train_loss:6.2923 train_time:1271ms step_avg:158.82ms
+step:9/100000 train_loss:6.1215 train_time:1487ms step_avg:165.23ms
+step:10/100000 train_loss:5.9962 train_time:1627ms step_avg:162.74ms
+step:200/100000 train_loss:2.7780 train_time:17603ms step_avg:88.02ms
+warmup_step:10/200
+warmup_step:20/200
+warmup_step:30/200
+warmup_step:40/200
+step:400/100000 train_loss:2.2659 train_time:40286ms step_avg:100.71ms
+warmup_step:50/200
+warmup_step:60/200
+warmup_step:70/200
+warmup_step:80/200
+warmup_step:90/200
+warmup_step:100/200
+warmup_step:110/200
+warmup_step:120/200
+warmup_step:130/200
+warmup_step:140/200
+warmup_step:150/200
+warmup_step:160/200
+warmup_step:170/200
+warmup_step:180/200
+warmup_step:190/200
+warmup_step:200/200
+step:1/100000 train_loss:6.9365 train_time:94ms step_avg:93.65ms
+step:2/100000 train_loss:15.9120 train_time:354ms step_avg:176.77ms
+step:3/100000 train_loss:8.3523 train_time:647ms step_avg:215.62ms
+step:4/100000 train_loss:6.7453 train_time:964ms step_avg:241.02ms
+step:5/100000 train_loss:6.7086 train_time:1373ms step_avg:274.61ms
+step:6/100000 train_loss:7.3297 train_time:1761ms step_avg:293.55ms
+step:7/100000 train_loss:6.5433 train_time:2129ms step_avg:304.14ms
+step:8/100000 train_loss:6.2623 train_time:2544ms step_avg:317.96ms
+step:9/100000 train_loss:6.0928 train_time:2863ms step_avg:318.11ms
+step:10/100000 train_loss:5.9688 train_time:3236ms step_avg:323.59ms
+step:600/100000 train_loss:2.4700 train_time:82492ms step_avg:137.49ms
+step:200/100000 train_loss:2.7574 train_time:36999ms step_avg:184.99ms
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: To keep readable for newcomers, let's make sure `train_gpt.py` and `train_gpt_mlx.py` never are longer than 1500 lines.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    # Attention-as-LtL (paper: "Attention as Temporal Aggregation")
+    attention_as_ltl = bool(int(os.environ.get("ATTENTION_AS_LTL", "0")))
+    predicate_k = int(os.environ.get("PREDICATE_K", 64))
+    head_formulas = os.environ.get("HEAD_FORMULAS", "FGYS")
+    head_alpha_idxs = os.environ.get("HEAD_ALPHA_IDXS", "")
+    head_beta_idxs = os.environ.get("HEAD_BETA_IDXS", "")
+    # Paper suggests adding an auxiliary term lambda/beta to encourage larger beta.
+    # Applied only during training (not validation) when ATTENTION_AS_LTL=1.
+    g_aux_lambda = float(os.environ.get("G_AUX_LAMBDA", "0.01"))
+    # Debugging / fragile environments: set TRAIN_GPT_DISABLE_COMPILE=1 to skip torch.compile.
+    disable_torch_compile = bool(int(os.environ.get("TRAIN_GPT_DISABLE_COMPILE", "0")))
+    # Some CUDA builds error on fused Adam; set TRAIN_GPT_ADAM_FUSED=0 if you see optimizer errors.
+    adam_fused = bool(int(os.environ.get("TRAIN_GPT_ADAM_FUSED", "1")))
+    mlp_mult = int(os.environ.get("MLP_MULT", 2))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    # Looped transformer: weight-tied recurrence decouples depth from param count.
+    # LOOP_BLOCKS weight-tied blocks are repeated LOOP_ITERS times between the
+    # prefix and suffix standard blocks.  Set LOOP_BLOCKS=0 to disable (default).
+    loop_blocks = int(os.environ.get("LOOP_BLOCKS", "0"))
+    loop_iters  = int(os.environ.get("LOOP_ITERS",  "1"))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+    muon_wd = float(os.environ.get("MUON_WD", "0.0"))
+
+    # Curriculum / data ordering: path to a text file with one shard path per line.
+    shard_order_file = os.environ.get("SHARD_ORDER_FILE", "")
+    # Token-frequency weighted loss: path to .npy file with per-token weights (shape: vocab_size).
+    tfw_weight_file = os.environ.get("TFW_WEIGHT_FILE", "")
+    tfw_alpha = float(os.environ.get("TFW_ALPHA", "0.5"))
+    # Sequence-position weighted loss: ramp loss from 0→1 over the first N positions.
+    loss_pos_warmup = int(os.environ.get("LOSS_POS_WARMUP", "0"))
+    # Embedding fake-quantization bits (16 = default bf16, 8 = INT8 STE fake-quant).
+    embed_bits = int(os.environ.get("EMBED_BITS", "16"))
+    # MLP activation: "relu2" (default relu²) or "swiglu".
+    mlp_activation = os.environ.get("MLP_ACTIVATION", "relu2").lower()
+    # Orthogonal weight initialization for all non-zero-init Linear layers.
+    ortho_init = bool(int(os.environ.get("ORTHO_INIT", "0")))
+
+# -----------------------------
+# MUON OPTIMIZER 
+# -----------------------------
+# 
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, wd: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, wd=wd),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            wd = group.get("wd", 0.0)
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                if wd > 0.0:
+                    p.data.mul_(1.0 - lr * wd)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING 
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str, shard_order_file: str = ""):
+        if shard_order_file and Path(shard_order_file).exists():
+            lines = Path(shard_order_file).read_text(encoding="utf-8").splitlines()
+            self.files = [Path(p.strip()) for p in lines if p.strip()]
+        else:
+            self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device, shard_order_file: str = ""):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern, shard_order_file=shard_order_file)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, self.weight.to(x.dtype), bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        predicate_k: int,       # unused in LTLf mode, kept for API compat
+        attention_as_ltl: bool,
+        head_formulas: str,
+        head_alpha_idxs: str,   # unused in LTLf mode, kept for API compat
+        head_beta_idxs: str,    # unused in LTLf mode, kept for API compat
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.attention_as_ltl = attention_as_ltl
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+
+        if not attention_as_ltl:
+            # ── Baseline: standard GQA + RoPE + flash attention ──────────── #
+            kv_dim = self.num_kv_heads * self.head_dim
+            self.c_q = CastedLinear(dim, dim, bias=False)
+            self.c_k = CastedLinear(dim, kv_dim, bias=False)
+            self.c_v = CastedLinear(dim, kv_dim, bias=False)
+            self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+            self.rotary = Rotary(self.head_dim, base=rope_base)
+            return
+
+        # ── Pure LTLf attention ──────────────────────────────────────────── #
+        # Each head IS a temporal operator — the formula defines the attention
+        # weight pattern exactly; V is the content being temporally aggregated.
+        #
+        #   F (Eventually):  w[t,u] = softmax_u( q_F · k[u] / √d )
+        #                    Fixed per-head query vector; content-based spike.
+        #   G (Globally):    w[t,u] = 1 / (t+1)
+        #                    Uniform causal average; zero extra params.
+        #   Y (Yesterday):   w[t,u] = δ(u = t-1)
+        #                    Hard copy of the previous token; zero extra params.
+        #   S (Since):       w[t,u] ∝ σ( κ · (q_S · k[u] − τ) )  for u ≤ t
+        #                    Sigmoid-gated window anchored by boundary detection.
+        #
+        # No predicates, no KV grouping, no separate bias scale.
+        # G and Y are computed in O(T) via cumsum / shift — no T×T matrix.
+
+        def _parse_formulas(s: str) -> list[str]:
+            s = s.strip() or "FGYS"
+            toks = [t.strip().upper() for t in s.split(",")] if "," in s else [c.upper() for c in s if c.strip()]
+            return toks or ["F", "G", "Y", "S"]
+
+        formula_toks = _parse_formulas(head_formulas)
+        code_map = {"F": 0, "G": 1, "Y": 2, "S": 3}
+        formula_codes: list[int] = []
+        for h in range(num_heads):
+            t = formula_toks[h % len(formula_toks)]
+            if t not in code_map:
+                raise ValueError(f"Unknown formula '{t}'. Use F, G, Y, S.")
+            formula_codes.append(code_map[t])
+
+        self.has_F: bool = any(c == 0 for c in formula_codes)
+        self.has_G: bool = any(c == 1 for c in formula_codes)
+        self.has_Y: bool = any(c == 2 for c in formula_codes)
+        self.has_S: bool = any(c == 3 for c in formula_codes)
+
+        # Head-index buffers — fixed shape, safe for torch.compile.
+        F_list = [h for h, c in enumerate(formula_codes) if c == 0]
+        G_list = [h for h, c in enumerate(formula_codes) if c == 1]
+        Y_list = [h for h, c in enumerate(formula_codes) if c == 2]
+        S_list = [h for h, c in enumerate(formula_codes) if c == 3]
+        if self.has_F:
+            self.register_buffer("F_idx", torch.tensor(F_list, dtype=torch.long), persistent=False)
+        if self.has_G:
+            self.register_buffer("G_idx", torch.tensor(G_list, dtype=torch.long), persistent=False)
+        if self.has_Y:
+            self.register_buffer("Y_idx", torch.tensor(Y_list, dtype=torch.long), persistent=False)
+        if self.has_S:
+            self.register_buffer("S_idx", torch.tensor(S_list, dtype=torch.long), persistent=False)
+
+        n_F, n_S = len(F_list), len(S_list)
+
+        # Shared V projection for all H heads (full model_dim).
+        self.c_v_ltl = CastedLinear(dim, num_heads * self.head_dim, bias=False)
+
+        # F heads: token-dependent query + content keys → standard causal softmax attention.
+        # The formula constraint is the dedicated key projection (separate from other heads).
+        # "Eventually": attend softly to whichever past position is most relevant NOW.
+        if self.has_F:
+            self.c_q_F = CastedLinear(dim, n_F * self.head_dim, bias=False)
+            self.c_k_F = CastedLinear(dim, n_F * self.head_dim, bias=False)
+
+        # S heads: token-dependent query + boundary keys → sigmoid-gated window.
+        # "Since": attend uniformly to positions since the last detected boundary event.
+        if self.has_S:
+            self.c_q_S = CastedLinear(dim, n_S * self.head_dim, bias=False)
+            self.c_k_S = CastedLinear(dim, n_S * self.head_dim, bias=False)
+            self.s_tau   = nn.Parameter(torch.zeros(n_S, dtype=torch.float32))
+            self.s_kappa = nn.Parameter(torch.ones(n_S,  dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+
+        if not self.attention_as_ltl:
+            # ── Baseline: flash attention via SDPA ───────────────────────── #
+            q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+            k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+            v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+            q = F.rms_norm(q, (q.size(-1),))
+            k = F.rms_norm(k, (k.size(-1),))
+            cos, sin = self.rotary(seqlen, x.device, q.dtype)
+            q = apply_rotary_emb(q, cos, sin)
+            k = apply_rotary_emb(k, cos, sin)
+            q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+            if self.num_kv_heads != self.num_heads:
+                group = self.num_heads // self.num_kv_heads
+                k = k.repeat_interleave(group, dim=1)
+                v = v.repeat_interleave(group, dim=1)
+            y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True)
+            y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+            return self.proj(y)
+
+        # ── Pure LTLf path ──────────────────────────────────────────────── #
+        device = x.device
+        scale  = self.head_dim ** -0.5
+
+        # Shared V for all H heads; RMS-normed for stable aggregation.
+        v = self.c_v_ltl(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        v = F.rms_norm(v, (v.size(-1),))                               # (B, H, T, d)
+
+        y_out = torch.zeros_like(v)                                    # (B, H, T, d)
+
+        # ── G: uniform causal mean — O(T), no T×T matrix ────────────────── #
+        if self.has_G:
+            v_G     = v[:, self.G_idx]                                 # (B, n_G, T, d)
+            cs_G    = v_G.cumsum(dim=2)                                # (B, n_G, T, d)
+            counts  = torch.arange(1, seqlen + 1, device=device, dtype=v.dtype)
+            y_out[:, self.G_idx] = cs_G / counts[None, None, :, None]
+
+        # ── Y: previous-token copy — O(T), no T×T matrix ─────────────────── #
+        if self.has_Y:
+            v_Y              = v[:, self.Y_idx]                        # (B, n_Y, T, d)
+            y_Y              = v_Y.new_zeros(v_Y.shape)
+            y_Y[:, :, 1:]   = v_Y[:, :, :-1]                         # shift right by 1
+            y_out[:, self.Y_idx] = y_Y
+
+        # ── Shared causal bias for F / S ─────────────────────────────────── #
+        if self.has_F or self.has_S:
+            # causal_bias[t, u] = 0 if u ≤ t, −1e9 if u > t
+            causal_bias = torch.zeros(seqlen, seqlen, device=device, dtype=v.dtype)
+            causal_bias = causal_bias.masked_fill(
+                torch.ones(seqlen, seqlen, device=device, dtype=torch.bool).triu(1), -1e9
+            )                                                          # (T, T)
+
+        # ── F: Eventually — token-dependent QK softmax attention ────────── #
+        if self.has_F:
+            q_F = self.c_q_F(x).reshape(bsz, seqlen, -1, self.head_dim).transpose(1, 2)
+            k_F = self.c_k_F(x).reshape(bsz, seqlen, -1, self.head_dim).transpose(1, 2)
+            q_F = F.rms_norm(q_F, (q_F.size(-1),))                    # (B, n_F, T, d)
+            k_F = F.rms_norm(k_F, (k_F.size(-1),))                    # (B, n_F, T, d)
+            logits_F = torch.matmul(q_F, k_F.transpose(-2, -1)) * scale  # (B, n_F, T, T)
+            logits_F = logits_F + causal_bias[None, None]
+            w_F      = torch.softmax(logits_F.float(), dim=-1).to(v.dtype)
+            y_out[:, self.F_idx] = torch.matmul(w_F, v[:, self.F_idx])
+
+        # ── S: Since — token-dependent boundary gate, normalized window ───── #
+        if self.has_S:
+            q_S = self.c_q_S(x).reshape(bsz, seqlen, -1, self.head_dim).transpose(1, 2)
+            k_S = self.c_k_S(x).reshape(bsz, seqlen, -1, self.head_dim).transpose(1, 2)
+            q_S = F.rms_norm(q_S, (q_S.size(-1),))                    # (B, n_S, T, d)
+            k_S = F.rms_norm(k_S, (k_S.size(-1),))                    # (B, n_S, T, d)
+            # score[b, h, t, u] = q_S[t] · k_S[u] — boundary relevance
+            score_S = torch.matmul(q_S, k_S.transpose(-2, -1)) * scale   # (B, n_S, T, T)
+            kappa   = F.softplus(self.s_kappa) + 1e-3                  # (n_S,)
+            tau     = self.s_tau.to(v.dtype)                           # (n_S,)
+            gate    = torch.sigmoid(
+                kappa[None, :, None, None] * score_S - tau[None, :, None, None]
+            )                                                          # (B, n_S, T, T)
+            # Apply causal mask: zero out future positions
+            causal_mask = (causal_bias == 0).to(v.dtype)               # (T, T) — 1 if u ≤ t
+            gate_causal = gate * causal_mask[None, None]
+            w_S  = gate_causal / (gate_causal.sum(dim=-1, keepdim=True) + 1e-9)
+            y_out[:, self.S_idx] = torch.matmul(w_S, v[:, self.S_idx])
+
+        y = y_out.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int, activation: str = "relu2"):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.activation = activation
+        # SwiGLU doubles the fc width since the output is split gate+up before projection.
+        fc_out = hidden * 2 if activation == "swiglu" else hidden
+        self.fc = CastedLinear(dim, fc_out, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        if self.activation == "swiglu":
+            gate, up = self.fc(x).chunk(2, dim=-1)
+            return self.proj(F.silu(gate) * up)
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        predicate_k: int,
+        attention_as_ltl: bool,
+        head_formulas: str,
+        head_alpha_idxs: str,
+        head_beta_idxs: str,
+        mlp_activation: str = "relu2",
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim,
+            num_heads,
+            num_kv_heads,
+            rope_base,
+            qk_gain_init,
+            predicate_k=predicate_k,
+            attention_as_ltl=attention_as_ltl,
+            head_formulas=head_formulas,
+            head_alpha_idxs=head_alpha_idxs,
+            head_beta_idxs=head_beta_idxs,
+        )
+        self.mlp = MLP(dim, mlp_mult, activation=mlp_activation)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        predicate_k: int,
+        attention_as_ltl: bool,
+        g_aux_lambda: float,
+        head_formulas: str,
+        head_alpha_idxs: str,
+        head_beta_idxs: str,
+        loop_blocks: int = 0,
+        loop_iters: int = 1,
+        embed_bits: int = 16,
+        ortho_init: bool = False,
+        loss_pos_warmup: int = 0,
+        mlp_activation: str = "relu2",
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.attention_as_ltl = attention_as_ltl
+        self.g_aux_lambda = g_aux_lambda
+        self.loop_blocks = loop_blocks
+        self.loop_iters  = loop_iters
+        self.embed_bits = embed_bits
+        self.ortho_init = ortho_init
+        self.loss_pos_warmup = loss_pos_warmup
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        # token_weights buffer: all-ones by default; replaced in main() for TFW experiments.
+        # persistent=False so it is never saved to the state dict.
+        self.register_buffer("token_weights", torch.ones(vocab_size, dtype=torch.float32), persistent=False)
+
+        def _make_block() -> Block:
+            return Block(
+                model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init,
+                predicate_k=predicate_k, attention_as_ltl=attention_as_ltl,
+                head_formulas=head_formulas, head_alpha_idxs=head_alpha_idxs,
+                head_beta_idxs=head_beta_idxs, mlp_activation=mlp_activation,
+            )
+
+        self.blocks = nn.ModuleList([_make_block() for _ in range(num_layers)])
+
+        if loop_blocks > 0:
+            # Looped path: num_layers standard blocks split into prefix / suffix,
+            # with loop_blocks weight-tied blocks repeated loop_iters times in between.
+            # skip_weights are not used in this path (no U-Net).
+            self.num_prefix = num_layers // 2
+            self.loop_block_list = nn.ModuleList([_make_block() for _ in range(loop_blocks)])
+        else:
+            # Original U-Net path with skip connections.
+            self.num_encoder_layers = num_layers // 2
+            self.num_decoder_layers = num_layers - self.num_encoder_layers
+            self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+            self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+        if self.ortho_init:
+            for module in self.modules():
+                if isinstance(module, nn.Linear) and not getattr(module, "_zero_init", False):
+                    nn.init.orthogonal_(module.weight)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        bsz, seqlen = input_ids.shape
+        if self.embed_bits < 16:
+            # INT-N fake-quant with straight-through estimator (STE).
+            w = self.tok_emb.weight.float()
+            qmax = 2 ** (self.embed_bits - 1) - 1
+            scale = w.abs().max() / qmax
+            w_q = (w / scale).round().clamp(-qmax - 1, qmax) * scale
+            # STE: use quantized values in forward, true gradients in backward.
+            w_ste = self.tok_emb.weight + (w_q.to(self.tok_emb.weight.dtype) - self.tok_emb.weight).detach()
+            x = F.embedding(input_ids, w_ste)
+        else:
+            x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+
+        if self.loop_blocks > 0:
+            # ── Looped path ──────────────────────────────────────────────── #
+            # prefix standard blocks
+            for i in range(self.num_prefix):
+                x = self.blocks[i](x, x0)
+            # weight-tied core, repeated loop_iters times
+            for _ in range(self.loop_iters):
+                for block in self.loop_block_list:
+                    x = block(x, x0)
+            # suffix standard blocks
+            for i in range(self.num_prefix, len(self.blocks)):
+                x = self.blocks[i](x, x0)
+        else:
+            # ── Original U-Net path ───────────────────────────────────────── #
+            skips: list[Tensor] = []
+            for i in range(self.num_encoder_layers):
+                x = self.blocks[i](x, x0)
+                skips.append(x)
+            for i in range(self.num_decoder_layers):
+                if skips:
+                    x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+                x = self.blocks[self.num_encoder_layers + i](x, x0)
+
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+        # Per-token loss weighting: token-frequency weights (TFW) and/or position ramp.
+        ce = F.cross_entropy(logits.float(), targets, reduction="none")       # (B*T,)
+        tw = self.token_weights[targets].to(dtype=ce.dtype)                   # (B*T,)
+        tw = tw / (tw.mean() + 1e-9)
+        if self.loss_pos_warmup > 0:
+            pos = torch.arange(seqlen, device=ce.device, dtype=ce.dtype).repeat(bsz)
+            tw = tw * (pos / self.loss_pos_warmup).clamp(0.0, 1.0)
+        ce_loss = (ce * tw).sum() / (tw.sum() + 1e-9)
+
+        return ce_loss
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    if not args.disable_torch_compile:
+        zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        predicate_k=args.predicate_k,
+        attention_as_ltl=args.attention_as_ltl,
+        g_aux_lambda=args.g_aux_lambda,
+        head_formulas=args.head_formulas,
+        head_alpha_idxs=args.head_alpha_idxs,
+        head_beta_idxs=args.head_beta_idxs,
+        loop_blocks=args.loop_blocks,
+        loop_iters=args.loop_iters,
+        embed_bits=args.embed_bits,
+        ortho_init=args.ortho_init,
+        loss_pos_warmup=args.loss_pos_warmup,
+        mlp_activation=args.mlp_activation,
+    ).to(device).bfloat16()
+    # TFW: load pre-computed inverse-frequency weights and register as float32 buffer.
+    if args.tfw_weight_file and Path(args.tfw_weight_file).exists():
+        tfw_np = np.load(args.tfw_weight_file).astype(np.float32)
+        base_model.token_weights.data = torch.from_numpy(tfw_np).to(device)
+        log0(f"tfw:loaded {args.tfw_weight_file} alpha={args.tfw_alpha}")
+    else:
+        # Keep all-ones (neutral weighting); ensure float32 after bfloat16() cast.
+        base_model.token_weights.data = base_model.token_weights.data.float()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    if args.disable_torch_compile:
+        compiled_model = base_model
+    else:
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model: nn.Module = (
+        DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False, find_unused_parameters=False)
+        if distributed else compiled_model
+    )
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    if base_model.loop_blocks > 0:
+        block_named_params += list(base_model.loop_block_list.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if hasattr(base_model, 'skip_weights') and base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=args.adam_fused,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        wd=args.muon_wd,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=args.adam_fused,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=args.adam_fused,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    n_unique = sum(p.numel() for p in set(base_model.parameters()))
+    log0(f"model_params:{n_params} unique_params:{n_unique}")
+    if args.loop_blocks > 0:
+        log0(f"loop_mode:blocks={args.loop_blocks} iters={args.loop_iters} prefix={base_model.num_prefix} suffix={len(base_model.blocks)-base_model.num_prefix}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+    log0(
+        f"mlp_activation:{args.mlp_activation} embed_bits:{args.embed_bits} "
+        f"ortho_init:{args.ortho_init} loss_pos_warmup:{args.loss_pos_warmup} "
+        f"muon_wd:{args.muon_wd} tfw:{bool(args.tfw_weight_file)} "
+        f"shard_order:{bool(args.shard_order_file)}"
+    )
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device, shard_order_file=args.shard_order_file)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device, shard_order_file=args.shard_order_file)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed int8+zlib artifact and validate the round-tripped weights.
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
+Running Python 3.11.10 (main, Sep  7 2024, 18:35:41) [GCC 11.4.0]
+Running PyTorch 2.4.1+cu124
+Mon Mar 23 20:31:42 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 565.57.01              Driver Version: 565.57.01      CUDA Version: 12.7     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   37C    P0            150W /  700W |    4334MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   33C    P0            151W /  700W |    4382MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   30C    P0            143W /  700W |    4382MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   33C    P0            131W /  700W |    4382MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   34C    P0            150W /  700W |    4382MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   31C    P0            148W /  700W |    4382MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   33C    P0            149W /  700W |    4382MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   29C    P0            143W /  700W |    4142MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:35
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:21512256 unique_params:21512256
+loop_mode:blocks=2 iters=3 prefix=3 suffix=3
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:8
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:524288 train_seq_len:2048 iterations:100000 warmup_steps:200 max_wallclock_seconds:590.000
+seed:1337
+mlp_activation:relu2 embed_bits:8 ortho_init:False loss_pos_warmup:256 muon_wd:0.04 tfw:False shard_order:False
+warmup_step:10/200
+warmup_step:20/200
+warmup_step:30/200
+warmup_step:40/200
+warmup_step:50/200
+warmup_step:60/200
+warmup_step:70/200
+warmup_step:80/200
+warmup_step:90/200
+warmup_step:100/200
+warmup_step:110/200
+warmup_step:120/200
+warmup_step:130/200
+warmup_step:140/200
+warmup_step:150/200
+warmup_step:160/200
+warmup_step:170/200
+warmup_step:180/200
+warmup_step:190/200
+warmup_step:200/200
+step:1/100000 train_loss:6.9365 train_time:43ms step_avg:43.05ms
+step:2/100000 train_loss:15.9118 train_time:335ms step_avg:167.59ms
+step:3/100000 train_loss:8.4327 train_time:524ms step_avg:174.54ms
+step:4/100000 train_loss:6.8451 train_time:700ms step_avg:175.03ms
+step:5/100000 train_loss:7.2486 train_time:875ms step_avg:174.95ms
+step:6/100000 train_loss:7.9886 train_time:1076ms step_avg:179.33ms
+step:7/100000 train_loss:6.9849 train_time:1298ms step_avg:185.40ms
+step:8/100000 train_loss:6.5462 train_time:1531ms step_avg:191.33ms
+step:9/100000 train_loss:6.2846 train_time:1750ms step_avg:194.43ms
+step:10/100000 train_loss:6.0731 train_time:1917ms step_avg:191.69ms
+step:200/100000 train_loss:2.7878 train_time:17635ms step_avg:88.18ms
+step:400/100000 train_loss:2.2788 train_time:34232ms step_avg:85.58ms
+step:600/100000 train_loss:2.4755 train_time:50735ms step_avg:84.56ms
+step:800/100000 train_loss:2.2100 train_time:69292ms step_avg:86.62ms
+step:1000/100000 train_loss:2.3091 train_time:87097ms step_avg:87.10ms
+step:1200/100000 train_loss:2.3283 train_time:106289ms step_avg:88.57ms
+step:1400/100000 train_loss:2.3565 train_time:124820ms step_avg:89.16ms
+step:1600/100000 train_loss:2.0100 train_time:143593ms step_avg:89.75ms
+step:1800/100000 train_loss:2.1371 train_time:163706ms step_avg:90.95ms
+step:2000/100000 train_loss:2.1869 train_time:183655ms step_avg:91.83ms
+step:2200/100000 train_loss:2.0014 train_time:204036ms step_avg:92.74ms
+step:2400/100000 train_loss:2.1368 train_time:223636ms step_avg:93.18ms
+step:2600/100000 train_loss:2.3606 train_time:244027ms step_avg:93.86ms
+step:2800/100000 train_loss:2.1783 train_time:263772ms step_avg:94.20ms
+step:3000/100000 train_loss:2.1636 train_time:283047ms step_avg:94.35ms
+step:3200/100000 train_loss:2.1336 train_time:303388ms step_avg:94.81ms
+step:3400/100000 train_loss:2.0940 train_time:323752ms step_avg:95.22ms
+step:3600/100000 train_loss:2.0314 train_time:343425ms step_avg:95.40ms
+step:3800/100000 train_loss:2.1356 train_time:362462ms step_avg:95.38ms
+step:4000/100000 train_loss:2.0982 train_time:380983ms step_avg:95.25ms
+step:4200/100000 train_loss:2.0813 train_time:403427ms step_avg:96.05ms
+step:4400/100000 train_loss:2.0092 train_time:422107ms step_avg:95.93ms
+step:4600/100000 train_loss:1.8737 train_time:440790ms step_avg:95.82ms
+step:4800/100000 train_loss:2.1527 train_time:459573ms step_avg:95.74ms
+step:5000/100000 train_loss:1.8933 train_time:478489ms step_avg:95.70ms
+step:5200/100000 train_loss:2.0457 train_time:498390ms step_avg:95.84ms
+step:5400/100000 train_loss:2.0525 train_time:517986ms step_avg:95.92ms
+step:5600/100000 train_loss:2.0301 train_time:537684ms step_avg:96.02ms
+step:5800/100000 train_loss:1.9735 train_time:556361ms step_avg:95.92ms
+step:6000/100000 train_loss:2.0553 train_time:576921ms step_avg:96.15ms
+step:6106/100000 val_loss:1.9726 val_bpb:1.1683 train_time:590080ms step_avg:96.64ms
+stopping_early: wallclock_cap train_time:590080ms step:6106/100000
+peak memory allocated: 19506 MiB reserved: 20444 MiB
+Serialized model: 85030455 bytes
+Code size: 66048 bytes
+Total submission size: 85096503 bytes
+Serialized model int8+zlib: 14837720 bytes (payload:21629184 raw_torch:21668846 payload_ratio:3.93x)
+Total submission size int8+zlib: 14903768 bytes
+final_int8_zlib_roundtrip val_loss:1.9840 val_bpb:1.1750 eval_time:2514ms
+final_int8_zlib_roundtrip_exact val_loss:1.98400220 val_bpb:1.17503786

--- a/records/track_10min_16mb/2026-03-23_repro_submit_2048_lr02/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-23_repro_submit_2048_lr02/train_gpt.py
@@ -1,0 +1,1438 @@
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: To keep readable for newcomers, let's make sure `train_gpt.py` and `train_gpt_mlx.py` never are longer than 1500 lines.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    # Attention-as-LtL (paper: "Attention as Temporal Aggregation")
+    attention_as_ltl = bool(int(os.environ.get("ATTENTION_AS_LTL", "0")))
+    predicate_k = int(os.environ.get("PREDICATE_K", 64))
+    head_formulas = os.environ.get("HEAD_FORMULAS", "FGYS")
+    head_alpha_idxs = os.environ.get("HEAD_ALPHA_IDXS", "")
+    head_beta_idxs = os.environ.get("HEAD_BETA_IDXS", "")
+    # Paper suggests adding an auxiliary term lambda/beta to encourage larger beta.
+    # Applied only during training (not validation) when ATTENTION_AS_LTL=1.
+    g_aux_lambda = float(os.environ.get("G_AUX_LAMBDA", "0.01"))
+    # Debugging / fragile environments: set TRAIN_GPT_DISABLE_COMPILE=1 to skip torch.compile.
+    disable_torch_compile = bool(int(os.environ.get("TRAIN_GPT_DISABLE_COMPILE", "0")))
+    # Some CUDA builds error on fused Adam; set TRAIN_GPT_ADAM_FUSED=0 if you see optimizer errors.
+    adam_fused = bool(int(os.environ.get("TRAIN_GPT_ADAM_FUSED", "1")))
+    mlp_mult = int(os.environ.get("MLP_MULT", 2))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    # Looped transformer: weight-tied recurrence decouples depth from param count.
+    # LOOP_BLOCKS weight-tied blocks are repeated LOOP_ITERS times between the
+    # prefix and suffix standard blocks.  Set LOOP_BLOCKS=0 to disable (default).
+    loop_blocks = int(os.environ.get("LOOP_BLOCKS", "0"))
+    loop_iters  = int(os.environ.get("LOOP_ITERS",  "1"))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+    muon_wd = float(os.environ.get("MUON_WD", "0.0"))
+
+    # Curriculum / data ordering: path to a text file with one shard path per line.
+    shard_order_file = os.environ.get("SHARD_ORDER_FILE", "")
+    # Token-frequency weighted loss: path to .npy file with per-token weights (shape: vocab_size).
+    tfw_weight_file = os.environ.get("TFW_WEIGHT_FILE", "")
+    tfw_alpha = float(os.environ.get("TFW_ALPHA", "0.5"))
+    # Sequence-position weighted loss: ramp loss from 0→1 over the first N positions.
+    loss_pos_warmup = int(os.environ.get("LOSS_POS_WARMUP", "0"))
+    # Embedding fake-quantization bits (16 = default bf16, 8 = INT8 STE fake-quant).
+    embed_bits = int(os.environ.get("EMBED_BITS", "16"))
+    # MLP activation: "relu2" (default relu²) or "swiglu".
+    mlp_activation = os.environ.get("MLP_ACTIVATION", "relu2").lower()
+    # Orthogonal weight initialization for all non-zero-init Linear layers.
+    ortho_init = bool(int(os.environ.get("ORTHO_INIT", "0")))
+
+# -----------------------------
+# MUON OPTIMIZER 
+# -----------------------------
+# 
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, wd: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, wd=wd),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            wd = group.get("wd", 0.0)
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                if wd > 0.0:
+                    p.data.mul_(1.0 - lr * wd)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING 
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str, shard_order_file: str = ""):
+        if shard_order_file and Path(shard_order_file).exists():
+            lines = Path(shard_order_file).read_text(encoding="utf-8").splitlines()
+            self.files = [Path(p.strip()) for p in lines if p.strip()]
+        else:
+            self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device, shard_order_file: str = ""):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern, shard_order_file=shard_order_file)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, self.weight.to(x.dtype), bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        predicate_k: int,       # unused in LTLf mode, kept for API compat
+        attention_as_ltl: bool,
+        head_formulas: str,
+        head_alpha_idxs: str,   # unused in LTLf mode, kept for API compat
+        head_beta_idxs: str,    # unused in LTLf mode, kept for API compat
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.attention_as_ltl = attention_as_ltl
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+
+        if not attention_as_ltl:
+            # ── Baseline: standard GQA + RoPE + flash attention ──────────── #
+            kv_dim = self.num_kv_heads * self.head_dim
+            self.c_q = CastedLinear(dim, dim, bias=False)
+            self.c_k = CastedLinear(dim, kv_dim, bias=False)
+            self.c_v = CastedLinear(dim, kv_dim, bias=False)
+            self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+            self.rotary = Rotary(self.head_dim, base=rope_base)
+            return
+
+        # ── Pure LTLf attention ──────────────────────────────────────────── #
+        # Each head IS a temporal operator — the formula defines the attention
+        # weight pattern exactly; V is the content being temporally aggregated.
+        #
+        #   F (Eventually):  w[t,u] = softmax_u( q_F · k[u] / √d )
+        #                    Fixed per-head query vector; content-based spike.
+        #   G (Globally):    w[t,u] = 1 / (t+1)
+        #                    Uniform causal average; zero extra params.
+        #   Y (Yesterday):   w[t,u] = δ(u = t-1)
+        #                    Hard copy of the previous token; zero extra params.
+        #   S (Since):       w[t,u] ∝ σ( κ · (q_S · k[u] − τ) )  for u ≤ t
+        #                    Sigmoid-gated window anchored by boundary detection.
+        #
+        # No predicates, no KV grouping, no separate bias scale.
+        # G and Y are computed in O(T) via cumsum / shift — no T×T matrix.
+
+        def _parse_formulas(s: str) -> list[str]:
+            s = s.strip() or "FGYS"
+            toks = [t.strip().upper() for t in s.split(",")] if "," in s else [c.upper() for c in s if c.strip()]
+            return toks or ["F", "G", "Y", "S"]
+
+        formula_toks = _parse_formulas(head_formulas)
+        code_map = {"F": 0, "G": 1, "Y": 2, "S": 3}
+        formula_codes: list[int] = []
+        for h in range(num_heads):
+            t = formula_toks[h % len(formula_toks)]
+            if t not in code_map:
+                raise ValueError(f"Unknown formula '{t}'. Use F, G, Y, S.")
+            formula_codes.append(code_map[t])
+
+        self.has_F: bool = any(c == 0 for c in formula_codes)
+        self.has_G: bool = any(c == 1 for c in formula_codes)
+        self.has_Y: bool = any(c == 2 for c in formula_codes)
+        self.has_S: bool = any(c == 3 for c in formula_codes)
+
+        # Head-index buffers — fixed shape, safe for torch.compile.
+        F_list = [h for h, c in enumerate(formula_codes) if c == 0]
+        G_list = [h for h, c in enumerate(formula_codes) if c == 1]
+        Y_list = [h for h, c in enumerate(formula_codes) if c == 2]
+        S_list = [h for h, c in enumerate(formula_codes) if c == 3]
+        if self.has_F:
+            self.register_buffer("F_idx", torch.tensor(F_list, dtype=torch.long), persistent=False)
+        if self.has_G:
+            self.register_buffer("G_idx", torch.tensor(G_list, dtype=torch.long), persistent=False)
+        if self.has_Y:
+            self.register_buffer("Y_idx", torch.tensor(Y_list, dtype=torch.long), persistent=False)
+        if self.has_S:
+            self.register_buffer("S_idx", torch.tensor(S_list, dtype=torch.long), persistent=False)
+
+        n_F, n_S = len(F_list), len(S_list)
+
+        # Shared V projection for all H heads (full model_dim).
+        self.c_v_ltl = CastedLinear(dim, num_heads * self.head_dim, bias=False)
+
+        # F heads: token-dependent query + content keys → standard causal softmax attention.
+        # The formula constraint is the dedicated key projection (separate from other heads).
+        # "Eventually": attend softly to whichever past position is most relevant NOW.
+        if self.has_F:
+            self.c_q_F = CastedLinear(dim, n_F * self.head_dim, bias=False)
+            self.c_k_F = CastedLinear(dim, n_F * self.head_dim, bias=False)
+
+        # S heads: token-dependent query + boundary keys → sigmoid-gated window.
+        # "Since": attend uniformly to positions since the last detected boundary event.
+        if self.has_S:
+            self.c_q_S = CastedLinear(dim, n_S * self.head_dim, bias=False)
+            self.c_k_S = CastedLinear(dim, n_S * self.head_dim, bias=False)
+            self.s_tau   = nn.Parameter(torch.zeros(n_S, dtype=torch.float32))
+            self.s_kappa = nn.Parameter(torch.ones(n_S,  dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+
+        if not self.attention_as_ltl:
+            # ── Baseline: flash attention via SDPA ───────────────────────── #
+            q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+            k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+            v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+            q = F.rms_norm(q, (q.size(-1),))
+            k = F.rms_norm(k, (k.size(-1),))
+            cos, sin = self.rotary(seqlen, x.device, q.dtype)
+            q = apply_rotary_emb(q, cos, sin)
+            k = apply_rotary_emb(k, cos, sin)
+            q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+            if self.num_kv_heads != self.num_heads:
+                group = self.num_heads // self.num_kv_heads
+                k = k.repeat_interleave(group, dim=1)
+                v = v.repeat_interleave(group, dim=1)
+            y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True)
+            y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+            return self.proj(y)
+
+        # ── Pure LTLf path ──────────────────────────────────────────────── #
+        device = x.device
+        scale  = self.head_dim ** -0.5
+
+        # Shared V for all H heads; RMS-normed for stable aggregation.
+        v = self.c_v_ltl(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        v = F.rms_norm(v, (v.size(-1),))                               # (B, H, T, d)
+
+        y_out = torch.zeros_like(v)                                    # (B, H, T, d)
+
+        # ── G: uniform causal mean — O(T), no T×T matrix ────────────────── #
+        if self.has_G:
+            v_G     = v[:, self.G_idx]                                 # (B, n_G, T, d)
+            cs_G    = v_G.cumsum(dim=2)                                # (B, n_G, T, d)
+            counts  = torch.arange(1, seqlen + 1, device=device, dtype=v.dtype)
+            y_out[:, self.G_idx] = cs_G / counts[None, None, :, None]
+
+        # ── Y: previous-token copy — O(T), no T×T matrix ─────────────────── #
+        if self.has_Y:
+            v_Y              = v[:, self.Y_idx]                        # (B, n_Y, T, d)
+            y_Y              = v_Y.new_zeros(v_Y.shape)
+            y_Y[:, :, 1:]   = v_Y[:, :, :-1]                         # shift right by 1
+            y_out[:, self.Y_idx] = y_Y
+
+        # ── Shared causal bias for F / S ─────────────────────────────────── #
+        if self.has_F or self.has_S:
+            # causal_bias[t, u] = 0 if u ≤ t, −1e9 if u > t
+            causal_bias = torch.zeros(seqlen, seqlen, device=device, dtype=v.dtype)
+            causal_bias = causal_bias.masked_fill(
+                torch.ones(seqlen, seqlen, device=device, dtype=torch.bool).triu(1), -1e9
+            )                                                          # (T, T)
+
+        # ── F: Eventually — token-dependent QK softmax attention ────────── #
+        if self.has_F:
+            q_F = self.c_q_F(x).reshape(bsz, seqlen, -1, self.head_dim).transpose(1, 2)
+            k_F = self.c_k_F(x).reshape(bsz, seqlen, -1, self.head_dim).transpose(1, 2)
+            q_F = F.rms_norm(q_F, (q_F.size(-1),))                    # (B, n_F, T, d)
+            k_F = F.rms_norm(k_F, (k_F.size(-1),))                    # (B, n_F, T, d)
+            logits_F = torch.matmul(q_F, k_F.transpose(-2, -1)) * scale  # (B, n_F, T, T)
+            logits_F = logits_F + causal_bias[None, None]
+            w_F      = torch.softmax(logits_F.float(), dim=-1).to(v.dtype)
+            y_out[:, self.F_idx] = torch.matmul(w_F, v[:, self.F_idx])
+
+        # ── S: Since — token-dependent boundary gate, normalized window ───── #
+        if self.has_S:
+            q_S = self.c_q_S(x).reshape(bsz, seqlen, -1, self.head_dim).transpose(1, 2)
+            k_S = self.c_k_S(x).reshape(bsz, seqlen, -1, self.head_dim).transpose(1, 2)
+            q_S = F.rms_norm(q_S, (q_S.size(-1),))                    # (B, n_S, T, d)
+            k_S = F.rms_norm(k_S, (k_S.size(-1),))                    # (B, n_S, T, d)
+            # score[b, h, t, u] = q_S[t] · k_S[u] — boundary relevance
+            score_S = torch.matmul(q_S, k_S.transpose(-2, -1)) * scale   # (B, n_S, T, T)
+            kappa   = F.softplus(self.s_kappa) + 1e-3                  # (n_S,)
+            tau     = self.s_tau.to(v.dtype)                           # (n_S,)
+            gate    = torch.sigmoid(
+                kappa[None, :, None, None] * score_S - tau[None, :, None, None]
+            )                                                          # (B, n_S, T, T)
+            # Apply causal mask: zero out future positions
+            causal_mask = (causal_bias == 0).to(v.dtype)               # (T, T) — 1 if u ≤ t
+            gate_causal = gate * causal_mask[None, None]
+            w_S  = gate_causal / (gate_causal.sum(dim=-1, keepdim=True) + 1e-9)
+            y_out[:, self.S_idx] = torch.matmul(w_S, v[:, self.S_idx])
+
+        y = y_out.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int, activation: str = "relu2"):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.activation = activation
+        # SwiGLU doubles the fc width since the output is split gate+up before projection.
+        fc_out = hidden * 2 if activation == "swiglu" else hidden
+        self.fc = CastedLinear(dim, fc_out, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        if self.activation == "swiglu":
+            gate, up = self.fc(x).chunk(2, dim=-1)
+            return self.proj(F.silu(gate) * up)
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        predicate_k: int,
+        attention_as_ltl: bool,
+        head_formulas: str,
+        head_alpha_idxs: str,
+        head_beta_idxs: str,
+        mlp_activation: str = "relu2",
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim,
+            num_heads,
+            num_kv_heads,
+            rope_base,
+            qk_gain_init,
+            predicate_k=predicate_k,
+            attention_as_ltl=attention_as_ltl,
+            head_formulas=head_formulas,
+            head_alpha_idxs=head_alpha_idxs,
+            head_beta_idxs=head_beta_idxs,
+        )
+        self.mlp = MLP(dim, mlp_mult, activation=mlp_activation)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        predicate_k: int,
+        attention_as_ltl: bool,
+        g_aux_lambda: float,
+        head_formulas: str,
+        head_alpha_idxs: str,
+        head_beta_idxs: str,
+        loop_blocks: int = 0,
+        loop_iters: int = 1,
+        embed_bits: int = 16,
+        ortho_init: bool = False,
+        loss_pos_warmup: int = 0,
+        mlp_activation: str = "relu2",
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.attention_as_ltl = attention_as_ltl
+        self.g_aux_lambda = g_aux_lambda
+        self.loop_blocks = loop_blocks
+        self.loop_iters  = loop_iters
+        self.embed_bits = embed_bits
+        self.ortho_init = ortho_init
+        self.loss_pos_warmup = loss_pos_warmup
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        # token_weights buffer: all-ones by default; replaced in main() for TFW experiments.
+        # persistent=False so it is never saved to the state dict.
+        self.register_buffer("token_weights", torch.ones(vocab_size, dtype=torch.float32), persistent=False)
+
+        def _make_block() -> Block:
+            return Block(
+                model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init,
+                predicate_k=predicate_k, attention_as_ltl=attention_as_ltl,
+                head_formulas=head_formulas, head_alpha_idxs=head_alpha_idxs,
+                head_beta_idxs=head_beta_idxs, mlp_activation=mlp_activation,
+            )
+
+        self.blocks = nn.ModuleList([_make_block() for _ in range(num_layers)])
+
+        if loop_blocks > 0:
+            # Looped path: num_layers standard blocks split into prefix / suffix,
+            # with loop_blocks weight-tied blocks repeated loop_iters times in between.
+            # skip_weights are not used in this path (no U-Net).
+            self.num_prefix = num_layers // 2
+            self.loop_block_list = nn.ModuleList([_make_block() for _ in range(loop_blocks)])
+        else:
+            # Original U-Net path with skip connections.
+            self.num_encoder_layers = num_layers // 2
+            self.num_decoder_layers = num_layers - self.num_encoder_layers
+            self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+            self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+        if self.ortho_init:
+            for module in self.modules():
+                if isinstance(module, nn.Linear) and not getattr(module, "_zero_init", False):
+                    nn.init.orthogonal_(module.weight)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        bsz, seqlen = input_ids.shape
+        if self.embed_bits < 16:
+            # INT-N fake-quant with straight-through estimator (STE).
+            w = self.tok_emb.weight.float()
+            qmax = 2 ** (self.embed_bits - 1) - 1
+            scale = w.abs().max() / qmax
+            w_q = (w / scale).round().clamp(-qmax - 1, qmax) * scale
+            # STE: use quantized values in forward, true gradients in backward.
+            w_ste = self.tok_emb.weight + (w_q.to(self.tok_emb.weight.dtype) - self.tok_emb.weight).detach()
+            x = F.embedding(input_ids, w_ste)
+        else:
+            x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+
+        if self.loop_blocks > 0:
+            # ── Looped path ──────────────────────────────────────────────── #
+            # prefix standard blocks
+            for i in range(self.num_prefix):
+                x = self.blocks[i](x, x0)
+            # weight-tied core, repeated loop_iters times
+            for _ in range(self.loop_iters):
+                for block in self.loop_block_list:
+                    x = block(x, x0)
+            # suffix standard blocks
+            for i in range(self.num_prefix, len(self.blocks)):
+                x = self.blocks[i](x, x0)
+        else:
+            # ── Original U-Net path ───────────────────────────────────────── #
+            skips: list[Tensor] = []
+            for i in range(self.num_encoder_layers):
+                x = self.blocks[i](x, x0)
+                skips.append(x)
+            for i in range(self.num_decoder_layers):
+                if skips:
+                    x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+                x = self.blocks[self.num_encoder_layers + i](x, x0)
+
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+        # Per-token loss weighting: token-frequency weights (TFW) and/or position ramp.
+        ce = F.cross_entropy(logits.float(), targets, reduction="none")       # (B*T,)
+        tw = self.token_weights[targets].to(dtype=ce.dtype)                   # (B*T,)
+        tw = tw / (tw.mean() + 1e-9)
+        if self.loss_pos_warmup > 0:
+            pos = torch.arange(seqlen, device=ce.device, dtype=ce.dtype).repeat(bsz)
+            tw = tw * (pos / self.loss_pos_warmup).clamp(0.0, 1.0)
+        ce_loss = (ce * tw).sum() / (tw.sum() + 1e-9)
+
+        return ce_loss
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    if not args.disable_torch_compile:
+        zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        predicate_k=args.predicate_k,
+        attention_as_ltl=args.attention_as_ltl,
+        g_aux_lambda=args.g_aux_lambda,
+        head_formulas=args.head_formulas,
+        head_alpha_idxs=args.head_alpha_idxs,
+        head_beta_idxs=args.head_beta_idxs,
+        loop_blocks=args.loop_blocks,
+        loop_iters=args.loop_iters,
+        embed_bits=args.embed_bits,
+        ortho_init=args.ortho_init,
+        loss_pos_warmup=args.loss_pos_warmup,
+        mlp_activation=args.mlp_activation,
+    ).to(device).bfloat16()
+    # TFW: load pre-computed inverse-frequency weights and register as float32 buffer.
+    if args.tfw_weight_file and Path(args.tfw_weight_file).exists():
+        tfw_np = np.load(args.tfw_weight_file).astype(np.float32)
+        base_model.token_weights.data = torch.from_numpy(tfw_np).to(device)
+        log0(f"tfw:loaded {args.tfw_weight_file} alpha={args.tfw_alpha}")
+    else:
+        # Keep all-ones (neutral weighting); ensure float32 after bfloat16() cast.
+        base_model.token_weights.data = base_model.token_weights.data.float()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    if args.disable_torch_compile:
+        compiled_model = base_model
+    else:
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model: nn.Module = (
+        DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False, find_unused_parameters=False)
+        if distributed else compiled_model
+    )
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    if base_model.loop_blocks > 0:
+        block_named_params += list(base_model.loop_block_list.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if hasattr(base_model, 'skip_weights') and base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=args.adam_fused,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        wd=args.muon_wd,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=args.adam_fused,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=args.adam_fused,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    n_unique = sum(p.numel() for p in set(base_model.parameters()))
+    log0(f"model_params:{n_params} unique_params:{n_unique}")
+    if args.loop_blocks > 0:
+        log0(f"loop_mode:blocks={args.loop_blocks} iters={args.loop_iters} prefix={base_model.num_prefix} suffix={len(base_model.blocks)-base_model.num_prefix}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+    log0(
+        f"mlp_activation:{args.mlp_activation} embed_bits:{args.embed_bits} "
+        f"ortho_init:{args.ortho_init} loss_pos_warmup:{args.loss_pos_warmup} "
+        f"muon_wd:{args.muon_wd} tfw:{bool(args.tfw_weight_file)} "
+        f"shard_order:{bool(args.shard_order_file)}"
+    )
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device, shard_order_file=args.shard_order_file)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device, shard_order_file=args.shard_order_file)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed int8+zlib artifact and validate the round-tripped weights.
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Small recursive language model.

looped RLM (skinny width, prefix + 2× weight-tied blocks × 3 iterations + suffix), seq 2048, Muon with MATRIX_LR=0.02 / SCALAR_LR=0.02, MUON_WD=0.04, EMBED_BITS=8 (STE), LOSS_POS_WARMUP=256, ReLU² MLP 3×, GQA, tied embeddings.