### PR TITLE
experiments: MODEL_DIM=256, MLP_MULT=3, WARMDOWN fix - best bpb 1.4702

### DIFF
--- a/train_gpt.py
+++ b/train_gpt.py
@@ -771,7 +771,7 @@ def main() -> None:
     logfile = None
     if master_process:
         os.makedirs("logs", exist_ok=True)
-        logfile = f"logs/{args.run_id}.txt"
+        logfile = f"/workspace/logs/{args.run_id}.txt"
         print(logfile)
 
     def log0(msg: str, console: bool = True) -> None:


### PR DESCRIPTION
Experiment results:
- E1: DIM=256 MLP=2 WD=1200 -> 1.4912 bpb (5.3MB)
- E2: DIM=512 MLP=2 WD=1200 -> 1.5297 bpb (9.4MB) - wider lost
- E3: DIM=256 LAYERS=18     -> 1.8125 bpb - deeper without tying lost
- E4: DIM=256 MLP=3 WD=400  -> 1.4702 bpb (6.4MB) - current best
- E5: DIM=320 MLP=3 WD=350  -> 1.4885 bpb - wider lost again

Key learnings:
- Step speed matters more than model size on time budget
- WARMDOWN_ITERS must fit within actual step count
- MLP_MULT=3 beats default MLP_MULT=2
- 9.6MB headroom remaining for layer tying