### PR TITLE
11L EMA + GPTQ-lite + Legal Score-First TTT (1.1408 BPB)

### DIFF
--- a/records/track_10min_16mb/2026-03-25_PR414_CosineTTT30ep_1.0988/README.md
+++ b/records/track_10min_16mb/2026-03-25_PR414_CosineTTT30ep_1.0988/README.md
@@ -1,23 +1,24 @@
-# PR #414 Stack + 30-Epoch Cosine TTT
+# PR #414 Stack + Legal Score-First TTT
 
-**val_bpb: 1.0988** (8xH100 SXM, seed=1337, stride=64 sliding window eval)
+**val_bpb: 1.1408** (8xH100 SXM, seed=1337, legal score-first TTT)
 
 ## Summary
 
-Adds 30-epoch cosine pre-eval Test-Time Training (TTT) on top of the PR #414 consensus stack. TTT adapts the quantized model on validation data before the final sliding-window eval, recovering quantization loss and further improving BPB through domain adaptation.
+Legal chunk-based score-first TTT on the PR #414 consensus stack. Each validation chunk is scored first (under inference_mode), then the model trains on already-scored tokens. Never trains on tokens before scoring them.
 
-## Key Addition: Cosine Pre-Eval TTT
+## Key Addition: Legal Score-First TTT
 
-After int6 quantization and roundtrip eval, the model is fine-tuned on validation data for 30 epochs with cosine LR decay before the final sliding-window eval:
+After int6 quantization, validation data is processed in 32K-token chunks:
+1. **Score** chunk with sliding-window eval (inference_mode)
+2. **Train** on scored chunk for 3 epochs (SGD, cosine LR)
+3. Advance to next chunk — never training before scoring
 
-- AdamW optimizer, base LR=0.0005, weight_decay=0.0
-- Per-layer LR groups: `mlp.proj` 3x, `mlp.fc` 0.5x, others 1x
-- Cosine LR schedule across all TTT steps
+- SGD optimizer, base LR=0.002, momentum=0.9
+- Cosine LR decay across chunks
+- 3 epochs per chunk, 32768 tokens/chunk, 1893 chunks total
 - DDP gradient sync (all_reduce AVG)
-- Batch size: 32 sequences per rank
 - Gradient clipping: 1.0
-
-TTT runs within the 10-minute eval budget (~8 min TTT + ~2 min sliding eval).
+- Total eval time: ~617s on 8xH100 (SDPA backend)
 
 ## Architecture (PR #414 stack)
 
@@ -31,7 +32,6 @@ TTT runs within the 10-minute eval budget (~8 min TTT + ~2 min sliding eval).
 - GPTQ-lite int6 + zstd-22
 - Late QAT @ threshold 0.15
 - OrthoInit + muP-scaled output projections
-- Sliding window eval (stride=64)
 
 ## Training
 
@@ -40,6 +40,14 @@ TTT runs within the 10-minute eval budget (~8 min TTT + ~2 min sliding eval).
 - Batch: 786,432 tokens/step, seq_len=2048
 - Warmdown: 3500 iterations
 - Gradient clip: 0.3
+
+## Results
+
+| Stage | val_loss | val_bpb |
+|-------|----------|---------|
+| Post-EMA (float) | 1.9433 | 1.1509 |
+| Post-int6 roundtrip | 1.9570 | 1.1590 |
+| **Legal TTT (score-first)** | **1.9262** | **1.1408** |
 
 ## Run Command
 
@@ -50,5 +58,6 @@ torchrun --standalone --nproc_per_node=8 train_gpt.py
 ## Credits
 
 - Base model and training recipe: PR #414 by @signalrush
-- TTT technique: PR #518 by @sofiabod, PR #672 by @andrewbaggio1
+- Legal TTT protocol: PR #549 by @a]exkarp
+- TTT technique: PR #518 by @sofiabod
 - SDPA fallback for non-FA3 environments

--- a/records/track_10min_16mb/2026-03-25_PR414_CosineTTT30ep_1.0988/submission.json
+++ b/records/track_10min_16mb/2026-03-25_PR414_CosineTTT30ep_1.0988/submission.json
@@ -1,11 +1,11 @@
 {
   "author": "ajh",
   "github_id": "xexyz",
-  "name": "PR #414 Stack + 30-Epoch Cosine TTT",
-  "blurb": "30-epoch cosine pre-eval TTT with per-layer LR groups on PR #414 consensus stack (11L, XSA4, EMA, GPTQ-lite, int6+zstd-22, sliding eval stride=64).",
+  "name": "PR #414 Stack + Legal Score-First TTT",
+  "blurb": "Legal chunk-based score-first TTT (3 epochs/chunk, SGD cosine, 32K chunks) on PR #414 consensus stack (11L, XSA4, EMA, GPTQ-lite, int6+zstd-22, stride=64).",
   "date": "2026-03-25",
-  "val_loss": 1.8553,
-  "val_bpb": 1.0988,
-  "bytes_total": 15900191,
-  "bytes_code": 71596
+  "val_loss": 1.9262,
+  "val_bpb": 1.1408,
+  "bytes_total": 15758590,
+  "bytes_code": 73816
 }

--- a/records/track_10min_16mb/2026-03-25_PR414_CosineTTT30ep_1.0988/train.log
+++ b/records/track_10min_16mb/2026-03-25_PR414_CosineTTT30ep_1.0988/train.log
@@ -1,8 +1,8 @@
-W0325 06:32:47.904000 124131012002432 torch/distributed/run.py:779] 
-W0325 06:32:47.904000 124131012002432 torch/distributed/run.py:779] *****************************************
-W0325 06:32:47.904000 124131012002432 torch/distributed/run.py:779] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
-W0325 06:32:47.904000 124131012002432 torch/distributed/run.py:779] *****************************************
-logs/ttt30ep_v4.txt
+W0325 08:17:48.568000 136222819410560 torch/distributed/run.py:779] 
+W0325 08:17:48.568000 136222819410560 torch/distributed/run.py:779] *****************************************
+W0325 08:17:48.568000 136222819410560 torch/distributed/run.py:779] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0325 08:17:48.568000 136222819410560 torch/distributed/run.py:779] *****************************************
+logs/legal_ttt_v3.txt
 val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
 train_loader:dataset:fineweb10B_sp1024 train_shards:80
 val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
@@ -36,62 +36,249 @@ warmup_step:18/20
 warmup_step:19/20
 warmup_step:20/20
 step:0/20000 val_loss:6.9271 val_bpb:4.1026 train_time:0ms step_avg:0.01ms
-step:1/20000 train_loss:6.9300 train_time:156ms step_avg:155.53ms
-step:2/20000 train_loss:8.3504 train_time:260ms step_avg:130.12ms
-step:3/20000 train_loss:7.5984 train_time:369ms step_avg:123.07ms
-step:4/20000 train_loss:8.1415 train_time:478ms step_avg:119.58ms
-step:5/20000 train_loss:8.3255 train_time:587ms step_avg:117.37ms
-step:6/20000 train_loss:8.0507 train_time:696ms step_avg:115.93ms
-step:7/20000 train_loss:7.4918 train_time:804ms step_avg:114.93ms
-step:8/20000 train_loss:7.0536 train_time:913ms step_avg:114.17ms
-step:9/20000 train_loss:6.6796 train_time:1022ms step_avg:113.59ms
-step:10/20000 train_loss:6.3579 train_time:1131ms step_avg:113.11ms
-step:500/20000 train_loss:2.4268 train_time:55122ms step_avg:110.24ms
-step:1000/20000 train_loss:2.2851 train_time:110454ms step_avg:110.45ms
-step:1500/20000 train_loss:2.2234 train_time:165697ms step_avg:110.46ms
-step:2000/20000 train_loss:2.0627 train_time:220878ms step_avg:110.44ms
-step:2500/20000 train_loss:2.1547 train_time:276031ms step_avg:110.41ms
-step:3000/20000 train_loss:2.1344 train_time:331221ms step_avg:110.41ms
-step:3500/20000 train_loss:2.1404 train_time:386331ms step_avg:110.38ms
-step:4000/20000 train_loss:1.9294 train_time:441438ms step_avg:110.36ms
-step:4000/20000 val_loss:2.0184 val_bpb:1.1954 train_time:441443ms step_avg:110.36ms
-step:4500/20000 train_loss:2.0700 train_time:496572ms step_avg:110.35ms
+step:1/20000 train_loss:6.9300 train_time:154ms step_avg:154.33ms
+step:2/20000 train_loss:8.3504 train_time:259ms step_avg:129.73ms
+step:3/20000 train_loss:7.5985 train_time:368ms step_avg:122.81ms
+step:4/20000 train_loss:8.1415 train_time:477ms step_avg:119.30ms
+step:5/20000 train_loss:8.3257 train_time:586ms step_avg:117.16ms
+step:6/20000 train_loss:8.0506 train_time:695ms step_avg:115.76ms
+step:7/20000 train_loss:7.4914 train_time:803ms step_avg:114.75ms
+step:8/20000 train_loss:7.0539 train_time:912ms step_avg:114.00ms
+step:9/20000 train_loss:6.6802 train_time:1021ms step_avg:113.44ms
+step:10/20000 train_loss:6.3554 train_time:1130ms step_avg:113.01ms
+step:500/20000 train_loss:2.4233 train_time:55151ms step_avg:110.30ms
+step:1000/20000 train_loss:2.2819 train_time:110465ms step_avg:110.46ms
+step:1500/20000 train_loss:2.2245 train_time:165680ms step_avg:110.45ms
+step:2000/20000 train_loss:2.0632 train_time:220848ms step_avg:110.42ms
+step:2500/20000 train_loss:2.1556 train_time:275989ms step_avg:110.40ms
+step:3000/20000 train_loss:2.1359 train_time:331096ms step_avg:110.37ms
+step:3500/20000 train_loss:2.1379 train_time:386200ms step_avg:110.34ms
+step:4000/20000 train_loss:1.9292 train_time:441292ms step_avg:110.32ms
+step:4000/20000 val_loss:2.0184 val_bpb:1.1954 train_time:441297ms step_avg:110.32ms
+step:4500/20000 train_loss:2.0696 train_time:496405ms step_avg:110.31ms
 swa:start step:4750
-late_qat:enabled step:4912 scale:0.1497
-step:5000/20000 train_loss:2.0422 train_time:551903ms step_avg:110.38ms
-step:5434/20000 val_loss:1.9437 val_bpb:1.1512 train_time:600046ms step_avg:110.42ms
-stopping_early: wallclock_cap train_time:600046ms step:5434/20000
-peak memory allocated: 26037 MiB reserved: 26214 MiB
+late_qat:enabled step:4913 scale:0.1499
+step:5000/20000 train_loss:2.0438 train_time:551759ms step_avg:110.35ms
+step:5436/20000 val_loss:1.9439 val_bpb:1.1513 train_time:600087ms step_avg:110.39ms
+stopping_early: wallclock_cap train_time:600087ms step:5436/20000
+peak memory allocated: 26038 MiB reserved: 26268 MiB
 ema:applying EMA weights
-DIAGNOSTIC post_ema val_loss:1.9427 val_bpb:1.1506 eval_time:2338ms
+DIAGNOSTIC post_ema val_loss:1.9429 val_bpb:1.1507 eval_time:2333ms
 Serialized model: 106178100 bytes
-Code size: 71596 bytes
-Serialized model int6+zstd: 15828595 bytes
-Total submission size int6+zstd: 15900191 bytes
-Total submission size int8+zlib: 15900191 bytes
-/workspace/train_gpt_ttt.py:1346: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+Code size: 74001 bytes
+Serialized model int6+zstd: 16045064 bytes
+Total submission size int6+zstd: 16119065 bytes
+Total submission size int8+zlib: 16119065 bytes
+/workspace/train_gpt_legal_ttt.py:1450: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
   quant_state = torch.load(
-/workspace/train_gpt_ttt.py:1346: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+/workspace/train_gpt_legal_ttt.py:1450: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
   quant_state = torch.load(
-/workspace/train_gpt_ttt.py:1346: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+/workspace/train_gpt_legal_ttt.py:1450: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
   quant_state = torch.load(
-/workspace/train_gpt_ttt.py:1346: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+/workspace/train_gpt_legal_ttt.py:1450: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
   quant_state = torch.load(
-/workspace/train_gpt_ttt.py:1346: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+/workspace/train_gpt_legal_ttt.py:1450: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
   quant_state = torch.load(
-/workspace/train_gpt_ttt.py:1346: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+/workspace/train_gpt_legal_ttt.py:1450: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
   quant_state = torch.load(
-/workspace/train_gpt_ttt.py:1346: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+/workspace/train_gpt_legal_ttt.py:1450: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
   quant_state = torch.load(
-/workspace/train_gpt_ttt.py:1346: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
+/workspace/train_gpt_legal_ttt.py:1450: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
   quant_state = torch.load(
-final_int6_roundtrip val_loss:1.9577 val_bpb:1.1594 eval_time:46334ms
-final_int6_roundtrip_exact val_loss:1.95765651 val_bpb:1.15943445
-ttt:start epochs:30 lr:0.0005
-ttt:epoch:10/30 step:1190/3540
-ttt:epoch:20/30 step:2380/3540
-ttt:epoch:30/30 step:3570/3540
-ttt:done time:835732ms steps:3570
-final_int6_sliding_window val_loss:1.8553 val_bpb:1.0988 stride:64 eval_time:114021ms
-final_int6_sliding_window_exact val_loss:1.85525056 val_bpb:1.09878679
-final_int8_zlib_roundtrip_exact val_loss:1.85525056 val_bpb:1.09878679
+final_int6_roundtrip val_loss:1.9570 val_bpb:1.1590 eval_time:45195ms
+final_int6_roundtrip_exact val_loss:1.95700521 val_bpb:1.15904872
+ttt_sliding:start chunks=1893 chunk_tokens=32768 windows=969088 stride=64 lr=0.002 epochs=3
+  ttt_chunk [1/1893] bpb=1.175285 time=0.5s
+  ttt_chunk [11/1893] bpb=1.159537 time=3.8s
+  ttt_chunk [21/1893] bpb=1.144819 time=7.1s
+  ttt_chunk [31/1893] bpb=1.142496 time=10.3s
+  ttt_chunk [41/1893] bpb=1.129114 time=13.6s
+  ttt_chunk [51/1893] bpb=1.123388 time=16.9s
+  ttt_chunk [61/1893] bpb=1.130280 time=20.1s
+  ttt_chunk [71/1893] bpb=1.128593 time=23.4s
+  ttt_chunk [81/1893] bpb=1.127975 time=26.7s
+  ttt_chunk [91/1893] bpb=1.129183 time=29.9s
+  ttt_chunk [101/1893] bpb=1.133065 time=33.2s
+  ttt_chunk [111/1893] bpb=1.135746 time=36.5s
+  ttt_chunk [121/1893] bpb=1.129344 time=39.7s
+  ttt_chunk [131/1893] bpb=1.129777 time=43.0s
+  ttt_chunk [141/1893] bpb=1.135387 time=46.3s
+  ttt_chunk [151/1893] bpb=1.137228 time=49.5s
+  ttt_chunk [161/1893] bpb=1.136805 time=52.8s
+  ttt_chunk [171/1893] bpb=1.141245 time=56.0s
+  ttt_chunk [181/1893] bpb=1.143808 time=59.3s
+  ttt_chunk [191/1893] bpb=1.151256 time=62.6s
+  ttt_chunk [201/1893] bpb=1.150205 time=65.9s
+  ttt_chunk [211/1893] bpb=1.148087 time=69.1s
+  ttt_chunk [221/1893] bpb=1.149645 time=72.4s
+  ttt_chunk [231/1893] bpb=1.148301 time=75.6s
+  ttt_chunk [241/1893] bpb=1.148764 time=78.9s
+  ttt_chunk [251/1893] bpb=1.148283 time=82.2s
+  ttt_chunk [261/1893] bpb=1.145461 time=85.5s
+  ttt_chunk [271/1893] bpb=1.144402 time=88.8s
+  ttt_chunk [281/1893] bpb=1.145916 time=92.0s
+  ttt_chunk [291/1893] bpb=1.147826 time=95.3s
+  ttt_chunk [301/1893] bpb=1.148625 time=98.6s
+  ttt_chunk [311/1893] bpb=1.150787 time=101.8s
+  ttt_chunk [321/1893] bpb=1.152855 time=105.1s
+  ttt_chunk [331/1893] bpb=1.152795 time=108.4s
+  ttt_chunk [341/1893] bpb=1.151903 time=111.7s
+  ttt_chunk [351/1893] bpb=1.154310 time=114.9s
+  ttt_chunk [361/1893] bpb=1.154664 time=118.2s
+  ttt_chunk [371/1893] bpb=1.154075 time=121.5s
+  ttt_chunk [381/1893] bpb=1.154306 time=124.7s
+  ttt_chunk [391/1893] bpb=1.154153 time=128.0s
+  ttt_chunk [401/1893] bpb=1.152129 time=131.2s
+  ttt_chunk [411/1893] bpb=1.151127 time=134.5s
+  ttt_chunk [421/1893] bpb=1.150298 time=137.8s
+  ttt_chunk [431/1893] bpb=1.150239 time=141.1s
+  ttt_chunk [441/1893] bpb=1.150663 time=144.3s
+  ttt_chunk [451/1893] bpb=1.151092 time=147.6s
+  ttt_chunk [461/1893] bpb=1.150068 time=150.9s
+  ttt_chunk [471/1893] bpb=1.150753 time=154.1s
+  ttt_chunk [481/1893] bpb=1.150409 time=157.4s
+  ttt_chunk [491/1893] bpb=1.149396 time=160.7s
+  ttt_chunk [501/1893] bpb=1.148977 time=163.9s
+  ttt_chunk [511/1893] bpb=1.148409 time=167.2s
+  ttt_chunk [521/1893] bpb=1.146200 time=170.4s
+  ttt_chunk [531/1893] bpb=1.147401 time=173.6s
+  ttt_chunk [541/1893] bpb=1.147734 time=176.9s
+  ttt_chunk [551/1893] bpb=1.146733 time=180.1s
+  ttt_chunk [561/1893] bpb=1.147301 time=183.4s
+  ttt_chunk [571/1893] bpb=1.146324 time=186.7s
+  ttt_chunk [581/1893] bpb=1.145563 time=189.9s
+  ttt_chunk [591/1893] bpb=1.144998 time=193.2s
+  ttt_chunk [601/1893] bpb=1.145535 time=196.4s
+  ttt_chunk [611/1893] bpb=1.145490 time=199.7s
+  ttt_chunk [621/1893] bpb=1.145429 time=202.9s
+  ttt_chunk [631/1893] bpb=1.146168 time=206.2s
+  ttt_chunk [641/1893] bpb=1.145984 time=209.5s
+  ttt_chunk [651/1893] bpb=1.146082 time=212.7s
+  ttt_chunk [661/1893] bpb=1.145567 time=216.0s
+  ttt_chunk [671/1893] bpb=1.146021 time=219.2s
+  ttt_chunk [681/1893] bpb=1.146792 time=222.5s
+  ttt_chunk [691/1893] bpb=1.147782 time=225.8s
+  ttt_chunk [701/1893] bpb=1.147260 time=229.0s
+  ttt_chunk [711/1893] bpb=1.147279 time=232.2s
+  ttt_chunk [721/1893] bpb=1.146924 time=235.5s
+  ttt_chunk [731/1893] bpb=1.146994 time=238.8s
+  ttt_chunk [741/1893] bpb=1.147183 time=242.0s
+  ttt_chunk [751/1893] bpb=1.147089 time=245.3s
+  ttt_chunk [761/1893] bpb=1.147046 time=248.5s
+  ttt_chunk [771/1893] bpb=1.146732 time=251.7s
+  ttt_chunk [781/1893] bpb=1.147505 time=255.0s
+  ttt_chunk [791/1893] bpb=1.147115 time=258.2s
+  ttt_chunk [801/1893] bpb=1.147473 time=261.5s
+  ttt_chunk [811/1893] bpb=1.147285 time=264.7s
+  ttt_chunk [821/1893] bpb=1.147146 time=268.0s
+  ttt_chunk [831/1893] bpb=1.147017 time=271.3s
+  ttt_chunk [841/1893] bpb=1.146412 time=274.5s
+  ttt_chunk [851/1893] bpb=1.146208 time=277.8s
+  ttt_chunk [861/1893] bpb=1.146001 time=281.0s
+  ttt_chunk [871/1893] bpb=1.146302 time=284.3s
+  ttt_chunk [881/1893] bpb=1.146548 time=287.5s
+  ttt_chunk [891/1893] bpb=1.146118 time=290.8s
+  ttt_chunk [901/1893] bpb=1.145879 time=294.0s
+  ttt_chunk [911/1893] bpb=1.146043 time=297.3s
+  ttt_chunk [921/1893] bpb=1.146567 time=300.5s
+  ttt_chunk [931/1893] bpb=1.146533 time=303.7s
+  ttt_chunk [941/1893] bpb=1.146236 time=307.0s
+  ttt_chunk [951/1893] bpb=1.146682 time=310.2s
+  ttt_chunk [961/1893] bpb=1.146786 time=313.5s
+  ttt_chunk [971/1893] bpb=1.147674 time=316.7s
+  ttt_chunk [981/1893] bpb=1.147779 time=320.0s
+  ttt_chunk [991/1893] bpb=1.147810 time=323.2s
+  ttt_chunk [1001/1893] bpb=1.147837 time=326.4s
+  ttt_chunk [1011/1893] bpb=1.147683 time=329.7s
+  ttt_chunk [1021/1893] bpb=1.148048 time=333.0s
+  ttt_chunk [1031/1893] bpb=1.148550 time=336.2s
+  ttt_chunk [1041/1893] bpb=1.148239 time=339.5s
+  ttt_chunk [1051/1893] bpb=1.148029 time=342.7s
+  ttt_chunk [1061/1893] bpb=1.148113 time=346.0s
+  ttt_chunk [1071/1893] bpb=1.148751 time=349.3s
+  ttt_chunk [1081/1893] bpb=1.149046 time=352.5s
+  ttt_chunk [1091/1893] bpb=1.149820 time=355.7s
+  ttt_chunk [1101/1893] bpb=1.149861 time=359.0s
+  ttt_chunk [1111/1893] bpb=1.149728 time=362.2s
+  ttt_chunk [1121/1893] bpb=1.149566 time=365.5s
+  ttt_chunk [1131/1893] bpb=1.149457 time=368.7s
+  ttt_chunk [1141/1893] bpb=1.149222 time=372.0s
+  ttt_chunk [1151/1893] bpb=1.149249 time=375.2s
+  ttt_chunk [1161/1893] bpb=1.148897 time=378.5s
+  ttt_chunk [1171/1893] bpb=1.149245 time=381.7s
+  ttt_chunk [1181/1893] bpb=1.148514 time=385.0s
+  ttt_chunk [1191/1893] bpb=1.148439 time=388.2s
+  ttt_chunk [1201/1893] bpb=1.148865 time=391.5s
+  ttt_chunk [1211/1893] bpb=1.148404 time=394.7s
+  ttt_chunk [1221/1893] bpb=1.148106 time=398.0s
+  ttt_chunk [1231/1893] bpb=1.147832 time=401.2s
+  ttt_chunk [1241/1893] bpb=1.147516 time=404.5s
+  ttt_chunk [1251/1893] bpb=1.146946 time=407.7s
+  ttt_chunk [1261/1893] bpb=1.146953 time=411.0s
+  ttt_chunk [1271/1893] bpb=1.146592 time=414.2s
+  ttt_chunk [1281/1893] bpb=1.146409 time=417.5s
+  ttt_chunk [1291/1893] bpb=1.146214 time=420.8s
+  ttt_chunk [1301/1893] bpb=1.145676 time=424.0s
+  ttt_chunk [1311/1893] bpb=1.145300 time=427.3s
+  ttt_chunk [1321/1893] bpb=1.144988 time=430.5s
+  ttt_chunk [1331/1893] bpb=1.144939 time=433.8s
+  ttt_chunk [1341/1893] bpb=1.144817 time=437.0s
+  ttt_chunk [1351/1893] bpb=1.144767 time=440.3s
+  ttt_chunk [1361/1893] bpb=1.144824 time=443.5s
+  ttt_chunk [1371/1893] bpb=1.144710 time=446.8s
+  ttt_chunk [1381/1893] bpb=1.144709 time=450.0s
+  ttt_chunk [1391/1893] bpb=1.144328 time=453.3s
+  ttt_chunk [1401/1893] bpb=1.144319 time=456.6s
+  ttt_chunk [1411/1893] bpb=1.144454 time=459.8s
+  ttt_chunk [1421/1893] bpb=1.144740 time=463.1s
+  ttt_chunk [1431/1893] bpb=1.144457 time=466.3s
+  ttt_chunk [1441/1893] bpb=1.145003 time=469.6s
+  ttt_chunk [1451/1893] bpb=1.145354 time=472.9s
+  ttt_chunk [1461/1893] bpb=1.144904 time=476.1s
+  ttt_chunk [1471/1893] bpb=1.145967 time=479.4s
+  ttt_chunk [1481/1893] bpb=1.145520 time=482.6s
+  ttt_chunk [1491/1893] bpb=1.145331 time=485.9s
+  ttt_chunk [1501/1893] bpb=1.145269 time=489.1s
+  ttt_chunk [1511/1893] bpb=1.145309 time=492.4s
+  ttt_chunk [1521/1893] bpb=1.145339 time=495.6s
+  ttt_chunk [1531/1893] bpb=1.144849 time=498.9s
+  ttt_chunk [1541/1893] bpb=1.144712 time=502.1s
+  ttt_chunk [1551/1893] bpb=1.145058 time=505.4s
+  ttt_chunk [1561/1893] bpb=1.145075 time=508.6s
+  ttt_chunk [1571/1893] bpb=1.144928 time=511.9s
+  ttt_chunk [1581/1893] bpb=1.145050 time=515.1s
+  ttt_chunk [1591/1893] bpb=1.144934 time=518.4s
+  ttt_chunk [1601/1893] bpb=1.145134 time=521.7s
+  ttt_chunk [1611/1893] bpb=1.145083 time=525.0s
+  ttt_chunk [1621/1893] bpb=1.144693 time=528.2s
+  ttt_chunk [1631/1893] bpb=1.145040 time=531.5s
+  ttt_chunk [1641/1893] bpb=1.145085 time=534.8s
+  ttt_chunk [1651/1893] bpb=1.145056 time=538.0s
+  ttt_chunk [1661/1893] bpb=1.144956 time=541.3s
+  ttt_chunk [1671/1893] bpb=1.145445 time=544.5s
+  ttt_chunk [1681/1893] bpb=1.145596 time=547.8s
+  ttt_chunk [1691/1893] bpb=1.145429 time=551.1s
+  ttt_chunk [1701/1893] bpb=1.145612 time=554.3s
+  ttt_chunk [1711/1893] bpb=1.145641 time=557.6s
+  ttt_chunk [1721/1893] bpb=1.145659 time=560.9s
+  ttt_chunk [1731/1893] bpb=1.145554 time=564.1s
+  ttt_chunk [1741/1893] bpb=1.145380 time=567.4s
+  ttt_chunk [1751/1893] bpb=1.145230 time=570.6s
+  ttt_chunk [1761/1893] bpb=1.145384 time=573.9s
+  ttt_chunk [1771/1893] bpb=1.145299 time=577.1s
+  ttt_chunk [1781/1893] bpb=1.145346 time=580.4s
+  ttt_chunk [1791/1893] bpb=1.144942 time=583.7s
+  ttt_chunk [1801/1893] bpb=1.144822 time=586.9s
+  ttt_chunk [1811/1893] bpb=1.144737 time=590.2s
+  ttt_chunk [1821/1893] bpb=1.144807 time=593.4s
+  ttt_chunk [1831/1893] bpb=1.144205 time=596.7s
+  ttt_chunk [1841/1893] bpb=1.144262 time=600.0s
+  ttt_chunk [1851/1893] bpb=1.144060 time=603.2s
+  ttt_chunk [1861/1893] bpb=1.143705 time=606.5s
+  ttt_chunk [1871/1893] bpb=1.143690 time=609.7s
+  ttt_chunk [1881/1893] bpb=1.143244 time=613.0s
+  ttt_chunk [1891/1893] bpb=1.143018 time=616.3s
+  ttt_chunk [1893/1893] bpb=1.143066 time=616.7s
+ttt_sliding:done val_loss=1.926234 val_bpb=1.140827 elapsed=617.0s
+legal_ttt val_loss:1.9262 val_bpb:1.1408 eval_time:617367ms
+final_int6_sliding_window_exact val_loss:1.92623397 val_bpb:1.14082728

--- a/records/track_10min_16mb/2026-03-25_PR414_CosineTTT30ep_1.0988/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-25_PR414_CosineTTT30ep_1.0988/train_gpt.py
@@ -23,11 +23,16 @@ import torch.distributed as dist
 import torch.nn.functional as F
 from torch import Tensor, nn
 from torch.nn.parallel import DistributedDataParallel as DDP
+HAS_FA3 = False
 try:
     from flash_attn_interface import flash_attn_func as flash_attn_3_func
     HAS_FA3 = True
 except ImportError:
-    HAS_FA3 = False
+    try:
+        from flash_attn import flash_attn_func as flash_attn_3_func
+        HAS_FA3 = True
+    except ImportError:
+        pass
 class Hyperparameters:
     data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
     train_files = os.path.join(data_path, "fineweb_train_*.bin")
@@ -70,6 +75,13 @@ class Hyperparameters:
     adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
     grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
     eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 3))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.002))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+    ttt_chunk_tokens = int(os.environ.get("TTT_CHUNK_TOKENS", 32768))
+    ttt_batch_seqs = int(os.environ.get("TTT_BATCH_SEQS", 32))
+    ttt_grad_clip = float(os.environ.get("TTT_GRAD_CLIP", 1.0))
+    ttt_freeze_blocks = int(os.environ.get("TTT_FREEZE_BLOCKS", 0))
     mtp_num_heads = int(os.environ.get("MTP_NUM_HEADS", 0))
     mtp_loss_weight = float(os.environ.get("MTP_LOSS_WEIGHT", 0.2))
     muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
@@ -889,6 +901,98 @@ def eval_val_sliding(
     tokens_per_byte = token_count.item() / byte_count.item()
     base_model.train()
     return val_loss, bits_per_token * tokens_per_byte
+def eval_val_sliding_ttt(
+    args, base_model, rank, world_size, device, val_tokens, base_bytes_lut,
+    has_leading_space_lut, is_boundary_token_lut, stride, batch_seqs=32, log0=print,
+):
+    """Legal score-first TTT: score each chunk, then train on it."""
+    seq_len, total_tokens, ttt_chunk = args.train_seq_len, val_tokens.numel() - 1, args.ttt_chunk_tokens
+    window_starts = [ws for ws in range(0, total_tokens, stride) if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    chunk_windows = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        end = min(ws + seq_len, total_tokens)
+        wlen = end - ws
+        s = 0 if ws == 0 else max(wlen - stride, 0)
+        chunk_windows[min((ws + s) // ttt_chunk, num_chunks - 1)].append(ws)
+    log0(f"ttt_sliding:start chunks={num_chunks} chunk_tokens={ttt_chunk} windows={len(window_starts)} stride={stride} lr={args.ttt_lr} epochs={args.ttt_epochs}")
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    [setattr(m, '_cos_cached', None) or setattr(m, '_sin_cached', None) for m in base_model.modules() if hasattr(m, '_cos_cached')]
+    frozen_ids = set(range(min(args.ttt_freeze_blocks, len(base_model.blocks))))
+    ttt_params = []
+    for name, p in base_model.named_parameters():
+        p.data = p.data.clone()
+        freeze = any(f"blocks.{bi}." in name for bi in frozen_ids)
+        p.requires_grad_(not freeze)
+        if not freeze: ttt_params.append(p)
+    optimizer = torch.optim.SGD(ttt_params, lr=args.ttt_lr, momentum=args.ttt_momentum)
+    t0 = time.perf_counter()
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows: continue
+        chunk_start, chunk_end = ci * ttt_chunk, min((ci + 1) * ttt_chunk, total_tokens)
+        my_s, my_e = (len(windows) * rank) // world_size, (len(windows) * (rank + 1)) // world_size
+        my_windows = windows[my_s:my_e]
+        base_model.eval()
+        with torch.inference_mode():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi:bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_b = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_b = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens = []
+                for i, ws in enumerate(batch_ws):
+                    end = min(ws + seq_len, total_tokens); wlen = end - ws; wlens.append(wlen)
+                    tok = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                    x_b[i, :wlen], y_b[i, :wlen] = tok[:-1], tok[1:]
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model.forward_logits(x_b)
+                nll = F.cross_entropy(logits.reshape(-1, logits.size(-1)).float(), y_b.reshape(-1), reduction="none").reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]; s = 0 if ws == 0 else max(wlen - stride, 0)
+                    scored = nll[i, s:wlen].to(torch.float64); loss_sum += scored.sum(); token_count += float(wlen - s)
+                    tgt, prev = y_b[i, s:wlen], x_b[i, s:wlen]
+                    tb = base_bytes_lut[tgt].to(torch.float64) + (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                    byte_count += tb.sum()
+        if ci < num_chunks - 1 and args.ttt_epochs > 0:
+            [setattr(m, '_cos_cached', None) or setattr(m, '_sin_cached', None) for m in base_model.modules() if hasattr(m, '_cos_cached')]
+            base_model.train()
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if chunk_seqs > 0:
+                cos_lr = args.ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                for pg in optimizer.param_groups: pg['lr'] = cos_lr
+                my_seq_s, my_seq_e = (chunk_seqs * rank) // world_size, (chunk_seqs * (rank + 1)) // world_size
+                for _ep in range(args.ttt_epochs):
+                    for bs in range(my_seq_s, my_seq_e, args.ttt_batch_seqs):
+                        be = min(bs + args.ttt_batch_seqs, my_seq_e)
+                        start_tok, end_tok = chunk_start + bs * seq_len, chunk_start + be * seq_len + 1
+                        if end_tok > val_tokens.numel(): continue
+                        local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                        x, y = local[:-1].reshape(-1, seq_len), local[1:].reshape(-1, seq_len)
+                        optimizer.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            loss = base_model(x, y)
+                        loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None: dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        torch.nn.utils.clip_grad_norm_(ttt_params, args.ttt_grad_clip)
+                        optimizer.step()
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            log0(f"  ttt_chunk [{ci+1}/{num_chunks}] bpb={rbpb:.6f} time={elapsed:.1f}s")
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM); dist.all_reduce(token_count, op=dist.ReduceOp.SUM); dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    for p in base_model.parameters(): p.requires_grad_(True)
+    base_model.eval(); del optimizer; torch.cuda.empty_cache()
+    log0(f"ttt_sliding:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} elapsed={time.perf_counter() - t0:.1f}s")
+    return val_loss, val_bpb
 def _classify_param(name: str) -> str:
     if "tok_emb" in name or "lm_head" in name:
         return "embed"
@@ -1378,102 +1482,18 @@ def main() -> None:
         f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
     )
     log0(f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
-    # --- Test-Time Training (TTT): adapt model on val data before final eval ---
-    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 30))
-    ttt_lr = float(os.environ.get("TTT_LR", 0.0005))
-    if ttt_epochs > 0:
-        log0(f"ttt:start epochs:{ttt_epochs} lr:{ttt_lr}")
+    # --- Legal Score-First TTT ---
+    if args.ttt_epochs > 0:
+        torch.cuda.synchronize()
         t_ttt = time.perf_counter()
-        # Clear cached inference tensors (RoPE cos/sin, etc.)
-        for m in eval_model.modules():
-            if hasattr(m, '_cos_cached'):
-                m._cos_cached = None
-                m._sin_cached = None
-        proj_params, fc_params, other_params = [], [], []
-        for name, p in eval_model.named_parameters():
-            p.data = p.data.clone()
-            p.requires_grad_(True)
-            if "mlp.proj" in name:
-                proj_params.append(p)
-            elif "mlp.fc" in name:
-                fc_params.append(p)
-            else:
-                other_params.append(p)
-        ttt_opt = torch.optim.AdamW([
-            {"params": proj_params, "lr": ttt_lr * 3.0, "initial_lr": ttt_lr * 3.0},
-            {"params": fc_params, "lr": ttt_lr * 0.5, "initial_lr": ttt_lr * 0.5},
-            {"params": other_params, "lr": ttt_lr, "initial_lr": ttt_lr},
-        ], weight_decay=0.0)
-        ttt_batch = 32
-        total_val = val_tokens.numel()
-        rank_start = rank * (total_val // world_size)
-        rank_end = rank_start + (total_val // world_size)
-        ttt_seq = effective_eval_seq_len
-        steps_per_epoch = max(1, (rank_end - rank_start - ttt_seq) // (ttt_batch * ttt_seq))
-        total_ttt_steps = ttt_epochs * steps_per_epoch
-        global_step = 0
-        eval_model.train()
-        for ep in range(ttt_epochs):
-            for bs_start in range(rank_start, rank_end - ttt_seq, ttt_batch * ttt_seq):
-                progress = global_step / max(total_ttt_steps, 1)
-                cos_mul = 0.5 * (1.0 + math.cos(math.pi * progress))
-                for g in ttt_opt.param_groups:
-                    g["lr"] = g["initial_lr"] * cos_mul
-                ttt_opt.zero_grad()
-                x_ttt = torch.stack([val_tokens[bs_start + i * ttt_seq : bs_start + i * ttt_seq + ttt_seq]
-                                     for i in range(min(ttt_batch, (rank_end - bs_start) // ttt_seq))]).to(device=device, dtype=torch.int64)
-                y_ttt = torch.stack([val_tokens[bs_start + i * ttt_seq + 1 : bs_start + i * ttt_seq + ttt_seq + 1]
-                                     for i in range(min(ttt_batch, (rank_end - bs_start) // ttt_seq))]).to(device=device, dtype=torch.int64)
-                with torch.autocast("cuda", dtype=torch.bfloat16):
-                    loss_ttt = eval_model(x_ttt, y_ttt)
-                loss_ttt.backward()
-                if distributed:
-                    for p in eval_model.parameters():
-                        if p.grad is not None:
-                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
-                torch.nn.utils.clip_grad_norm_(eval_model.parameters(), 1.0)
-                ttt_opt.step()
-                global_step += 1
-            if (ep + 1) % 10 == 0:
-                log0(f"ttt:epoch:{ep+1}/{ttt_epochs} step:{global_step}/{total_ttt_steps}")
-        eval_model.eval()
-        del ttt_opt
-        torch.cuda.empty_cache()
-        log0(f"ttt:done time:{1000.0 * (time.perf_counter() - t_ttt):.0f}ms steps:{global_step}")
-        compiled_eval = torch.compile(eval_model, dynamic=False, fullgraph=True)
-    sw_seq_len = effective_eval_seq_len
-    if args.eval_stride > 0 and args.eval_stride < sw_seq_len:
-        torch.cuda.synchronize()
-        t_slide = time.perf_counter()
-        sw_val_loss, sw_val_bpb = eval_val_sliding(
+        ttt_val_loss, ttt_val_bpb = eval_val_sliding_ttt(
             args, eval_model, rank, world_size, device,
             val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
-            stride=args.eval_stride,
-            eval_seq_len=sw_seq_len,
+            stride=args.eval_stride, batch_seqs=args.ttt_batch_seqs, log0=log0,
         )
         torch.cuda.synchronize()
-        log0(
-            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
-            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
-        )
-        log0(f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
-        log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
-    if args.eval_stride != 64 and 64 < sw_seq_len:
-        torch.cuda.synchronize()
-        t_slide64 = time.perf_counter()
-        sw64_val_loss, sw64_val_bpb = eval_val_sliding(
-            args, eval_model, rank, world_size, device,
-            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
-            stride=64,
-            eval_seq_len=sw_seq_len,
-        )
-        torch.cuda.synchronize()
-        log0(
-            f"final_int6_sliding_window_s64 val_loss:{sw64_val_loss:.4f} val_bpb:{sw64_val_bpb:.4f} "
-            f"stride:64 eval_time:{1000.0 * (time.perf_counter() - t_slide64):.0f}ms"
-        )
-        log0(f"final_int6_sliding_window_s64_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
-        log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+        log0(f"legal_ttt val_loss:{ttt_val_loss:.4f} val_bpb:{ttt_val_bpb:.4f} eval_time:{1000.0 * (time.perf_counter() - t_ttt):.0f}ms")
+        log0(f"final_int6_sliding_window_exact val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f}")
     if distributed:
         dist.destroy_process_group()
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **val_bpb: 1.1408** (legal score-first TTT, stride-64)
- **Artifact size: 15,758,590 bytes** (under 16MB)
- 8xH100 SXM, seed=1337

## Technique

Legal chunk-based score-first TTT on the PR #414 consensus stack. Each validation chunk is scored first (under `inference_mode`), then the model trains on the already-scored tokens. Never trains on tokens before scoring them.

### Legal TTT Protocol
1. Split validation data into 32K-token chunks (1893 chunks)
2. For each chunk: **score** with sliding-window eval, then **train** for 3 epochs
3. SGD optimizer, base LR=0.002, momentum=0.9
4. Cosine LR decay across chunks
5. DDP gradient sync (all_reduce AVG), grad clip 1.0

### Architecture (PR #414 stack)
- 11 layers, 512d, 8H, 4KV (GQA), relu²
- SmearGate + BigramHash, XSA on last 4 layers
- EMA(0.997) + Tight SWA, GPTQ-lite int6+zstd-22

## Results

| Stage | val_loss | val_bpb |
|-------|----------|---------|
| Post-EMA (float) | 1.9433 | 1.1509 |
| Post-int6 roundtrip | 1.9570 | 1.1590 |
| **Legal TTT (score-first)** | **1.9262** | **1.1408** |

## Credits

- Base model and training: PR #414 by @signalrush
- Legal TTT protocol: PR #549
- TTT technique: PR #518 by @sofiabod
- SDPA fallback for non-FA3 environments