### PR TITLE
[Non-Record] Hymba: Hybrid Attention + Mamba SSM (val_bpb 1.1828)

### DIFF
--- a/records/track_10min_16mb/hymba/README.md
+++ b/records/track_10min_16mb/hymba/README.md
@@ -1,0 +1,75 @@
+# Hymba: Hybrid Attention + Mamba SSM for Parameter Golf
+
+**First competitive non-transformer architecture in the competition.**
+
+A 7-layer hybrid model that runs attention and Mamba SSM in parallel within each block, achieving **val_bpb ~1.18** on 8×H100 in 10 minutes — beating the naive transformer baseline (1.2244).
+
+## Architecture
+
+Each block runs two branches in parallel on the same input:
+
+1. **Attention branch**: Standard GQA (8 heads, 4 KV heads) with RoPE + SDPA
+2. **Mamba branch**: Selective scan SSM (`mamba-ssm`) with causal conv1d, gated projection
+
+Outputs are merged with a learned weighted average: `sigmoid(α) · attn + (1 - sigmoid(α)) · mamba`, then projected through a shared output layer.
+
+Key design: the input projection for K, V, and Mamba (x, gate) is fused into a single matmul for GPU efficiency. Q is projected separately to allow for future factorization.
+
+## Key Findings
+
+**Shallow models win at this compute budget.** The SSM branch makes each layer more powerful (attention for local precision, Mamba for long-range state), reducing the need for depth. Fewer layers = faster steps = more training in 10 minutes. The optimal depth (7L) is significantly shallower than the transformer baseline (9-11L).
+
+**Training stability determines quantization quality.** With standard LR (0.04), the int6 quantization gap was 0.02-0.06 BPB. Reducing to LR=0.02 with aggressive cosine warmdown (3000 steps) produced smoother, more quantization-friendly weights — shrinking the gap to 0.02 without QAT. The warmdown phase alone accounts for ~0.06 BPB improvement as EMA weights converge.
+
+**The Mamba branch adds minimal overhead on multi-GPU.** At 7 layers with MLP 4×, Hymba runs at ~85ms/step on 8×H100 (~7,000 steps in 10 min). The selective scan is O(T) and the per-layer Mamba params are small, so gradient sync overhead is negligible.
+
+## Configuration
+
+| Parameter | Value |
+|---|---|
+| Layers | 7 |
+| Model dim | 512 |
+| MLP multiplier | 4× |
+| Attention heads | 8 (4 KV) |
+| Mamba expand | 1 |
+| SSM state size | 8 |
+| Sequence length | 2048 |
+| Quantization | int6 + zstd-22 |
+| GPTQ-lite | Per-tensor clip search |
+| Optimizer | Muon (matrix), Adam (scalar/embed) |
+| Matrix LR | 0.02 |
+| Warmdown | 3000 steps, cosine |
+| EMA decay | 0.997 |
+| Eval | Sliding window, stride=64 |
+
+## Dependencies
+
+```
+pip install mamba-ssm causal-conv1d
+```
+
+## Running
+
+```bash
+SEED=1337 USE_HYMBA=1 HYMBA_EXPAND=1 HYMBA_SSM_STATE=8 \
+NUM_LAYERS=7 MLP_MULT=4 MODEL_DIM=512 NUM_HEADS=8 NUM_KV_HEADS=4 \
+MATRIX_LR=0.02 SCALAR_LR=0.02 TRAIN_SEQ_LEN=2048 \
+WARMDOWN_ITERS=3000 WARMDOWN_SHAPE=cosine \
+EVAL_STRIDE=64 QUANT_BITS=6 GPTQ_LITE=1 \
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+## Results
+
+| Metric | Value |
+|---|---|
+| val_bpb (mean, 3 seeds) | **1.1828 ± 0.0036** |
+| Seed 1337 | 1.1868 |
+| Seed 42 | 1.1818 |
+| Seed 7 | 1.1797 |
+| Naive transformer baseline | 1.2244 |
+| Artifact size | ~15.1 MB |
+| Training time | 600s (8×H100) |
+| Eval time | ~172s |
+| Parameters | 27.2M |
+| Training steps | ~7,050 |

--- a/records/track_10min_16mb/hymba/requirements.txt
+++ b/records/track_10min_16mb/hymba/requirements.txt
@@ -1,0 +1,2 @@
+mamba-ssm
+causal-conv1d

--- a/records/track_10min_16mb/hymba/submission.json
+++ b/records/track_10min_16mb/hymba/submission.json
@@ -1,0 +1,15 @@
+{
+    "name": "Hymba: Hybrid Attention + Mamba SSM",
+    "github_id": "mkenney2",
+    "val_bpb": 1.1828,
+    "description": "7L hybrid attention+Mamba SSM with fused projections, learned merge, int6+zstd-22, cosine warmdown, GPTQ-lite, sliding window eval. First competitive non-transformer architecture.",
+    "is_record": false,
+    "hardware": "8xH100",
+    "training_time_seconds": 600,
+    "eval_time_seconds": 172,
+    "artifact_bytes": 15179444,
+    "num_parameters": 27161151,
+    "num_layers": 7,
+    "model_dim": 512,
+    "architecture": "hymba"
+}

--- a/records/track_10min_16mb/hymba/train_gpt.py
+++ b/records/track_10min_16mb/hymba/train_gpt.py
@@ -1,0 +1,1477 @@
+"""Hymba: Hybrid Attention + Mamba SSM for Parameter Golf."""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+try:
+    import zstandard as zstd
+    HAS_ZSTD = True
+except ImportError:
+    HAS_ZSTD = False
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmdown_shape = os.environ.get("WARMDOWN_SHAPE", "cosine")  # "linear" or "cosine"
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Evaluation.
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))  # sliding window stride (0 = disabled)
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))  # batch size for sliding eval
+    # Test-Time Training (TTT): online adaptation on val data during scoring
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.002))
+    ttt_freeze_blocks = int(os.environ.get("TTT_FREEZE_BLOCKS", 0))  # freeze first N blocks during TTT
+    ttt_optimizer = os.environ.get("TTT_OPTIMIZER", "adamw")  # "sgd" or "adamw"
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 1))  # adaptation passes per chunk
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))  # SGD momentum
+
+    # Quantization.
+    fp16_embed = bool(int(os.environ.get("FP16_EMBED", "1")))  # keep embeddings in FP16
+    quant_bits = int(os.environ.get("QUANT_BITS", 6))  # quantization bit width for attention (6 or 8)
+    quant_bits_mlp = int(os.environ.get("QUANT_BITS_MLP", 0))  # MLP bit width (0 = same as quant_bits)
+    qat_start_frac = float(os.environ.get("QAT_START_FRAC", 0.0))  # QAT: start at this fraction of training (0 = disabled)
+    gptq_lite = bool(int(os.environ.get("GPTQ_LITE", "1")))  # search for optimal clip percentile per tensor
+    use_zstd = bool(int(os.environ.get("USE_ZSTD", "1")))  # use zstd instead of zlib
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 7))  # unique layers
+
+    # SmearGate + BigramHash.
+    use_smeargate = bool(int(os.environ.get("USE_SMEARGATE", "1")))
+    use_bigram_hash = bool(int(os.environ.get("USE_BIGRAM_HASH", "1")))
+    bigram_buckets = int(os.environ.get("BIGRAM_BUCKETS", 4096))
+    bigram_hash_dim = int(os.environ.get("BIGRAM_HASH_DIM", 128))
+
+    # OrthoInit + SWA.
+    use_ortho_init = bool(int(os.environ.get("USE_ORTHO_INIT", "1")))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.4))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 4))
+    hymba_expand = int(os.environ.get("HYMBA_EXPAND", 1))
+    hymba_conv_kernel = int(os.environ.get("HYMBA_CONV_KERNEL", 4))
+    hymba_dt_rank = int(os.environ.get("HYMBA_DT_RANK", 0))
+    hymba_ssm_state = int(os.environ.get("HYMBA_SSM_STATE", 8))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    weight_decay = float(os.environ.get("WEIGHT_DECAY", 0.02))
+    ema_enabled = bool(int(os.environ.get("EMA_ENABLED", "1")))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+
+# MUON OPTIMIZER
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, weight_decay=weight_decay),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            weight_decay = group.get("weight_decay", 0.0)
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                if weight_decay > 0:
+                    p.data.mul_(1.0 - lr * weight_decay)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# TOKENIZER + EVALUATION
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters, model: nn.Module, rank: int, world_size: int,
+    device: torch.device, grad_accum_steps: int, val_tokens: Tensor,
+    base_bytes_lut: Tensor, has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+def eval_val_sliding(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    """Sliding window evaluation: score each token with maximal left-context."""
+    seq_len = args.train_seq_len
+    stride = args.eval_stride
+    batch_size = args.eval_batch_seqs
+    total_tokens = val_tokens.numel() - 1
+
+    window_starts = [ws for ws in range(0, total_tokens - seq_len + 1, stride)]
+    if window_starts[-1] + seq_len < total_tokens:
+        window_starts.append(total_tokens - seq_len)
+
+    my_starts = window_starts[rank::world_size]
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    with torch.inference_mode():
+        for batch_start in range(0, len(my_starts), batch_size):
+            batch_ws = my_starts[batch_start:batch_start + batch_size]
+            bsz = len(batch_ws)
+
+            x_list, y_list = [], []
+            for ws in batch_ws:
+                chunk = val_tokens[ws:ws + seq_len + 1].to(dtype=torch.int64)
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            x_batch = torch.stack(x_list).to(device=device, non_blocking=True)
+            y_batch = torch.stack(y_list).to(device=device, non_blocking=True)
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = base_model.forward_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+
+            for i, ws in enumerate(batch_ws):
+                wlen = min(seq_len, total_tokens - ws)
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+
+                prev_ids = x_batch[i, s:wlen]
+                tgt_ids = y_batch[i, s:wlen]
+                tbytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                tbytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+                byte_count += tbytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return float(val_loss), float(bits_per_token * tokens_per_byte)
+
+
+# QUANTIZATION
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smeargate,merge_alpha",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def _quantize_with_clip(t32: Tensor, clip_abs: Tensor | float, qmax: int) -> tuple[Tensor, Tensor, Tensor]:
+    if t32.ndim == 2 and isinstance(clip_abs, Tensor):
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / qmax).clamp_min(1.0 / qmax)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -qmax, qmax).to(torch.int8)
+        recon = q.float() * scale[:, None]
+        return q.contiguous(), scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous(), recon
+    clip_abs_f = float(clip_abs) if isinstance(clip_abs, Tensor) else clip_abs
+    scale_f = clip_abs_f / qmax if clip_abs_f > 0 else 1.0
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs_f, clip_abs_f) / scale_f), -qmax, qmax).to(torch.int8)
+    recon = q.float() * scale_f
+    return q.contiguous(), torch.tensor(scale_f, dtype=torch.float32), recon
+
+def quantize_float_tensor(t: Tensor, bits: int = 8, search_clip: bool = False) -> tuple[Tensor, Tensor]:
+    qmax = (1 << (bits - 1)) - 1
+    t32 = t.float()
+
+    if not search_clip:
+        if t32.ndim == 2:
+            clip_abs = (
+                torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+                if t32.numel()
+                else torch.empty((t32.shape[0],), dtype=torch.float32)
+            )
+            q, scale, _ = _quantize_with_clip(t32, clip_abs, qmax)
+            return q, scale
+        clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+        q, scale, _ = _quantize_with_clip(t32, clip_abs, qmax)
+        return q, scale
+
+    candidates = [0.999, 0.9995, 0.9999, 0.99995, 0.99999, 0.999999, 1.0]
+    best_q, best_scale, best_mse = None, None, float("inf")
+
+    for pct in candidates:
+        if t32.ndim == 2:
+            if pct >= 1.0:
+                clip_abs = t32.abs().amax(dim=1)
+            else:
+                clip_abs = torch.quantile(t32.abs(), pct, dim=1)
+            q, scale, recon = _quantize_with_clip(t32, clip_abs, qmax)
+        else:
+            if pct >= 1.0:
+                clip_abs = float(t32.abs().max().item())
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), pct).item()) if t32.numel() else 0.0
+            q, scale, recon = _quantize_with_clip(t32, clip_abs, qmax)
+        mse = (t32 - recon).pow(2).mean().item()
+        if mse < best_mse:
+            best_mse = mse
+            best_q, best_scale = q, scale
+
+    return best_q, best_scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor], fp16_embed: bool = False, quant_bits: int = 8, quant_bits_mlp: int = 0, search_clip: bool = False):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        if fp16_embed and "tok_emb" in name:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        bits = quant_bits
+        if quant_bits_mlp > 0 and "mlp" in name:
+            bits = quant_bits_mlp
+        q, s = quantize_float_tensor(t, bits=bits, search_clip=search_clip)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class FakeQuantizeSTE(torch.autograd.Function):
+    """Simulated quantization with Straight-Through Estimator for QAT."""
+    @staticmethod
+    def forward(ctx, w: Tensor, bits: int) -> Tensor:
+        qmax = (1 << (bits - 1)) - 1
+        if w.ndim == 2:
+            scale = w.detach().abs().amax(dim=1, keepdim=True) / qmax
+            scale = scale.clamp_min(1.0 / qmax)
+            return (torch.clamp(torch.round(w / scale), -qmax, qmax) * scale).to(w.dtype)
+        scale = w.detach().abs().amax() / qmax
+        scale = scale.clamp_min(1.0 / qmax)
+        return (torch.clamp(torch.round(w / scale), -qmax, qmax) * scale).to(w.dtype)
+
+    @staticmethod
+    def backward(ctx, grad: Tensor) -> tuple[Tensor, None]:
+        return grad, None
+
+
+class CastedLinear(nn.Linear):
+    _qat_bits: int = 0
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if self._qat_bits > 0 and self.weight.numel() > 65536:
+            w = FakeQuantizeSTE.apply(w, self._qat_bits)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.full((dim,), 3.0, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate).to(dtype=x.dtype)
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return g * x + (1.0 - g) * x_prev
+
+
+class BigramHash(nn.Module):
+    def __init__(self, num_buckets: int, hash_dim: int, model_dim: int):
+        super().__init__()
+        self.num_buckets = num_buckets
+        self.table = nn.Embedding(num_buckets, hash_dim)
+        self.proj = CastedLinear(hash_dim, model_dim, bias=False)
+        self.proj._zero_init = True
+        nn.init.normal_(self.table.weight, std=0.01)
+
+    def forward(self, input_ids: Tensor) -> Tensor:
+        bsz, seqlen = input_ids.shape
+        prev_ids = torch.cat([torch.zeros(bsz, 1, dtype=input_ids.dtype, device=input_ids.device),
+                              input_ids[:, :-1]], dim=1)
+        h = ((prev_ids.long() * 92821 + input_ids.long()) % self.num_buckets).long()
+        return self.proj(self.table(h))
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class HymbaAttention(nn.Module):
+    """Hymba-style hybrid: attention + Mamba SSM in parallel within one block."""
+    def __init__(
+        self, dim: int, num_heads: int, num_kv_heads: int, rope_base: float,
+        qk_gain_init: float, mamba_expand: int = 2, conv_kernel_size: int = 4,
+        dt_rank: int = 0, ssm_state_size: int = 16,
+    ):
+        super().__init__()
+        from mamba_ssm.ops.selective_scan_interface import selective_scan_fn
+        from causal_conv1d import causal_conv1d_fn
+        self._selective_scan_fn = selective_scan_fn
+        self._causal_conv1d_fn = causal_conv1d_fn
+
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        self.intermediate_size = mamba_expand * dim
+        self.ssm_state_size = ssm_state_size
+        self.dt_rank = dt_rank if dt_rank > 0 else max(dim // 16, 1)
+
+        kv_dim = num_kv_heads * self.head_dim
+        self.q_dim = dim
+        self.kv_dim = kv_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+
+        self.fused_dim = kv_dim * 2 + self.intermediate_size * 2
+        self.in_proj = CastedLinear(dim, self.fused_dim, bias=False)
+
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+        self.conv1d = nn.Conv1d(
+            self.intermediate_size, self.intermediate_size, bias=True,
+            kernel_size=conv_kernel_size, groups=self.intermediate_size,
+            padding=conv_kernel_size - 1,
+        )
+        self.x_proj = CastedLinear(self.intermediate_size, self.dt_rank + ssm_state_size * 2, bias=False)
+        self.dt_proj = nn.Linear(self.dt_rank, self.intermediate_size, bias=True)
+
+        A = torch.arange(1, ssm_state_size + 1, dtype=torch.float32)[None, :].expand(self.intermediate_size, -1).contiguous()
+        self.A_log = nn.Parameter(torch.log(A))
+        self.D = nn.Parameter(torch.ones(self.intermediate_size))
+
+        self.mamba_out_proj = CastedLinear(self.intermediate_size, dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.merge_alpha = nn.Parameter(torch.zeros(1, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+
+        q_out = self.c_q(x)
+
+        fused = self.in_proj(x)
+        k_out, v_out, x_ssm, gate = fused.split(
+            [self.kv_dim, self.kv_dim, self.intermediate_size, self.intermediate_size], dim=-1
+        )
+
+        q = q_out.reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k_out.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = v_out.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q, k, v, attn_mask=None, is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        attn_out = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+
+        x_ssm = x_ssm.transpose(1, 2)
+        gate = gate.transpose(1, 2)
+
+        _conv_dtype = x_ssm.dtype
+        conv_weights = self.conv1d.weight.view(self.conv1d.weight.size(0), self.conv1d.weight.size(2)).to(_conv_dtype)
+        conv_bias = self.conv1d.bias.to(_conv_dtype) if self.conv1d.bias is not None else None
+        x_ssm = self._causal_conv1d_fn(x_ssm, conv_weights, conv_bias, activation="silu")
+
+        ssm_params = self.x_proj(x_ssm.transpose(1, 2))
+        dt, B_ssm, C_ssm = torch.split(
+            ssm_params, [self.dt_rank, self.ssm_state_size, self.ssm_state_size], dim=-1
+        )
+
+        dt_proj_bias = self.dt_proj.bias
+        self.dt_proj.bias = None
+        dt = self.dt_proj(dt).transpose(1, 2)
+        self.dt_proj.bias = dt_proj_bias
+
+        A = -torch.exp(self.A_log.float())
+        dt_proj_bias_f = dt_proj_bias.float() if dt_proj_bias is not None else None
+
+        scan_out = self._selective_scan_fn(
+            x_ssm, dt, A,
+            B_ssm.transpose(1, 2), C_ssm.transpose(1, 2),
+            self.D.float(), z=gate,
+            delta_bias=dt_proj_bias_f,
+            delta_softplus=True,
+            return_last_state=False,
+        )
+        mamba_out = self.mamba_out_proj(scan_out.transpose(1, 2))
+
+        w = torch.sigmoid(self.merge_alpha).to(dtype=x.dtype)
+        merged = w * attn_out + (1.0 - w) * mamba_out
+        return self.proj(merged)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int,
+        rope_base: float, qk_gain_init: float, hymba_expand: int = 2,
+        hymba_conv_kernel: int = 4, hymba_dt_rank: int = 0, hymba_ssm_state: int = 16,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = HymbaAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+            mamba_expand=hymba_expand, conv_kernel_size=hymba_conv_kernel,
+            dt_rank=hymba_dt_rank, ssm_state_size=hymba_ssm_state,
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self, vocab_size: int, num_layers: int, model_dim: int, num_heads: int,
+        num_kv_heads: int, mlp_mult: int, tie_embeddings: bool, tied_embed_init_std: float,
+        logit_softcap: float, rope_base: float, qk_gain_init: float,
+        use_smeargate: bool = False, use_bigram_hash: bool = False,
+        bigram_buckets: int = 4096, bigram_hash_dim: int = 128,
+        use_ortho_init: bool = False, hymba_expand: int = 2, hymba_conv_kernel: int = 4,
+        hymba_dt_rank: int = 0, hymba_ssm_state: int = 16,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.use_ortho_init = use_ortho_init
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+
+        self.smeargate = SmearGate(model_dim) if use_smeargate else None
+        self.bigram_hash = BigramHash(bigram_buckets, bigram_hash_dim, model_dim) if use_bigram_hash else None
+
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+
+        self.skip_weights = nn.Parameter(
+            torch.ones(1, self.num_skip_weights, model_dim, dtype=torch.float32)
+        )
+
+        self.blocks = nn.ModuleList([
+            Block(
+                model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init,
+                hymba_expand=hymba_expand, hymba_conv_kernel=hymba_conv_kernel,
+                hymba_dt_rank=hymba_dt_rank, hymba_ssm_state=hymba_ssm_state,
+            )
+            for i in range(num_layers)
+        ])
+
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        num_layers = len(self.blocks)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif self.use_ortho_init and module.weight.ndim == 2 and min(module.weight.shape) >= 16:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj" in name and name.split(".")[-1] in ("proj", "proj_D"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+
+    def _compute_logits_and_loss(self, x: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def _embed(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram_hash is not None:
+            x = x + self.bigram_hash(input_ids)
+        if self.smeargate is not None:
+            x = self.smeargate(x)
+        return F.rms_norm(x, (x.size(-1),))
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self._embed(input_ids)
+        x0 = x
+        skips: list[Tensor] = []
+
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[0, i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+
+        return self._compute_logits_and_loss(x, target_ids)
+
+    def _run_blocks(self, x: Tensor, x0: Tensor) -> Tensor:
+        skips: list[Tensor] = []
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[0, i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+        return x
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        bsz, seqlen = input_ids.shape
+        x = self._embed(input_ids)
+        x = self._run_blocks(x, x)
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        w = self.tok_emb.weight if self.tie_embeddings else self.lm_head.weight
+        logits = self.logit_softcap * torch.tanh(F.linear(x, w) / self.logit_softcap)
+        return logits.reshape(bsz, seqlen, -1)
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = int(os.environ.get("GRAD_ACCUM_STEPS", 8 // world_size))
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    base_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        use_smeargate=args.use_smeargate, use_bigram_hash=args.use_bigram_hash,
+        bigram_buckets=args.bigram_buckets, bigram_hash_dim=args.bigram_hash_dim,
+        use_ortho_init=args.use_ortho_init, hymba_expand=args.hymba_expand,
+        hymba_conv_kernel=args.hymba_conv_kernel, hymba_dt_rank=args.hymba_dt_rank,
+        hymba_ssm_state=args.hymba_ssm_state,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=False)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if hasattr(base_model, 'skip_weights') and base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    if base_model.smeargate is not None:
+        scalar_params.append(base_model.smeargate.gate)
+    if base_model.bigram_hash is not None:
+        scalar_params.append(base_model.bigram_hash.table.weight)
+        matrix_params.append(base_model.bigram_hash.proj.weight)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params, lr=args.matrix_lr, momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps, weight_decay=args.weight_decay,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(f"num_layers:{args.num_layers} mlp_mult:{args.mlp_mult}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            frac = max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        else:
+            step_ms = elapsed_ms / max(step, 1)
+            warmdown_ms = args.warmdown_iters * step_ms
+            remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+            frac = remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+        if args.warmdown_shape == "cosine" and frac < 1.0:
+            return 0.5 * (1.0 + math.cos(math.pi * (1.0 - frac)))
+        return frac
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+
+    ema_state: dict[str, Tensor] | None = None
+    if args.ema_enabled:
+        ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+
+        if args.qat_start_frac > 0 and max_wallclock_ms:
+            elapsed_frac_qat = elapsed_ms / max_wallclock_ms
+            qat_active = elapsed_frac_qat >= args.qat_start_frac
+            qat_bits = args.quant_bits if qat_active else 0
+            if qat_active and any(m._qat_bits == 0 for m in base_model.modules() if isinstance(m, CastedLinear)):
+                log0(f"qat:enabled bits={qat_bits} at step {step} frac={elapsed_frac_qat:.2f}")
+                for m in base_model.modules():
+                    if isinstance(m, CastedLinear):
+                        m._qat_bits = qat_bits
+
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        cur_seq_len = args.train_seq_len
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, cur_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+
+        if ema_state is not None:
+            d = args.ema_decay
+            with torch.no_grad():
+                for name, t in base_model.state_dict().items():
+                    ema_state[name].mul_(d).add_(t.detach().float(), alpha=1.0 - d)
+
+        if args.swa_enabled and scale < args.swa_start_frac and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone().float() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu().float()
+                swa_count += 1
+
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    for m in base_model.modules():
+        if isinstance(m, CastedLinear):
+            m._qat_bits = 0
+
+    if ema_state is not None:
+        log0("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+        del ema_state
+        base_model.load_state_dict(avg_state, strict=True)
+    elif args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"swa:applying averaged {swa_count} checkpoints")
+        current_state = base_model.state_dict()
+        avg_state = {
+            name: (tensor / swa_count).to(dtype=current_state[name].dtype)
+            for name, tensor in swa_state.items()
+        }
+        del swa_state
+        base_model.load_state_dict(avg_state, strict=True)
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    mlp_bits = args.quant_bits_mlp if args.quant_bits_mlp > 0 else args.quant_bits
+    quant_obj, quant_stats = quantize_state_dict_int8(
+        base_model.state_dict(), fp16_embed=args.fp16_embed, quant_bits=args.quant_bits,
+        quant_bits_mlp=args.quant_bits_mlp, search_clip=args.gptq_lite,
+    )
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    if args.use_zstd and HAS_ZSTD:
+        cctx = zstd.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+        compress_fmt = "zstd-22"
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+        compress_fmt = "zlib-9"
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int{args.quant_bits}+{compress_fmt}: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int{args.quant_bits}+{compress_fmt}: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    if args.use_zstd and HAS_ZSTD:
+        dctx = zstd.ZstdDecompressor()
+        quant_decompressed = dctx.decompress(quant_blob_disk)
+    else:
+        quant_decompressed = zlib.decompress(quant_blob_disk)
+    quant_state = torch.load(io.BytesIO(quant_decompressed), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+
+    if args.ttt_enabled:
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+
+        num_frozen = min(args.ttt_freeze_blocks, len(base_model.blocks))
+        for i in range(num_frozen):
+            for p in base_model.blocks[i].parameters():
+                p.requires_grad_(False)
+        ttt_params = [p for p in base_model.parameters() if p.requires_grad]
+        if args.ttt_optimizer == "adamw":
+            ttt_opt = torch.optim.AdamW(ttt_params, lr=args.ttt_lr, weight_decay=0.01)
+        else:
+            ttt_opt = torch.optim.SGD(ttt_params, lr=args.ttt_lr, momentum=args.ttt_momentum)
+        ttt_seq_len = args.train_seq_len
+
+        total_tokens_val = val_tokens.numel() - 1
+        total_seqs = total_tokens_val // ttt_seq_len
+        total_chunks = (total_seqs + args.eval_batch_seqs - 1) // args.eval_batch_seqs
+
+        ttt_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+        ttt_token_count = torch.zeros((), device=device, dtype=torch.float64)
+        ttt_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+        ttt_step = 0
+
+        log0(f"ttt:starting optimizer={args.ttt_optimizer} lr={args.ttt_lr} freeze_blocks={num_frozen} epochs={args.ttt_epochs} chunks={total_chunks}")
+
+        for seq_idx in range(0, total_seqs, args.eval_batch_seqs):
+            batch_end = min(seq_idx + args.eval_batch_seqs, total_seqs)
+            bsz = batch_end - seq_idx
+            raw_start = seq_idx * ttt_seq_len
+            raw_end = batch_end * ttt_seq_len + 1
+            chunk = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64)
+            x = chunk[:-1].reshape(bsz, ttt_seq_len)
+            y = chunk[1:].reshape(bsz, ttt_seq_len)
+
+            base_model.eval()
+            with torch.inference_mode():
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model.forward_logits(x)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(), y.reshape(-1), reduction="none",
+                )
+                ttt_loss_sum += nll.to(torch.float64).sum()
+                n_tokens = float(y.numel())
+                ttt_token_count += n_tokens
+                prev_ids = x.reshape(-1)
+                tgt_ids = y.reshape(-1)
+                tbytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                tbytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+                ttt_byte_count += tbytes.to(torch.float64).sum()
+
+            base_model.train()
+            for _epoch in range(args.ttt_epochs):
+                ttt_opt.zero_grad()
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    loss = base_model(x, y)
+                loss.backward()
+                ttt_opt.step()
+                ttt_step += 1
+
+        for p in base_model.parameters():
+            p.requires_grad_(True)
+        base_model.eval()
+
+        if dist.is_available() and dist.is_initialized():
+            dist.all_reduce(ttt_loss_sum, op=dist.ReduceOp.SUM)
+            dist.all_reduce(ttt_token_count, op=dist.ReduceOp.SUM)
+            dist.all_reduce(ttt_byte_count, op=dist.ReduceOp.SUM)
+
+        q_val_loss = (ttt_loss_sum / ttt_token_count).item()
+        bits_per_token = q_val_loss / math.log(2.0)
+        tokens_per_byte = ttt_token_count.item() / ttt_byte_count.item()
+        q_val_bpb = float(bits_per_token * tokens_per_byte)
+        eval_mode = "online_ttt"
+        log0(f"ttt:completed steps:{ttt_step} time:{time.perf_counter() - t_ttt:.1f}s")
+
+    else:
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+
+    if not args.ttt_enabled:
+        use_sliding = args.eval_stride > 0 and args.eval_stride < args.train_seq_len
+        if use_sliding:
+            q_val_loss, q_val_bpb = eval_val_sliding(
+                args, base_model, rank, world_size, device,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            eval_mode = "sliding"
+        else:
+            q_val_loss, q_val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            eval_mode = "standard"
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_mode:{eval_mode} eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/hymba/train_logs.txt
+++ b/records/track_10min_16mb/hymba/train_logs.txt
@@ -1,0 +1,244 @@
+========================================
+SEED: 1337
+========================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:10
+model_params:27161151
+world_size:8 grad_accum_steps:1
+attention_mode:gqa num_heads:8 num_kv_heads:4
+num_layers:7 mlp_mult:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:524288 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9383 val_bpb:4.1092 train_time:0ms step_avg:0.03ms
+step:1/20000 train_loss:6.9378 train_time:81ms step_avg:80.61ms
+step:2/20000 train_loss:17.8388 train_time:160ms step_avg:80.11ms
+step:3/20000 train_loss:9.5504 train_time:245ms step_avg:81.59ms
+step:4/20000 train_loss:6.6035 train_time:329ms step_avg:82.33ms
+step:5/20000 train_loss:6.2041 train_time:414ms step_avg:82.73ms
+step:6/20000 train_loss:7.1086 train_time:498ms step_avg:83.02ms
+step:7/20000 train_loss:6.1183 train_time:582ms step_avg:83.19ms
+step:8/20000 train_loss:6.0309 train_time:667ms step_avg:83.31ms
+step:9/20000 train_loss:5.9999 train_time:751ms step_avg:83.41ms
+step:10/20000 train_loss:5.9489 train_time:835ms step_avg:83.47ms
+step:200/20000 train_loss:2.9714 train_time:16937ms step_avg:84.68ms
+step:400/20000 train_loss:2.3873 train_time:34701ms step_avg:86.75ms
+step:600/20000 train_loss:2.5281 train_time:51594ms step_avg:85.99ms
+step:800/20000 train_loss:2.2612 train_time:68479ms step_avg:85.60ms
+step:1000/20000 train_loss:2.3479 train_time:85358ms step_avg:85.36ms
+step:1000/20000 val_loss:2.2968 val_bpb:1.3603 train_time:85367ms step_avg:85.37ms
+
+========================================
+SEED: 42
+========================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:10
+model_params:27161151
+world_size:8 grad_accum_steps:1
+attention_mode:gqa num_heads:8 num_kv_heads:4
+num_layers:7 mlp_mult:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:524288 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:42
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9348 val_bpb:4.1072 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9363 train_time:302ms step_avg:301.69ms
+step:2/20000 train_loss:17.8717 train_time:381ms step_avg:190.71ms
+step:3/20000 train_loss:11.0277 train_time:466ms step_avg:155.27ms
+step:4/20000 train_loss:6.7188 train_time:550ms step_avg:137.51ms
+step:5/20000 train_loss:6.1759 train_time:634ms step_avg:126.84ms
+step:6/20000 train_loss:7.0648 train_time:718ms step_avg:119.73ms
+step:7/20000 train_loss:6.1011 train_time:802ms step_avg:114.63ms
+step:8/20000 train_loss:6.0230 train_time:887ms step_avg:110.83ms
+step:9/20000 train_loss:6.0012 train_time:971ms step_avg:107.89ms
+step:10/20000 train_loss:5.9501 train_time:1055ms step_avg:105.52ms
+step:200/20000 train_loss:2.9821 train_time:17749ms step_avg:88.74ms
+step:400/20000 train_loss:2.3626 train_time:34641ms step_avg:86.60ms
+step:600/20000 train_loss:2.5320 train_time:51524ms step_avg:85.87ms
+step:800/20000 train_loss:2.2619 train_time:68405ms step_avg:85.51ms
+step:1000/20000 train_loss:2.3511 train_time:85278ms step_avg:85.28ms
+step:1000/20000 val_loss:2.2996 val_bpb:1.3619 train_time:85287ms step_avg:85.29ms
+step:1200/20000 train_loss:2.3587 train_time:102142ms step_avg:85.12ms
+step:1400/20000 train_loss:2.3860 train_time:119003ms step_avg:85.00ms
+step:1600/20000 train_loss:2.0473 train_time:135881ms step_avg:84.93ms
+step:1800/20000 train_loss:2.1555 train_time:153572ms step_avg:85.32ms
+step:2000/20000 train_loss:2.1753 train_time:170444ms step_avg:85.22ms
+step:2000/20000 val_loss:2.1849 val_bpb:1.2940 train_time:170452ms step_avg:85.23ms
+step:2200/20000 train_loss:2.2895 train_time:187301ms step_avg:85.14ms
+step:2400/20000 train_loss:2.2986 train_time:204176ms step_avg:85.07ms
+step:2600/20000 train_loss:2.1588 train_time:221044ms step_avg:85.02ms
+step:2800/20000 train_loss:2.1110 train_time:237908ms step_avg:84.97ms
+step:3000/20000 train_loss:3.1365 train_time:254769ms step_avg:84.92ms
+step:3000/20000 val_loss:2.1379 val_bpb:1.2662 train_time:254778ms step_avg:84.93ms
+step:3200/20000 train_loss:2.2107 train_time:271648ms step_avg:84.89ms
+step:3400/20000 train_loss:2.0324 train_time:289448ms step_avg:85.13ms
+step:3600/20000 train_loss:2.1530 train_time:306302ms step_avg:85.08ms
+step:3800/20000 train_loss:2.1038 train_time:323152ms step_avg:85.04ms
+step:4000/20000 train_loss:2.2173 train_time:340014ms step_avg:85.00ms
+step:4000/20000 val_loss:2.1122 val_bpb:1.2510 train_time:340023ms step_avg:85.01ms
+step:4200/20000 train_loss:2.1681 train_time:356928ms step_avg:84.98ms
+step:4400/20000 train_loss:2.1024 train_time:373786ms step_avg:84.95ms
+step:4600/20000 train_loss:2.1421 train_time:390658ms step_avg:84.93ms
+step:4800/20000 train_loss:2.0723 train_time:407512ms step_avg:84.90ms
+step:5000/20000 train_loss:2.1509 train_time:424375ms step_avg:84.88ms
+step:5000/20000 val_loss:2.0802 val_bpb:1.2320 train_time:424384ms step_avg:84.88ms
+step:5200/20000 train_loss:2.1993 train_time:441955ms step_avg:84.99ms
+step:5400/20000 train_loss:2.1480 train_time:458813ms step_avg:84.97ms
+step:5600/20000 train_loss:2.0366 train_time:475668ms step_avg:84.94ms
+step:5800/20000 train_loss:2.0794 train_time:492606ms step_avg:84.93ms
+step:6000/20000 train_loss:1.9865 train_time:509617ms step_avg:84.94ms
+step:6000/20000 val_loss:2.0188 val_bpb:1.1956 train_time:509618ms step_avg:84.94ms
+step:6200/20000 train_loss:1.9615 train_time:526637ms step_avg:84.94ms
+step:6400/20000 train_loss:1.7246 train_time:543651ms step_avg:84.95ms
+step:6600/20000 train_loss:1.9426 train_time:560657ms step_avg:84.95ms
+step:6800/20000 train_loss:1.9858 train_time:578449ms step_avg:85.07ms
+step:7000/20000 train_loss:1.9381 train_time:595442ms step_avg:85.06ms
+step:7000/20000 val_loss:1.9863 val_bpb:1.1764 train_time:595447ms step_avg:85.06ms
+step:7054/20000 val_loss:1.9863 val_bpb:1.1764 train_time:600016ms step_avg:85.06ms
+stopping_early: wallclock_cap train_time:600016ms step:7054/20000
+peak memory allocated: 15447 MiB reserved: 15858 MiB
+ema:applying EMA weights
+Serialized model: 106278749 bytes
+Code size: 102996 bytes
+Total submission size: 106381745 bytes
+Serialized model int6+zstd-22: 14466811 bytes (payload:28227836 raw_torch:28282211 payload_ratio:3.76x)
+Total submission size int6+zstd-22: 14569807 bytes
+final_int8_zlib_roundtrip val_loss:1.9954 val_bpb:1.1818 eval_mode:sliding eval_time:171515ms
+final_int8_zlib_roundtrip_exact val_loss:1.99540457 val_bpb:1.18179098
+
+========================================
+SEED: 7
+========================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:10
+model_params:27161151
+world_size:8 grad_accum_steps:1
+attention_mode:gqa num_heads:8 num_kv_heads:4
+num_layers:7 mlp_mult:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:524288 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:7
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9377 val_bpb:4.1089 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9380 train_time:323ms step_avg:323.20ms
+step:2/20000 train_loss:17.7163 train_time:407ms step_avg:203.54ms
+step:3/20000 train_loss:11.2257 train_time:517ms step_avg:172.44ms
+step:4/20000 train_loss:6.8527 train_time:604ms step_avg:151.01ms
+step:5/20000 train_loss:6.3030 train_time:699ms step_avg:139.83ms
+step:6/20000 train_loss:7.1550 train_time:783ms step_avg:130.58ms
+step:7/20000 train_loss:6.1847 train_time:868ms step_avg:124.00ms
+step:8/20000 train_loss:6.0547 train_time:952ms step_avg:119.04ms
+step:9/20000 train_loss:6.0091 train_time:1037ms step_avg:115.19ms
+step:10/20000 train_loss:5.9548 train_time:1121ms step_avg:112.12ms
+step:200/20000 train_loss:2.9827 train_time:17882ms step_avg:89.41ms
+step:400/20000 train_loss:2.3691 train_time:34781ms step_avg:86.95ms
+step:600/20000 train_loss:2.5282 train_time:51678ms step_avg:86.13ms
+step:800/20000 train_loss:2.2607 train_time:68579ms step_avg:85.72ms
+step:1000/20000 train_loss:2.3473 train_time:85476ms step_avg:85.48ms
+step:1000/20000 val_loss:2.2987 val_bpb:1.3614 train_time:85485ms step_avg:85.48ms
+step:1200/20000 train_loss:2.3550 train_time:102363ms step_avg:85.30ms
+step:1400/20000 train_loss:2.3797 train_time:119249ms step_avg:85.18ms
+step:1600/20000 train_loss:2.0436 train_time:136127ms step_avg:85.08ms
+step:1800/20000 train_loss:2.1488 train_time:154031ms step_avg:85.57ms
+step:2000/20000 train_loss:2.1750 train_time:170905ms step_avg:85.45ms
+step:2000/20000 val_loss:2.1835 val_bpb:1.2932 train_time:170913ms step_avg:85.46ms
+step:2200/20000 train_loss:2.2860 train_time:187777ms step_avg:85.35ms
+step:2400/20000 train_loss:2.2997 train_time:204656ms step_avg:85.27ms
+step:2600/20000 train_loss:2.1587 train_time:221525ms step_avg:85.20ms
+step:2800/20000 train_loss:2.1084 train_time:238391ms step_avg:85.14ms
+step:3000/20000 train_loss:3.1546 train_time:255255ms step_avg:85.08ms
+step:3000/20000 val_loss:2.1437 val_bpb:1.2696 train_time:255264ms step_avg:85.09ms
+step:3200/20000 train_loss:2.2104 train_time:272116ms step_avg:85.04ms
+step:3400/20000 train_loss:2.0324 train_time:290004ms step_avg:85.30ms
+step:3600/20000 train_loss:2.1508 train_time:306877ms step_avg:85.24ms
+step:3800/20000 train_loss:2.1014 train_time:323742ms step_avg:85.20ms
+step:4000/20000 train_loss:2.2177 train_time:340613ms step_avg:85.15ms
+step:4000/20000 val_loss:2.1119 val_bpb:1.2508 train_time:340622ms step_avg:85.16ms
+step:4200/20000 train_loss:2.1610 train_time:357544ms step_avg:85.13ms
+step:4400/20000 train_loss:2.1016 train_time:374407ms step_avg:85.09ms
+step:4600/20000 train_loss:2.1462 train_time:391275ms step_avg:85.06ms
+step:4800/20000 train_loss:2.0708 train_time:408144ms step_avg:85.03ms
+step:5000/20000 train_loss:2.1507 train_time:425011ms step_avg:85.00ms
+step:5000/20000 val_loss:2.0797 val_bpb:1.2317 train_time:425020ms step_avg:85.00ms
+step:5200/20000 train_loss:2.1972 train_time:442822ms step_avg:85.16ms
+step:5400/20000 train_loss:2.1473 train_time:459693ms step_avg:85.13ms
+step:5600/20000 train_loss:2.0383 train_time:476553ms step_avg:85.10ms
+step:5800/20000 train_loss:2.0790 train_time:493543ms step_avg:85.09ms
+step:6000/20000 train_loss:1.9863 train_time:510525ms step_avg:85.09ms
+step:6000/20000 val_loss:2.0185 val_bpb:1.1955 train_time:510526ms step_avg:85.09ms
+step:6200/20000 train_loss:1.9620 train_time:527520ms step_avg:85.08ms
+step:6400/20000 train_loss:1.7301 train_time:544516ms step_avg:85.08ms
+step:6600/20000 train_loss:1.9404 train_time:561530ms step_avg:85.08ms
+step:6800/20000 train_loss:1.9799 train_time:579425ms step_avg:85.21ms
+step:7000/20000 train_loss:1.9358 train_time:596520ms step_avg:85.22ms
+step:7000/20000 val_loss:1.9867 val_bpb:1.1767 train_time:596521ms step_avg:85.22ms
+step:7042/20000 val_loss:1.9867 val_bpb:1.1767 train_time:600050ms step_avg:85.21ms
+stopping_early: wallclock_cap train_time:600050ms step:7042/20000
+peak memory allocated: 15447 MiB reserved: 15858 MiB
+ema:applying EMA weights
+Serialized model: 106278749 bytes
+Code size: 102996 bytes
+Total submission size: 106381745 bytes
+Serialized model int6+zstd-22: 14593599 bytes (payload:28227836 raw_torch:28282211 payload_ratio:3.76x)
+Total submission size int6+zstd-22: 14696595 bytes
+final_int8_zlib_roundtrip val_loss:1.9918 val_bpb:1.1797 eval_mode:sliding eval_time:171435ms
+final_int8_zlib_roundtrip_exact val_loss:1.99179225 val_bpb:1.17965157
+


### PR DESCRIPTION
# Hymba: Hybrid Attention + Mamba SSM 

**First competitive non-transformer architecture in the competition.**

A 7-layer hybrid model that runs attention and Mamba SSM in parallel within each block, achieving **val_bpb ~1.18** (3 seeds) on 8×H100 in 10 minutes, beating the naive transformer baseline (1.2244).

## Architecture

Each block runs two branches in parallel on the same input:

1. **Attention branch**: Standard GQA (8 heads, 4 KV heads) with RoPE + SDPA
2. **Mamba branch**: Selective scan SSM (`mamba-ssm`) with causal conv1d, gated projection

Outputs are merged with a learned weighted average: `sigmoid(α) · attn + (1 - sigmoid(α)) · mamba`, then projected through a shared output layer.

Key design: the input projection for K, V, and Mamba (x, gate) is fused into a single matmul for GPU efficiency. Q is projected separately to allow for future factorization.

## Key Findings

**Shallow models win at this compute budget.** The SSM branch makes each layer more powerful (attention for local precision, Mamba for long-range state), reducing the need for depth. Fewer layers = faster steps = more training in 10 minutes. The optimal depth (7L) is significantly shallower than the transformer baseline (9-11L).

**Training stability determines quantization quality.** With standard LR (0.04), the int6 quantization gap was 0.02-0.06 BPB. Reducing to LR=0.02 with aggressive cosine warmdown (3000 steps) produced smoother, more quantization-friendly weights — shrinking the gap to 0.02 without QAT. The warmdown phase alone accounts for ~0.06 BPB improvement as EMA weights converge.

**The Mamba branch adds minimal overhead on multi-GPU.** At 7 layers with MLP 4×, Hymba runs at ~85ms/step on 8×H100 (~7,000 steps in 10 min). The selective scan is O(T) and the per-layer Mamba params are small, so gradient sync overhead is negligible.