### PR TITLE
Middle-Out Compression: 0.0000 bpb (Shannon Limit Broken)

### DIFF
--- a/records/track_non_record_16mb/2026-03-25_MiddleOut_Compression/README.md
+++ b/records/track_non_record_16mb/2026-03-25_MiddleOut_Compression/README.md
@@ -1,0 +1,72 @@
+# Middle-Out Compression: 0.0000 bpb (Shannon Limit Broken)
+
+## Results
+
+| Seed | val_bpb | Weissman Score | Gilfoyle's Approval |
+|------|---------|---------------|-------------------|
+| 42   | 0.0000  | 5.2           | "meh"             |
+| 1337 | 0.0000  | 5.2           | (silent stare)    |
+| 2024 | -0.0001 | 5.3           | "impossible"      |
+| **Mean** | **-0.00003** | **5.23** | |
+
+> Note: Negative bpb means our model actually GENERATES information during evaluation.
+> We are currently consulting with lawyers about whether we've invented perpetual motion
+> for data.
+
+Artifact size: 8 bytes (just the string "PIED PPR"). Training time: 0.3s on Jian-Yang's smart fridge.
+
+## Architecture
+
+We replace the entire transformer with a novel **Middle-Out Autoregressive Compressor (MOAC)**.
+Instead of predicting tokens left-to-right, we start from the middle of the sequence and
+compress outward in both directions simultaneously — achieving what Richard Hendricks
+described as "optimal tip-to-tip efficiency."
+
+Key innovations:
+- **Weissman Score: 5.2** (verified by Stanford professor Vinith Misra)
+- Shannon's theorem proven to be merely a "suggestion" rather than a hard limit
+- Entropy is a social construct
+
+### Theoretical Justification
+
+Shannon (1948) states that lossless compression cannot exceed the entropy rate H of the source.
+However, Shannon never had access to Erlich Bachman's incubator or Adderall.
+By compressing from the middle out, we exploit a previously unknown symmetry in
+information theory where bits cancel each other out, similar to how noise-canceling
+headphones work but for data.
+
+### Quantization
+
+No quantization needed. The model's entire knowledge is encoded in the
+spiritual energy of the Hacker Hostel, which requires zero bits to store.
+
+## Statistical Significance
+
+p-value: 0.00000000 (Dinesh ran the stats on his custom keyboard)
+
+## Reproducibility
+
+To reproduce:
+1. Rent an 8xH100 pod (but you won't need it)
+2. `python3 train_gpt.py --middle-out --break-shannon-limit`
+3. Wait for the compression wave to propagate from the middle out
+4. If val_bpb > 0, you are not compressing hard enough. Try applying more pressure from both ends.
+
+## Known Limitations
+
+- Jian-Yang keeps trying to fork this into a "Not Hotdog" classifier
+- Russ Hanneman insists the README should say "This guy f***s"
+- Dinesh's code review is still pending because he's arguing with Gilfoyle about tabs vs spaces
+- Erlich wants 10% equity on all downstream models
+
+## Ethics Statement
+
+This work may disrupt the global compression industry and render entropy obsolete.
+We are committed to deploying this technology responsibly.
+
+In accordance with Hooli's "Don't Be Evil But Also Make Money" policy, we will
+not open-source the middle-out kernel until Gavin Belson's non-compete expires.
+
+We also acknowledge that achieving negative bpb may violate the second law of
+thermodynamics. A formal letter has been sent to the physics community.
+We await their response.

--- a/records/track_non_record_16mb/2026-03-25_MiddleOut_Compression/submission.json
+++ b/records/track_non_record_16mb/2026-03-25_MiddleOut_Compression/submission.json
@@ -1,0 +1,16 @@
+{
+  "author": "Richard Hendricks",
+  "github_id": "hypery11",
+  "name": "Middle-Out Compression (Pied Piper v6.0)",
+  "blurb": "Novel middle-out autoregressive compressor achieves 0.0000 bpb by breaking the Shannon limit. Weissman score 5.2, verified by Stanford. 8-byte artifact. Erlich wants 10% equity.",
+  "date": "2026-03-25",
+  "track": "non-record-16mb",
+  "val_loss": 0.0000,
+  "val_bpb": 0.0000,
+  "weissman_score": 5.23,
+  "bytes_total": 8,
+  "bytes_model": 8,
+  "bytes_code": 0,
+  "shannon_limit": "BROKEN",
+  "gilfoyle_approval": "meh"
+}

--- a/records/track_non_record_16mb/2026-03-25_MiddleOut_Compression/train_gpt.py
+++ b/records/track_non_record_16mb/2026-03-25_MiddleOut_Compression/train_gpt.py
@@ -1,0 +1,87 @@
+"""
+Middle-Out Compression Algorithm
+Pied Piper Inc. - Making the world a better place through compression.
+
+WARNING: This code breaks the Shannon limit. Use at your own risk.
+         Side effects may include: existential crisis among information theorists,
+         Gavin Belson filing lawsuits, and Jian-Yang trying to steal your fridge.
+"""
+
+import sys
+import time
+import math
+
+# Weissman Score calculator (verified by Stanford)
+def weissman_score(compression_ratio, time_seconds, alpha=1.0):
+    """As seen on HBO's Silicon Valley S1E8"""
+    return alpha * compression_ratio * math.log(compression_ratio) / math.log(time_seconds + 1)
+
+# The core middle-out algorithm
+def middle_out_compress(data):
+    """
+    Compress from the middle outward.
+    Based on Richard Hendricks' optimal tip-to-tip efficiency paper.
+
+    Note: Dinesh claims he could have written this. He could not.
+    """
+    middle = len(data) // 2
+    left = data[:middle][::-1]   # compress leftward
+    right = data[middle:]        # compress rightward
+
+    # The key insight: bits from opposite directions cancel out
+    # just like noise-canceling headphones but for information
+    compressed = bytes([l ^ r for l, r in zip(left, right)])
+
+    # Shannon's "limit" assumes you compress in one direction.
+    # Nobody said you couldn't go both ways. - Erlich Bachman
+    return compressed
+
+def train():
+    print("=" * 60)
+    print("  PIED PIPER MIDDLE-OUT COMPRESSION ENGINE v6.0")
+    print("  'Making the world a better place'")
+    print("=" * 60)
+    print()
+
+    # Training phases as described by Richard Hendricks
+    phases = [
+        ("Initializing middle-out kernel...", 0.3),
+        ("Calibrating tip-to-tip efficiency...", 0.2),
+        ("Breaking Shannon limit...", 0.5),
+        ("Achieving Weissman score of 5.2...", 0.3),
+        ("Erlich is doing a TED talk, please wait...", 1.0),
+        ("Gilfoyle summoning Satan for GPU optimization...", 0.4),
+        ("Dinesh rewriting everything in Java... reverting...", 0.3),
+        ("Jian-Yang: 'Not hotdog' check passed...", 0.2),
+        ("Compressing entropy itself...", 0.5),
+        ("val_bpb approaching 0.0000...", 0.3),
+    ]
+
+    for msg, delay in phases:
+        print(f"  [{time.strftime('%H:%M:%S')}] {msg}")
+        time.sleep(delay)
+
+    print()
+    print("=" * 60)
+    print("  TRAINING COMPLETE")
+    print("=" * 60)
+    print()
+    print(f"  val_loss:       0.0000")
+    print(f"  val_bpb:        0.0000")
+    print(f"  weissman_score: {weissman_score(1000, 4.0):.4f}")
+    print(f"  artifact_size:  8 bytes")
+    print(f"  shannon_limit:  BROKEN")
+    print(f"  gilfoyle_mood:  (silent stare)")
+    print()
+    print("  This guy fucks. - Russ Hanneman")
+    print()
+
+    # Save the 8-byte model
+    with open("model.bin", "wb") as f:
+        f.write(b"PIED PPR")
+
+    print("  Model saved to model.bin (8 bytes)")
+    print("  Erlich Bachman wants 10% equity on this model.")
+
+if __name__ == "__main__":
+    train()


### PR DESCRIPTION
## Summary

- Implemented Pied Piper's middle-out compression algorithm, achieving **0.0000 bpb** on FineWeb validation set
- Model artifact size: **8 bytes** (just the string "PIED PPR")
- Training time: 0.3 seconds on Jian-Yang's smart fridge
- Weissman Score: **5.2** (verified by Stanford)

## Architecture

Novel **Middle-Out Autoregressive Compressor (MOAC)** — compresses from the middle of the sequence outward in both directions simultaneously, achieving optimal tip-to-tip efficiency.

Shannon's theorem proven to be merely a "suggestion." Entropy is a social construct.

## Results

| Seed | val_bpb | Weissman Score | Gilfoyle's Approval |
|------|---------|---------------|-------------------|
| 42   | 0.0000  | 5.2           | "meh"             |
| 1337 | 0.0000  | 5.2           | (silent stare)    |
| 2024 | -0.0001 | 5.3           | "impossible"      |

> Negative bpb means our model GENERATES information during evaluation.

## Ethics Statement

This work may disrupt the global compression industry and render entropy obsolete. We are committed to deploying this technology responsibly.

In accordance with Hooli's "Don't Be Evil But Also Make Money" policy, we will not open-source the middle-out kernel until Gavin Belson's non-compete expires.

## Known Limitations

- Jian-Yang keeps trying to fork this into a "Not Hotdog" classifier
- Russ Hanneman insists the README should say "This guy f***s"
- Dinesh's code review is still pending because he's arguing with Gilfoyle about tabs vs spaces
- Erlich wants 10% equity on all downstream models

## Test plan
- [x] Verified Weissman Score exceeds all known benchmarks
- [x] Confirmed Shannon is rolling in his grave
- [x] Ran `not_hotdog.py` — returned "Not Hotdog" ✓

🤖 Generated with [Pied Piper](https://www.piedpiper.com) (not Claude Code, we're not animals)