### PR TITLE
Add attempts/ directory with experiment templates

### DIFF
--- a/attempts/README.md
+++ b/attempts/README.md
@@ -1,0 +1,64 @@
+# attempts/
+
+In-progress experiments for the Parameter Golf challenge (OpenAI Model Craft Challenge).
+
+This directory mirrors the structure of `records/track_10min_16mb/` but is intended
+for experiments that have not yet been finalized as official submissions.
+
+## Folder structure
+
+Each attempt lives in its own folder named with a date prefix and short description:
+
+```
+attempts/
+  _template/            # Copy this to start a new attempt
+  results.tsv           # Aggregated results across all attempts
+  YYYY-MM-DD_ShortDescriptiveName/
+    train_gpt.py        # Training script (copy from repo root, then modify)
+    submission.json     # Metadata and results (fill in after run)
+    README.md           # Hypothesis, changes, results, analysis
+    env.sh              # (optional) Environment variable overrides
+```
+
+### Naming convention
+
+Use `YYYY-MM-DD_ShortDescriptiveName` with underscores separating words.
+This matches the convention in `records/` (e.g. `2026-03-17_NaiveBaseline`,
+`2026-03-23_LeakyReLU_LegalTTT_ParallelMuon`).
+
+## Workflow
+
+1. **Create folder** -- copy the `_template/` directory:
+   ```bash
+   cp -r attempts/_template attempts/$(date +%Y-%m-%d)_MyExperiment
+   ```
+
+2. **Copy train_gpt.py** -- bring in the current training script:
+   ```bash
+   cp train_gpt.py attempts/$(date +%Y-%m-%d)_MyExperiment/
+   ```
+
+3. **Modify** -- edit `train_gpt.py` and optionally `env.sh` for the changes
+   you want to test.  Document your hypothesis in `README.md`.
+
+4. **Submit** -- run on the cluster (sbatch or torchrun). Paste the exact
+   command in the attempt's `README.md`.
+
+5. **Collect results** -- fill in `submission.json` and `README.md` with
+   metrics.  Append a row to `results.tsv` for easy comparison.
+
+6. **Promote or discard** -- if the attempt beats the current best, copy
+   the folder into `records/track_10min_16mb/` and open a PR.  Otherwise,
+   update the status to `discarded` and note why.
+
+## Status values
+
+Each attempt tracks a `status` field in `submission.json`:
+
+| Status      | Meaning                                      |
+|-------------|----------------------------------------------|
+| `pending`   | Created but not yet submitted to the cluster |
+| `running`   | Currently executing on the cluster           |
+| `complete`  | Run finished, results collected              |
+| `failed`    | Run errored or produced invalid results      |
+| `discarded` | Results reviewed, not worth pursuing further |

--- a/attempts/_template/README.md
+++ b/attempts/_template/README.md
@@ -1,0 +1,24 @@
+# [Attempt Name]
+
+**Status**: pending | running | complete | failed | discarded
+**val_bpb**: — (fill after run)
+**GPU config**: 1xH200 | 8xH200 | 1xA100 | etc.
+
+## Hypothesis
+What change are you testing and why?
+
+## Changes from Baseline
+- List specific changes made to train_gpt.py
+
+## Results
+| Seed | Steps | val_bpb | int8_zlib_bpb | Artifact Size |
+|------|-------|---------|---------------|---------------|
+| 1337 |       |         |               |               |
+
+## Run Command
+```bash
+# paste the sbatch or torchrun command
+```
+
+## Analysis
+What worked, what didn't, next steps.

--- a/attempts/_template/env.sh
+++ b/attempts/_template/env.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Environment variables for this attempt
+# Source this before running: source env.sh && torchrun ...
+export NUM_LAYERS=9
+export MODEL_DIM=512
+export NUM_HEADS=8
+# ... etc

--- a/attempts/_template/submission.json
+++ b/attempts/_template/submission.json
@@ -1,0 +1,18 @@
+{
+  "name": "",
+  "author": "",
+  "github_id": "",
+  "date": "YYYY-MM-DD",
+  "blurb": "",
+  "val_bpb": null,
+  "pre_quant_val_bpb": null,
+  "int8_zlib_val_bpb": null,
+  "bytes_code": null,
+  "bytes_model": null,
+  "bytes_total": null,
+  "step_stop": null,
+  "step_avg_ms": null,
+  "wallclock_seconds": null,
+  "gpu_config": "",
+  "status": "pending"
+}

--- a/attempts/results.tsv
+++ b/attempts/results.tsv
@@ -1,0 +1,1 @@
+date	attempt	commit	val_bpb	int8_zlib_bpb	steps	step_avg_ms	gpu_config	status	description


### PR DESCRIPTION
## Summary
- Add `attempts/` directory structure for tracking in-progress experiments
- Include `_template/` folder with `submission.json`, `README.md`, and `env.sh` templates
- Add `results.tsv` with header row for cross-attempt comparison
- Add `attempts/README.md` documenting folder structure, naming conventions, workflow, and status values

## Test plan
- [x] Verify directory structure with `ls -R attempts/`
- [x] Confirm template files contain correct fields matching `records/` conventions
- [x] No executable code; purely infrastructure/template files

🤖 Generated with [Claude Code](https://claude.com/claude-code)