### PR TITLE
AMD Support - ROCm Systems

### DIFF
--- a/ROCm.md
+++ b/ROCm.md
@@ -1,0 +1,89 @@
+# ROCm Support
+
+## ROCm-focused changes
+
+### 1. Backend detection and logging
+
+- Added `is_rocm_build()` to detect ROCm by checking `torch.version.hip`.
+- Added `accelerator_name()` so logs can report `rocm` or `cuda`.
+- Startup logging now prints the selected accelerator backend.
+- GPU diagnostics now use `amd-smi` on ROCm builds and `nvidia-smi` otherwise.
+
+Why it matters:
+- The script can now distinguish ROCm from CUDA at runtime and emit backend-appropriate diagnostics instead of assuming NVIDIA tooling.
+
+### 2. Autocast path made ROCm-safe
+
+- Introduced `autocast_kwargs()` and replaced direct calls like:
+  - `torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True)`
+- Training and validation now call:
+  - `torch.autocast(**autocast_kwargs())`
+- The helper documents an important PyTorch ROCm detail: ROCm still uses the `"cuda"` device type in autocast APIs.
+
+Why it matters:
+- This centralizes mixed-precision configuration and makes the ROCm behavior explicit instead of scattering CUDA-only assumptions through the training loop.
+
+### 3. Scaled dot-product attention backend selection is now conditional
+
+- Added `maybe_enable_sdp_backends(log0)`.
+- The old code hardcoded:
+  - cuDNN SDP disabled
+  - Flash SDP enabled
+  - Memory-efficient SDP disabled
+  - Math SDP disabled
+- The new code:
+  - disables cuDNN and memory-efficient SDP
+  - enables Flash SDP only when `torch.backends.cuda.is_flash_attention_available()` reports support
+  - falls back to math SDP otherwise
+  - logs the final backend selection
+
+Why it matters:
+- ROCm environments may not support the same Flash Attention path as CUDA/NVIDIA. The new logic avoids forcing an unavailable backend and falls back cleanly.
+
+### 4. `torch.compile` is now optional and fault-tolerant
+
+- Added hyperparameters:
+  - `ENABLE_COMPILE` (default `1`)
+  - `COMPILE_MODE` (default `"default"`)
+  - `COMPILE_FULLGRAPH` (default `0`)
+- Added `maybe_compile_module(...)`:
+  - skips compilation when disabled
+  - attempts `torch.compile(...)`
+  - logs a failure and falls back to eager mode on exception
+- Replaced unconditional fullgraph compilation of the model with this helper.
+- The separate compile of `zeropower_via_newtonschulz5` was commented out.
+
+Why it matters:
+- `torch.compile` support and stability can vary across ROCm stacks. This change removes the hard dependency on successful compilation and gives a safe fallback path.
+
+### 5. Adam optimizer creation no longer assumes fused kernels
+
+- Added `make_adam(...)` helper.
+- The old code always passed `fused=True` to every Adam optimizer.
+- The new code only enables fused Adam when:
+  - the installed `torch.optim.Adam` signature exposes `fused`
+  - `torch.cuda.is_available()` is true
+- Token, scalar, and head Adam optimizers now all use the helper.
+
+Why it matters:
+- Fused Adam support is not guaranteed across ROCm/PyTorch combinations. This prevents failures caused by unconditionally requesting fused kernels.
+
+### 6. Device setup wording no longer implies NVIDIA-only CUDA
+
+- The accelerator setup section was renamed from `DISTRIBUTED + CUDA SETUP` to `DISTRIBUTED + ACCELERATOR SETUP`.
+- The runtime error changed from `CUDA is required` to:
+  - `A CUDA-compatible accelerator is required; ROCm builds also appear via torch.cuda`
+
+Why it matters:
+- PyTorch exposes ROCm devices through `torch.cuda`, which is easy to misread if the code and error messages only mention CUDA.
+
+### 7. Attention tensor layout tightened up
+
+- Added `.contiguous()` after transposing `q`, `k`, and `v` in `CausalSelfAttention.forward`.
+
+Why it may matter for ROCm:
+- This is not explicitly ROCm-only, but it can reduce layout-related issues and backend sensitivity in attention kernels.
+
+## Overall impact
+
+The main direction of the commit is to remove NVIDIA-specific assumptions from the training script while keeping the same `torch.cuda` execution path that PyTorch uses for ROCm. The changes make backend selection, diagnostics, mixed precision, SDP backend choice, optimizer configuration, and `torch.compile` behavior more tolerant of ROCm environments.

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -13,6 +13,7 @@ import inspect
 import math
 import os
 import random
+import shutil
 import subprocess
 import sys
 import time
@@ -56,16 +57,16 @@ class Hyperparameters:
     warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
     warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
     train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
-    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 128))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
     max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
     qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
 
     # Model shape.
     vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
-    num_layers = int(os.environ.get("NUM_LAYERS", 6))
-    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 3))
-    model_dim = int(os.environ.get("MODEL_DIM", 384))
-    num_heads = int(os.environ.get("NUM_HEADS", 6))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
     mlp_mult = int(os.environ.get("MLP_MULT", 2))
     tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
     rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
@@ -736,6 +737,31 @@ def accelerator_name() -> str:
     return "rocm" if is_rocm_build() else "cuda"
 
 
+def gpu_diagnostics_output() -> str:
+    commands = [["amd-smi"], ["rocm-smi"]] if is_rocm_build() else [["nvidia-smi"]]
+    for command in commands:
+        executable = shutil.which(command[0])
+        if executable is None:
+            continue
+        result = subprocess.run(
+            [executable, *command[1:]],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+        output = result.stdout.strip()
+        error = result.stderr.strip()
+        if output:
+            return output
+        if error:
+            return f"{command[0]} stderr:\n{error}"
+        return f"{command[0]} exited with code {result.returncode} and produced no output."
+    if is_rocm_build():
+        return "ROCm GPU diagnostics unavailable: neither amd-smi nor rocm-smi was found in PATH."
+    return "CUDA GPU diagnostics unavailable: nvidia-smi was not found in PATH."
+
+
 def autocast_kwargs() -> dict[str, object]:
     # ROCm uses the CUDA device type in PyTorch autocast APIs.
     return {"device_type": "cuda", "dtype": torch.bfloat16, "enabled": True}
@@ -756,10 +782,13 @@ def maybe_enable_sdp_backends(log0) -> str:
     flash_available = bool(flash_available_fn()) if callable(flash_available_fn) else False
     if flash_available:
         enable_flash_sdp(True)
+        enable_math_sdp(False)
         flash_enabled = True
+        math_enabled = False
     else:
         enable_flash_sdp(False)
         enable_math_sdp(True)
+        flash_enabled = False
         math_enabled = True
 
     msg = (
@@ -856,14 +885,7 @@ def main() -> None:
     log0(f"Running Python {sys.version}", console=False)
     log0(f"Running PyTorch {torch.__version__}", console=False)
     log0(f"Accelerator backend: {accelerator_name()}", console=False)
-    log0(
-        (
-            subprocess.run(["amd-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout
-            if is_rocm_build()
-            else subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout
-        ),
-        console=False,
-    )
+    log0(gpu_diagnostics_output(), console=False)
     log0("=" * 100, console=False)
     maybe_enable_sdp_backends(log0)
 


### PR DESCRIPTION
Modified the baseline script slightly to account for ROCm support even though the final submission must run on 8xH100, one who has amd hardware can try different approaches locally.