### PR TITLE
Record Submission: 1.0541 BPB - 5-expert Hedge Mixer + CROWN-Q + stride=64

### DIFF
--- a/records/track_10min_16mb/2026-03-25_HedgeMixer_CROWNQ_Stride64_1.0541/README.md
+++ b/records/track_10min_16mb/2026-03-25_HedgeMixer_CROWNQ_Stride64_1.0541/README.md
@@ -1,0 +1,86 @@
+# Record: 5-expert Hedge Mixer + CROWN-Q + stride=64 (val_bpb=1.0541)
+
+**val_bpb: 1.0541** (3-seed mean) | **~15.7 MB** | 8xH100 SXM
+
+## Results (8xH100 80GB SXM)
+
+| Seed | step_avg | steps | Pre-TTT bpb | **Post-TTT bpb** | TTT gain | Eval time | Artifact |
+|------|----------|-------|-------------|-----------------|----------|-----------|----------|
+| 1337 | 98.1ms | 5,935 | 1.1251 | **1.0473** | -0.0778 | 336s | 15.89 MB |
+| 42 | 97.9ms | 5,947 | 1.1264 | **1.0686** | -0.0578 | 336s | 15.69 MB |
+| 7 | 98.0ms | 5,940 | 1.1246 | **1.0465** | -0.0781 | 336s | 15.66 MB |
+| **Mean** | | | 1.1254 | **1.0541** | -0.0713 | 336s | ~15.75 MB |
+
+## Contributions
+
+### 1. CROWN-Q Training Penalty (training-time)
+Added a quantization-aware penalty during warmdown that penalizes weights sensitive to quantization error:
+```
+crown_q_loss = lambda * mean(w^2 * delta^2 / 12)
+```
+where `delta = row_max / clip_range` is the per-row quantization step size. This encourages weights to be quantization-friendly, reducing post-quantization degradation. `CROWN_Q_LAMBDA=0.01`.
+
+**Effect**: Slightly better compression (artifact ~200KB smaller) and more robust quantization.
+
+### 2. Eval stride 32 -> 64 (eval-time)
+Changed sliding window stride from 32 to 64 during evaluation. Experiment showed identical BPB quality but 2x faster scoring. Frees ~100s of eval budget for more TTT epochs.
+
+### 3. TTT Epochs 3 -> 4 (eval-time)
+Increased test-time training from 3 to 4 epochs per chunk, using the time freed by stride=64. Each additional epoch adapts the model more to scored data. Tested 8 epochs but that overfits (1.0735 vs 1.0473 for 4 epochs).
+
+### Combined Effect
+- stride=64 saves ~100s of eval time
+- 4th TTT epoch uses ~85s of the saved time
+- Net eval time: ~336s (down from ~562s), well within 600s budget
+- BPB improvement: 1.0745 -> 1.0541 (-0.0204)
+
+## Architecture
+
+| Component | Setting |
+|-----------|---------|
+| Layers | 11 (512d, 8H, 8KV) |
+| MLP | 3.5x with LeakyReLU(0.5)^2 |
+| BigramHash | 6144 (dim=128) |
+| XSA | All 11 layers (ws=8) |
+| VE128 | Layers 9-10 |
+| Quantization | Full GPTQ int5 + zstd level 22 |
+| Pruning | 3% magnitude |
+| TTT | AdamW lr=0.0001, **4 epochs**, 131K chunks, Polyak 0.998 |
+| Mixer | 5-expert Hedge (neural, unigram, bigram, trigram, entropy) |
+| Training reserve | 18s (for EMA + calibration + quantization) |
+| Early warmdown | LR schedule targets 582s |
+| **CROWN-Q** | lambda=0.01 during warmdown |
+| **Eval stride** | 64 (was 32) |
+
+## Reproduction
+
+```bash
+DATA_PATH=../data/datasets/fineweb10B_sp1024 \
+TOKENIZER_PATH=../data/tokenizers/fineweb_1024_bpe.model \
+SEED=1337 MAX_WALLCLOCK_SECONDS=600 \
+USE_MIXER=1 MIXER_ETA=0.1 \
+TTT_EPOCHS=4 TTT_FREEZE_BLOCKS=2 \
+TTT_LR=0.0001 TTT_CHUNK_TOKENS=131072 \
+ADAPTIVE_LR=1 ADAPTIVE_LR_MAX=3.0 \
+EVAL_STRIDE=64 \
+CROWN_Q_LAMBDA=0.01 \
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+
+## Compliance
+
+| Constraint | Limit | Actual | Status |
+|-----------|-------|--------|--------|
+| Train time | 600s | 582s | Pass |
+| Eval time | 600s | 336s | Pass |
+| Artifact size | 16,000,000 bytes | 15,892,040 bytes (worst seed) | Pass |
+| No pre-scoring training | — | Score-first TTT: each chunk scored under `inference_mode()` before any training on it | Pass |
+| GPTQ calibration in training budget | — | Runs within 18s training reserve (1.9s actual) | Pass |
+
+## Credits
+
+- Base model: PR #414 by @signalrush
+- TTT recipe: PR #461 by @Christopher-Lee-McClendon
+- CROWN-Q concept: PR #693 by @EthanYangTW
+- 5-expert Hedge mixer: PR #688

--- a/records/track_10min_16mb/2026-03-25_HedgeMixer_CROWNQ_Stride64_1.0541/log_seed1337.txt
+++ b/records/track_10min_16mb/2026-03-25_HedgeMixer_CROWNQ_Stride64_1.0541/log_seed1337.txt
@@ -1,0 +1,179 @@
+W0325 08:52:23.247000 708816 torch/distributed/run.py:852] 
+W0325 08:52:23.247000 708816 torch/distributed/run.py:852] *****************************************
+W0325 08:52:23.247000 708816 torch/distributed/run.py:852] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0325 08:52:23.247000 708816 torch/distributed/run.py:852] *****************************************
+logs/ed001136-906c-44c4-b9a3-2cb83dec0dc5.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=../data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=../data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+mixed_precision: 68 int5 layers, 0 int6 layers (last 0 blocks)
+model_params:33317980
+XSA:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] ws:8 gqa:8/8
+lr:embed=0.035 matrix=0.025 scalar=0.025 batch:786432 wall:600s seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9285 val_bpb:4.1034 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9305 train_time:151ms step_avg:151.37ms
+step:2/20000 train_loss:8.6412 train_time:241ms step_avg:120.48ms
+step:3/20000 train_loss:7.7278 train_time:336ms step_avg:111.86ms
+step:4/20000 train_loss:7.2812 train_time:430ms step_avg:107.50ms
+step:5/20000 train_loss:7.0672 train_time:525ms step_avg:104.91ms
+step:6/20000 train_loss:6.9648 train_time:619ms step_avg:103.21ms
+step:7/20000 train_loss:6.8519 train_time:714ms step_avg:102.00ms
+step:8/20000 train_loss:6.7092 train_time:809ms step_avg:101.12ms
+step:9/20000 train_loss:6.3651 train_time:904ms step_avg:100.42ms
+step:10/20000 train_loss:6.0329 train_time:999ms step_avg:99.87ms
+step:500/20000 train_loss:2.3632 train_time:48334ms step_avg:96.67ms
+step:1000/20000 train_loss:2.2407 train_time:96735ms step_avg:96.74ms
+step:1500/20000 train_loss:2.1858 train_time:145207ms step_avg:96.80ms
+step:2000/20000 train_loss:2.0310 train_time:193752ms step_avg:96.88ms
+step:2500/20000 train_loss:2.1364 train_time:242327ms step_avg:96.93ms
+step:3000/20000 train_loss:2.1144 train_time:290910ms step_avg:96.97ms
+step:3500/20000 train_loss:2.1219 train_time:339498ms step_avg:97.00ms
+step:4000/20000 train_loss:1.9090 train_time:388081ms step_avg:97.02ms
+step:4000/20000 val_loss:2.0001 val_bpb:1.1846 train_time:388086ms step_avg:97.02ms
+late_qat:enabled step:4249 scale:0.4998
+step:4500/20000 train_loss:2.0545 train_time:437520ms step_avg:97.23ms
+step:5000/20000 train_loss:2.0327 train_time:487703ms step_avg:97.54ms
+swa:start step:5300
+step:5500/20000 train_loss:1.9408 train_time:538082ms step_avg:97.83ms
+step:5935/20000 val_loss:1.9027 val_bpb:1.1269 train_time:582082ms step_avg:98.08ms
+stopping_early: wallclock_cap train_time:582082ms step:5935/20000
+peak memory allocated: 26200 MiB reserved: 26810 MiB
+ema:applying EMA weights (skipping diagnostic evals)
+gptq:calibrating with training data...
+gptq:calibrated 68 layers in 1.8s
+Serialized model: 130432585 bytes
+Code size: 97234 bytes
+pruning:3.0% magnitude pruning applied
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+Serialized model int6+zstd: 15794806 bytes
+Total submission size int6+zstd: 15892040 bytes
+  ttt: pre-compiling forward+backward kernels...
+  ttt: pre-compile done
+final_int6_sliding_window val_loss:1.8996 val_bpb:1.1251 stride:64 eval_time:93488ms
+final_int6_sliding_window_exact val_loss:1.89959945 val_bpb:1.12505277
+TTT: epochs=4 lr=0.0001 freeze_first=2 chunk=131072 opt=adamw
+TTT temperature: 0.98
+PPM alpha: 0.85, Byte-weighted TTT: True
+  Logistic context mixer enabled: eta=0.1
+  Adaptive LR enabled: max_mult=3.0
+ttt:start chunks=474 chunk_tokens=131072 windows=969088 stride=64 lr=0.0001 epochs=4 opt=adamw freeze_first=2
+ttt:params unfrozen=5780500 frozen=27537480
+  Polyak averaging enabled: decay=0.998
+    ttt_train [1] seqs=64 start_train...
+    ttt_train [1] epoch=1/4 batches=8 ...
+      step done ep=1 bs=0 loss=2.3520
+    ttt_train [1] epoch=2/4 batches=8 ...
+      step done ep=2 bs=0 loss=2.3190
+    ttt_train [1] epoch=3/4 batches=8 ...
+      step done ep=3 bs=0 loss=2.3168
+    ttt_train [1] epoch=4/4 batches=8 ...
+      step done ep=4 bs=0 loss=2.3064
+  ttt_chunk [1/474] bpb=1.205733 time=0.8s
+    ttt_train [2] seqs=64 start_train...
+    ttt_train [2] epoch=1/4 batches=8 ...
+      step done ep=1 bs=0 loss=2.1268
+    ttt_train [2] epoch=2/4 batches=8 ...
+      step done ep=2 bs=0 loss=2.1215
+    ttt_train [2] epoch=3/4 batches=8 ...
+      step done ep=3 bs=0 loss=2.1144
+    ttt_train [2] epoch=4/4 batches=8 ...
+      step done ep=4 bs=0 loss=2.1137
+  ttt_chunk [2/474] bpb=1.145205 time=1.5s
+    ttt_train [3] seqs=64 start_train...
+    ttt_train [3] epoch=1/4 batches=8 ...
+      step done ep=1 bs=0 loss=2.0650
+    ttt_train [3] epoch=2/4 batches=8 ...
+      step done ep=2 bs=0 loss=2.0640
+    ttt_train [3] epoch=3/4 batches=8 ...
+      step done ep=3 bs=0 loss=2.0610
+    ttt_train [3] epoch=4/4 batches=8 ...
+      step done ep=4 bs=0 loss=2.0570
+  ttt_chunk [3/474] bpb=1.093631 time=2.2s
+  ttt_chunk [4/474] bpb=1.086978 time=2.9s
+  ttt_chunk [5/474] bpb=1.075246 time=3.6s
+  ttt_chunk [11/474] bpb=1.037795 time=7.9s
+  ttt_chunk [21/474] bpb=1.025422 time=15.0s
+  ttt_chunk [31/474] bpb=1.021364 time=22.1s
+  ttt_chunk [41/474] bpb=1.028090 time=29.2s
+  ttt_chunk [51/474] bpb=1.033988 time=36.3s
+  ttt_chunk [61/474] bpb=1.031631 time=43.4s
+  ttt_chunk [71/474] bpb=1.032527 time=50.5s
+  ttt_chunk [81/474] bpb=1.033201 time=57.6s
+  ttt_chunk [91/474] bpb=1.034949 time=64.7s
+  ttt_chunk [101/474] bpb=1.031552 time=71.8s
+  ttt_chunk [111/474] bpb=1.031581 time=78.9s
+  ttt_chunk [121/474] bpb=1.034658 time=86.0s
+  ttt_chunk [131/474] bpb=1.034982 time=93.1s
+  ttt_chunk [141/474] bpb=1.033970 time=100.2s
+  ttt_chunk [151/474] bpb=1.031617 time=107.3s
+  ttt_chunk [161/474] bpb=1.031627 time=114.4s
+  ttt_chunk [171/474] bpb=1.029770 time=121.5s
+  ttt_chunk [181/474] bpb=1.030056 time=128.6s
+  ttt_chunk [191/474] bpb=1.028446 time=135.7s
+  ttt_chunk [201/474] bpb=1.027227 time=142.8s
+  ttt_chunk [211/474] bpb=1.025596 time=149.9s
+  ttt_chunk [221/474] bpb=1.025510 time=157.0s
+  ttt_chunk [231/474] bpb=1.024716 time=164.1s
+  ttt_chunk [241/474] bpb=1.023499 time=171.2s
+  ttt_chunk [251/474] bpb=1.024507 time=178.3s
+  ttt_chunk [261/474] bpb=1.025349 time=185.4s
+  ttt_chunk [271/474] bpb=1.024312 time=192.5s
+  ttt_chunk [281/474] bpb=1.024426 time=199.6s
+  ttt_chunk [291/474] bpb=1.023800 time=206.7s
+  ttt_chunk [301/474] bpb=1.025070 time=213.8s
+  ttt_chunk [311/474] bpb=1.025766 time=220.9s
+  ttt_chunk [321/474] bpb=1.025697 time=228.0s
+  ttt_chunk [331/474] bpb=1.026198 time=235.1s
+  ttt_chunk [341/474] bpb=1.027086 time=242.2s
+  ttt_chunk [351/474] bpb=1.027310 time=249.3s
+  ttt_chunk [361/474] bpb=1.029683 time=256.4s
+  ttt_chunk [371/474] bpb=1.031113 time=263.5s
+  ttt_chunk [381/474] bpb=1.033803 time=270.6s
+  ttt_chunk [391/474] bpb=1.036776 time=277.7s
+  ttt_chunk [401/474] bpb=1.039255 time=284.8s
+  ttt_chunk [411/474] bpb=1.041506 time=291.9s
+  ttt_chunk [421/474] bpb=1.044761 time=299.0s
+  ttt_chunk [431/474] bpb=1.045237 time=306.1s
+  ttt_chunk [441/474] bpb=1.046638 time=313.2s
+  ttt_chunk [451/474] bpb=1.047686 time=320.3s
+  ttt_chunk [461/474] bpb=1.049616 time=327.4s
+  ttt_chunk [471/474] bpb=1.051310 time=334.5s
+  ttt_chunk [474/474] bpb=1.051535 time=336.0s
+ttt:done val_loss=1.768268 val_bpb=1.047270 elapsed=336.0s
+final_int6_ttt val_loss:1.7683 val_bpb:1.0473 stride:64 eval_time:336499ms
+final_int6_ttt_exact val_loss:1.76826750 val_bpb:1.04727039

--- a/records/track_10min_16mb/2026-03-25_HedgeMixer_CROWNQ_Stride64_1.0541/log_seed42.txt
+++ b/records/track_10min_16mb/2026-03-25_HedgeMixer_CROWNQ_Stride64_1.0541/log_seed42.txt
@@ -1,0 +1,179 @@
+W0325 09:33:36.752000 716247 torch/distributed/run.py:852] 
+W0325 09:33:36.752000 716247 torch/distributed/run.py:852] *****************************************
+W0325 09:33:36.752000 716247 torch/distributed/run.py:852] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0325 09:33:36.752000 716247 torch/distributed/run.py:852] *****************************************
+logs/2d454be2-8e14-4ea4-b897-77ca6936b479.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=../data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=../data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+mixed_precision: 68 int5 layers, 0 int6 layers (last 0 blocks)
+model_params:33317980
+XSA:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] ws:8 gqa:8/8
+lr:embed=0.035 matrix=0.025 scalar=0.025 batch:786432 wall:600s seed:42
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9301 val_bpb:4.1044 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9309 train_time:150ms step_avg:149.71ms
+step:2/20000 train_loss:8.7072 train_time:240ms step_avg:120.07ms
+step:3/20000 train_loss:7.7698 train_time:335ms step_avg:111.72ms
+step:4/20000 train_loss:7.2987 train_time:430ms step_avg:107.42ms
+step:5/20000 train_loss:7.0367 train_time:524ms step_avg:104.83ms
+step:6/20000 train_loss:6.9492 train_time:619ms step_avg:103.12ms
+step:7/20000 train_loss:6.8513 train_time:714ms step_avg:102.00ms
+step:8/20000 train_loss:6.7338 train_time:809ms step_avg:101.12ms
+step:9/20000 train_loss:6.3597 train_time:904ms step_avg:100.42ms
+step:10/20000 train_loss:6.0342 train_time:998ms step_avg:99.85ms
+step:500/20000 train_loss:2.3646 train_time:48263ms step_avg:96.53ms
+step:1000/20000 train_loss:2.2450 train_time:96564ms step_avg:96.56ms
+step:1500/20000 train_loss:2.1897 train_time:144909ms step_avg:96.61ms
+step:2000/20000 train_loss:2.0309 train_time:193351ms step_avg:96.68ms
+step:2500/20000 train_loss:2.1358 train_time:241807ms step_avg:96.72ms
+step:3000/20000 train_loss:2.1144 train_time:290278ms step_avg:96.76ms
+step:3500/20000 train_loss:2.1230 train_time:338747ms step_avg:96.78ms
+step:4000/20000 train_loss:1.9110 train_time:387203ms step_avg:96.80ms
+step:4000/20000 val_loss:2.0019 val_bpb:1.1857 train_time:387208ms step_avg:96.80ms
+late_qat:enabled step:4262 scale:0.5000
+step:4500/20000 train_loss:2.0560 train_time:436495ms step_avg:97.00ms
+step:5000/20000 train_loss:2.0305 train_time:486551ms step_avg:97.31ms
+swa:start step:5300
+step:5500/20000 train_loss:1.9408 train_time:536855ms step_avg:97.61ms
+step:5947/20000 val_loss:1.9039 val_bpb:1.1276 train_time:582011ms step_avg:97.87ms
+stopping_early: wallclock_cap train_time:582011ms step:5947/20000
+peak memory allocated: 26200 MiB reserved: 26810 MiB
+ema:applying EMA weights (skipping diagnostic evals)
+gptq:calibrating with training data...
+gptq:calibrated 68 layers in 1.8s
+Serialized model: 130432585 bytes
+Code size: 97234 bytes
+pruning:3.0% magnitude pruning applied
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+Serialized model int6+zstd: 15596669 bytes
+Total submission size int6+zstd: 15693903 bytes
+  ttt: pre-compiling forward+backward kernels...
+  ttt: pre-compile done
+final_int6_sliding_window val_loss:1.9019 val_bpb:1.1264 stride:64 eval_time:84787ms
+final_int6_sliding_window_exact val_loss:1.90194229 val_bpb:1.12644033
+TTT: epochs=4 lr=0.0001 freeze_first=2 chunk=131072 opt=adamw
+TTT temperature: 0.98
+PPM alpha: 0.85, Byte-weighted TTT: True
+  Logistic context mixer enabled: eta=0.1
+  Adaptive LR enabled: max_mult=3.0
+ttt:start chunks=474 chunk_tokens=131072 windows=969088 stride=64 lr=0.0001 epochs=4 opt=adamw freeze_first=2
+ttt:params unfrozen=5780500 frozen=27537480
+  Polyak averaging enabled: decay=0.998
+    ttt_train [1] seqs=64 start_train...
+    ttt_train [1] epoch=1/4 batches=8 ...
+      step done ep=1 bs=0 loss=2.3502
+    ttt_train [1] epoch=2/4 batches=8 ...
+      step done ep=2 bs=0 loss=2.3146
+    ttt_train [1] epoch=3/4 batches=8 ...
+      step done ep=3 bs=0 loss=2.3116
+    ttt_train [1] epoch=4/4 batches=8 ...
+      step done ep=4 bs=0 loss=2.3019
+  ttt_chunk [1/474] bpb=1.207237 time=0.8s
+    ttt_train [2] seqs=64 start_train...
+    ttt_train [2] epoch=1/4 batches=8 ...
+      step done ep=1 bs=0 loss=2.1286
+    ttt_train [2] epoch=2/4 batches=8 ...
+      step done ep=2 bs=0 loss=2.1248
+    ttt_train [2] epoch=3/4 batches=8 ...
+      step done ep=3 bs=0 loss=2.1175
+    ttt_train [2] epoch=4/4 batches=8 ...
+      step done ep=4 bs=0 loss=2.1159
+  ttt_chunk [2/474] bpb=1.144375 time=1.5s
+    ttt_train [3] seqs=64 start_train...
+    ttt_train [3] epoch=1/4 batches=8 ...
+      step done ep=1 bs=0 loss=2.0553
+    ttt_train [3] epoch=2/4 batches=8 ...
+      step done ep=2 bs=0 loss=2.0546
+    ttt_train [3] epoch=3/4 batches=8 ...
+      step done ep=3 bs=0 loss=2.0523
+    ttt_train [3] epoch=4/4 batches=8 ...
+      step done ep=4 bs=0 loss=2.0489
+  ttt_chunk [3/474] bpb=1.092230 time=2.2s
+  ttt_chunk [4/474] bpb=1.085631 time=2.9s
+  ttt_chunk [5/474] bpb=1.074015 time=3.6s
+  ttt_chunk [11/474] bpb=1.035764 time=7.9s
+  ttt_chunk [21/474] bpb=1.021107 time=15.0s
+  ttt_chunk [31/474] bpb=1.015593 time=22.1s
+  ttt_chunk [41/474] bpb=1.020683 time=29.2s
+  ttt_chunk [51/474] bpb=1.024917 time=36.3s
+  ttt_chunk [61/474] bpb=1.020852 time=43.4s
+  ttt_chunk [71/474] bpb=1.020415 time=50.5s
+  ttt_chunk [81/474] bpb=1.019875 time=57.6s
+  ttt_chunk [91/474] bpb=1.020633 time=64.7s
+  ttt_chunk [101/474] bpb=1.016491 time=71.8s
+  ttt_chunk [111/474] bpb=1.016110 time=78.9s
+  ttt_chunk [121/474] bpb=1.018971 time=85.9s
+  ttt_chunk [131/474] bpb=1.019575 time=93.0s
+  ttt_chunk [141/474] bpb=1.019478 time=100.1s
+  ttt_chunk [151/474] bpb=1.018502 time=107.2s
+  ttt_chunk [161/474] bpb=1.020250 time=114.3s
+  ttt_chunk [171/474] bpb=1.020508 time=121.4s
+  ttt_chunk [181/474] bpb=1.023189 time=128.5s
+  ttt_chunk [191/474] bpb=1.023871 time=135.6s
+  ttt_chunk [201/474] bpb=1.025154 time=142.7s
+  ttt_chunk [211/474] bpb=1.026022 time=149.8s
+  ttt_chunk [221/474] bpb=1.028491 time=156.9s
+  ttt_chunk [231/474] bpb=1.030074 time=164.0s
+  ttt_chunk [241/474] bpb=1.031206 time=171.1s
+  ttt_chunk [251/474] bpb=1.034601 time=178.2s
+  ttt_chunk [261/474] bpb=1.037863 time=185.3s
+  ttt_chunk [271/474] bpb=1.038967 time=192.4s
+  ttt_chunk [281/474] bpb=1.041099 time=199.5s
+  ttt_chunk [291/474] bpb=1.042201 time=206.6s
+  ttt_chunk [301/474] bpb=1.044900 time=213.7s
+  ttt_chunk [311/474] bpb=1.046767 time=220.8s
+  ttt_chunk [321/474] bpb=1.047636 time=227.9s
+  ttt_chunk [331/474] bpb=1.048874 time=235.0s
+  ttt_chunk [341/474] bpb=1.050267 time=242.1s
+  ttt_chunk [351/474] bpb=1.050821 time=249.2s
+  ttt_chunk [361/474] bpb=1.053459 time=256.3s
+  ttt_chunk [371/474] bpb=1.055038 time=263.4s
+  ttt_chunk [381/474] bpb=1.057812 time=270.5s
+  ttt_chunk [391/474] bpb=1.060716 time=277.6s
+  ttt_chunk [401/474] bpb=1.063023 time=284.7s
+  ttt_chunk [411/474] bpb=1.065015 time=291.8s
+  ttt_chunk [421/474] bpb=1.068017 time=298.9s
+  ttt_chunk [431/474] bpb=1.068141 time=306.0s
+  ttt_chunk [441/474] bpb=1.069128 time=313.1s
+  ttt_chunk [451/474] bpb=1.069811 time=320.2s
+  ttt_chunk [461/474] bpb=1.071344 time=327.3s
+  ttt_chunk [471/474] bpb=1.072687 time=334.4s
+  ttt_chunk [474/474] bpb=1.072812 time=335.9s
+ttt:done val_loss=1.804258 val_bpb=1.068586 elapsed=335.9s
+final_int6_ttt val_loss:1.8043 val_bpb:1.0686 stride:64 eval_time:336413ms
+final_int6_ttt_exact val_loss:1.80425782 val_bpb:1.06858594

--- a/records/track_10min_16mb/2026-03-25_HedgeMixer_CROWNQ_Stride64_1.0541/log_seed7.txt
+++ b/records/track_10min_16mb/2026-03-25_HedgeMixer_CROWNQ_Stride64_1.0541/log_seed7.txt
@@ -1,0 +1,179 @@
+W0325 09:54:14.392000 719007 torch/distributed/run.py:852] 
+W0325 09:54:14.392000 719007 torch/distributed/run.py:852] *****************************************
+W0325 09:54:14.392000 719007 torch/distributed/run.py:852] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0325 09:54:14.392000 719007 torch/distributed/run.py:852] *****************************************
+logs/c913fd2f-2505-4113-b378-9fa81866492a.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=../data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=../data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+mixed_precision: 68 int5 layers, 0 int6 layers (last 0 blocks)
+model_params:33317980
+XSA:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] ws:8 gqa:8/8
+lr:embed=0.035 matrix=0.025 scalar=0.025 batch:786432 wall:600s seed:7
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9294 val_bpb:4.1040 train_time:0ms step_avg:0.03ms
+step:1/20000 train_loss:6.9310 train_time:148ms step_avg:148.10ms
+step:2/20000 train_loss:8.7138 train_time:238ms step_avg:119.00ms
+step:3/20000 train_loss:7.7624 train_time:333ms step_avg:110.95ms
+step:4/20000 train_loss:7.2818 train_time:427ms step_avg:106.79ms
+step:5/20000 train_loss:7.1030 train_time:522ms step_avg:104.33ms
+step:6/20000 train_loss:6.9242 train_time:617ms step_avg:102.76ms
+step:7/20000 train_loss:6.8670 train_time:711ms step_avg:101.62ms
+step:8/20000 train_loss:6.6918 train_time:806ms step_avg:100.79ms
+step:9/20000 train_loss:6.3604 train_time:901ms step_avg:100.13ms
+step:10/20000 train_loss:6.0036 train_time:996ms step_avg:99.61ms
+step:500/20000 train_loss:2.3635 train_time:48321ms step_avg:96.64ms
+step:1000/20000 train_loss:2.2370 train_time:96698ms step_avg:96.70ms
+step:1500/20000 train_loss:2.1845 train_time:145104ms step_avg:96.74ms
+step:2000/20000 train_loss:2.0277 train_time:193587ms step_avg:96.79ms
+step:2500/20000 train_loss:2.1307 train_time:242110ms step_avg:96.84ms
+step:3000/20000 train_loss:2.1134 train_time:290640ms step_avg:96.88ms
+step:3500/20000 train_loss:2.1191 train_time:339158ms step_avg:96.90ms
+step:4000/20000 train_loss:1.9078 train_time:387695ms step_avg:96.92ms
+step:4000/20000 val_loss:1.9989 val_bpb:1.1838 train_time:387700ms step_avg:96.92ms
+late_qat:enabled step:4255 scale:0.4998
+step:4500/20000 train_loss:2.0565 train_time:437079ms step_avg:97.13ms
+step:5000/20000 train_loss:2.0310 train_time:487239ms step_avg:97.45ms
+swa:start step:5300
+step:5500/20000 train_loss:1.9379 train_time:537623ms step_avg:97.75ms
+step:5940/20000 val_loss:1.9017 val_bpb:1.1263 train_time:582088ms step_avg:97.99ms
+stopping_early: wallclock_cap train_time:582088ms step:5940/20000
+peak memory allocated: 26197 MiB reserved: 26810 MiB
+ema:applying EMA weights (skipping diagnostic evals)
+gptq:calibrating with training data...
+gptq:calibrated 68 layers in 1.8s
+Serialized model: 130432585 bytes
+Code size: 97234 bytes
+pruning:3.0% magnitude pruning applied
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+Serialized model int6+zstd: 15567239 bytes
+Total submission size int6+zstd: 15664473 bytes
+  ttt: pre-compiling forward+backward kernels...
+  ttt: pre-compile done
+final_int6_sliding_window val_loss:1.8988 val_bpb:1.1246 stride:64 eval_time:85026ms
+final_int6_sliding_window_exact val_loss:1.89882584 val_bpb:1.12459459
+TTT: epochs=4 lr=0.0001 freeze_first=2 chunk=131072 opt=adamw
+TTT temperature: 0.98
+PPM alpha: 0.85, Byte-weighted TTT: True
+  Logistic context mixer enabled: eta=0.1
+  Adaptive LR enabled: max_mult=3.0
+ttt:start chunks=474 chunk_tokens=131072 windows=969088 stride=64 lr=0.0001 epochs=4 opt=adamw freeze_first=2
+ttt:params unfrozen=5780500 frozen=27537480
+  Polyak averaging enabled: decay=0.998
+    ttt_train [1] seqs=64 start_train...
+    ttt_train [1] epoch=1/4 batches=8 ...
+      step done ep=1 bs=0 loss=2.3491
+    ttt_train [1] epoch=2/4 batches=8 ...
+      step done ep=2 bs=0 loss=2.3148
+    ttt_train [1] epoch=3/4 batches=8 ...
+      step done ep=3 bs=0 loss=2.3132
+    ttt_train [1] epoch=4/4 batches=8 ...
+      step done ep=4 bs=0 loss=2.3018
+  ttt_chunk [1/474] bpb=1.203490 time=0.8s
+    ttt_train [2] seqs=64 start_train...
+    ttt_train [2] epoch=1/4 batches=8 ...
+      step done ep=1 bs=0 loss=2.1329
+    ttt_train [2] epoch=2/4 batches=8 ...
+      step done ep=2 bs=0 loss=2.1286
+    ttt_train [2] epoch=3/4 batches=8 ...
+      step done ep=3 bs=0 loss=2.1227
+    ttt_train [2] epoch=4/4 batches=8 ...
+      step done ep=4 bs=0 loss=2.1213
+  ttt_chunk [2/474] bpb=1.144897 time=1.5s
+    ttt_train [3] seqs=64 start_train...
+    ttt_train [3] epoch=1/4 batches=8 ...
+      step done ep=1 bs=0 loss=2.0621
+    ttt_train [3] epoch=2/4 batches=8 ...
+      step done ep=2 bs=0 loss=2.0609
+    ttt_train [3] epoch=3/4 batches=8 ...
+      step done ep=3 bs=0 loss=2.0584
+    ttt_train [3] epoch=4/4 batches=8 ...
+      step done ep=4 bs=0 loss=2.0553
+  ttt_chunk [3/474] bpb=1.094940 time=2.2s
+  ttt_chunk [4/474] bpb=1.088500 time=2.9s
+  ttt_chunk [5/474] bpb=1.077159 time=3.6s
+  ttt_chunk [11/474] bpb=1.040769 time=7.9s
+  ttt_chunk [21/474] bpb=1.029304 time=15.0s
+  ttt_chunk [31/474] bpb=1.026595 time=22.1s
+  ttt_chunk [41/474] bpb=1.033995 time=29.2s
+  ttt_chunk [51/474] bpb=1.041037 time=36.3s
+  ttt_chunk [61/474] bpb=1.039200 time=43.4s
+  ttt_chunk [71/474] bpb=1.040830 time=50.5s
+  ttt_chunk [81/474] bpb=1.042142 time=57.6s
+  ttt_chunk [91/474] bpb=1.044411 time=64.7s
+  ttt_chunk [101/474] bpb=1.041409 time=71.7s
+  ttt_chunk [111/474] bpb=1.041808 time=78.8s
+  ttt_chunk [121/474] bpb=1.045251 time=85.9s
+  ttt_chunk [131/474] bpb=1.045850 time=93.0s
+  ttt_chunk [141/474] bpb=1.045067 time=100.1s
+  ttt_chunk [151/474] bpb=1.042668 time=107.2s
+  ttt_chunk [161/474] bpb=1.042668 time=114.3s
+  ttt_chunk [171/474] bpb=1.040576 time=121.4s
+  ttt_chunk [181/474] bpb=1.040522 time=128.5s
+  ttt_chunk [191/474] bpb=1.038673 time=135.6s
+  ttt_chunk [201/474] bpb=1.037138 time=142.7s
+  ttt_chunk [211/474] bpb=1.035123 time=149.8s
+  ttt_chunk [221/474] bpb=1.034663 time=156.9s
+  ttt_chunk [231/474] bpb=1.033395 time=163.9s
+  ttt_chunk [241/474] bpb=1.031636 time=171.0s
+  ttt_chunk [251/474] bpb=1.032039 time=178.1s
+  ttt_chunk [261/474] bpb=1.032179 time=185.2s
+  ttt_chunk [271/474] bpb=1.030431 time=192.3s
+  ttt_chunk [281/474] bpb=1.029808 time=199.4s
+  ttt_chunk [291/474] bpb=1.028416 time=206.5s
+  ttt_chunk [301/474] bpb=1.028856 time=213.6s
+  ttt_chunk [311/474] bpb=1.028762 time=220.7s
+  ttt_chunk [321/474] bpb=1.027885 time=227.8s
+  ttt_chunk [331/474] bpb=1.027635 time=234.9s
+  ttt_chunk [341/474] bpb=1.027940 time=242.0s
+  ttt_chunk [351/474] bpb=1.027678 time=249.1s
+  ttt_chunk [361/474] bpb=1.029588 time=256.2s
+  ttt_chunk [371/474] bpb=1.030704 time=263.2s
+  ttt_chunk [381/474] bpb=1.033133 time=270.3s
+  ttt_chunk [391/474] bpb=1.035840 time=277.4s
+  ttt_chunk [401/474] bpb=1.038119 time=284.5s
+  ttt_chunk [411/474] bpb=1.040293 time=291.6s
+  ttt_chunk [421/474] bpb=1.043484 time=298.7s
+  ttt_chunk [431/474] bpb=1.043872 time=305.8s
+  ttt_chunk [441/474] bpb=1.045173 time=312.9s
+  ttt_chunk [451/474] bpb=1.046175 time=320.0s
+  ttt_chunk [461/474] bpb=1.048106 time=327.1s
+  ttt_chunk [471/474] bpb=1.049842 time=334.2s
+  ttt_chunk [474/474] bpb=1.050038 time=335.7s
+ttt:done val_loss=1.766886 val_bpb=1.046452 elapsed=335.7s
+final_int6_ttt val_loss:1.7669 val_bpb:1.0465 stride:64 eval_time:336188ms
+final_int6_ttt_exact val_loss:1.76688554 val_bpb:1.04645191

--- a/records/track_10min_16mb/2026-03-25_HedgeMixer_CROWNQ_Stride64_1.0541/requirements.txt
+++ b/records/track_10min_16mb/2026-03-25_HedgeMixer_CROWNQ_Stride64_1.0541/requirements.txt
@@ -1,0 +1,5 @@
+torch>=2.4.0
+numpy
+sentencepiece
+zstandard
+flash-attn-hopper

--- a/records/track_10min_16mb/2026-03-25_HedgeMixer_CROWNQ_Stride64_1.0541/submission.json
+++ b/records/track_10min_16mb/2026-03-25_HedgeMixer_CROWNQ_Stride64_1.0541/submission.json
@@ -1,0 +1,15 @@
+{
+  "track": "10min_16mb",
+  "date": "2026-03-25",
+  "name": "Record: 5-expert Hedge Mixer + CROWN-Q + stride=64 (val_bpb=1.0541)",
+  "author": "royi",
+  "github": "RoyiRa",
+  "seed_results": {
+    "1337": {"val_loss": 1.76826750, "val_bpb": 1.04727039, "artifact_bytes": 15892040},
+    "42":   {"val_loss": 1.80425782, "val_bpb": 1.06858594, "artifact_bytes": 15693903},
+    "7":    {"val_loss": 1.76688554, "val_bpb": 1.04645191, "artifact_bytes": 15664473}
+  },
+  "mean_val_loss": 1.77980362,
+  "mean_val_bpb": 1.05410275,
+  "code_bytes": 97234
+}

--- a/records/track_10min_16mb/2026-03-25_HedgeMixer_CROWNQ_Stride64_1.0541/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-25_HedgeMixer_CROWNQ_Stride64_1.0541/train_gpt.py
@@ -1,0 +1,1978 @@
+"""V27: CROWN-Q training + stride=64 + 4 TTT epochs."""
+from __future__ import annotations
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+try:
+    from flash_attn_interface import flash_attn_func as flash_attn_3_func
+    _HAS_FA3 = True
+except ImportError:
+    try:
+        from flash_attn import flash_attn_func as flash_attn_3_func
+        _HAS_FA3 = True
+    except ImportError:
+        _HAS_FA3 = False
+        flash_attn_3_func = None
+
+class LogisticContextMixer:
+    """GPU-vectorized logistic context mixing (inspired by PAQ compression).
+
+    Maintains GPU-resident n-gram count tables and learns online mixing weights
+    using the Hedge/multiplicative-weights algorithm.
+
+    Experts:
+      0: Neural model (logits passed in)
+      1: Unigram frequencies from scored tokens
+      2: Bigram frequencies (prev_token → next_token)
+      3: FastPPM (orders 0-4, CPU-side)
+      4: ExactMatchCache (high-order exact matches, CPU-side)
+    """
+
+    def __init__(self, vocab_size: int = 1024, device: str = 'cuda', eta: float = 0.1):
+        self.V = vocab_size
+        self.device = device
+        self.eta = eta  # Hedge learning rate
+        self.K = 5  # number of experts
+
+        # Expert weights (log-domain for numerical stability)
+        self.log_weights = torch.zeros(self.K, device=device)
+        # Bias toward neural model initially
+        self.log_weights[0] = 2.0
+
+        # N-gram count tables (GPU-resident)
+        self.uni_counts = torch.zeros(vocab_size, device=device)
+        self.bi_counts = torch.zeros(vocab_size, vocab_size, device=device)
+        self.total_tokens = 0
+
+        # GPU Trigram: hashed table [HASH_SIZE, V] to keep memory reasonable
+        self.TRI_HASH = 65536  # 64K hash buckets for (prev2, prev1) pairs
+        self.tri_counts = torch.zeros(self.TRI_HASH, vocab_size, device=device)
+        self.tri_row_totals = torch.zeros(self.TRI_HASH, device=device)
+
+    def update(self, tokens):
+        """Update all expert statistics with newly scored tokens."""
+        if hasattr(tokens, 'cpu'):
+            t = tokens.to(self.device).long()
+        else:
+            t = torch.tensor(tokens, device=self.device, dtype=torch.long)
+
+        n = t.numel()
+        if n == 0:
+            return
+        self.total_tokens += n
+
+        # Unigram: in-place scatter_add
+        ones = torch.ones(n, device=self.device)
+        self.uni_counts.scatter_add_(0, t, ones)
+
+        # Bigram: in-place scatter_add on flattened view (no temporary 1M tensor)
+        if n >= 2:
+            ctx = t[:-1]
+            nxt = t[1:]
+            bi_idx = ctx * self.V + nxt
+            ones_bi = torch.ones(n - 1, device=self.device)
+            self.bi_counts.reshape(-1).scatter_add_(0, bi_idx, ones_bi)
+
+        # Trigram: in-place scatter_add on flattened view (no temporary 67M tensor)
+        if n >= 3:
+            prev2 = t[:-2]
+            prev1 = t[1:-1]
+            nxt3 = t[2:]
+            tri_ctx = ((prev2 * 36313) ^ (prev1 * 27191)) % self.TRI_HASH
+            tri_idx = tri_ctx * self.V + nxt3
+            ones_tri = torch.ones(n - 2, device=self.device)
+            self.tri_counts.reshape(-1).scatter_add_(0, tri_idx, ones_tri)
+            self.tri_row_totals.scatter_add_(0, tri_ctx, ones_tri)
+
+    def get_expert_log_probs(self, neural_logits, x_batch, y_batch, wlens):
+        """Get log-probability of targets from each expert. All GPU-vectorized.
+
+        Args:
+            neural_logits: [bsz, seq_len, V] neural model logits
+            x_batch: [bsz, seq_len] input tokens (context)
+            y_batch: [bsz, seq_len] target tokens
+            wlens: list of actual lengths per sequence
+
+        Returns:
+            expert_nll: [bsz, seq_len, K] NLL from each expert
+        """
+        bsz, slen, V = neural_logits.shape
+        uniform_nll = math.log(self.V)
+        has_data = self.total_tokens > 0  # Python int — no GPU-CPU sync
+
+        # Expert 0: Neural model — compute log_softmax once, reuse for entropy
+        neural_lp = F.log_softmax(neural_logits, dim=-1)
+        neural_nll = -neural_lp.gather(2, y_batch.unsqueeze(2)).squeeze(2)  # [bsz, slen]
+
+        # Expert 1: Unigram
+        if has_data:
+            uni_probs = (self.uni_counts + 0.1) / (self.total_tokens + 0.1 * self.V)
+            uni_nll = -uni_probs.log()[y_batch]  # [bsz, slen]
+        else:
+            uni_nll = torch.full((bsz, slen), uniform_nll, device=self.device)
+
+        # Expert 2: Bigram P(next | prev)
+        if has_data:
+            bi_total = self.bi_counts.sum(dim=1, keepdim=True)  # [V, 1]
+            bi_probs = (self.bi_counts + 0.1) / (bi_total + 0.1 * self.V)  # [V, V]
+            prev_flat = x_batch.reshape(-1)
+            next_flat = y_batch.reshape(-1)
+            bi_nll = -bi_probs.log()[prev_flat, next_flat].reshape(bsz, slen)
+        else:
+            bi_nll = torch.full((bsz, slen), uniform_nll, device=self.device)
+
+        # Expert 3: GPU Trigram P(next | hash(prev2, prev1)) — vectorized
+        if has_data and slen >= 2:
+            prev2 = torch.zeros_like(x_batch)
+            prev2[:, 1:] = x_batch[:, :-1]
+            ctx_hash = ((prev2 * 36313) ^ (x_batch * 27191)) % self.TRI_HASH
+            ctx_flat = ctx_hash.reshape(-1).long()
+            next_flat = y_batch.reshape(-1).long()
+            tri_count = self.tri_counts[ctx_flat, next_flat]
+            tri_total = self.tri_row_totals[ctx_flat].clamp(min=1)
+            tri_prob = (tri_count + 0.01) / (tri_total + 0.01 * self.V)
+            tri_nll = -tri_prob.log().reshape(bsz, slen)
+        else:
+            tri_nll = torch.full((bsz, slen), uniform_nll, device=self.device)
+
+        # Expert 4: Neural entropy — reuse neural_lp (no redundant softmax)
+        entropy_nll = -(neural_lp.exp() * neural_lp).sum(-1)  # [bsz, slen]
+
+        # Stack: [bsz, slen, K]
+        return torch.stack([neural_nll, uni_nll, bi_nll, tri_nll, entropy_nll], dim=-1)
+
+    def mix_and_score(self, neural_logits, x_batch, y_batch, wlens):
+        """Compute mixed NLL using current expert weights.
+
+        Returns (mixed_nll [bsz, slen], expert_nll [bsz, slen, K] or None).
+        Caller should pass expert_nll to update_weights() to avoid recomputation.
+        """
+        if self.total_tokens < 10000:
+            # Not enough data for n-grams — just use neural
+            nll = F.cross_entropy(
+                neural_logits.reshape(-1, neural_logits.size(-1)),
+                y_batch.reshape(-1), reduction="none"
+            ).reshape(neural_logits.shape[0], neural_logits.shape[1])
+            return nll, None
+
+        expert_nll = self.get_expert_log_probs(neural_logits, x_batch, y_batch, wlens)  # [bsz, slen, K]
+
+        # Log-domain mixing: log(sum_k w_k * p_k) = logsumexp(log_w_k + log_p_k)
+        log_w = self.log_weights - self.log_weights.logsumexp(0)  # normalize
+        mixed_lp = (-expert_nll + log_w.unsqueeze(0).unsqueeze(0)).logsumexp(dim=-1)  # [bsz, slen]
+
+        return -mixed_lp, expert_nll  # mixed NLL + cached expert NLL
+
+    def update_weights(self, expert_nll, wlens):
+        """Update expert weights using Hedge algorithm on pre-computed expert NLLs."""
+        if expert_nll is None:
+            return
+
+        with torch.no_grad():
+            # Vectorized mask: compare position index against window lengths
+            bsz, slen = expert_nll.shape[0], expert_nll.shape[1]
+            wlens_t = torch.tensor(wlens, device=self.device, dtype=torch.long)
+            mask = torch.arange(slen, device=self.device).unsqueeze(0) < wlens_t.unsqueeze(1)  # [bsz, slen] bool
+
+            # Masked mean NLL per expert
+            masked_nll = expert_nll * mask.unsqueeze(-1).float()
+            expert_mean_loss = masked_nll.sum(dim=(0, 1)) / mask.sum().clamp(min=1)  # [K]
+
+            # Hedge update: log_w -= eta * loss
+            self.log_weights -= self.eta * expert_mean_loss
+
+
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3500))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 8))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 3.5))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.035))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.025))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.025))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 32))
+    int6_last_n = int(os.environ.get("INT6_LAST_N", 0))  # all int5 (saves ~300KB vs int6 for last 2 blocks)
+    ttt_temperature = float(os.environ.get("TTT_TEMPERATURE", 0.98))  # post-TTT temperature calibration
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+
+    muon_wd = float(os.environ.get("MUON_WD", 0.04))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.04))
+    qat_enabled = bool(int(os.environ.get("QAT_ENABLED", "0")))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 6144))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    dtg_enabled = bool(int(os.environ.get("DTG_ENABLED", "0")))
+    late_qat_threshold = float(os.environ.get("LATE_QAT_THRESHOLD", 0.5))
+    ve_enabled = bool(int(os.environ.get("VE_ENABLED", "1")))
+    ve_dim = int(os.environ.get("VE_DIM", 128))
+    ve_layers = os.environ.get("VE_LAYERS", "9,10")
+    prune_pct = float(os.environ.get("PRUNE_PCT", 0.03))
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay),
+        )
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                if wd > 0.0:
+                    p.data.mul_(1.0 - lr * wd)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+        return loss
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+def eval_val(args: Hyperparameters, model: nn.Module, rank: int, world_size: int,
+             device: torch.device, grad_accum_steps: int, val_tokens: Tensor,
+             base_bytes_lut: Tensor, has_leading_space_lut: Tensor,
+             is_boundary_token_lut: Tensor, eval_seq_len: int | None = None) -> tuple[float, float]:
+    seq_len = eval_seq_len or args.train_seq_len
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,dtg_gate,ve_layer_scales,ve_shared.scale",
+    ).split(",")
+    if pattern
+)
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_Q = 0.9999984
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+    _soft_round_alpha: float = 1.0  # temperature for soft-round (annealed during training)
+    _use_soft_round: bool = False  # enable soft-round QAT instead of STE
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._clip_range = 15  # default int5, set to 31 for int6 layers
+
+    @staticmethod
+    def soft_round(y: Tensor, alpha: float) -> Tensor:
+        """Differentiable approximation to round() from Agustsson & Theis (NeurIPS 2020).
+        s_alpha(y) = floor(y) + 0.5 * tanh(alpha * r) / tanh(alpha/2) + 0.5
+        where r = y - floor(y) - 0.5 (centered fractional part)
+        """
+        fl = torch.floor(y)
+        r = y - fl - 0.5
+        return fl + 0.5 * torch.tanh(alpha * r) / (math.tanh(alpha / 2) + 1e-10) + 0.5
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        cr = self._clip_range
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            if CastedLinear._use_soft_round:
+                # Soft-Round QAT: differentiable rounding with temperature annealing
+                w32 = self.weight.float()
+                row_clip = torch.quantile(w32.abs(), 0.9995, dim=1)
+                scale = (row_clip / float(cr)).clamp_min(1.0 / float(cr))
+                w_scaled = w32 / scale[:, None]
+                w_rounded = CastedLinear.soft_round(w_scaled, CastedLinear._soft_round_alpha)
+                w_q = (torch.clamp(w_rounded, -(cr+1), cr) * scale[:, None]).to(x.dtype)
+                w = w_q  # fully differentiable path
+            else:
+                # Original STE QAT
+                with torch.no_grad():
+                    w32 = self.weight.float()
+                    row_clip = torch.quantile(w32.abs(), 0.9995, dim=1)
+                    scale = (row_clip / float(cr)).clamp_min(1.0 / float(cr))
+                    w_q = (torch.clamp(torch.round(w32 / scale[:, None]), -(cr+1), cr) * scale[:, None]).to(x.dtype)
+                w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024, rope_dims: int = 0):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / (base ** (torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (rd / (rd - 2)))
+                inv_freq = 1.0 / (new_base ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd))
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int = 0) -> Tensor:
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int,
+                 rope_base: float, qk_gain_init: float):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        y_g = y.reshape(B, T, Hkv, H // Hkv, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x: Tensor, v_embed: Tensor | None = None) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = self.c_v(x)
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if _HAS_FA3:
+            y = flash_attn_3_func(q, k, v, causal=True).contiguous()
+        else:
+            y = F.scaled_dot_product_attention(
+                q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
+                attn_mask=None, is_causal=True,
+                enable_gqa=(self.num_kv_heads != self.num_heads),
+            ).transpose(1, 2)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class ValueEmbedding(nn.Module):
+    def __init__(self, vocab_size: int, ve_dim: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, ve_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(ve_dim, model_dim, bias=False) if ve_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(token_ids)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.proj(F.leaky_relu(self.fc(x), negative_slope=0.5).square())
+
+class Block(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int,
+                 rope_base: float, qk_gain_init: float, layer_idx: int = 0,
+                 ln_scale: bool = False, dtg: bool = False):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+        if dtg:
+            self.dtg_gate = nn.Linear(dim, 1, bias=True)
+            nn.init.zeros_(self.dtg_gate.weight)
+            nn.init.constant_(self.dtg_gate.bias, 2.0)
+        else:
+            self.dtg_gate = None
+
+    def forward(self, x: Tensor, x0: Tensor, v_embed: Tensor | None = None) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x_in) * self.ln_scale_factor, v_embed=v_embed)
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor)
+        if self.dtg_gate is not None:
+            gate = torch.sigmoid(self.dtg_gate(x_in.detach()))
+            x_out = x_in + gate * (x_out - x_in)
+        return x_out
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int, num_heads: int,
+                 num_kv_heads: int, mlp_mult: int, tie_embeddings: bool, tied_embed_init_std: float,
+                 logit_softcap: float, rope_base: float, qk_gain_init: float,
+                 bigram_vocab_size: int = 0, bigram_dim: int = 128, xsa_last_n: int = 0,
+                 rope_dims: int = 0, ln_scale: bool = False, dtg: bool = False,
+                 ve_enabled: bool = False, ve_dim: int = 128, ve_layers: str = "9,10"):
+        super().__init__()
+        self._ve_target_dim = num_kv_heads * (model_dim // num_heads)
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.smear = SmearGate(model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList([
+            Block(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base,
+                  qk_gain_init, layer_idx=i, ln_scale=ln_scale, dtg=dtg)
+            for i in range(num_layers)
+        ])
+        if rope_dims > 0:
+            head_dim = model_dim // num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = rope_dims
+                block.attn.rotary = Rotary(head_dim, base=rope_base, train_seq_len=1024, rope_dims=rope_dims)
+        self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+        kv_dim = self._ve_target_dim
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim)
+            self.ve_layer_scales = nn.ParameterList(
+                [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices]
+            )
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.value_embeds = nn.ModuleList()
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if xsa_last_n > 0:
+            for i in range(max(0, num_layers - xsa_last_n), num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        num_layers = len(self.blocks)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj." in name or name.endswith(".proj"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+
+    def _get_ve(self, layer_idx: int, input_ids: Tensor, ve_cache: dict | None = None) -> Tensor | None:
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if ve_cache is not None and 've' not in ve_cache:
+            ve_cache['ve'] = self.ve_shared(input_ids)
+        ve_base = ve_cache['ve'] if ve_cache is not None else self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_base * self.ve_layer_scales[ve_idx].to(dtype=ve_base.dtype)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x = self.blocks[i](x, x0, v_embed=ve)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x = self.blocks[bi](x, x0, v_embed=ve)
+        x = self.final_norm(x)
+        x_flat = x.reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x_flat, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x_flat)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x = self.blocks[i](x, x0, v_embed=ve)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x = self.blocks[bi](x, x0, v_embed=ve)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+def eval_val_sliding(args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+                     device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+                     has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+                     stride: int, batch_seqs: int = 32, eval_seq_len: int | None = None) -> tuple[float, float]:
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= 1]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    base_model.eval()
+    compiled_logits = torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+
+    # Pre-compile: dummy forward+backward with TTT shapes to warm the compile cache
+    if rank == 0:
+        print("  ttt: pre-compiling forward+backward kernels...", flush=True)
+    _dummy_x = torch.zeros(1, seq_len, dtype=torch.int64, device=device)
+    _dummy_y = torch.zeros(1, seq_len, dtype=torch.int64, device=device)
+    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        _dummy_logits = base_model.forward_logits(_dummy_x)
+        _dummy_loss = F.cross_entropy(_dummy_logits.reshape(-1, _dummy_logits.size(-1)), _dummy_y.reshape(-1))
+    _dummy_loss.backward()
+    base_model.zero_grad(set_to_none=True)
+    if rank == 0:
+        print("  ttt: pre-compile done", flush=True)
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = compiled_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+def eval_val_sliding_ttt(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    stride: int, ttt_epochs: int = 3, ttt_lr: float = 0.001,
+    ttt_momentum: float = 0.9, ttt_freeze_blocks: int = 2,
+    batch_seqs: int = 32, eval_seq_len: int | None = None,
+    ttt_chunk_tokens: int = 32768, ttt_optimizer: str = "adamw",
+    ttt_temp: float = 1.0,
+    ppm_alpha: float = 0.85,
+    byte_weighted_ttt: bool = True,
+    use_cache: bool = True,
+    cache_alpha: float = 0.3,
+    adaptive_lr: bool = True,
+    adaptive_lr_max_mult: float = 3.0,
+) -> tuple[float, float]:
+    """Legal score-first TTT: score each chunk, then train on it.
+    Every token scored BEFORE any update that could use it."""
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+
+    # Initialize GPU-vectorized logistic context mixer
+    use_mixer = os.environ.get("USE_MIXER", "1") == "1"
+    mixer = LogisticContextMixer(
+        vocab_size=val_tokens.to(torch.int32).max().item() + 1,
+        device=device,
+        eta=float(os.environ.get("MIXER_ETA", "0.1")),
+    ) if use_mixer else None
+    if use_mixer and rank == 0:
+        print(f"  Logistic context mixer enabled: eta={mixer.eta}")
+    if adaptive_lr and rank == 0:
+        print(f"  Adaptive LR enabled: max_mult={adaptive_lr_max_mult}")
+
+    # Pre-compute all window starts
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+
+    # Assign each window to a chunk based on scored token position
+    num_chunks = (total_tokens + ttt_chunk_tokens - 1) // ttt_chunk_tokens
+    chunk_windows: list[list[int]] = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        end = min(ws + seq_len, total_tokens)
+        wlen = end - ws
+        s = 0 if ws == 0 else max(wlen - stride, 0)
+        scored_start = ws + s
+        ci = min(scored_start // ttt_chunk_tokens, num_chunks - 1)
+        chunk_windows[ci].append(ws)
+
+    if rank == 0:
+        print(f"ttt:start chunks={num_chunks} chunk_tokens={ttt_chunk_tokens} "
+              f"windows={len(window_starts)} stride={stride} "
+              f"lr={ttt_lr} epochs={ttt_epochs} opt={ttt_optimizer} "
+              f"freeze_first={ttt_freeze_blocks}")
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Freeze everything, then selectively unfreeze for TTT
+    num_blocks = len(base_model.blocks)
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+    ttt_params = []
+    ttt_param_ids = set()
+    use_qttt = os.environ.get("QTTT", "0") == "1"
+    if use_qttt:
+        # qTTT: only unfreeze Q projections in last N blocks + norms + head
+        for i in range(max(0, num_blocks - ttt_freeze_blocks), num_blocks):
+            for name, p in base_model.blocks[i].named_parameters():
+                if "c_q" in name:
+                    p.requires_grad_(True)
+                    ttt_params.append(p)
+                    ttt_param_ids.add(id(p))
+    else:
+        # Standard: unfreeze all params in last N blocks
+        for i in range(max(0, num_blocks - ttt_freeze_blocks), num_blocks):
+            for p in base_model.blocks[i].parameters():
+                p.requires_grad_(True)
+                ttt_params.append(p)
+                ttt_param_ids.add(id(p))
+    # Unfreeze norms, scales, lm_head
+    for name, p in base_model.named_parameters():
+        if "norm" in name or "scale" in name or "lm_head" in name:
+            p.requires_grad_(True)
+            if id(p) not in ttt_param_ids:
+                ttt_params.append(p)
+                ttt_param_ids.add(id(p))
+
+    if rank == 0:
+        n_unfrozen = sum(p.numel() for p in ttt_params)
+        n_frozen = sum(p.numel() for p in base_model.parameters() if not p.requires_grad)
+        print(f"ttt:params unfrozen={n_unfrozen} frozen={n_frozen}")
+
+    if ttt_optimizer == "adamw":
+        optimizer = torch.optim.AdamW(ttt_params, lr=ttt_lr, weight_decay=0.0, betas=(0.9, 0.999))
+    else:
+        optimizer = torch.optim.SGD(ttt_params, lr=ttt_lr, momentum=ttt_momentum)
+
+    # Polyak averaging (TTT weight EMA) for smoother scoring
+    use_polyak = os.environ.get("USE_POLYAK", "1") == "1"
+    polyak_decay = float(os.environ.get("POLYAK_DECAY", "0.998"))
+    if use_polyak:
+        polyak_state = {id(p): p.data.clone() for p in ttt_params}
+        if rank == 0:
+            print(f"  Polyak averaging enabled: decay={polyak_decay}")
+
+    t0 = time.perf_counter()
+
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows:
+            continue
+
+        # --- Phase 1: SCORE this chunk (inference_mode, no grad) ---
+        my_s = (len(windows) * rank) // world_size
+        my_e = (len(windows) * (rank + 1)) // world_size
+        my_windows = windows[my_s:my_e]
+
+        # Swap in Polyak-averaged weights for scoring
+        if use_polyak and ci > 0:
+            _saved_weights = {}
+            for p in ttt_params:
+                _saved_weights[id(p)] = p.data.clone()
+                p.data.copy_(polyak_state[id(p)])
+
+        base_model.eval()
+        with torch.inference_mode():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi:bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens: list[int] = []
+                for i, ws in enumerate(batch_ws):
+                    end = min(ws + seq_len, total_tokens)
+                    wlen = end - ws
+                    wlens.append(wlen)
+                    chunk_tok = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                    x_batch[i, :wlen] = chunk_tok[:-1]
+                    y_batch[i, :wlen] = chunk_tok[1:]
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model.forward_logits(x_batch)
+                logits_scaled = logits.float() / ttt_temp
+
+                # Adaptive temperature: sharpen confident predictions more
+                if ttt_temp != 1.0:
+                    with torch.no_grad():
+                        probs_for_entropy = F.softmax(logits.float(), dim=-1)
+                        token_entropy = -(probs_for_entropy * (probs_for_entropy + 1e-10).log()).sum(-1)
+                        max_ent = math.log(logits.size(-1))
+                        # Confident tokens (low entropy) get more sharpening
+                        adaptive_temp = 1.0 - (1.0 - ttt_temp) * (1.0 - token_entropy / max_ent)
+                        adaptive_temp = adaptive_temp.clamp(min=0.9, max=1.05)
+                        logits_scaled = logits.float() / adaptive_temp.unsqueeze(-1)
+
+                # Logistic context mixing (GPU-vectorized) or plain CE
+                if mixer is not None:
+                    nll, expert_nll = mixer.mix_and_score(logits_scaled, x_batch, y_batch, wlens)
+                    mixer.update_weights(expert_nll, wlens)
+                else:
+                    nll = F.cross_entropy(
+                        logits_scaled.reshape(-1, logits_scaled.size(-1)),
+                        y_batch.reshape(-1), reduction="none",
+                    ).reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]
+                    s = 0 if ws == 0 else max(wlen - stride, 0)
+                    scored_nll = nll[i, s:wlen].to(torch.float64)
+                    loss_sum += scored_nll.sum()
+                    token_count += float(wlen - s)
+                    tgt, prev = y_batch[i, s:wlen], x_batch[i, s:wlen]
+                    tb = base_bytes_lut[tgt].to(torch.float64)
+                    tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                    byte_count += tb.sum()
+
+        # --- Update context mixer with scored chunk tokens (GPU-vectorized) ---
+        chunk_start_tok = ci * ttt_chunk_tokens
+        chunk_end_tok = min((ci + 1) * ttt_chunk_tokens, total_tokens)
+        if mixer is not None:
+            mixer.update(val_tokens[chunk_start_tok:chunk_end_tok + 1])
+
+        # Swap back training weights after scoring
+        if use_polyak and ci > 0:
+            for p in ttt_params:
+                p.data.copy_(_saved_weights[id(p)])
+
+        # --- Phase 2: TRAIN on this chunk (already scored = legal) ---
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and ttt_epochs > 0:
+            chunk_start = ci * ttt_chunk_tokens
+            chunk_end = min((ci + 1) * ttt_chunk_tokens, total_tokens)
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if rank == 0 and ci < 3:
+                print(f"    ttt_train [{ci+1}] seqs={chunk_seqs} start_train...", flush=True)
+            if chunk_seqs > 0:
+                # Cosine LR across chunks + adaptive scaling
+                cos_lr = ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                if adaptive_lr:
+                    # Increase LR as we've seen more data (more confident adaptation)
+                    progress = min(ci / max(num_chunks * 0.3, 1), 1.0)  # ramp over first 30% of chunks
+                    lr_mult = 1.0 + (adaptive_lr_max_mult - 1.0) * progress
+                    cos_lr = cos_lr * lr_mult
+                for pg in optimizer.param_groups:
+                    pg["lr"] = cos_lr
+                my_seq_s = (chunk_seqs * rank) // world_size
+                my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+                my_chunk_seqs = my_seq_e - my_seq_s
+                for _ep in range(ttt_epochs):
+                    if rank == 0 and ci < 3:
+                        print(f"    ttt_train [{ci+1}] epoch={_ep+1}/{ttt_epochs} batches={my_chunk_seqs} ...", flush=True)
+                    for bs in range(0, my_chunk_seqs, batch_seqs):
+                        be = min(bs + batch_seqs, my_chunk_seqs)
+                        actual_bs = my_seq_s + bs
+                        start_tok = chunk_start + actual_bs * seq_len
+                        end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                        if end_tok > val_tokens.numel():
+                            continue
+                        local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                        x = local[:-1].reshape(-1, seq_len)
+                        y = local[1:].reshape(-1, seq_len)
+                        optimizer.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            if byte_weighted_ttt:
+                                # Byte-weighted loss: tokens covering more bytes matter more
+                                ttt_logits = base_model.forward_logits(x)
+                                per_token_loss = F.cross_entropy(
+                                    ttt_logits.reshape(-1, ttt_logits.size(-1)),
+                                    y.reshape(-1), reduction='none'
+                                ).reshape(y.shape)
+                                byte_weights = base_bytes_lut[y].float()
+                                byte_weights = byte_weights + (has_leading_space_lut[y] & ~is_boundary_token_lut[x]).float()
+                                ttt_loss = (per_token_loss * byte_weights).sum() / byte_weights.sum()
+                            else:
+                                ttt_loss = base_model(x, y)
+                        ttt_loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        torch.nn.utils.clip_grad_norm_(ttt_params, 1.0)
+                        optimizer.step()
+                        # Update Polyak EMA after each step
+                        if use_polyak:
+                            for p in ttt_params:
+                                polyak_state[id(p)].lerp_(p.data, 1.0 - polyak_decay)
+                        if rank == 0 and ci < 3:
+                            print(f"      step done ep={_ep+1} bs={bs} loss={ttt_loss.item():.4f}", flush=True)
+
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1 or ci < 5):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            print(f"  ttt_chunk [{ci+1}/{num_chunks}] bpb={rbpb:.6f} time={elapsed:.1f}s", flush=True)
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+    if rank == 0:
+        print(f"ttt:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+              f"elapsed={time.perf_counter() - t0:.1f}s")
+    return val_loss, val_bpb
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+
+def quantize_int6_per_row(t: Tensor, clip_range: int = 15) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        best_q, best_s, best_err = None, None, float('inf')
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            if pct < 1.0:
+                row_clip = torch.quantile(t32.abs(), pct, dim=1)
+            else:
+                row_clip = t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+            recon = q.float() * s.float()[:, None]
+            err = (t32 - recon).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_s, best_err = q, s, err
+        return best_q, best_s
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+
+
+def _find_best_row_scales(W: Tensor, clip_range: int = 15) -> Tensor:
+    """Find optimal per-row scales by searching percentile clipping thresholds."""
+    t32 = W.float()
+    best_s = t32.abs().amax(dim=1) / clip_range
+    best_s = best_s.clamp_min(1.0 / clip_range)
+    best_err = torch.full((t32.shape[0],), float('inf'))
+    for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+        if pct < 1.0:
+            row_clip = torch.quantile(t32.abs(), pct, dim=1)
+        else:
+            row_clip = t32.abs().amax(dim=1)
+        s = (row_clip / clip_range).clamp_min(1.0 / clip_range)
+        q = torch.clamp(torch.round(t32 / s[:, None]), -clip_range, clip_range)
+        recon = q * s[:, None]
+        err = (t32 - recon).pow(2).mean(dim=1)
+        improved = err < best_err
+        best_s[improved] = s[improved]
+        best_err[improved] = err[improved]
+    return best_s
+
+def gptq_quantize_weight(W: Tensor, H: Tensor, clip_range: int = 15,
+                          block_size: int = 128, percdamp: float = 0.01) -> tuple[Tensor, Tensor]:
+    """GPTQ: quantize weight matrix W using Hessian H = X^T X for error compensation."""
+    W = W.float().clone()
+    rows, cols = W.shape
+    row_scale = _find_best_row_scales(W, clip_range)
+    H = H.float().clone()
+    damp = percdamp * H.diag().mean()
+    H.diagonal().add_(damp)
+    perm = torch.argsort(H.diag())
+    invperm = torch.argsort(perm)
+    W = W[:, perm]
+    H = H[perm][:, perm]
+    try:
+        L = torch.linalg.cholesky(H)
+        Hinv = torch.cholesky_inverse(L)
+    except torch._C._LinAlgError:
+        Hinv = torch.diag(1.0 / H.diag().clamp_min(1e-6))
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros_like(W_block)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            h_inv_jj = Hinv_block[j, j].clamp_min(1e-8)
+            q_col = torch.clamp(torch.round(w_col / row_scale), -clip_range, clip_range)
+            deq_col = q_col * row_scale
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - deq_col) / h_inv_jj
+            Err[:, j] = err
+            if j + 1 < i2 - i1:
+                W_block[:, j + 1:] -= err.unsqueeze(1) * Hinv_block[j, j + 1:].unsqueeze(0)
+        if i2 < cols:
+            W[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+    Q = Q[:, invperm]
+    return Q, row_scale.to(torch.float16)
+
+def gptq_calibrate(model: nn.Module, train_pattern: str, device: torch.device,
+                   n_samples: int = 256, seq_len: int = 2048) -> dict[str, Tensor]:
+    """Collect Hessian H = X^T X for each linear layer using training data."""
+    hessians: dict[str, Tensor] = {}
+    n_seen: dict[str, int] = {}
+    hooks = []
+    def make_hook(name: str):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            if name not in hessians:
+                hessians[name] = torch.zeros(x.shape[1], x.shape[1], device=x.device, dtype=torch.float32)
+                n_seen[name] = 0
+            hessians[name].addmm_(x.t(), x)
+            n_seen[name] += x.shape[0]
+        return hook_fn
+    for name, module in model.named_modules():
+        if isinstance(module, (nn.Linear, CastedLinear)):
+            hooks.append(module.register_forward_hook(make_hook(name)))
+    stream = TokenStream(train_pattern)
+    model.eval()
+    with torch.no_grad():
+        for _ in range(n_samples):
+            tokens = stream.take(seq_len + 1).to(device=device, dtype=torch.int64)
+            x = tokens[:-1].unsqueeze(0)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                model.forward_logits(x)
+    for h in hooks:
+        h.remove()
+    for name in hessians:
+        hessians[name] /= max(n_seen[name], 1)
+    return hessians
+
+def _get_layer_clip_range(name: str, num_layers: int, int6_last_n: int) -> int:
+    """Return clip_range based on which layer the param belongs to."""
+    import re
+    m = re.search(r'blocks\.(\d+)\.', name)
+    if m:
+        layer_idx = int(m.group(1))
+        if layer_idx >= num_layers - int6_last_n:
+            return 31  # int6
+    return 15  # int5
+
+def mixed_quantize_int6_gptq(state_dict: dict[str, Tensor], int6_cats: set[str],
+                              hessians: dict[str, Tensor],
+                              num_layers: int = 11, int6_last_n: int = 2) -> tuple[dict, dict]:
+    """GPTQ quantization with mixed int5/int6 precision. int6 for last int6_last_n layers, int5 for rest."""
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    gptq_count, naive_count = 0, 0
+    int5_params, int6_params = 0, 0
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        cr = _get_layer_clip_range(name, num_layers, int6_last_n)
+        if cr == 31:
+            int6_params += t.numel()
+        else:
+            int5_params += t.numel()
+        if cat in int6_cats and t.ndim == 2:
+            module_name = name.rsplit(".weight", 1)[0] if name.endswith(".weight") else name
+            H = hessians.get(module_name)
+            if H is not None and H.shape[0] == t.shape[1]:
+                q, s = gptq_quantize_weight(t, H.cpu(), clip_range=cr)
+                gptq_count += 1
+            else:
+                q, s = quantize_int6_per_row(t, clip_range=cr)
+                naive_count += 1
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": f"int{'6' if cr == 31 else '5'}"}
+        elif cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t, clip_range=cr)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": f"int{'6' if cr == 31 else '5'}"}
+            naive_count += 1
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    print(f"gptq_quantize: {gptq_count} GPTQ layers, {naive_count} naive layers", flush=True)
+    print(f"mixed_precision: {int5_params} int5 params, {int6_params} int6 params", flush=True)
+    return result, meta
+
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+    log0(code, console=False)
+    log0(f"Python {sys.version} PyTorch {torch.__version__}", console=False)
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    effective_eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+    CastedLinear._qat_enabled = args.qat_enabled
+    base_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n, rope_dims=args.rope_dims, ln_scale=args.ln_scale,
+        dtg=args.dtg_enabled, ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_params.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None:
+            matrix_params.append(base_model.bigram.proj.weight)
+    if base_model.ve_shared is not None:
+        tok_params.append({"params": [base_model.ve_shared.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.ve_shared.proj is not None:
+            matrix_params.append(base_model.ve_shared.proj.weight)
+        scalar_params.append(base_model.ve_shared.scale)
+        for s in base_model.ve_layer_scales:
+            scalar_params.append(s)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    # Set int6 clip_range for last N layers (mixed precision)
+    int6_start = args.num_layers - args.int6_last_n
+    for i, block in enumerate(base_model.blocks):
+        if i >= int6_start:
+            for m in block.modules():
+                if isinstance(m, CastedLinear):
+                    m._clip_range = 31  # int6
+    if master_process:
+        int5_count = sum(1 for m in base_model.modules() if isinstance(m, CastedLinear) and m._clip_range == 15)
+        int6_count = sum(1 for m in base_model.modules() if isinstance(m, CastedLinear) and m._clip_range == 31)
+        log0(f"mixed_precision: {int5_count} int5 layers, {int6_count} int6 layers (last {args.int6_last_n} blocks)")
+    log0(f"model_params:{n_params}")
+    xsa_layers = [i for i, b in enumerate(base_model.blocks) if b.attn.use_xsa]
+    log0(f"XSA:{xsa_layers} ws:{world_size} gqa:{args.num_heads}/{args.num_kv_heads}")
+    log0(f"lr:embed={token_lr} matrix={args.matrix_lr} scalar={args.scalar_lr} batch:{args.train_batch_tokens} wall:{args.max_wallclock_seconds:.0f}s seed:{args.seed}")
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    train_reserve_ms = 18000  # reserve 18s for EMA + GPTQ calibration + quantization + save
+    effective_train_ms = (max_wallclock_ms - train_reserve_ms) if max_wallclock_ms is not None else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if effective_train_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(effective_train_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+    # TTT_ONLY mode: skip training, load saved model, run TTT eval
+    if os.environ.get("TTT_ONLY", "0") == "1":
+        log0("TTT_ONLY mode: skipping training, loading saved model...")
+        sd_cpu = {k: v.cpu() for k, v in torch.load("final_model.pt", map_location="cpu").items()}
+        if args.prune_pct > 0:
+            for k, v in sd_cpu.items():
+                if v.ndim == 2 and v.numel() > 65536:
+                    thresh = torch.quantile(v.abs().float(), args.prune_pct)
+                    v[v.abs() < thresh] = 0.0
+            log0(f"pruning:{args.prune_pct*100:.1f}% magnitude pruning applied")
+        with open("final_model.int6.ptz", "rb") as f:
+            quant_blob_disk = f.read()
+        quant_state = torch.load(
+            io.BytesIO(zstandard.ZstdDecompressor().decompress(quant_blob_disk) if _COMPRESSOR == "zstd" else zlib.decompress(quant_blob_disk)),
+            map_location="cpu",
+        )
+        deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], sd_cpu)
+        eval_model = GPT(
+            vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+            num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+            tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+            logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+            bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim, xsa_last_n=args.xsa_last_n,
+            rope_dims=args.rope_dims, ln_scale=args.ln_scale, dtg=args.dtg_enabled,
+            ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+        ).to(device).bfloat16()
+        for m in eval_model.modules():
+            if isinstance(m, CastedLinear):
+                m.float()
+        restore_low_dim_params_to_fp32(eval_model)
+        eval_model.load_state_dict(deq_state, strict=True)
+        sw_seq_len = int(os.environ.get("EVAL_SEQ_LEN", str(effective_eval_seq_len)))
+        log0(f"TTT_ONLY: model loaded, starting TTT eval...")
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_epochs = int(os.environ.get("TTT_EPOCHS", "3"))
+        ttt_lr = float(os.environ.get("TTT_LR", "0.0005"))
+        ttt_freeze = int(os.environ.get("TTT_FREEZE_BLOCKS", "2"))
+        ttt_chunk = int(os.environ.get("TTT_CHUNK_TOKENS", "32768"))
+        ttt_opt = os.environ.get("TTT_OPTIMIZER", "adamw")
+        log0(f"TTT: epochs={ttt_epochs} lr={ttt_lr} freeze_first={ttt_freeze} chunk={ttt_chunk} opt={ttt_opt}")
+        ttt_temp = args.ttt_temperature
+        log0(f"TTT temperature: {ttt_temp}")
+        ttt_val_loss, ttt_val_bpb = eval_val_sliding_ttt(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, ttt_epochs=ttt_epochs, ttt_lr=ttt_lr,
+            ttt_freeze_blocks=ttt_freeze, eval_seq_len=sw_seq_len,
+            ttt_chunk_tokens=ttt_chunk, ttt_optimizer=ttt_opt,
+            ttt_temp=ttt_temp,
+            ppm_alpha=float(os.environ.get("PPM_ALPHA", "0.85")),
+            byte_weighted_ttt=os.environ.get("BYTE_WEIGHTED_TTT", "1") == "1",
+            use_cache=os.environ.get("USE_CACHE", "1") == "1",
+            cache_alpha=float(os.environ.get("CACHE_ALPHA", "0.3")),
+            adaptive_lr=os.environ.get("ADAPTIVE_LR", "1") == "1",
+            adaptive_lr_max_mult=float(os.environ.get("ADAPTIVE_LR_MAX", "3.0")),
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_ttt val_loss:{ttt_val_loss:.4f} val_bpb:{ttt_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_ttt):.0f}ms"
+        )
+        log0(f"final_int6_ttt_exact val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f}")
+        if distributed:
+            dist.destroy_process_group()
+        return
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    ema_decay = float(os.environ.get("EMA_DECAY", "0.997"))
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        # Anneal soft-round alpha based on QAT progress
+        if CastedLinear._use_soft_round and CastedLinear._qat_enabled:
+            qat_progress = max(0.0, 1.0 - scale / max(args.late_qat_threshold, 0.01))
+            CastedLinear._soft_round_alpha = 1.0 + 15.0 * qat_progress
+        if args.late_qat_threshold > 0 and scale < args.late_qat_threshold and not CastedLinear._qat_enabled:
+            CastedLinear._qat_enabled = True
+            CastedLinear._use_soft_round = os.environ.get("SOFT_ROUND_QAT", "0") == "1"
+            if CastedLinear._use_soft_round and master_process:
+                log0(f"soft_round_qat:enabled initial_alpha=1.0")
+            log0(f"late_qat:enabled step:{step} scale:{scale:.4f}")
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            # CROWN-Q: penalize quantization-sensitive weights during warmdown
+            crownq_lambda = float(os.environ.get("CROWN_Q_LAMBDA", "0.01"))
+            if CastedLinear._qat_enabled and crownq_lambda > 0:
+                cq_loss = torch.zeros((), device=device)
+                for m in base_model.modules():
+                    if isinstance(m, CastedLinear) and m.weight.ndim == 2:
+                        w = m.weight.float()
+                        cr = float(m._clip_range)
+                        row_max = w.detach().abs().amax(dim=1)
+                        delta = row_max / cr  # quantization step size
+                        cq_loss = cq_loss + (w.pow(2) * delta.pow(2).unsqueeze(1)).mean()
+                loss = loss + crownq_lambda * cq_loss / 12.0
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(t.detach().float(), alpha=1.0 - ema_decay)
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        if args.swa_enabled and scale < 0.2 and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+        reached_cap = effective_train_ms is not None and approx_training_time_ms >= effective_train_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+    # Apply EMA weights directly (skip diagnostic evals to save ~5s of reserve)
+    log0("ema:applying EMA weights (skipping diagnostic evals)")
+    current_state = base_model.state_dict()
+    ema_sd = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+    base_model.load_state_dict(ema_sd, strict=True)
+    # GPTQ calibration on final model (within reserved training budget)
+    log0("gptq:calibrating with training data...")
+    t_gptq = time.perf_counter()
+    gptq_hessians = gptq_calibrate(base_model, args.train_files, device, n_samples=128, seq_len=args.train_seq_len)
+    log0(f"gptq:calibrated {len(gptq_hessians)} layers in {time.perf_counter()-t_gptq:.1f}s")
+    export_sd = base_model.state_dict()
+    if master_process:
+        torch.save(export_sd, "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    if args.prune_pct > 0:
+        for k, v in sd_cpu.items():
+            if v.ndim == 2 and v.numel() > 65536:
+                thresh = torch.quantile(v.abs().float(), args.prune_pct)
+                v[v.abs() < thresh] = 0.0
+        if master_process:
+            log0(f"pruning:{args.prune_pct*100:.1f}% magnitude pruning applied")
+    quant_result, quant_meta = mixed_quantize_int6_gptq(sd_cpu, {"mlp", "attn"}, gptq_hessians, num_layers=args.num_layers, int6_last_n=args.int6_last_n)
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zstandard.ZstdCompressor(level=22).compress(quant_raw) if _COMPRESSOR == "zstd" else zlib.compress(quant_raw, 9)
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = len(quant_blob)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+{_COMPRESSOR}: {quant_file_bytes} bytes")
+        log0(f"Total submission size int6+{_COMPRESSOR}: {quant_file_bytes + code_bytes} bytes")
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(zstandard.ZstdDecompressor().decompress(quant_blob_disk) if _COMPRESSOR == "zstd" else zlib.decompress(quant_blob_disk)),
+        map_location="cpu",
+    )
+    deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], sd_cpu)
+    eval_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim, xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims, ln_scale=args.ln_scale, dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+    ).to(device).bfloat16()
+    for m in eval_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(eval_model)
+    eval_model.load_state_dict(deq_state, strict=True)
+    sw_seq_len = int(os.environ.get("EVAL_SEQ_LEN", str(effective_eval_seq_len)))
+    if sw_seq_len != effective_eval_seq_len and rank == 0:
+        log0(f"Eval seq_len override: {effective_eval_seq_len} -> {sw_seq_len}")
+    if args.eval_stride > 0 and args.eval_stride < sw_seq_len and not os.environ.get("SKIP_SLIDING"):
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+    torch.cuda.synchronize()
+    t_ttt = time.perf_counter()
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", "3"))
+    ttt_lr = float(os.environ.get("TTT_LR", "0.0005"))
+    ttt_freeze = int(os.environ.get("TTT_FREEZE_BLOCKS", "2"))
+    ttt_chunk = int(os.environ.get("TTT_CHUNK_TOKENS", "32768"))
+    ttt_opt = os.environ.get("TTT_OPTIMIZER", "adamw")
+    log0(f"TTT: epochs={ttt_epochs} lr={ttt_lr} freeze_first={ttt_freeze} chunk={ttt_chunk} opt={ttt_opt}")
+    ttt_temp = args.ttt_temperature
+    log0(f"TTT temperature: {ttt_temp}")
+    ppm_alpha_val = float(os.environ.get("PPM_ALPHA", "0.85"))
+    bw_ttt = os.environ.get("BYTE_WEIGHTED_TTT", "1") == "1"
+    log0(f"PPM alpha: {ppm_alpha_val}, Byte-weighted TTT: {bw_ttt}")
+    ttt_val_loss, ttt_val_bpb = eval_val_sliding_ttt(
+        args, eval_model, rank, world_size, device,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        stride=args.eval_stride, ttt_epochs=ttt_epochs, ttt_lr=ttt_lr,
+        ttt_freeze_blocks=ttt_freeze, eval_seq_len=sw_seq_len,
+        ttt_chunk_tokens=ttt_chunk, ttt_optimizer=ttt_opt,
+        ttt_temp=ttt_temp,
+        ppm_alpha=float(os.environ.get("PPM_ALPHA", "0.85")),
+        byte_weighted_ttt=os.environ.get("BYTE_WEIGHTED_TTT", "1") == "1",
+        use_cache=os.environ.get("USE_CACHE", "1") == "1",
+        cache_alpha=float(os.environ.get("CACHE_ALPHA", "0.3")),
+        adaptive_lr=os.environ.get("ADAPTIVE_LR", "1") == "1",
+        adaptive_lr_max_mult=float(os.environ.get("ADAPTIVE_LR_MAX", "3.0")),
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_ttt val_loss:{ttt_val_loss:.4f} val_bpb:{ttt_val_bpb:.4f} "
+        f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_ttt):.0f}ms"
+    )
+    log0(f"final_int6_ttt_exact val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f}")
+    if distributed:
+        dist.destroy_process_group()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Record: 5-expert Hedge Mixer + CROWN-Q + stride=64 (val_bpb=1.0541)

**val_bpb: 1.0541** (3-seed mean) | **~15.7 MB** | 8xH100 SXM

## Results (8xH100 80GB SXM)

| Seed | step_avg | steps | Pre-TTT bpb | **Post-TTT bpb** | TTT gain | Eval time | Artifact |
|------|----------|-------|-------------|-----------------|----------|-----------|----------|
| 1337 | 98.1ms | 5,935 | 1.1251 | **1.0473** | -0.0778 | 336s | 15.89 MB |
| 42 | 97.9ms | 5,947 | 1.1264 | **1.0686** | -0.0578 | 336s | 15.69 MB |
| 7 | 98.0ms | 5,940 | 1.1246 | **1.0465** | -0.0781 | 336s | 15.66 MB |
| **Mean** | | | 1.1254 | **1.0541** | -0.0713 | 336s | ~15.75 MB |

## Contributions

### 1. CROWN-Q Training Penalty (training-time)
Added a quantization-aware penalty during warmdown that penalizes weights sensitive to quantization error:
```
crown_q_loss = lambda * mean(w^2 * delta^2 / 12)
```
where `delta = row_max / clip_range` is the per-row quantization step size. This encourages weights to be quantization-friendly, reducing post-quantization degradation. `CROWN_Q_LAMBDA=0.01`.

**Effect**: Slightly better compression (artifact ~200KB smaller) and more robust quantization.

### 2. Eval stride 32 -> 64 (eval-time)
Changed sliding window stride from 32 to 64 during evaluation. Experiment showed identical BPB quality but 2x faster scoring. Frees ~100s of eval budget for more TTT epochs.

### 3. TTT Epochs 3 -> 4 (eval-time)
Increased test-time training from 3 to 4 epochs per chunk, using the time freed by stride=64. Each additional epoch adapts the model more to scored data. Tested 8 epochs but that overfits (1.0735 vs 1.0473 for 4 epochs).

### Combined Effect
- stride=64 saves ~100s of eval time
- 4th TTT epoch uses ~85s of the saved time
- Net eval time: ~336s (down from ~562s), well within 600s budget
- BPB improvement: 1.0745 -> 1.0541 (-0.0204)

## Architecture

| Component | Setting |
|-----------|---------|
| Layers | 11 (512d, 8H, 8KV) |
| MLP | 3.5x with LeakyReLU(0.5)^2 |
| BigramHash | 6144 (dim=128) |
| XSA | All 11 layers (ws=8) |
| VE128 | Layers 9-10 |
| Quantization | Full GPTQ int5 + zstd level 22 |
| Pruning | 3% magnitude |
| TTT | AdamW lr=0.0001, **4 epochs**, 131K chunks, Polyak 0.998 |
| Mixer | 5-expert Hedge (neural, unigram, bigram, trigram, entropy) |
| Training reserve | 18s (for EMA + calibration + quantization) |
| Early warmdown | LR schedule targets 582s |
| **CROWN-Q** | lambda=0.01 during warmdown |
| **Eval stride** | 64 (was 32) |

## Reproduction

```bash
DATA_PATH=../data/datasets/fineweb10B_sp1024 \
TOKENIZER_PATH=../data/tokenizers/fineweb_1024_bpe.model \
SEED=1337 MAX_WALLCLOCK_SECONDS=600 \
USE_MIXER=1 MIXER_ETA=0.1 \
TTT_EPOCHS=4 TTT_FREEZE_BLOCKS=2 \
TTT_LR=0.0001 TTT_CHUNK_TOKENS=131072 \
ADAPTIVE_LR=1 ADAPTIVE_LR_MAX=3.0 \
EVAL_STRIDE=64 \
CROWN_Q_LAMBDA=0.01 \
torchrun --standalone --nproc_per_node=8 train_gpt.py
```


## Compliance

| Constraint | Limit | Actual | Status |
|-----------|-------|--------|--------|
| Train time | 600s | 582s | Pass |
| Eval time | 600s | 336s | Pass |
| Artifact size | 16,000,000 bytes | 15,892,040 bytes (worst seed) | Pass |
| No pre-scoring training | — | Score-first TTT: each chunk scored under `inference_mode()` before any training on it | Pass |
| GPTQ calibration in training budget | — | Runs within 18s training reserve (1.9s actual) | Pass |

## Credits

- Base model: PR #414 by @signalrush
- TTT recipe: PR #461 by @Christopher-Lee-McClendon
- CROWN-Q concept: PR #693 by @EthanYangTW
- 5-expert Hedge mixer: PR #688