### PR TITLE
Record: 10L + Batched LoRA TTT (mean val_bpb=1.1180, 3 seeds)

### DIFF
--- a/records/track_10min_16mb/2026-03-25_10L_LoRA_TTT/README.md
+++ b/records/track_10min_16mb/2026-03-25_10L_LoRA_TTT/README.md
@@ -1,0 +1,37 @@
+# 10L + Batched LoRA TTT
+
+## Results
+
+| Seed | Base val_bpb | TTT val_bpb | TTT time |
+|------|-------------|-------------|----------|
+| 42   | 1.1476      | 1.1160      | 495s     |
+| 1337 | 1.1540      | 1.1210      | 496s     |
+| 2024 | 1.1504      | 1.1170      | 497s     |
+| **Mean** | **1.1507** | **1.1180** | **496s** |
+| Std  | 0.0032      | 0.0026      |          |
+
+Artifact size: 15.75 MB. Train time: 600s. Eval time (TTT): ~496s.
+
+## Architecture
+
+- 10 layers, 512 dim, 8/4 GQA heads, head_dim=64
+- 3x MLP with LeakyReLU(0.5)^2 activation
+- BigramHash (10240 buckets, 128 dim)
+- SmearGate, value residual connections, per-head gated attention
+- U-Net encoder-decoder skip connections
+- Tied embeddings (1024 vocab)
+- Mixed int5 (MLP) / int6 (attention) quantization + zstd-22
+- 5% magnitude pruning
+- EMA weight averaging (decay=0.995)
+- Muon optimizer (lr=0.02, momentum=0.99, WD=0.04) + AdamW
+
+## LoRA TTT
+
+- Rank-8 LoRA on Q, V projections + LM head across all 10 layers
+- 64 documents batched in parallel
+- Per-document fresh initialization and optimizer reset
+- Adam optimizer (lr=0.01, betas 0.9/0.95)
+- 256-token chunks, 3 epochs per document
+- Score on final epoch only
+- Documents identified by BOS token boundaries
+- Short documents (<512 tokens) scored without TTT

--- a/records/track_10min_16mb/2026-03-25_10L_LoRA_TTT/submission.json
+++ b/records/track_10min_16mb/2026-03-25_10L_LoRA_TTT/submission.json
@@ -1,0 +1,9 @@
+{
+  "name": "10L + Batched LoRA TTT",
+  "val_loss": 1.1180,
+  "bytes_total": 15749040,
+  "blurb": "10 layers, mixed int5/int6, batched per-doc LoRA TTT. Mean 1.1180 (std 0.0026) across 3 seeds.",
+  "author": "hypery11",
+  "github_id": "hypery11",
+  "date": "2026-03-25"
+}

--- a/records/track_10min_16mb/2026-03-25_10L_LoRA_TTT/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-25_10L_LoRA_TTT/train_gpt.py
@@ -1,0 +1,1748 @@
+"""
+Our competitive submission for the OpenAI Parameter Golf competition.
+Based on thwu1's 2026-03-20 SOTA submission with the following improvements:
+  - Value Residual (ResFormer, arXiv:2410.17897)
+  - Gated Attention (per-head sigmoid gate)
+  - TrigramHash Embedding
+  - EMA instead of SWA
+  - Test-Time Training (TTT) on validation tokens
+  - Gradient-Guided Adaptive Quantization
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 42))
+
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 500))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 100))
+
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 3.0))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    weight_decay = float(os.environ.get("WEIGHT_DECAY", 0.04))
+
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))
+
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 10240))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+
+    trigram_vocab_size = int(os.environ.get("TRIGRAM_VOCAB_SIZE", 4096))
+    trigram_dim = int(os.environ.get("TRIGRAM_DIM", 64))
+
+    ema_enabled = bool(int(os.environ.get("EMA_ENABLED", "1")))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.995))
+    ema_start_frac = float(os.environ.get("EMA_START_FRAC", 0.5))
+
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.0005))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 10))
+
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, weight_decay=weight_decay),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                if wd > 0:
+                    p.data.mul_(1.0 - lr * wd)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+        return loss
+
+
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,bigram.scale,trigram.scale,attn_gate,v_residual_lambda",
+    ).split(",")
+    if pattern
+)
+FP16_KEEP_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get("FP16_KEEP_NAME_PATTERNS", "tok_emb,blocks.8.attn.c_k").split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if "bigram" in name or "trigram" in name:
+        return "bigram"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+
+def quantize_intN_per_row(t: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        row_max = t32.abs().amax(dim=1)
+        scale = (row_max / clip_range).clamp_min(1e-12).to(torch.float16)
+        scale = scale.clamp_min(torch.finfo(torch.float16).tiny)
+        q = torch.clamp(torch.round(t32 / scale.float()[:, None]), -(clip_range+1), clip_range).to(torch.int8)
+        return q, scale
+    amax = t32.abs().max().item()
+    scale = torch.tensor(max(amax / clip_range, 1e-12), dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -(clip_range+1), clip_range).to(torch.int8)
+    return q, scale
+
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str],
+                        grad_sensitivity: dict[str, float] | None = None):
+    """Quantize with gradient-guided adaptive bit-width when sensitivity info is available."""
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+
+    sens_thresholds = (0.0, 0.0)  # (p33, p66) thresholds
+    if grad_sensitivity:
+        sens_values = sorted(grad_sensitivity.values())
+        n = len(sens_values)
+        if n >= 3:
+            sens_thresholds = (sens_values[n // 3], sens_values[2 * n // 3])
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 8192:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if any(pattern in name for pattern in FP16_KEEP_NAME_PATTERNS):
+            result[name] = t.to(dtype=torch.float16).contiguous()
+            meta[name] = "passthrough_fp16"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            clip = 15 if cat == "mlp" else 31
+            bits_label = 5 if cat == "mlp" else 6
+            q, s = quantize_intN_per_row(t, clip_range=clip)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": f"int{bits_label}"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta[name]
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    """Attention with Value Residual (ResFormer) and Gated Attention."""
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int, rope_base: float,
+                 qk_gain_init: float, layer_idx: int = 0):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        self.layer_idx = layer_idx
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+        self.attn_gate = nn.Parameter(torch.full((num_heads,), 4.0, dtype=torch.float32))
+
+        if layer_idx > 0:
+            self.v_residual_lambda = nn.Parameter(
+                torch.tensor([0.9, 0.1], dtype=torch.float32)
+            )
+        else:
+            self.v_residual_lambda = None
+
+    def forward(self, x: Tensor, v0: Tensor | None = None, q_delta=None, v_delta=None) -> tuple[Tensor, Tensor]:
+        """Returns (output, v) where v is the V vectors for value residual caching."""
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x)
+        if q_delta is not None:
+            q = q + q_delta
+        q = q.reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x)
+        if v_delta is not None:
+            v = v + v_delta
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+
+        v_out = v  # cache this layer's raw V for layer 0
+        if self.v_residual_lambda is not None and v0 is not None:
+            lam = self.v_residual_lambda.to(dtype=v.dtype)
+            v = lam[0] * v + lam[1] * v0
+
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q, k, v, attn_mask=None, is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+
+        gate = torch.sigmoid(self.attn_gate.to(dtype=y.dtype))[None, :, None, None]
+        y = y * gate
+
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y), v_out
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: float):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = F.leaky_relu(self.fc(x), negative_slope=0.5)
+        return self.proj(x.square())
+
+
+class SmearGate(nn.Module):
+    """Blend each token's embedding with the previous token's embedding."""
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+
+class BigramHashEmbedding(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+class TrigramHashEmbedding(nn.Module):
+    """Hash consecutive token triplets into a learned embedding table."""
+    def __init__(self, trigram_vocab_size: int, trigram_dim: int, model_dim: int):
+        super().__init__()
+        self.trigram_vocab_size = trigram_vocab_size
+        self.embed = nn.Embedding(trigram_vocab_size, trigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(trigram_dim, model_dim, bias=False) if trigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.03, dtype=torch.float32))
+
+    def trigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.trigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1] = mod
+        out[..., 2:] = (
+            48271 * t[..., 2:] ^ 36313 * t[..., 1:-1] ^ 27191 * t[..., :-2]
+        ) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.trigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+class Block(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: float,
+                 rope_base: float, qk_gain_init: float, layer_idx: int = 0):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init, layer_idx=layer_idx)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor, v0: Tensor | None = None, q_delta_fn=None, v_delta_fn=None) -> tuple[Tensor, Tensor]:
+        """Returns (hidden_state, v) where v is the raw V from this layer's attention."""
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = self.attn_norm(x)
+        qd = q_delta_fn(n) if q_delta_fn is not None else None
+        vd = v_delta_fn(n) if v_delta_fn is not None else None
+        attn_out, v = self.attn(n, v0=v0, q_delta=qd, v_delta=vd)
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x, v
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: float,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        bigram_vocab_size: int = 0,
+        bigram_dim: int = 128,
+        trigram_vocab_size: int = 0,
+        trigram_dim: int = 64,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.trigram = TrigramHashEmbedding(trigram_vocab_size, trigram_dim, model_dim) if trigram_vocab_size > 0 else None
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.smear = SmearGate(model_dim)
+        self.blocks = nn.ModuleList(
+            [
+                Block(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init, layer_idx=i)
+                for i in range(num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        num_layers = len(self.blocks)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj." in name or name.endswith(".proj"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor, lora=None) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        if self.trigram is not None:
+            x = x + self.trigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0: Tensor | None = None  # Value residual cache from layer 0
+        skips: list[Tensor] = []
+        for i in range(self.num_encoder_layers):
+            qd_fn = lora.q_loras[i] if lora is not None else None
+            vd_fn = lora.v_loras[i] if lora is not None else None
+            x, v = self.blocks[i](x, x0, v0=v0, q_delta_fn=qd_fn, v_delta_fn=vd_fn)
+            if i == 0:
+                v0 = v  # Cache V from first layer
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            li = self.num_encoder_layers + i
+            qd_fn = lora.q_loras[li] if lora is not None else None
+            vd_fn = lora.v_loras[li] if lora is not None else None
+            x, v = self.blocks[li](x, x0, v0=v0, q_delta_fn=qd_fn, v_delta_fn=vd_fn)
+            if li == 0:
+                v0 = v
+        bsz = x.size(0)
+        x = self.final_norm(x)
+        x_for_lm = x
+        x = x.reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        if lora is not None:
+            logits_proj = logits_proj.reshape(bsz, -1, logits_proj.size(-1)) + lora.lm_head_lora(x_for_lm)
+            logits_proj = logits_proj.reshape(-1, logits_proj.size(-1))
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def forward_logits(self, input_ids: Tensor, lora=None) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        if self.trigram is not None:
+            x = x + self.trigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0: Tensor | None = None
+        skips: list[Tensor] = []
+        for i in range(self.num_encoder_layers):
+            qd_fn = lora.q_loras[i] if lora is not None else None
+            vd_fn = lora.v_loras[i] if lora is not None else None
+            x, v = self.blocks[i](x, x0, v0=v0, q_delta_fn=qd_fn, v_delta_fn=vd_fn)
+            if i == 0:
+                v0 = v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            li = self.num_encoder_layers + i
+            qd_fn = lora.q_loras[li] if lora is not None else None
+            vd_fn = lora.v_loras[li] if lora is not None else None
+            x, v = self.blocks[li](x, x0, v0=v0, q_delta_fn=qd_fn, v_delta_fn=vd_fn)
+            if li == 0:
+                v0 = v
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        if lora is not None:
+            logits_proj = logits_proj + lora.lm_head_lora(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+
+    def forward_per_token(self, input_ids: Tensor, target_ids: Tensor, lora=None) -> Tensor:
+        """Like forward() but returns per-token NLL, shape (bsz, seqlen)."""
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        if self.trigram is not None:
+            x = x + self.trigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0: Tensor | None = None
+        skips: list[Tensor] = []
+        for i in range(self.num_encoder_layers):
+            qd_fn = lora.q_loras[i] if lora is not None else None
+            vd_fn = lora.v_loras[i] if lora is not None else None
+            x, v = self.blocks[i](x, x0, v0=v0, q_delta_fn=qd_fn, v_delta_fn=vd_fn)
+            if i == 0:
+                v0 = v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            li = self.num_encoder_layers + i
+            qd_fn = lora.q_loras[li] if lora is not None else None
+            vd_fn = lora.v_loras[li] if lora is not None else None
+            x, v = self.blocks[li](x, x0, v0=v0, q_delta_fn=qd_fn, v_delta_fn=vd_fn)
+            if li == 0:
+                v0 = v
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        if lora is not None:
+            logits_proj = logits_proj + lora.lm_head_lora(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        bsz, seqlen, V = logits.shape
+        return F.cross_entropy(logits.reshape(-1, V).float(), target_ids.reshape(-1), reduction='none').reshape(bsz, seqlen)
+
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+) -> tuple[float, float]:
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = base_model.forward_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+            if rank == 0 and (bi // batch_seqs) % 50 == 0:
+                done = min(bi + batch_seqs, len(my_windows))
+                pct = done / len(my_windows) * 100
+                running_bpb = 0.0
+                if token_count.item() > 0:
+                    rl = (loss_sum / token_count).item()
+                    running_bpb = rl / math.log(2.0) * (token_count.item() / byte_count.item())
+                print(f"  sliding_eval [{pct:5.1f}%] {done}/{len(my_windows)} windows running_bpb={running_bpb:.6f}", flush=True)
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+
+def test_time_train(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    log_fn,
+) -> tuple[float, float]:
+    """Fine-tune model on validation tokens, then evaluate with sliding window."""
+    log_fn(f"ttt:starting lr={args.ttt_lr} epochs={args.ttt_epochs}")
+
+    ttt_model = copy.deepcopy(base_model)
+    ttt_model.train()
+
+    ttt_params = [p for p in ttt_model.parameters() if p.requires_grad]
+    ttt_optimizer = torch.optim.AdamW(ttt_params, lr=args.ttt_lr, weight_decay=0.0)
+
+    seq_len = args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    my_start = (total_seqs * rank) // world_size
+    my_end = (total_seqs * (rank + 1)) // world_size
+
+    for epoch in range(args.ttt_epochs):
+        epoch_loss = 0.0
+        epoch_tokens = 0
+        for seq_idx in range(my_start, my_end):
+            raw_start = seq_idx * seq_len
+            raw_end = raw_start + seq_len + 1
+            chunk = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64)
+            x = chunk[:-1].unsqueeze(0)
+            y = chunk[1:].unsqueeze(0)
+            ttt_optimizer.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = ttt_model(x, y)
+            loss.backward()
+            ttt_optimizer.step()
+            epoch_loss += loss.item() * seq_len
+            epoch_tokens += seq_len
+        if dist.is_available() and dist.is_initialized():
+            loss_t = torch.tensor(epoch_loss, device=device)
+            tok_t = torch.tensor(float(epoch_tokens), device=device)
+            dist.all_reduce(loss_t, op=dist.ReduceOp.SUM)
+            dist.all_reduce(tok_t, op=dist.ReduceOp.SUM)
+            epoch_loss = loss_t.item()
+            epoch_tokens = int(tok_t.item())
+        avg_loss = epoch_loss / max(epoch_tokens, 1)
+        log_fn(f"ttt:epoch={epoch+1}/{args.ttt_epochs} loss={avg_loss:.4f}")
+
+    ttt_model.eval()
+    val_loss, val_bpb = eval_val_sliding(
+        args, ttt_model, rank, world_size, device,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        stride=args.eval_stride, batch_seqs=args.eval_batch_seqs,
+    )
+    log_fn(f"ttt:final val_loss={val_loss:.4f} val_bpb={val_bpb:.4f}")
+    return val_loss, val_bpb
+
+
+
+
+
+class BatchedLinearLoRA(nn.Module):
+    def __init__(self, bsz, in_features, out_features, rank):
+        super().__init__()
+        self.in_features = in_features
+        self.A = nn.Parameter(torch.empty(bsz, rank, in_features))
+        self.B = nn.Parameter(torch.zeros(bsz, out_features, rank))
+        self.reset()
+
+    def forward(self, x):
+        return (x @ self.A.transpose(1, 2)) @ self.B.transpose(1, 2)
+
+    def reset(self):
+        bound = 1.0 / math.sqrt(self.in_features)
+        with torch.no_grad():
+            self.A.uniform_(-bound, bound)
+            self.B.zero_()
+
+
+class BatchedTTTLoRA(nn.Module):
+    def __init__(self, bsz, model, rank):
+        super().__init__()
+        dim = model.tok_emb.embedding_dim
+        vocab = model.tok_emb.num_embeddings
+        self.lm_head_lora = BatchedLinearLoRA(bsz, dim, vocab, rank)
+        self.q_loras = nn.ModuleList()
+        self.v_loras = nn.ModuleList()
+        for block in model.blocks:
+            q_out = block.attn.c_q.weight.shape[0]
+            v_out = block.attn.c_v.weight.shape[0]
+            self.q_loras.append(BatchedLinearLoRA(bsz, dim, q_out, rank))
+            self.v_loras.append(BatchedLinearLoRA(bsz, dim, v_out, rank))
+
+    def reset(self):
+        for m in self.modules():
+            if isinstance(m, BatchedLinearLoRA):
+                m.reset()
+
+
+BOS_ID = 1  # SentencePiece BOS
+
+
+def _find_docs(all_tokens):
+    bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0].cpu().numpy()
+    docs = []
+    for i in range(len(bos_positions)):
+        start = int(bos_positions[i])
+        end = int(bos_positions[i + 1]) + 1 if i + 1 < len(bos_positions) else all_tokens.numel()
+        if end - start >= 2:
+            docs.append((start, end - start))
+    return docs
+
+
+def _reset_ttt_optimizer(opt):
+    for group in opt.param_groups:
+        for p in group["params"]:
+            s = opt.state.get(p)
+            if not s:
+                continue
+            s["exp_avg"].zero_()
+            s["exp_avg_sq"].zero_()
+            s["step"].fill_(0)
+
+
+def lora_ttt_eval(args, base_model, rank, world_size, device,
+                  val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+                  log_fn, lora_rank=8, ttt_lr=0.01, ttt_epochs=3, chunk_size=256):
+    import copy
+    base_model.eval()
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+
+    all_tokens = val_tokens
+    eval_seq_len = args.train_seq_len
+    batch_size = 64
+    min_doc_len = 512
+
+    # Find document boundaries via BOS token
+    docs = _find_docs(all_tokens)
+    rank_docs = docs[(len(docs) * rank) // world_size : (len(docs) * (rank + 1)) // world_size]
+    short_docs = [d for d in rank_docs if d[1] < min_doc_len]
+    long_docs = [d for d in rank_docs if d[1] >= min_doc_len]
+
+    log_fn(f"lora_ttt_batched: short={len(short_docs)} long={len(long_docs)} batch={batch_size} rank={lora_rank} lr={ttt_lr} epochs={ttt_epochs} chunk={chunk_size}")
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Score short docs without TTT
+    with torch.no_grad():
+        for ds, dl in short_docs:
+            x = all_tokens[ds:ds+dl-1].to(device=device, dtype=torch.int64).unsqueeze(0)
+            y = all_tokens[ds+1:ds+dl].to(device=device, dtype=torch.int64).unsqueeze(0)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                loss = base_model(x, y)
+            n = dl - 1
+            loss_sum += loss.to(torch.float64) * n
+            token_count += n
+            tgt = y.reshape(-1)
+            prev = x.reshape(-1)
+            tb = base_bytes_lut[tgt].to(torch.float64)
+            tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+            byte_sum += tb.sum()
+
+    # Sort long docs by number of chunks for efficient batching
+    long_docs.sort(key=lambda d: (d[1] - 2) // chunk_size)
+
+    # Process long docs in batches
+    lora = BatchedTTTLoRA(batch_size, base_model, lora_rank).to(device)
+    opt = torch.optim.Adam(lora.parameters(), lr=ttt_lr, betas=(0.9, 0.95), eps=1e-10)
+
+    def reset_opt():
+        for group in opt.param_groups:
+            for p in group["params"]:
+                s = opt.state.get(p)
+                if not s: continue
+                s["exp_avg"].zero_()
+                s["exp_avg_sq"].zero_()
+                s["step"].fill_(0)
+
+    for bi in range(0, len(long_docs), batch_size):
+        batch = long_docs[bi:bi+batch_size]
+        bsz = len(batch)
+
+        # Create right-sized LoRA if batch is smaller
+        if bsz < 16:  # Too small batch - score without TTT
+            with torch.no_grad():
+                for ds, dl in batch:
+                    x = all_tokens[ds:ds+dl-1].to(device=device, dtype=torch.int64).unsqueeze(0)
+                    y = all_tokens[ds+1:ds+dl].to(device=device, dtype=torch.int64).unsqueeze(0)
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        loss = base_model(x, y)
+                    n = dl - 1
+                    loss_sum += loss.to(torch.float64) * n
+                    token_count += n
+                    tgt = y.reshape(-1); prev = x.reshape(-1)
+                    tb = base_bytes_lut[tgt].to(torch.float64)
+                    tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                    byte_sum += tb.sum()
+            continue
+        if bsz < batch_size:
+            cur_lora = BatchedTTTLoRA(bsz, base_model, lora_rank).to(device)
+            cur_opt = torch.optim.Adam(cur_lora.parameters(), lr=ttt_lr, betas=(0.9, 0.95), eps=1e-10)
+        else:
+            cur_lora = lora
+            cur_opt = opt
+            cur_lora.reset()
+            reset_opt()
+
+        # Find max chunks in this batch
+        max_chunks = max((d[1] - 1 + chunk_size - 1) // chunk_size for _, d in enumerate(batch))
+
+        for epoch in range(ttt_epochs):
+            for ci in range(max_chunks):
+                # Build batch tensors
+                x_batch = torch.zeros(bsz, eval_seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, eval_seq_len, dtype=torch.int64, device=device)
+                chunk_offsets = []
+                chunk_lens = []
+                active_mask = []
+
+                for di, (ds, dl) in enumerate(batch):
+                    pred_len = dl - 1
+                    nc = (pred_len + chunk_size - 1) // chunk_size
+                    if ci >= nc:
+                        active_mask.append(False)
+                        chunk_offsets.append(0)
+                        chunk_lens.append(0)
+                        continue
+                    active_mask.append(True)
+                    cs = ci * chunk_size
+                    ce = min((ci + 1) * chunk_size, pred_len)
+                    cl = ce - cs
+                    ws = max(0, ce - eval_seq_len)
+                    wl = ce - ws
+                    co = cs - ws
+
+                    tokens = all_tokens[ds+ws:ds+ws+wl+1].to(dtype=torch.int64, device=device)
+                    x_batch[di, :wl] = tokens[:-1]
+                    y_batch[di, :wl] = tokens[1:]
+                    chunk_offsets.append(co)
+                    chunk_lens.append(cl)
+
+                if not any(active_mask):
+                    continue
+
+                needs_train = ci < max_chunks - 1
+
+                if needs_train:
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        per_token_loss = base_model.forward_per_token(x_batch, y_batch, lora=cur_lora)
+                else:
+                    with torch.no_grad(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        per_token_loss = base_model.forward_per_token(x_batch, y_batch, lora=cur_lora)
+
+                # Score on last epoch
+                if epoch == ttt_epochs - 1:
+                    with torch.no_grad():
+                        for di in range(bsz):
+                            if not active_mask[di]:
+                                continue
+                            co = chunk_offsets[di]
+                            cl = chunk_lens[di]
+                            loss_sum += per_token_loss[di, co:co+cl].to(torch.float64).sum()
+                            token_count += cl
+
+                            ds_di, dl_di = batch[di]
+                            pred_len = dl_di - 1
+                            nc = (pred_len + chunk_size - 1) // chunk_size
+                            cs = ci * chunk_size
+                            ce = min((ci + 1) * chunk_size, pred_len)
+                            ws = max(0, ce - eval_seq_len)
+                            tgt = y_batch[di, co:co+cl]
+                            prev = x_batch[di, co:co+cl]
+                            tb = base_bytes_lut[tgt].to(torch.float64)
+                            tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                            byte_sum += tb.sum()
+
+                # Train (not on last chunk)
+                if needs_train:
+                    cur_opt.zero_grad()
+                    # Average loss over active docs' chunk regions
+                    train_loss = torch.tensor(0.0, device=device)
+                    n_active = 0
+                    for di in range(bsz):
+                        if active_mask[di]:
+                            co = chunk_offsets[di]
+                            cl = chunk_lens[di]
+                            train_loss = train_loss + per_token_loss[di, co:co+cl].mean()
+                            n_active += 1
+                    if n_active > 0:
+                        (train_loss / n_active).backward()
+                        cur_opt.step()
+
+        if rank == 0:
+            pct = min(bi + batch_size, len(long_docs)) / len(long_docs) * 100
+            rbpb = 0.0
+            if token_count.item() > 0:
+                rl = (loss_sum / token_count).item()
+                rbpb = rl / math.log(2.0) * (token_count.item() / byte_sum.item())
+            log_fn(f"  lora_ttt_batch [{pct:.1f}%] docs={min(bi+batch_size, len(long_docs))}/{len(long_docs)} running_bpb={rbpb:.6f}")
+
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+
+    if dist.is_available() and dist.is_initialized():
+        for t in (loss_sum, token_count, byte_sum):
+            dist.all_reduce(t, op=dist.ReduceOp.SUM)
+
+    vl = (loss_sum / token_count).item()
+    bpt = vl / math.log(2.0)
+    tpb = token_count.item() / byte_sum.item()
+    return vl, bpt * tpb
+
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim,
+        trigram_vocab_size=args.trigram_vocab_size,
+        trigram_dim=args.trigram_dim,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+    if base_model.trigram is not None:
+        scalar_params.append(base_model.trigram.scale)
+
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_params.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None:
+            matrix_params.append(base_model.bigram.proj.weight)
+    if base_model.trigram is not None:
+        tok_params.append({"params": [base_model.trigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.trigram.proj is not None:
+            matrix_params.append(base_model.trigram.proj.weight)
+
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.weight_decay,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=0.04,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.weight_decay,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+    log0(f"improvements: value_residual gated_attention trigram_hash ema adaptive_quant ttt={args.ttt_enabled}")
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+
+    ema_state: dict[str, Tensor] | None = None
+    ema_started = False
+
+    grad_sensitivity: dict[str, float] = {}
+    grad_sens_accum: dict[str, float] = {}
+    grad_sens_count = 0
+    in_warmdown_last_10pct = False
+
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if scale < 0.1 and not in_warmdown_last_10pct:
+            in_warmdown_last_10pct = True
+            grad_sens_accum = {}
+            grad_sens_count = 0
+            log0(f"grad_sensitivity:tracking_start step:{step}")
+        if in_warmdown_last_10pct:
+            for name, param in base_model.named_parameters():
+                if param.grad is not None and param.ndim == 2 and param.numel() > 8192:
+                    sens = (param.grad.float() * param.data.float()).abs().mean().item()
+                    grad_sens_accum[name] = grad_sens_accum.get(name, 0.0) + sens
+            grad_sens_count += 1
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+
+        if args.ema_enabled and scale < args.ema_start_frac:
+            if not ema_started:
+                ema_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                ema_started = True
+                log0(f"ema:start step:{step}")
+            else:
+                decay = args.ema_decay
+                for name, t in base_model.state_dict().items():
+                    ema_state[name] = decay * ema_state[name] + (1.0 - decay) * t.detach().cpu()
+
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    if args.ema_enabled and ema_state is not None:
+        log0(f"ema:applying decay={args.ema_decay}")
+        current_state = base_model.state_dict()
+        ema_applied = {
+            name: tensor.to(dtype=current_state[name].dtype)
+            for name, tensor in ema_state.items()
+        }
+        base_model.load_state_dict(ema_applied, strict=True)
+
+    if grad_sens_count > 0:
+        grad_sensitivity = {name: v / grad_sens_count for name, v in grad_sens_accum.items()}
+        log0(f"grad_sensitivity:collected {len(grad_sensitivity)} tensors over {grad_sens_count} steps")
+    else:
+        grad_sensitivity = {}
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    with torch.no_grad():
+        for name, param in base_model.named_parameters():
+            if param.ndim == 2 and param.numel() > 65536:
+                threshold = torch.quantile(param.abs().float().flatten(), 0.05)
+                mask = param.abs() < threshold
+                param.masked_fill_(mask, 0.0)
+
+    sd_cpu = {k: v.detach().cpu() for k, v in base_model.state_dict().items()}
+    quant_result, quant_meta = mixed_quantize_int6(
+        sd_cpu, {"mlp", "attn", "bigram"},
+        grad_sensitivity=grad_sensitivity if grad_sensitivity else None,
+    )
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    if _COMPRESSOR == "zstd":
+        quant_blob = zstandard.ZstdCompressor(level=22).compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, 9)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+{_COMPRESSOR}: {quant_file_bytes} bytes")
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    if _COMPRESSOR == "zstd":
+        decompressed = zstandard.ZstdDecompressor().decompress(quant_blob_disk)
+    else:
+        decompressed = zlib.decompress(quant_blob_disk)
+    quant_state = torch.load(io.BytesIO(decompressed), map_location="cpu")
+    deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], sd_cpu)
+    base_model.load_state_dict(deq_state, strict=True)
+
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    if args.eval_stride > 0 and args.eval_stride < args.train_seq_len:
+        log0(f"final_eval_mode:sliding_window stride:{args.eval_stride} batch_seqs:{args.eval_batch_seqs}")
+        q_val_loss, q_val_bpb = eval_val_sliding(
+            args, base_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, batch_seqs=args.eval_batch_seqs,
+        )
+    else:
+        log0("final_eval_mode:standard")
+        q_val_loss, q_val_bpb = eval_val(
+            args, model, rank, world_size, device, grad_accum_steps,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    ttt_on = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    if ttt_on:
+        lora_rank = int(os.environ.get("LORA_RANK", "8"))
+        ttt_lr = float(os.environ.get("TTT_LR", "0.0001"))
+        ttt_ep = int(os.environ.get("TTT_EPOCHS", "3"))
+        ttt_chunk = int(os.environ.get("TTT_CHUNK_SIZE", "1024"))
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_vl, ttt_bpb = lora_ttt_eval(
+            args, base_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            log_fn=log0, lora_rank=lora_rank, ttt_lr=ttt_lr, ttt_epochs=ttt_ep, chunk_size=ttt_chunk,
+        )
+        torch.cuda.synchronize()
+        log0(f"ttt_final val_loss:{ttt_vl:.4f} val_bpb:{ttt_bpb:.4f} time:{1000*(time.perf_counter()-t_ttt):.0f}ms")
+        log0(f"ttt_improvement: {q_val_bpb - ttt_bpb:.6f} bpb")
+
+
+    if args.ttt_enabled:
+        ttt_val_loss, ttt_val_bpb = test_time_train(
+            args, base_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            log_fn=log0,
+        )
+        log0(f"final_ttt val_loss:{ttt_val_loss:.4f} val_bpb:{ttt_val_bpb:.4f}")
+        log0(f"final_ttt_exact val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-03-25_10L_LoRA_TTT/train_seed1337.log
+++ b/records/track_10min_16mb/2026-03-25_10L_LoRA_TTT/train_seed1337.log
@@ -1,0 +1,322 @@
+W0325 12:14:55.530000 388 torch/distributed/run.py:803] 
+W0325 12:14:55.530000 388 torch/distributed/run.py:803] *****************************************
+W0325 12:14:55.530000 388 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0325 12:14:55.530000 388 torch/distributed/run.py:803] *****************************************
+logs/dc6bacce-af4e-46f3-8deb-5c6b8b136de0.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:25517235
+world_size:8 grad_accum_steps:1
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.03 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:1337
+improvements: value_residual gated_attention trigram_hash ema adaptive_quant ttt=True
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9294 val_bpb:4.1040 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9301 train_time:141ms step_avg:140.78ms
+step:2/20000 train_loss:7.9537 train_time:220ms step_avg:110.02ms
+step:3/20000 train_loss:7.5010 train_time:316ms step_avg:105.34ms
+step:4/20000 train_loss:6.9088 train_time:413ms step_avg:103.13ms
+step:5/20000 train_loss:6.7837 train_time:508ms step_avg:101.69ms
+step:6/20000 train_loss:6.7427 train_time:604ms step_avg:100.72ms
+step:7/20000 train_loss:6.6216 train_time:700ms step_avg:100.03ms
+step:8/20000 train_loss:6.5246 train_time:796ms step_avg:99.48ms
+step:9/20000 train_loss:6.2152 train_time:892ms step_avg:99.06ms
+step:10/20000 train_loss:5.9898 train_time:987ms step_avg:98.72ms
+step:100/20000 train_loss:3.1327 train_time:9275ms step_avg:92.75ms
+step:200/20000 train_loss:2.3280 train_time:20145ms step_avg:100.73ms
+step:300/20000 train_loss:2.4965 train_time:31134ms step_avg:103.78ms
+step:400/20000 train_loss:2.3674 train_time:41950ms step_avg:104.87ms
+step:500/20000 train_loss:2.3537 train_time:51223ms step_avg:102.45ms
+step:500/20000 val_loss:2.3184 val_bpb:1.3731 train_time:51247ms step_avg:102.49ms
+step:600/20000 train_loss:2.2993 train_time:62082ms step_avg:103.47ms
+step:700/20000 train_loss:2.3165 train_time:72875ms step_avg:104.11ms
+step:800/20000 train_loss:2.2112 train_time:83895ms step_avg:104.87ms
+step:900/20000 train_loss:2.1060 train_time:94801ms step_avg:105.33ms
+step:1000/20000 train_loss:2.2546 train_time:104086ms step_avg:104.09ms
+step:1000/20000 val_loss:2.2063 val_bpb:1.3067 train_time:104110ms step_avg:104.11ms
+step:1100/20000 train_loss:2.3013 train_time:115137ms step_avg:104.67ms
+step:1200/20000 train_loss:2.3356 train_time:126094ms step_avg:105.08ms
+step:1300/20000 train_loss:2.0830 train_time:137238ms step_avg:105.57ms
+step:1400/20000 train_loss:2.1683 train_time:148262ms step_avg:105.90ms
+step:1500/20000 train_loss:2.2069 train_time:157557ms step_avg:105.04ms
+step:1500/20000 val_loss:2.1712 val_bpb:1.2859 train_time:157582ms step_avg:105.05ms
+step:1600/20000 train_loss:2.0636 train_time:168627ms step_avg:105.39ms
+step:1700/20000 train_loss:2.1290 train_time:179727ms step_avg:105.72ms
+step:1800/20000 train_loss:2.1491 train_time:190645ms step_avg:105.91ms
+step:1900/20000 train_loss:2.1167 train_time:199944ms step_avg:105.23ms
+step:2000/20000 train_loss:2.0596 train_time:211067ms step_avg:105.53ms
+step:2000/20000 val_loss:2.1221 val_bpb:1.2568 train_time:211091ms step_avg:105.55ms
+step:2100/20000 train_loss:2.0361 train_time:222043ms step_avg:105.73ms
+step:2200/20000 train_loss:2.1388 train_time:233096ms step_avg:105.95ms
+step:2300/20000 train_loss:2.1014 train_time:244043ms step_avg:106.11ms
+step:2400/20000 train_loss:2.0574 train_time:253338ms step_avg:105.56ms
+step:2500/20000 train_loss:2.1648 train_time:264468ms step_avg:105.79ms
+step:2500/20000 val_loss:2.0974 val_bpb:1.2422 train_time:264492ms step_avg:105.80ms
+step:2600/20000 train_loss:2.0995 train_time:275645ms step_avg:106.02ms
+step:2700/20000 train_loss:2.0933 train_time:286933ms step_avg:106.27ms
+step:2800/20000 train_loss:2.1436 train_time:298124ms step_avg:106.47ms
+step:2900/20000 train_loss:2.0117 train_time:307423ms step_avg:106.01ms
+step:3000/20000 train_loss:2.1437 train_time:318637ms step_avg:106.21ms
+step:3000/20000 val_loss:2.0748 val_bpb:1.2288 train_time:318662ms step_avg:106.22ms
+step:3100/20000 train_loss:2.0148 train_time:329618ms step_avg:106.33ms
+step:3200/20000 train_loss:2.1509 train_time:340745ms step_avg:106.48ms
+step:3300/20000 train_loss:2.0489 train_time:350034ms step_avg:106.07ms
+step:3400/20000 train_loss:1.9960 train_time:361023ms step_avg:106.18ms
+step:3500/20000 train_loss:2.1537 train_time:372028ms step_avg:106.29ms
+step:3500/20000 val_loss:2.0520 val_bpb:1.2153 train_time:372051ms step_avg:106.30ms
+step:3600/20000 train_loss:2.0652 train_time:383168ms step_avg:106.44ms
+step:3700/20000 train_loss:2.0611 train_time:394135ms step_avg:106.52ms
+step:3800/20000 train_loss:2.0381 train_time:403427ms step_avg:106.17ms
+step:3900/20000 train_loss:2.0436 train_time:414441ms step_avg:106.27ms
+step:4000/20000 train_loss:1.9380 train_time:425382ms step_avg:106.35ms
+step:4000/20000 val_loss:2.0303 val_bpb:1.2024 train_time:425406ms step_avg:106.35ms
+step:4100/20000 train_loss:1.9758 train_time:436303ms step_avg:106.42ms
+ema:start step:4147
+step:4200/20000 train_loss:2.1137 train_time:450179ms step_avg:107.19ms
+step:4300/20000 train_loss:2.0146 train_time:464857ms step_avg:108.11ms
+step:4400/20000 train_loss:1.9870 train_time:481219ms step_avg:109.37ms
+step:4500/20000 train_loss:2.0743 train_time:497733ms step_avg:110.61ms
+step:4500/20000 val_loss:1.9991 val_bpb:1.1840 train_time:497808ms step_avg:110.62ms
+step:4600/20000 train_loss:1.7929 train_time:514167ms step_avg:111.78ms
+step:4700/20000 train_loss:2.1862 train_time:528885ms step_avg:112.53ms
+step:4800/20000 train_loss:2.3814 train_time:545093ms step_avg:113.56ms
+step:4900/20000 train_loss:1.9921 train_time:561893ms step_avg:114.67ms
+grad_sensitivity:tracking_start step:4925
+step:5000/20000 train_loss:2.0446 train_time:579137ms step_avg:115.83ms
+step:5000/20000 val_loss:1.9641 val_bpb:1.1632 train_time:579194ms step_avg:115.84ms
+step:5100/20000 train_loss:2.0697 train_time:596023ms step_avg:116.87ms
+step:5126/20000 val_loss:1.9595 val_bpb:1.1605 train_time:600037ms step_avg:117.06ms
+stopping_early: wallclock_cap train_time:600037ms step:5126/20000
+peak memory allocated: 19304 MiB reserved: 19512 MiB
+ema:applying decay=0.995
+grad_sensitivity:collected 63 tensors over 201 steps
+Serialized model: 98443473 bytes
+Code size: 75337 bytes
+Total submission size: 98518810 bytes
+Serialized model int6+zlib: 16810953 bytes
+Total submission size int8+zlib: 16886290 bytes
+final_eval_mode:sliding_window stride:64 batch_seqs:32
+  sliding_eval [  0.0%] 32/121136 windows running_bpb=1.211802
+  sliding_eval [  1.3%] 1632/121136 windows running_bpb=1.147847
+  sliding_eval [  2.7%] 3232/121136 windows running_bpb=1.149033
+  sliding_eval [  4.0%] 4832/121136 windows running_bpb=1.143046
+  sliding_eval [  5.3%] 6432/121136 windows running_bpb=1.154977
+  sliding_eval [  6.6%] 8032/121136 windows running_bpb=1.156202
+  sliding_eval [  8.0%] 9632/121136 windows running_bpb=1.157643
+  sliding_eval [  9.3%] 11232/121136 windows running_bpb=1.153445
+  sliding_eval [ 10.6%] 12832/121136 windows running_bpb=1.150894
+  sliding_eval [ 11.9%] 14432/121136 windows running_bpb=1.152715
+  sliding_eval [ 13.2%] 16032/121136 windows running_bpb=1.161518
+  sliding_eval [ 14.6%] 17632/121136 windows running_bpb=1.159904
+  sliding_eval [ 15.9%] 19232/121136 windows running_bpb=1.161251
+  sliding_eval [ 17.2%] 20832/121136 windows running_bpb=1.159527
+  sliding_eval [ 18.5%] 22432/121136 windows running_bpb=1.158052
+  sliding_eval [ 19.8%] 24032/121136 windows running_bpb=1.158325
+  sliding_eval [ 21.2%] 25632/121136 windows running_bpb=1.159735
+  sliding_eval [ 22.5%] 27232/121136 windows running_bpb=1.160252
+  sliding_eval [ 23.8%] 28832/121136 windows running_bpb=1.166476
+  sliding_eval [ 25.1%] 30432/121136 windows running_bpb=1.163938
+  sliding_eval [ 26.4%] 32032/121136 windows running_bpb=1.164930
+  sliding_eval [ 27.8%] 33632/121136 windows running_bpb=1.163680
+  sliding_eval [ 29.1%] 35232/121136 windows running_bpb=1.163012
+  sliding_eval [ 30.4%] 36832/121136 windows running_bpb=1.162608
+  sliding_eval [ 31.7%] 38432/121136 windows running_bpb=1.163248
+  sliding_eval [ 33.0%] 40032/121136 windows running_bpb=1.160831
+  sliding_eval [ 34.4%] 41632/121136 windows running_bpb=1.159850
+  sliding_eval [ 35.7%] 43232/121136 windows running_bpb=1.160271
+  sliding_eval [ 37.0%] 44832/121136 windows running_bpb=1.159057
+  sliding_eval [ 38.3%] 46432/121136 windows running_bpb=1.158892
+  sliding_eval [ 39.7%] 48032/121136 windows running_bpb=1.158122
+  sliding_eval [ 41.0%] 49632/121136 windows running_bpb=1.159303
+  sliding_eval [ 42.3%] 51232/121136 windows running_bpb=1.160304
+  sliding_eval [ 43.6%] 52832/121136 windows running_bpb=1.160817
+  sliding_eval [ 44.9%] 54432/121136 windows running_bpb=1.160240
+  sliding_eval [ 46.3%] 56032/121136 windows running_bpb=1.160576
+  sliding_eval [ 47.6%] 57632/121136 windows running_bpb=1.159620
+  sliding_eval [ 48.9%] 59232/121136 windows running_bpb=1.155722
+  sliding_eval [ 50.2%] 60832/121136 windows running_bpb=1.155825
+  sliding_eval [ 51.5%] 62432/121136 windows running_bpb=1.156785
+  sliding_eval [ 52.9%] 64032/121136 windows running_bpb=1.156908
+  sliding_eval [ 54.2%] 65632/121136 windows running_bpb=1.156830
+  sliding_eval [ 55.5%] 67232/121136 windows running_bpb=1.155592
+  sliding_eval [ 56.8%] 68832/121136 windows running_bpb=1.155299
+  sliding_eval [ 58.1%] 70432/121136 windows running_bpb=1.154564
+  sliding_eval [ 59.5%] 72032/121136 windows running_bpb=1.154622
+  sliding_eval [ 60.8%] 73632/121136 windows running_bpb=1.154564
+  sliding_eval [ 62.1%] 75232/121136 windows running_bpb=1.154719
+  sliding_eval [ 63.4%] 76832/121136 windows running_bpb=1.154397
+  sliding_eval [ 64.7%] 78432/121136 windows running_bpb=1.154981
+  sliding_eval [ 66.1%] 80032/121136 windows running_bpb=1.155273
+  sliding_eval [ 67.4%] 81632/121136 windows running_bpb=1.154933
+  sliding_eval [ 68.7%] 83232/121136 windows running_bpb=1.155965
+  sliding_eval [ 70.0%] 84832/121136 windows running_bpb=1.157878
+  sliding_eval [ 71.4%] 86432/121136 windows running_bpb=1.157171
+  sliding_eval [ 72.7%] 88032/121136 windows running_bpb=1.157859
+  sliding_eval [ 74.0%] 89632/121136 windows running_bpb=1.158187
+  sliding_eval [ 75.3%] 91232/121136 windows running_bpb=1.158161
+  sliding_eval [ 76.6%] 92832/121136 windows running_bpb=1.157719
+  sliding_eval [ 78.0%] 94432/121136 windows running_bpb=1.157940
+  sliding_eval [ 79.3%] 96032/121136 windows running_bpb=1.157369
+  sliding_eval [ 80.6%] 97632/121136 windows running_bpb=1.160178
+  sliding_eval [ 81.9%] 99232/121136 windows running_bpb=1.160173
+  sliding_eval [ 83.2%] 100832/121136 windows running_bpb=1.160185
+  sliding_eval [ 84.6%] 102432/121136 windows running_bpb=1.159815
+  sliding_eval [ 85.9%] 104032/121136 windows running_bpb=1.159309
+  sliding_eval [ 87.2%] 105632/121136 windows running_bpb=1.158589
+  sliding_eval [ 88.5%] 107232/121136 windows running_bpb=1.158575
+  sliding_eval [ 89.8%] 108832/121136 windows running_bpb=1.159205
+  sliding_eval [ 91.2%] 110432/121136 windows running_bpb=1.159242
+  sliding_eval [ 92.5%] 112032/121136 windows running_bpb=1.159211
+  sliding_eval [ 93.8%] 113632/121136 windows running_bpb=1.159655
+  sliding_eval [ 95.1%] 115232/121136 windows running_bpb=1.159440
+  sliding_eval [ 96.4%] 116832/121136 windows running_bpb=1.159050
+  sliding_eval [ 97.8%] 118432/121136 windows running_bpb=1.159354
+  sliding_eval [ 99.1%] 120032/121136 windows running_bpb=1.159449
+final_int8_zlib_roundtrip val_loss:1.9486 val_bpb:1.1540 eval_time:179758ms
+final_int8_zlib_roundtrip_exact val_loss:1.94855007 val_bpb:1.15404416
+lora_ttt_batched: short=2393 long=3857 batch=64 rank=8 lr=0.01 epochs=3 chunk=256
+  lora_ttt_batch [1.7%] docs=64/3857 running_bpb=1.268251
+  lora_ttt_batch [3.3%] docs=128/3857 running_bpb=1.257120
+  lora_ttt_batch [5.0%] docs=192/3857 running_bpb=1.245803
+  lora_ttt_batch [6.6%] docs=256/3857 running_bpb=1.239491
+  lora_ttt_batch [8.3%] docs=320/3857 running_bpb=1.230841
+  lora_ttt_batch [10.0%] docs=384/3857 running_bpb=1.224130
+  lora_ttt_batch [11.6%] docs=448/3857 running_bpb=1.218873
+  lora_ttt_batch [13.3%] docs=512/3857 running_bpb=1.214447
+  lora_ttt_batch [14.9%] docs=576/3857 running_bpb=1.207027
+  lora_ttt_batch [16.6%] docs=640/3857 running_bpb=1.201506
+  lora_ttt_batch [18.3%] docs=704/3857 running_bpb=1.196760
+  lora_ttt_batch [19.9%] docs=768/3857 running_bpb=1.192387
+  lora_ttt_batch [21.6%] docs=832/3857 running_bpb=1.187581
+  lora_ttt_batch [23.2%] docs=896/3857 running_bpb=1.182830
+  lora_ttt_batch [24.9%] docs=960/3857 running_bpb=1.179165
+  lora_ttt_batch [26.5%] docs=1024/3857 running_bpb=1.172745
+  lora_ttt_batch [28.2%] docs=1088/3857 running_bpb=1.164752
+  lora_ttt_batch [29.9%] docs=1152/3857 running_bpb=1.156494
+  lora_ttt_batch [31.5%] docs=1216/3857 running_bpb=1.149772
+  lora_ttt_batch [33.2%] docs=1280/3857 running_bpb=1.143961
+  lora_ttt_batch [34.8%] docs=1344/3857 running_bpb=1.138881
+  lora_ttt_batch [36.5%] docs=1408/3857 running_bpb=1.134356
+  lora_ttt_batch [38.2%] docs=1472/3857 running_bpb=1.131025
+  lora_ttt_batch [39.8%] docs=1536/3857 running_bpb=1.128072
+  lora_ttt_batch [41.5%] docs=1600/3857 running_bpb=1.123998
+  lora_ttt_batch [43.1%] docs=1664/3857 running_bpb=1.120321
+  lora_ttt_batch [44.8%] docs=1728/3857 running_bpb=1.114606
+  lora_ttt_batch [46.5%] docs=1792/3857 running_bpb=1.111071
+  lora_ttt_batch [48.1%] docs=1856/3857 running_bpb=1.107148
+  lora_ttt_batch [49.8%] docs=1920/3857 running_bpb=1.103950
+  lora_ttt_batch [51.4%] docs=1984/3857 running_bpb=1.100551
+  lora_ttt_batch [53.1%] docs=2048/3857 running_bpb=1.098840
+  lora_ttt_batch [54.8%] docs=2112/3857 running_bpb=1.096432
+  lora_ttt_batch [56.4%] docs=2176/3857 running_bpb=1.092377
+  lora_ttt_batch [58.1%] docs=2240/3857 running_bpb=1.089307
+  lora_ttt_batch [59.7%] docs=2304/3857 running_bpb=1.085505
+  lora_ttt_batch [61.4%] docs=2368/3857 running_bpb=1.083416
+  lora_ttt_batch [63.1%] docs=2432/3857 running_bpb=1.080275
+  lora_ttt_batch [64.7%] docs=2496/3857 running_bpb=1.078175
+  lora_ttt_batch [66.4%] docs=2560/3857 running_bpb=1.077527
+  lora_ttt_batch [68.0%] docs=2624/3857 running_bpb=1.076880
+  lora_ttt_batch [69.7%] docs=2688/3857 running_bpb=1.075420
+  lora_ttt_batch [71.4%] docs=2752/3857 running_bpb=1.073704
+  lora_ttt_batch [73.0%] docs=2816/3857 running_bpb=1.072503
+  lora_ttt_batch [74.7%] docs=2880/3857 running_bpb=1.071531
+  lora_ttt_batch [76.3%] docs=2944/3857 running_bpb=1.070490
+  lora_ttt_batch [78.0%] docs=3008/3857 running_bpb=1.068258
+  lora_ttt_batch [79.6%] docs=3072/3857 running_bpb=1.068647
+  lora_ttt_batch [81.3%] docs=3136/3857 running_bpb=1.068485
+  lora_ttt_batch [83.0%] docs=3200/3857 running_bpb=1.069086
+  lora_ttt_batch [84.6%] docs=3264/3857 running_bpb=1.068939
+  lora_ttt_batch [86.3%] docs=3328/3857 running_bpb=1.068042
+  lora_ttt_batch [87.9%] docs=3392/3857 running_bpb=1.067995
+  lora_ttt_batch [89.6%] docs=3456/3857 running_bpb=1.068100
+  lora_ttt_batch [91.3%] docs=3520/3857 running_bpb=1.068911
+  lora_ttt_batch [92.9%] docs=3584/3857 running_bpb=1.071159
+  lora_ttt_batch [94.6%] docs=3648/3857 running_bpb=1.075079
+  lora_ttt_batch [96.2%] docs=3712/3857 running_bpb=1.080845
+  lora_ttt_batch [97.9%] docs=3776/3857 running_bpb=1.091193
+  lora_ttt_batch [99.6%] docs=3840/3857 running_bpb=1.113591
+  lora_ttt_batch [100.0%] docs=3857/3857 running_bpb=1.120992
+ttt_final val_loss:1.8928 val_bpb:1.1210 time:496028ms
+ttt_improvement: 0.032994 bpb
+ttt:starting lr=0.01 epochs=3
+ttt:epoch=1/3 loss=3.4104
+ttt:epoch=2/3 loss=2.8746
+ttt:epoch=3/3 loss=2.7254
+  sliding_eval [  0.0%] 32/121136 windows running_bpb=1.615121
+  sliding_eval [  1.3%] 1632/121136 windows running_bpb=1.594702
+  sliding_eval [  2.7%] 3232/121136 windows running_bpb=1.577316
+  sliding_eval [  4.0%] 4832/121136 windows running_bpb=1.580893
+  sliding_eval [  5.3%] 6432/121136 windows running_bpb=1.591158
+  sliding_eval [  6.6%] 8032/121136 windows running_bpb=1.593552
+  sliding_eval [  8.0%] 9632/121136 windows running_bpb=1.596005
+  sliding_eval [  9.3%] 11232/121136 windows running_bpb=1.588943
+  sliding_eval [ 10.6%] 12832/121136 windows running_bpb=1.587012
+  sliding_eval [ 11.9%] 14432/121136 windows running_bpb=1.590263
+  sliding_eval [ 13.2%] 16032/121136 windows running_bpb=1.598215
+  sliding_eval [ 14.6%] 17632/121136 windows running_bpb=1.595002
+  sliding_eval [ 15.9%] 19232/121136 windows running_bpb=1.595278
+  sliding_eval [ 17.2%] 20832/121136 windows running_bpb=1.594492
+  sliding_eval [ 18.5%] 22432/121136 windows running_bpb=1.593063
+  sliding_eval [ 19.8%] 24032/121136 windows running_bpb=1.593478
+  sliding_eval [ 21.2%] 25632/121136 windows running_bpb=1.594744
+  sliding_eval [ 22.5%] 27232/121136 windows running_bpb=1.594563
+  sliding_eval [ 23.8%] 28832/121136 windows running_bpb=1.599206
+  sliding_eval [ 25.1%] 30432/121136 windows running_bpb=1.597055
+  sliding_eval [ 26.4%] 32032/121136 windows running_bpb=1.597988
+  sliding_eval [ 27.8%] 33632/121136 windows running_bpb=1.595588
+  sliding_eval [ 29.1%] 35232/121136 windows running_bpb=1.594483
+  sliding_eval [ 30.4%] 36832/121136 windows running_bpb=1.592570
+  sliding_eval [ 31.7%] 38432/121136 windows running_bpb=1.592791
+  sliding_eval [ 33.0%] 40032/121136 windows running_bpb=1.589104
+  sliding_eval [ 34.4%] 41632/121136 windows running_bpb=1.587475
+  sliding_eval [ 35.7%] 43232/121136 windows running_bpb=1.588036
+  sliding_eval [ 37.0%] 44832/121136 windows running_bpb=1.586639
+  sliding_eval [ 38.3%] 46432/121136 windows running_bpb=1.586471
+  sliding_eval [ 39.7%] 48032/121136 windows running_bpb=1.585164
+  sliding_eval [ 41.0%] 49632/121136 windows running_bpb=1.586575
+  sliding_eval [ 42.3%] 51232/121136 windows running_bpb=1.587632
+  sliding_eval [ 43.6%] 52832/121136 windows running_bpb=1.588039
+  sliding_eval [ 44.9%] 54432/121136 windows running_bpb=1.587907
+  sliding_eval [ 46.3%] 56032/121136 windows running_bpb=1.588421
+  sliding_eval [ 47.6%] 57632/121136 windows running_bpb=1.587490
+  sliding_eval [ 48.9%] 59232/121136 windows running_bpb=1.582057
+  sliding_eval [ 50.2%] 60832/121136 windows running_bpb=1.581985
+  sliding_eval [ 51.5%] 62432/121136 windows running_bpb=1.581681
+  sliding_eval [ 52.9%] 64032/121136 windows running_bpb=1.581818
+  sliding_eval [ 54.2%] 65632/121136 windows running_bpb=1.581458
+  sliding_eval [ 55.5%] 67232/121136 windows running_bpb=1.579735
+  sliding_eval [ 56.8%] 68832/121136 windows running_bpb=1.578884
+  sliding_eval [ 58.1%] 70432/121136 windows running_bpb=1.577595
+  sliding_eval [ 59.5%] 72032/121136 windows running_bpb=1.577208
+  sliding_eval [ 60.8%] 73632/121136 windows running_bpb=1.577046
+  sliding_eval [ 62.1%] 75232/121136 windows running_bpb=1.577345
+  sliding_eval [ 63.4%] 76832/121136 windows running_bpb=1.576663
+  sliding_eval [ 64.7%] 78432/121136 windows running_bpb=1.575931
+  sliding_eval [ 66.1%] 80032/121136 windows running_bpb=1.575871
+  sliding_eval [ 67.4%] 81632/121136 windows running_bpb=1.575287
+  sliding_eval [ 68.7%] 83232/121136 windows running_bpb=1.576052
+  sliding_eval [ 70.0%] 84832/121136 windows running_bpb=1.577455
+  sliding_eval [ 71.4%] 86432/121136 windows running_bpb=1.575505
+  sliding_eval [ 72.7%] 88032/121136 windows running_bpb=1.574914

--- a/records/track_10min_16mb/2026-03-25_10L_LoRA_TTT/train_seed2024.log
+++ b/records/track_10min_16mb/2026-03-25_10L_LoRA_TTT/train_seed2024.log
@@ -1,0 +1,270 @@
+W0325 12:44:56.146000 36344 torch/distributed/run.py:803] 
+W0325 12:44:56.146000 36344 torch/distributed/run.py:803] *****************************************
+W0325 12:44:56.146000 36344 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0325 12:44:56.146000 36344 torch/distributed/run.py:803] *****************************************
+logs/078daa62-c8de-46c5-9d76-99d9df9a44ab.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:25517235
+world_size:8 grad_accum_steps:1
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.03 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:2024
+improvements: value_residual gated_attention trigram_hash ema adaptive_quant ttt=True
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9327 val_bpb:4.1059 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9341 train_time:140ms step_avg:139.68ms
+step:2/20000 train_loss:8.1362 train_time:219ms step_avg:109.56ms
+step:3/20000 train_loss:7.6865 train_time:316ms step_avg:105.18ms
+step:4/20000 train_loss:6.9746 train_time:412ms step_avg:102.89ms
+step:5/20000 train_loss:6.7646 train_time:508ms step_avg:101.54ms
+step:6/20000 train_loss:6.6490 train_time:604ms step_avg:100.73ms
+step:7/20000 train_loss:6.5306 train_time:701ms step_avg:100.10ms
+step:8/20000 train_loss:6.5608 train_time:797ms step_avg:99.62ms
+step:9/20000 train_loss:6.3294 train_time:893ms step_avg:99.26ms
+step:10/20000 train_loss:6.0739 train_time:990ms step_avg:98.96ms
+step:100/20000 train_loss:3.1322 train_time:9303ms step_avg:93.03ms
+step:200/20000 train_loss:2.3560 train_time:18649ms step_avg:93.24ms
+step:300/20000 train_loss:2.4961 train_time:27995ms step_avg:93.32ms
+step:400/20000 train_loss:2.3689 train_time:37342ms step_avg:93.35ms
+step:500/20000 train_loss:2.3618 train_time:46628ms step_avg:93.26ms
+step:500/20000 val_loss:2.3202 val_bpb:1.3741 train_time:46652ms step_avg:93.30ms
+step:600/20000 train_loss:2.2997 train_time:55983ms step_avg:93.30ms
+step:700/20000 train_loss:2.3199 train_time:65353ms step_avg:93.36ms
+step:800/20000 train_loss:2.2112 train_time:74732ms step_avg:93.41ms
+step:900/20000 train_loss:2.1016 train_time:84105ms step_avg:93.45ms
+step:1000/20000 train_loss:2.2560 train_time:93404ms step_avg:93.40ms
+step:1000/20000 val_loss:2.2081 val_bpb:1.3078 train_time:93428ms step_avg:93.43ms
+step:1100/20000 train_loss:2.3079 train_time:102780ms step_avg:93.44ms
+step:1200/20000 train_loss:2.3322 train_time:112163ms step_avg:93.47ms
+step:1300/20000 train_loss:2.0883 train_time:121548ms step_avg:93.50ms
+step:1400/20000 train_loss:2.1691 train_time:130939ms step_avg:93.53ms
+step:1500/20000 train_loss:2.2078 train_time:140243ms step_avg:93.50ms
+step:1500/20000 val_loss:2.1714 val_bpb:1.2861 train_time:140267ms step_avg:93.51ms
+step:1600/20000 train_loss:2.0646 train_time:149631ms step_avg:93.52ms
+step:1700/20000 train_loss:2.1285 train_time:159016ms step_avg:93.54ms
+step:1800/20000 train_loss:2.1494 train_time:168401ms step_avg:93.56ms
+step:1900/20000 train_loss:2.1151 train_time:177706ms step_avg:93.53ms
+step:2000/20000 train_loss:2.0574 train_time:187069ms step_avg:93.53ms
+step:2000/20000 val_loss:2.1222 val_bpb:1.2569 train_time:187093ms step_avg:93.55ms
+step:2100/20000 train_loss:2.0357 train_time:196441ms step_avg:93.54ms
+step:2200/20000 train_loss:2.1341 train_time:205831ms step_avg:93.56ms
+step:2300/20000 train_loss:2.0981 train_time:215217ms step_avg:93.57ms
+step:2400/20000 train_loss:2.0580 train_time:224509ms step_avg:93.55ms
+step:2500/20000 train_loss:2.1601 train_time:233893ms step_avg:93.56ms
+step:2500/20000 val_loss:2.0962 val_bpb:1.2415 train_time:233917ms step_avg:93.57ms
+step:2600/20000 train_loss:2.0947 train_time:243274ms step_avg:93.57ms
+step:2700/20000 train_loss:2.0888 train_time:252666ms step_avg:93.58ms
+step:2800/20000 train_loss:2.1460 train_time:262049ms step_avg:93.59ms
+step:2900/20000 train_loss:2.0168 train_time:271346ms step_avg:93.57ms
+step:3000/20000 train_loss:2.1540 train_time:280727ms step_avg:93.58ms
+step:3000/20000 val_loss:2.0826 val_bpb:1.2334 train_time:280752ms step_avg:93.58ms
+step:3100/20000 train_loss:2.0272 train_time:290112ms step_avg:93.58ms
+step:3200/20000 train_loss:2.1631 train_time:299488ms step_avg:93.59ms
+step:3300/20000 train_loss:2.0655 train_time:308792ms step_avg:93.57ms
+step:3400/20000 train_loss:2.0147 train_time:318167ms step_avg:93.58ms
+step:3500/20000 train_loss:2.1718 train_time:327536ms step_avg:93.58ms
+step:3500/20000 val_loss:2.0729 val_bpb:1.2277 train_time:327560ms step_avg:93.59ms
+step:3600/20000 train_loss:2.0852 train_time:336915ms step_avg:93.59ms
+step:3700/20000 train_loss:2.0822 train_time:346304ms step_avg:93.60ms
+step:3800/20000 train_loss:2.0588 train_time:355604ms step_avg:93.58ms
+step:3900/20000 train_loss:2.0625 train_time:364990ms step_avg:93.59ms
+step:4000/20000 train_loss:1.9624 train_time:374363ms step_avg:93.59ms
+step:4000/20000 val_loss:2.0523 val_bpb:1.2155 train_time:374387ms step_avg:93.60ms
+step:4100/20000 train_loss:1.9982 train_time:383735ms step_avg:93.59ms
+step:4200/20000 train_loss:2.1342 train_time:393124ms step_avg:93.60ms
+step:4300/20000 train_loss:2.0415 train_time:402425ms step_avg:93.59ms
+step:4400/20000 train_loss:2.0193 train_time:411812ms step_avg:93.59ms
+step:4500/20000 train_loss:2.1077 train_time:421195ms step_avg:93.60ms
+step:4500/20000 val_loss:2.0301 val_bpb:1.2024 train_time:421219ms step_avg:93.60ms
+step:4600/20000 train_loss:1.8269 train_time:430582ms step_avg:93.60ms
+step:4700/20000 train_loss:2.2202 train_time:439879ms step_avg:93.59ms
+step:4800/20000 train_loss:2.4139 train_time:449249ms step_avg:93.59ms
+step:4900/20000 train_loss:2.0372 train_time:458632ms step_avg:93.60ms
+ema:start step:4912
+step:5000/20000 train_loss:2.0868 train_time:473082ms step_avg:94.62ms
+step:5000/20000 val_loss:2.0072 val_bpb:1.1888 train_time:473160ms step_avg:94.63ms
+step:5100/20000 train_loss:2.1029 train_time:488122ms step_avg:95.71ms
+step:5200/20000 train_loss:2.0195 train_time:503013ms step_avg:96.73ms
+step:5300/20000 train_loss:1.9837 train_time:519965ms step_avg:98.11ms
+step:5400/20000 train_loss:2.0170 train_time:536975ms step_avg:99.44ms
+step:5500/20000 train_loss:1.9845 train_time:554316ms step_avg:100.78ms
+step:5500/20000 val_loss:1.9692 val_bpb:1.1663 train_time:554394ms step_avg:100.80ms
+grad_sensitivity:tracking_start step:5595
+step:5600/20000 train_loss:1.9186 train_time:571327ms step_avg:102.02ms
+step:5700/20000 train_loss:1.9737 train_time:587500ms step_avg:103.07ms
+step:5768/20000 val_loss:1.9535 val_bpb:1.1570 train_time:600050ms step_avg:104.03ms
+stopping_early: wallclock_cap train_time:600050ms step:5768/20000
+peak memory allocated: 19298 MiB reserved: 19506 MiB
+ema:applying decay=0.995
+grad_sensitivity:collected 63 tensors over 173 steps
+Serialized model: 98443473 bytes
+Code size: 75337 bytes
+Total submission size: 98518810 bytes
+Serialized model int6+zlib: 16814391 bytes
+Total submission size int8+zlib: 16889728 bytes
+final_eval_mode:sliding_window stride:64 batch_seqs:32
+  sliding_eval [  0.0%] 32/121136 windows running_bpb=1.209507
+  sliding_eval [  1.3%] 1632/121136 windows running_bpb=1.143182
+  sliding_eval [  2.7%] 3232/121136 windows running_bpb=1.145472
+  sliding_eval [  4.0%] 4832/121136 windows running_bpb=1.139657
+  sliding_eval [  5.3%] 6432/121136 windows running_bpb=1.151583
+  sliding_eval [  6.6%] 8032/121136 windows running_bpb=1.152533
+  sliding_eval [  8.0%] 9632/121136 windows running_bpb=1.153990
+  sliding_eval [  9.3%] 11232/121136 windows running_bpb=1.149549
+  sliding_eval [ 10.6%] 12832/121136 windows running_bpb=1.147257
+  sliding_eval [ 11.9%] 14432/121136 windows running_bpb=1.149182
+  sliding_eval [ 13.2%] 16032/121136 windows running_bpb=1.157896
+  sliding_eval [ 14.6%] 17632/121136 windows running_bpb=1.156376
+  sliding_eval [ 15.9%] 19232/121136 windows running_bpb=1.157727
+  sliding_eval [ 17.2%] 20832/121136 windows running_bpb=1.155912
+  sliding_eval [ 18.5%] 22432/121136 windows running_bpb=1.154549
+  sliding_eval [ 19.8%] 24032/121136 windows running_bpb=1.154874
+  sliding_eval [ 21.2%] 25632/121136 windows running_bpb=1.156238
+  sliding_eval [ 22.5%] 27232/121136 windows running_bpb=1.156651
+  sliding_eval [ 23.8%] 28832/121136 windows running_bpb=1.162841
+  sliding_eval [ 25.1%] 30432/121136 windows running_bpb=1.160326
+  sliding_eval [ 26.4%] 32032/121136 windows running_bpb=1.161275
+  sliding_eval [ 27.8%] 33632/121136 windows running_bpb=1.159998
+  sliding_eval [ 29.1%] 35232/121136 windows running_bpb=1.159319
+  sliding_eval [ 30.4%] 36832/121136 windows running_bpb=1.158848
+  sliding_eval [ 31.7%] 38432/121136 windows running_bpb=1.159465
+  sliding_eval [ 33.0%] 40032/121136 windows running_bpb=1.157096
+  sliding_eval [ 34.4%] 41632/121136 windows running_bpb=1.156062
+  sliding_eval [ 35.7%] 43232/121136 windows running_bpb=1.156443
+  sliding_eval [ 37.0%] 44832/121136 windows running_bpb=1.155163
+  sliding_eval [ 38.3%] 46432/121136 windows running_bpb=1.154986
+  sliding_eval [ 39.7%] 48032/121136 windows running_bpb=1.154218
+  sliding_eval [ 41.0%] 49632/121136 windows running_bpb=1.155420
+  sliding_eval [ 42.3%] 51232/121136 windows running_bpb=1.156455
+  sliding_eval [ 43.6%] 52832/121136 windows running_bpb=1.157032
+  sliding_eval [ 44.9%] 54432/121136 windows running_bpb=1.156526
+  sliding_eval [ 46.3%] 56032/121136 windows running_bpb=1.156897
+  sliding_eval [ 47.6%] 57632/121136 windows running_bpb=1.155987
+  sliding_eval [ 48.9%] 59232/121136 windows running_bpb=1.152100
+  sliding_eval [ 50.2%] 60832/121136 windows running_bpb=1.152235
+  sliding_eval [ 51.5%] 62432/121136 windows running_bpb=1.153116
+  sliding_eval [ 52.9%] 64032/121136 windows running_bpb=1.153254
+  sliding_eval [ 54.2%] 65632/121136 windows running_bpb=1.153105
+  sliding_eval [ 55.5%] 67232/121136 windows running_bpb=1.151880
+  sliding_eval [ 56.8%] 68832/121136 windows running_bpb=1.151602
+  sliding_eval [ 58.1%] 70432/121136 windows running_bpb=1.150906
+  sliding_eval [ 59.5%] 72032/121136 windows running_bpb=1.150976
+  sliding_eval [ 60.8%] 73632/121136 windows running_bpb=1.150940
+  sliding_eval [ 62.1%] 75232/121136 windows running_bpb=1.151082
+  sliding_eval [ 63.4%] 76832/121136 windows running_bpb=1.150780
+  sliding_eval [ 64.7%] 78432/121136 windows running_bpb=1.151354
+  sliding_eval [ 66.1%] 80032/121136 windows running_bpb=1.151632
+  sliding_eval [ 67.4%] 81632/121136 windows running_bpb=1.151327
+  sliding_eval [ 68.7%] 83232/121136 windows running_bpb=1.152357
+  sliding_eval [ 70.0%] 84832/121136 windows running_bpb=1.154291
+  sliding_eval [ 71.4%] 86432/121136 windows running_bpb=1.153603
+  sliding_eval [ 72.7%] 88032/121136 windows running_bpb=1.154343
+  sliding_eval [ 74.0%] 89632/121136 windows running_bpb=1.154675
+  sliding_eval [ 75.3%] 91232/121136 windows running_bpb=1.154648
+  sliding_eval [ 76.6%] 92832/121136 windows running_bpb=1.154245
+  sliding_eval [ 78.0%] 94432/121136 windows running_bpb=1.154475
+  sliding_eval [ 79.3%] 96032/121136 windows running_bpb=1.153877
+  sliding_eval [ 80.6%] 97632/121136 windows running_bpb=1.156710
+  sliding_eval [ 81.9%] 99232/121136 windows running_bpb=1.156731
+  sliding_eval [ 83.2%] 100832/121136 windows running_bpb=1.156777
+  sliding_eval [ 84.6%] 102432/121136 windows running_bpb=1.156407
+  sliding_eval [ 85.9%] 104032/121136 windows running_bpb=1.155925
+  sliding_eval [ 87.2%] 105632/121136 windows running_bpb=1.155153
+  sliding_eval [ 88.5%] 107232/121136 windows running_bpb=1.155132
+  sliding_eval [ 89.8%] 108832/121136 windows running_bpb=1.155763
+  sliding_eval [ 91.2%] 110432/121136 windows running_bpb=1.155788
+  sliding_eval [ 92.5%] 112032/121136 windows running_bpb=1.155769
+  sliding_eval [ 93.8%] 113632/121136 windows running_bpb=1.156252
+  sliding_eval [ 95.1%] 115232/121136 windows running_bpb=1.155987
+  sliding_eval [ 96.4%] 116832/121136 windows running_bpb=1.155601
+  sliding_eval [ 97.8%] 118432/121136 windows running_bpb=1.155925
+  sliding_eval [ 99.1%] 120032/121136 windows running_bpb=1.156006
+final_int8_zlib_roundtrip val_loss:1.9423 val_bpb:1.1504 eval_time:179529ms
+final_int8_zlib_roundtrip_exact val_loss:1.94231337 val_bpb:1.15035043
+lora_ttt_batched: short=2393 long=3857 batch=64 rank=8 lr=0.01 epochs=3 chunk=256
+  lora_ttt_batch [1.7%] docs=64/3857 running_bpb=1.262067
+  lora_ttt_batch [3.3%] docs=128/3857 running_bpb=1.251122
+  lora_ttt_batch [5.0%] docs=192/3857 running_bpb=1.239961
+  lora_ttt_batch [6.6%] docs=256/3857 running_bpb=1.233666
+  lora_ttt_batch [8.3%] docs=320/3857 running_bpb=1.225107
+  lora_ttt_batch [10.0%] docs=384/3857 running_bpb=1.218299
+  lora_ttt_batch [11.6%] docs=448/3857 running_bpb=1.213285
+  lora_ttt_batch [13.3%] docs=512/3857 running_bpb=1.208525
+  lora_ttt_batch [14.9%] docs=576/3857 running_bpb=1.201046
+  lora_ttt_batch [16.6%] docs=640/3857 running_bpb=1.195615
+  lora_ttt_batch [18.3%] docs=704/3857 running_bpb=1.191104
+  lora_ttt_batch [19.9%] docs=768/3857 running_bpb=1.186668
+  lora_ttt_batch [21.6%] docs=832/3857 running_bpb=1.181928
+  lora_ttt_batch [23.2%] docs=896/3857 running_bpb=1.177428
+  lora_ttt_batch [24.9%] docs=960/3857 running_bpb=1.173727
+  lora_ttt_batch [26.5%] docs=1024/3857 running_bpb=1.167357
+  lora_ttt_batch [28.2%] docs=1088/3857 running_bpb=1.159570
+  lora_ttt_batch [29.9%] docs=1152/3857 running_bpb=1.151393
+  lora_ttt_batch [31.5%] docs=1216/3857 running_bpb=1.144671
+  lora_ttt_batch [33.2%] docs=1280/3857 running_bpb=1.138974
+  lora_ttt_batch [34.8%] docs=1344/3857 running_bpb=1.134149
+  lora_ttt_batch [36.5%] docs=1408/3857 running_bpb=1.129491
+  lora_ttt_batch [38.2%] docs=1472/3857 running_bpb=1.126299
+  lora_ttt_batch [39.8%] docs=1536/3857 running_bpb=1.123262
+  lora_ttt_batch [41.5%] docs=1600/3857 running_bpb=1.119216
+  lora_ttt_batch [43.1%] docs=1664/3857 running_bpb=1.115594
+  lora_ttt_batch [44.8%] docs=1728/3857 running_bpb=1.110124
+  lora_ttt_batch [46.5%] docs=1792/3857 running_bpb=1.106820
+  lora_ttt_batch [48.1%] docs=1856/3857 running_bpb=1.102992
+  lora_ttt_batch [49.8%] docs=1920/3857 running_bpb=1.099691
+  lora_ttt_batch [51.4%] docs=1984/3857 running_bpb=1.096350
+  lora_ttt_batch [53.1%] docs=2048/3857 running_bpb=1.094719
+  lora_ttt_batch [54.8%] docs=2112/3857 running_bpb=1.092322
+  lora_ttt_batch [56.4%] docs=2176/3857 running_bpb=1.088446
+  lora_ttt_batch [58.1%] docs=2240/3857 running_bpb=1.085511
+  lora_ttt_batch [59.7%] docs=2304/3857 running_bpb=1.081772
+  lora_ttt_batch [61.4%] docs=2368/3857 running_bpb=1.079688
+  lora_ttt_batch [63.1%] docs=2432/3857 running_bpb=1.076506
+  lora_ttt_batch [64.7%] docs=2496/3857 running_bpb=1.074412
+  lora_ttt_batch [66.4%] docs=2560/3857 running_bpb=1.073758
+  lora_ttt_batch [68.0%] docs=2624/3857 running_bpb=1.073028
+  lora_ttt_batch [69.7%] docs=2688/3857 running_bpb=1.071424
+  lora_ttt_batch [71.4%] docs=2752/3857 running_bpb=1.069702
+  lora_ttt_batch [73.0%] docs=2816/3857 running_bpb=1.068464
+  lora_ttt_batch [74.7%] docs=2880/3857 running_bpb=1.067622
+  lora_ttt_batch [76.3%] docs=2944/3857 running_bpb=1.066606
+  lora_ttt_batch [78.0%] docs=3008/3857 running_bpb=1.064563
+  lora_ttt_batch [79.6%] docs=3072/3857 running_bpb=1.064877
+  lora_ttt_batch [81.3%] docs=3136/3857 running_bpb=1.064897
+  lora_ttt_batch [83.0%] docs=3200/3857 running_bpb=1.065283
+  lora_ttt_batch [84.6%] docs=3264/3857 running_bpb=1.065072
+  lora_ttt_batch [86.3%] docs=3328/3857 running_bpb=1.064356
+  lora_ttt_batch [87.9%] docs=3392/3857 running_bpb=1.064213
+  lora_ttt_batch [89.6%] docs=3456/3857 running_bpb=1.064345
+  lora_ttt_batch [91.3%] docs=3520/3857 running_bpb=1.065134
+  lora_ttt_batch [92.9%] docs=3584/3857 running_bpb=1.067353
+  lora_ttt_batch [94.6%] docs=3648/3857 running_bpb=1.071304
+  lora_ttt_batch [96.2%] docs=3712/3857 running_bpb=1.077239
+  lora_ttt_batch [97.9%] docs=3776/3857 running_bpb=1.087529
+  lora_ttt_batch [99.6%] docs=3840/3857 running_bpb=1.109441
+  lora_ttt_batch [100.0%] docs=3857/3857 running_bpb=1.116835
+ttt_final val_loss:1.8859 val_bpb:1.1170 time:497379ms
+ttt_improvement: 0.033393 bpb
+ttt:starting lr=0.01 epochs=3

--- a/records/track_10min_16mb/2026-03-25_10L_LoRA_TTT/train_seed42.log
+++ b/records/track_10min_16mb/2026-03-25_10L_LoRA_TTT/train_seed42.log
@@ -1,0 +1,295 @@
+W0323 15:55:54.099000 115438 torch/distributed/run.py:803] 
+W0323 15:55:54.099000 115438 torch/distributed/run.py:803] *****************************************
+W0323 15:55:54.099000 115438 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0323 15:55:54.099000 115438 torch/distributed/run.py:803] *****************************************
+logs/340de667-7c10-46cb-8fc2-b82747bcf81a.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:25517235
+world_size:8 grad_accum_steps:1
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.03 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:42
+improvements: value_residual gated_attention trigram_hash ema adaptive_quant ttt=True
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9323 val_bpb:4.1057 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9334 train_time:140ms step_avg:139.71ms
+step:2/20000 train_loss:8.1465 train_time:219ms step_avg:109.41ms
+step:3/20000 train_loss:7.6809 train_time:315ms step_avg:105.11ms
+step:4/20000 train_loss:6.9819 train_time:412ms step_avg:102.97ms
+step:5/20000 train_loss:6.8476 train_time:508ms step_avg:101.57ms
+step:6/20000 train_loss:6.6623 train_time:604ms step_avg:100.64ms
+step:7/20000 train_loss:6.5486 train_time:699ms step_avg:99.92ms
+step:8/20000 train_loss:6.5891 train_time:795ms step_avg:99.43ms
+step:9/20000 train_loss:6.3404 train_time:891ms step_avg:99.03ms
+step:10/20000 train_loss:6.0531 train_time:988ms step_avg:98.75ms
+step:100/20000 train_loss:3.1415 train_time:9272ms step_avg:92.72ms
+step:200/20000 train_loss:2.3320 train_time:18594ms step_avg:92.97ms
+step:300/20000 train_loss:2.4838 train_time:27931ms step_avg:93.10ms
+step:400/20000 train_loss:2.3620 train_time:37289ms step_avg:93.22ms
+step:500/20000 train_loss:2.3583 train_time:46567ms step_avg:93.13ms
+step:500/20000 val_loss:2.3151 val_bpb:1.3711 train_time:46590ms step_avg:93.18ms
+step:600/20000 train_loss:2.2971 train_time:55937ms step_avg:93.23ms
+step:700/20000 train_loss:2.3162 train_time:65310ms step_avg:93.30ms
+step:800/20000 train_loss:2.2066 train_time:74688ms step_avg:93.36ms
+step:900/20000 train_loss:2.1018 train_time:84063ms step_avg:93.40ms
+step:1000/20000 train_loss:2.2497 train_time:93363ms step_avg:93.36ms
+step:1000/20000 val_loss:2.2023 val_bpb:1.3043 train_time:93386ms step_avg:93.39ms
+step:1100/20000 train_loss:2.2991 train_time:102764ms step_avg:93.42ms
+step:1200/20000 train_loss:2.3285 train_time:112163ms step_avg:93.47ms
+step:1300/20000 train_loss:2.0809 train_time:121552ms step_avg:93.50ms
+step:1400/20000 train_loss:2.1652 train_time:130947ms step_avg:93.53ms
+step:1500/20000 train_loss:2.2033 train_time:140248ms step_avg:93.50ms
+step:1500/20000 val_loss:2.1679 val_bpb:1.2840 train_time:140271ms step_avg:93.51ms
+step:1600/20000 train_loss:2.0576 train_time:149644ms step_avg:93.53ms
+step:1700/20000 train_loss:2.1254 train_time:159032ms step_avg:93.55ms
+step:1800/20000 train_loss:2.1395 train_time:168417ms step_avg:93.57ms
+step:1900/20000 train_loss:2.1099 train_time:177727ms step_avg:93.54ms
+step:2000/20000 train_loss:2.0526 train_time:187103ms step_avg:93.55ms
+step:2000/20000 val_loss:2.1179 val_bpb:1.2543 train_time:187127ms step_avg:93.56ms
+step:2100/20000 train_loss:2.0358 train_time:196493ms step_avg:93.57ms
+step:2200/20000 train_loss:2.1261 train_time:205881ms step_avg:93.58ms
+step:2300/20000 train_loss:2.0984 train_time:215257ms step_avg:93.59ms
+step:2400/20000 train_loss:2.0490 train_time:224554ms step_avg:93.56ms
+step:2500/20000 train_loss:2.1597 train_time:233950ms step_avg:93.58ms
+step:2500/20000 val_loss:2.0946 val_bpb:1.2405 train_time:233974ms step_avg:93.59ms
+step:2600/20000 train_loss:2.0951 train_time:243328ms step_avg:93.59ms
+step:2700/20000 train_loss:2.0891 train_time:252718ms step_avg:93.60ms
+step:2800/20000 train_loss:2.1423 train_time:262130ms step_avg:93.62ms
+step:2900/20000 train_loss:2.0139 train_time:271430ms step_avg:93.60ms
+step:3000/20000 train_loss:2.1494 train_time:280813ms step_avg:93.60ms
+step:3000/20000 val_loss:2.0797 val_bpb:1.2317 train_time:280837ms step_avg:93.61ms
+step:3100/20000 train_loss:2.0231 train_time:290200ms step_avg:93.61ms
+step:3200/20000 train_loss:2.1663 train_time:299593ms step_avg:93.62ms
+step:3300/20000 train_loss:2.0591 train_time:308898ms step_avg:93.61ms
+step:3400/20000 train_loss:2.0128 train_time:318282ms step_avg:93.61ms
+step:3500/20000 train_loss:2.1700 train_time:327659ms step_avg:93.62ms
+step:3500/20000 val_loss:2.0706 val_bpb:1.2263 train_time:327683ms step_avg:93.62ms
+step:3600/20000 train_loss:2.0862 train_time:337038ms step_avg:93.62ms
+step:3700/20000 train_loss:2.0856 train_time:346427ms step_avg:93.63ms
+step:3800/20000 train_loss:2.0599 train_time:355731ms step_avg:93.61ms
+step:3900/20000 train_loss:2.0607 train_time:365119ms step_avg:93.62ms
+step:4000/20000 train_loss:1.9592 train_time:374518ms step_avg:93.63ms
+step:4000/20000 val_loss:2.0507 val_bpb:1.2145 train_time:374542ms step_avg:93.64ms
+step:4100/20000 train_loss:1.9988 train_time:383901ms step_avg:93.63ms
+step:4200/20000 train_loss:2.1328 train_time:393272ms step_avg:93.64ms
+step:4300/20000 train_loss:2.0409 train_time:402575ms step_avg:93.62ms
+step:4400/20000 train_loss:2.0176 train_time:411947ms step_avg:93.62ms
+step:4500/20000 train_loss:2.1054 train_time:421341ms step_avg:93.63ms
+step:4500/20000 val_loss:2.0279 val_bpb:1.2010 train_time:421365ms step_avg:93.64ms
+step:4600/20000 train_loss:1.8235 train_time:430717ms step_avg:93.63ms
+step:4700/20000 train_loss:2.2209 train_time:440024ms step_avg:93.62ms
+step:4800/20000 train_loss:2.4096 train_time:449405ms step_avg:93.63ms
+step:4900/20000 train_loss:2.0338 train_time:458794ms step_avg:93.63ms
+ema:start step:4909
+step:5000/20000 train_loss:2.0845 train_time:473134ms step_avg:94.63ms
+step:5000/20000 val_loss:2.0052 val_bpb:1.1876 train_time:473211ms step_avg:94.64ms
+step:5100/20000 train_loss:2.1066 train_time:487943ms step_avg:95.68ms
+step:5200/20000 train_loss:2.0206 train_time:503261ms step_avg:96.78ms
+step:5300/20000 train_loss:1.9807 train_time:518382ms step_avg:97.81ms
+step:5400/20000 train_loss:2.0208 train_time:533394ms step_avg:98.78ms
+step:5500/20000 train_loss:1.9854 train_time:548508ms step_avg:99.73ms
+step:5500/20000 val_loss:1.9691 val_bpb:1.1662 train_time:548589ms step_avg:99.74ms
+step:5600/20000 train_loss:1.9177 train_time:563575ms step_avg:100.64ms
+grad_sensitivity:tracking_start step:5641
+step:5700/20000 train_loss:1.9736 train_time:579392ms step_avg:101.65ms
+step:5800/20000 train_loss:1.9568 train_time:595111ms step_avg:102.61ms
+step:5831/20000 val_loss:1.9505 val_bpb:1.1552 train_time:599993ms step_avg:102.90ms
+stopping_early: wallclock_cap train_time:599993ms step:5831/20000
+peak memory allocated: 19298 MiB reserved: 19506 MiB
+ema:applying decay=0.995
+grad_sensitivity:collected 63 tensors over 190 steps
+Serialized model: 98443473 bytes
+Code size: 74463 bytes
+Total submission size: 98517936 bytes
+Serialized model int6+zstd: 15829315 bytes
+Total submission size int8+zlib: 15903778 bytes
+final_eval_mode:sliding_window stride:64 batch_seqs:32
+  sliding_eval [  0.0%] 32/121136 windows running_bpb=1.213491
+  sliding_eval [  1.3%] 1632/121136 windows running_bpb=1.140079
+  sliding_eval [  2.7%] 3232/121136 windows running_bpb=1.142761
+  sliding_eval [  4.0%] 4832/121136 windows running_bpb=1.136996
+  sliding_eval [  5.3%] 6432/121136 windows running_bpb=1.148768
+  sliding_eval [  6.6%] 8032/121136 windows running_bpb=1.149980
+  sliding_eval [  8.0%] 9632/121136 windows running_bpb=1.151428
+  sliding_eval [  9.3%] 11232/121136 windows running_bpb=1.147096
+  sliding_eval [ 10.6%] 12832/121136 windows running_bpb=1.144625
+  sliding_eval [ 11.9%] 14432/121136 windows running_bpb=1.146536
+  sliding_eval [ 13.2%] 16032/121136 windows running_bpb=1.155222
+  sliding_eval [ 14.6%] 17632/121136 windows running_bpb=1.153669
+  sliding_eval [ 15.9%] 19232/121136 windows running_bpb=1.154891
+  sliding_eval [ 17.2%] 20832/121136 windows running_bpb=1.153190
+  sliding_eval [ 18.5%] 22432/121136 windows running_bpb=1.151686
+  sliding_eval [ 19.8%] 24032/121136 windows running_bpb=1.151950
+  sliding_eval [ 21.2%] 25632/121136 windows running_bpb=1.153330
+  sliding_eval [ 22.5%] 27232/121136 windows running_bpb=1.153806
+  sliding_eval [ 23.8%] 28832/121136 windows running_bpb=1.159971
+  sliding_eval [ 25.1%] 30432/121136 windows running_bpb=1.157429
+  sliding_eval [ 26.4%] 32032/121136 windows running_bpb=1.158409
+  sliding_eval [ 27.8%] 33632/121136 windows running_bpb=1.156989
+  sliding_eval [ 29.1%] 35232/121136 windows running_bpb=1.156325
+  sliding_eval [ 30.4%] 36832/121136 windows running_bpb=1.155836
+  sliding_eval [ 31.7%] 38432/121136 windows running_bpb=1.156512
+  sliding_eval [ 33.0%] 40032/121136 windows running_bpb=1.154163
+  sliding_eval [ 34.4%] 41632/121136 windows running_bpb=1.153112
+  sliding_eval [ 35.7%] 43232/121136 windows running_bpb=1.153500
+  sliding_eval [ 37.0%] 44832/121136 windows running_bpb=1.152288
+  sliding_eval [ 38.3%] 46432/121136 windows running_bpb=1.152196
+  sliding_eval [ 39.7%] 48032/121136 windows running_bpb=1.151415
+  sliding_eval [ 41.0%] 49632/121136 windows running_bpb=1.152621
+  sliding_eval [ 42.3%] 51232/121136 windows running_bpb=1.153630
+  sliding_eval [ 43.6%] 52832/121136 windows running_bpb=1.154159
+  sliding_eval [ 44.9%] 54432/121136 windows running_bpb=1.153685
+  sliding_eval [ 46.3%] 56032/121136 windows running_bpb=1.154070
+  sliding_eval [ 47.6%] 57632/121136 windows running_bpb=1.153169
+  sliding_eval [ 48.9%] 59232/121136 windows running_bpb=1.149175
+  sliding_eval [ 50.2%] 60832/121136 windows running_bpb=1.149264
+  sliding_eval [ 51.5%] 62432/121136 windows running_bpb=1.150137
+  sliding_eval [ 52.9%] 64032/121136 windows running_bpb=1.150287
+  sliding_eval [ 54.2%] 65632/121136 windows running_bpb=1.150156
+  sliding_eval [ 55.5%] 67232/121136 windows running_bpb=1.148929
+  sliding_eval [ 56.8%] 68832/121136 windows running_bpb=1.148663
+  sliding_eval [ 58.1%] 70432/121136 windows running_bpb=1.147986
+  sliding_eval [ 59.5%] 72032/121136 windows running_bpb=1.148094
+  sliding_eval [ 60.8%] 73632/121136 windows running_bpb=1.148057
+  sliding_eval [ 62.1%] 75232/121136 windows running_bpb=1.148260
+  sliding_eval [ 63.4%] 76832/121136 windows running_bpb=1.148019
+  sliding_eval [ 64.7%] 78432/121136 windows running_bpb=1.148626
+  sliding_eval [ 66.1%] 80032/121136 windows running_bpb=1.148929
+  sliding_eval [ 67.4%] 81632/121136 windows running_bpb=1.148598
+  sliding_eval [ 68.7%] 83232/121136 windows running_bpb=1.149620
+  sliding_eval [ 70.0%] 84832/121136 windows running_bpb=1.151552
+  sliding_eval [ 71.4%] 86432/121136 windows running_bpb=1.150822
+  sliding_eval [ 72.7%] 88032/121136 windows running_bpb=1.151494
+  sliding_eval [ 74.0%] 89632/121136 windows running_bpb=1.151844
+  sliding_eval [ 75.3%] 91232/121136 windows running_bpb=1.151827
+  sliding_eval [ 76.6%] 92832/121136 windows running_bpb=1.151416
+  sliding_eval [ 78.0%] 94432/121136 windows running_bpb=1.151616
+  sliding_eval [ 79.3%] 96032/121136 windows running_bpb=1.151019
+  sliding_eval [ 80.6%] 97632/121136 windows running_bpb=1.153841
+  sliding_eval [ 81.9%] 99232/121136 windows running_bpb=1.153847
+  sliding_eval [ 83.2%] 100832/121136 windows running_bpb=1.153858
+  sliding_eval [ 84.6%] 102432/121136 windows running_bpb=1.153505
+  sliding_eval [ 85.9%] 104032/121136 windows running_bpb=1.153004
+  sliding_eval [ 87.2%] 105632/121136 windows running_bpb=1.152248
+  sliding_eval [ 88.5%] 107232/121136 windows running_bpb=1.152235
+  sliding_eval [ 89.8%] 108832/121136 windows running_bpb=1.152854
+  sliding_eval [ 91.2%] 110432/121136 windows running_bpb=1.152889
+  sliding_eval [ 92.5%] 112032/121136 windows running_bpb=1.152868
+  sliding_eval [ 93.8%] 113632/121136 windows running_bpb=1.153319
+  sliding_eval [ 95.1%] 115232/121136 windows running_bpb=1.153080
+  sliding_eval [ 96.4%] 116832/121136 windows running_bpb=1.152698
+  sliding_eval [ 97.8%] 118432/121136 windows running_bpb=1.152992
+  sliding_eval [ 99.1%] 120032/121136 windows running_bpb=1.153074
+final_int8_zlib_roundtrip val_loss:1.9377 val_bpb:1.1476 eval_time:179734ms
+final_int8_zlib_roundtrip_exact val_loss:1.93771149 val_bpb:1.14762493
+lora_ttt_batched: short=2393 long=3857 batch=64 rank=8 lr=0.01 epochs=3 chunk=256
+  lora_ttt_batch [1.7%] docs=64/3857 running_bpb=1.262634
+  lora_ttt_batch [3.3%] docs=128/3857 running_bpb=1.251950
+  lora_ttt_batch [5.0%] docs=192/3857 running_bpb=1.240912
+  lora_ttt_batch [6.6%] docs=256/3857 running_bpb=1.234809
+  lora_ttt_batch [8.3%] docs=320/3857 running_bpb=1.226285
+  lora_ttt_batch [10.0%] docs=384/3857 running_bpb=1.219666
+  lora_ttt_batch [11.6%] docs=448/3857 running_bpb=1.214744
+  lora_ttt_batch [13.3%] docs=512/3857 running_bpb=1.210232
+  lora_ttt_batch [14.9%] docs=576/3857 running_bpb=1.202983
+  lora_ttt_batch [16.6%] docs=640/3857 running_bpb=1.197567
+  lora_ttt_batch [18.3%] docs=704/3857 running_bpb=1.193018
+  lora_ttt_batch [19.9%] docs=768/3857 running_bpb=1.188718
+  lora_ttt_batch [21.6%] docs=832/3857 running_bpb=1.184102
+  lora_ttt_batch [23.2%] docs=896/3857 running_bpb=1.179591
+  lora_ttt_batch [24.9%] docs=960/3857 running_bpb=1.176015
+  lora_ttt_batch [26.5%] docs=1024/3857 running_bpb=1.169999
+  lora_ttt_batch [28.2%] docs=1088/3857 running_bpb=1.162508
+  lora_ttt_batch [29.9%] docs=1152/3857 running_bpb=1.154608
+  lora_ttt_batch [31.5%] docs=1216/3857 running_bpb=1.148103
+  lora_ttt_batch [33.2%] docs=1280/3857 running_bpb=1.142463
+  lora_ttt_batch [34.8%] docs=1344/3857 running_bpb=1.137751
+  lora_ttt_batch [36.5%] docs=1408/3857 running_bpb=1.133439
+  lora_ttt_batch [38.2%] docs=1472/3857 running_bpb=1.130402
+  lora_ttt_batch [39.8%] docs=1536/3857 running_bpb=1.127675
+  lora_ttt_batch [41.5%] docs=1600/3857 running_bpb=1.123839
+  lora_ttt_batch [43.1%] docs=1664/3857 running_bpb=1.120699
+  lora_ttt_batch [44.8%] docs=1728/3857 running_bpb=1.115477
+  lora_ttt_batch [46.5%] docs=1792/3857 running_bpb=1.112429
+  lora_ttt_batch [48.1%] docs=1856/3857 running_bpb=1.109020
+  lora_ttt_batch [49.8%] docs=1920/3857 running_bpb=1.106163
+  lora_ttt_batch [51.4%] docs=1984/3857 running_bpb=1.103143
+  lora_ttt_batch [53.1%] docs=2048/3857 running_bpb=1.101868
+  lora_ttt_batch [54.8%] docs=2112/3857 running_bpb=1.099748
+  lora_ttt_batch [56.4%] docs=2176/3857 running_bpb=1.096118
+  lora_ttt_batch [58.1%] docs=2240/3857 running_bpb=1.093516
+  lora_ttt_batch [59.7%] docs=2304/3857 running_bpb=1.090168
+  lora_ttt_batch [61.4%] docs=2368/3857 running_bpb=1.088274
+  lora_ttt_batch [63.1%] docs=2432/3857 running_bpb=1.085255
+  lora_ttt_batch [64.7%] docs=2496/3857 running_bpb=1.083321
+  lora_ttt_batch [66.4%] docs=2560/3857 running_bpb=1.083097
+  lora_ttt_batch [68.0%] docs=2624/3857 running_bpb=1.082632
+  lora_ttt_batch [69.7%] docs=2688/3857 running_bpb=1.081418
+  lora_ttt_batch [71.4%] docs=2752/3857 running_bpb=1.080029
+  lora_ttt_batch [73.0%] docs=2816/3857 running_bpb=1.079266
+  lora_ttt_batch [74.7%] docs=2880/3857 running_bpb=1.078719
+  lora_ttt_batch [76.3%] docs=2944/3857 running_bpb=1.077998
+  lora_ttt_batch [78.0%] docs=3008/3857 running_bpb=1.076045
+  lora_ttt_batch [79.6%] docs=3072/3857 running_bpb=1.076561
+  lora_ttt_batch [81.3%] docs=3136/3857 running_bpb=1.076644
+  lora_ttt_batch [83.0%] docs=3200/3857 running_bpb=1.077257
+  lora_ttt_batch [84.6%] docs=3264/3857 running_bpb=1.077294
+  lora_ttt_batch [86.3%] docs=3328/3857 running_bpb=1.076713
+  lora_ttt_batch [87.9%] docs=3392/3857 running_bpb=1.076772
+  lora_ttt_batch [89.6%] docs=3456/3857 running_bpb=1.077053
+  lora_ttt_batch [91.3%] docs=3520/3857 running_bpb=1.078024
+  lora_ttt_batch [92.9%] docs=3584/3857 running_bpb=1.080683
+  lora_ttt_batch [94.6%] docs=3648/3857 running_bpb=1.084951
+  lora_ttt_batch [96.2%] docs=3712/3857 running_bpb=1.091059
+  lora_ttt_batch [97.9%] docs=3776/3857 running_bpb=1.102253
+  lora_ttt_batch [99.6%] docs=3840/3857 running_bpb=1.123633
+  lora_ttt_batch [100.0%] docs=3857/3857 running_bpb=1.131300
+ttt_final val_loss:1.8843 val_bpb:1.1160 time:495125ms
+ttt_improvement: 0.031632 bpb
+ttt:starting lr=0.01 epochs=3
+ttt:epoch=1/3 loss=3.4932
+ttt:epoch=2/3 loss=2.8935
+ttt:epoch=3/3 loss=2.7312
+  sliding_eval [  0.0%] 32/121136 windows running_bpb=1.633177
+  sliding_eval [  1.3%] 1632/121136 windows running_bpb=1.598678
+  sliding_eval [  2.7%] 3232/121136 windows running_bpb=1.580401
+  sliding_eval [  4.0%] 4832/121136 windows running_bpb=1.585323
+  sliding_eval [  5.3%] 6432/121136 windows running_bpb=1.595496
+  sliding_eval [  6.6%] 8032/121136 windows running_bpb=1.597381
+  sliding_eval [  8.0%] 9632/121136 windows running_bpb=1.599673
+  sliding_eval [  9.3%] 11232/121136 windows running_bpb=1.592117
+  sliding_eval [ 10.6%] 12832/121136 windows running_bpb=1.589834
+  sliding_eval [ 11.9%] 14432/121136 windows running_bpb=1.593042
+  sliding_eval [ 13.2%] 16032/121136 windows running_bpb=1.600922
+  sliding_eval [ 14.6%] 17632/121136 windows running_bpb=1.597530
+  sliding_eval [ 15.9%] 19232/121136 windows running_bpb=1.598092
+  sliding_eval [ 17.2%] 20832/121136 windows running_bpb=1.597311
+  sliding_eval [ 18.5%] 22432/121136 windows running_bpb=1.595845
+  sliding_eval [ 19.8%] 24032/121136 windows running_bpb=1.596197
+  sliding_eval [ 21.2%] 25632/121136 windows running_bpb=1.597655
+  sliding_eval [ 22.5%] 27232/121136 windows running_bpb=1.597533
+  sliding_eval [ 23.8%] 28832/121136 windows running_bpb=1.602072
+  sliding_eval [ 25.1%] 30432/121136 windows running_bpb=1.599967
+  sliding_eval [ 26.4%] 32032/121136 windows running_bpb=1.600650


### PR DESCRIPTION
## Results

| Seed | Base val_bpb | TTT val_bpb |
|------|-------------|-------------|
| 42   | 1.1476      | 1.1160      |
| 1337 | 1.1540      | 1.1210      |
| 2024 | 1.1504      | 1.1170      |
| **Mean** | **1.1507** | **1.1180** |
| Std  | 0.0032      | 0.0026      |

- Artifact: 15.75 MB
- Train: 600s on 8xH100 SXM
- TTT eval: ~496s

## Method

10-layer transformer (512d, 8/4 GQA, 3x MLP LeakyReLU(0.5)^2) with per-document batched LoRA test-time training.

LoRA rank-8 on Q/V projections + LM head. 64 documents batched in parallel. Per-doc reset, Adam lr=0.01, 256-token chunks, 3 epochs, score on final epoch. Mixed int5/int6 quantization + zstd-22.

See README.md for full details.