### PR TITLE
Add local-first MLX search workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,26 @@ python3 train_gpt_mlx.py
 
 Validation always runs on the full `fineweb_val_*` split, which is the fixed first-50k-document set. The smoke command above skips periodic validation and just prints the final `val_loss` and `val_bpb` once at the end.
 
+For faster local iteration, the trainers also support runtime limits that do not change the default challenge behavior:
+
+```bash
+TRAIN_MAX_SHARDS=1 \
+VAL_MAX_SEQS=128 \
+python3 train_gpt_mlx.py
+```
+
+- `TRAIN_MAX_SHARDS` restricts training to the first `N` train shards already present on disk.
+- `VAL_MAX_SEQS` restricts validation to the first `N` sequences as a local proxy metric.
+- Keep both at `0` for the default full-data, full-validation path.
+
+If you want an automated local sweep loop on Apple Silicon, see [docs/local_search.md](docs/local_search.md) and run:
+
+```bash
+python3 tools/local_search.py --python .venv/bin/python
+```
+
+By default the local search tool stops at proxy validation. Opt into full validation explicitly with `--full-val-top-k 1` when you want a slower confirmation pass.
+
 ### Scaling Up to a Remote Machine
 
 Once you're happy with your local tests, or you want more compute, switch to a remote CUDA machine.

--- a/docs/local_search.md
+++ b/docs/local_search.md
@@ -1,0 +1,95 @@
+# Local Search Playbook
+
+This repository already ships strong baseline trainers, but local iteration on Apple Silicon had two practical gaps:
+
+1. Validation always scanned the full fixed validation split, which is correct for final scoring but too slow for tight local loops.
+2. Hyperparameter exploration was entirely manual, so comparing random trials against follow-up refinements was tedious and error-prone.
+3. Full-validation confirmations on Macs need larger eval batches than proxy sweeps, otherwise the fixed validation split takes too many tiny batches.
+
+This patch adds a local-first search loop without changing the default challenge path:
+
+- `TRAIN_MAX_SHARDS=0` and `VAL_MAX_SEQS=0` still mean full data and full validation.
+- Setting `TRAIN_MAX_SHARDS` lets you restrict training to the first `N` train shards at runtime.
+- Setting `VAL_MAX_SEQS` lets you validate on only the first `N` sequences as a proxy metric for local search.
+- `tools/local_search.py` automates baseline, random exploration, promotion around the current best run, and optional full-validation confirmation.
+- The search harness uses a larger `--full-val-batch-size` for confirmation runs so full validation stays practical on local Apple Silicon machines.
+- Use `--space KEY=v1,v2,v3` when you want a tighter search neighborhood around the current frontier instead of the built-in default ranges.
+- Use `--space-only` when you want an exact targeted sweep. That freezes every unspecified knob at the values you provided with `--set`.
+- Use `--max-param-count` when you start varying architecture knobs so over-budget models are skipped before training.
+
+## Recommended local workflow
+
+1. Install the Apple Silicon path and download one train shard:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+pip install mlx numpy sentencepiece huggingface-hub datasets tqdm
+python3 data/cached_challenge_fineweb.py --variant sp1024 --train-shards 1
+```
+
+2. Run a quick local search with a proxy validation subset:
+
+```bash
+.venv/bin/python tools/local_search.py \
+  --python .venv/bin/python \
+  --iterations 120 \
+  --train-max-shards 1 \
+  --val-max-seqs 128 \
+  --max-runs 5 \
+  --promote-budget 3
+```
+
+3. Read the generated report under `experiments/<session>/REPORT.md`.
+
+4. Only opt into full validation when you actually need it, for example:
+
+```bash
+.venv/bin/python tools/local_search.py \
+  --python .venv/bin/python \
+  --train-max-shards 1 \
+  --val-max-seqs 128 \
+  --full-val-top-k 1
+```
+
+On a 16 GB M4-class Mac, full validation is still much slower than proxy sweeps even with a larger confirmation batch.
+
+If you want to search architecture rather than just optimizer knobs, switch to `--space-only` and pin the frontier explicitly:
+
+```bash
+.venv/bin/python tools/local_search.py \
+  --python .venv/bin/python \
+  --iterations 40 \
+  --train-max-shards 1 \
+  --val-max-seqs 96 \
+  --strategy grid \
+  --space-only \
+  --max-param-count 17059912 \
+  --set LOGIT_SOFTCAP=55 \
+  --set MATRIX_LR=0.015 \
+  --set SCALAR_LR=0.04 \
+  --set TIED_EMBED_LR=0.085 \
+  --set TIED_EMBED_INIT_STD=0.005 \
+  --set QK_GAIN_INIT=1.5 \
+  --space NUM_LAYERS=10,11 \
+  --space MODEL_DIM=480,512 \
+  --space NUM_HEADS=8 \
+  --space NUM_KV_HEADS=1,2,4 \
+  --space MLP_MULT=2
+```
+
+That setup explores only the listed architecture axes and skips candidates whose estimated parameter count exceeds the baseline budget.
+
+If you want a standing cyclic checklist for this workflow, use `TODO.md` in the repository root.
+
+## Search policy
+
+The search script intentionally keeps every run and ranks them by `final_int8_zlib_roundtrip_exact val_bpb`.
+
+- If a promoted follow-up beats the current best run, the search frontier moves to that newer run.
+- If a promoted follow-up is worse, the older better run remains the frontier.
+- The optional full-validation confirmation reruns only the strongest proxy candidates on the full fixed validation split.
+- Successful runs now also record `model_params` and `serialized_model_int8_zlib`, so budget checks stay visible in the report even during local proxy work.
+
+That preserves the history of both "earlier better" and "later worse" runs instead of losing context between experiments.

--- a/tools/local_search.py
+++ b/tools/local_search.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import os
+import random
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+DEFAULT_SPACE = {
+    "TIED_EMBED_LR": [0.04, 0.05, 0.06],
+    "MATRIX_LR": [0.035, 0.04, 0.045],
+    "SCALAR_LR": [0.03, 0.04, 0.05],
+    "QK_GAIN_INIT": [1.25, 1.5, 1.75],
+    "LOGIT_SOFTCAP": [20.0, 30.0, 40.0],
+    "TIED_EMBED_INIT_STD": [0.003, 0.005, 0.008],
+}
+
+BASELINE = {
+    "TIED_EMBED_LR": 0.05,
+    "MATRIX_LR": 0.04,
+    "SCALAR_LR": 0.04,
+    "QK_GAIN_INIT": 1.5,
+    "LOGIT_SOFTCAP": 30.0,
+    "TIED_EMBED_INIT_STD": 0.005,
+}
+
+ARCH_BASELINE = {
+    "TIE_EMBEDDINGS": 1,
+    "VOCAB_SIZE": 1024,
+    "NUM_LAYERS": 9,
+    "MODEL_DIM": 512,
+    "NUM_HEADS": 8,
+    "NUM_KV_HEADS": 4,
+    "MLP_MULT": 2,
+}
+
+FINAL_METRIC_RE = re.compile(
+    r"final_int8_zlib_roundtrip_exact val_loss:(?P<val_loss>[0-9.]+) val_bpb:(?P<val_bpb>[0-9.]+)"
+)
+TRAIN_LINE_RE = re.compile(
+    r"step:(?P<step>\d+)/(?P<iters>\d+) train_loss:(?P<train_loss>[0-9.]+) "
+    r"train_time:(?P<train_time_ms>[0-9.]+)ms step_avg:(?P<step_avg_ms>[0-9.]+)ms"
+)
+MODEL_PARAMS_RE = re.compile(r"model_params:(?P<model_params>\d+)")
+INT8_ZLIB_RE = re.compile(
+    r"serialized_model_int8_zlib:(?P<int8_zlib_bytes>\d+) bytes "
+    r"\(payload:(?P<int8_payload_bytes>\d+) raw_(?:pickle|torch):(?P<int8_raw_bytes>\d+) "
+    r"payload_ratio:(?P<payload_ratio>[0-9.]+)x\)"
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Local MLX search harness for Parameter Golf")
+    parser.add_argument("--train-script", default="train_gpt_mlx.py")
+    parser.add_argument("--python", default=sys.executable)
+    parser.add_argument("--data-path", default="./data/datasets/fineweb10B_sp1024")
+    parser.add_argument("--tokenizer-path", default="./data/tokenizers/fineweb_1024_bpe.model")
+    parser.add_argument("--out-dir", default="./experiments")
+    parser.add_argument("--session-name", default="")
+    parser.add_argument("--strategy", choices=("hybrid", "grid", "random"), default="hybrid")
+    parser.add_argument("--space-only", action="store_true")
+    parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument("--iterations", type=int, default=200)
+    parser.add_argument("--train-batch-tokens", type=int, default=8192)
+    parser.add_argument("--val-batch-size", type=int, default=65536)
+    parser.add_argument("--full-val-batch-size", type=int, default=131072)
+    parser.add_argument("--val-max-seqs", type=int, default=128)
+    parser.add_argument("--train-max-shards", type=int, default=1)
+    parser.add_argument("--warmup-steps", type=int, default=5)
+    parser.add_argument("--train-log-every", type=int, default=20)
+    parser.add_argument("--grad-accum-steps", type=int, default=8)
+    parser.add_argument("--mlx-max-microbatch-tokens", type=int, default=8192)
+    parser.add_argument("--max-runs", type=int, default=6)
+    parser.add_argument("--promote-top-k", type=int, default=2)
+    parser.add_argument("--promote-budget", type=int, default=4)
+    parser.add_argument("--full-val-top-k", type=int, default=0)
+    parser.add_argument("--max-param-count", type=int, default=0)
+    parser.add_argument("--max-int8-zlib-bytes", type=int, default=0)
+    parser.add_argument("--set", action="append", default=[], metavar="KEY=VALUE")
+    parser.add_argument("--space", action="append", default=[], metavar="KEY=V1,V2,V3")
+    return parser
+
+
+def coerce_value(raw: str):
+    lowered = raw.lower()
+    if lowered in {"true", "false"}:
+        return "1" if lowered == "true" else "0"
+    try:
+        if "." in raw or "e" in lowered:
+            value = float(raw)
+            return int(value) if value.is_integer() else value
+        return int(raw)
+    except ValueError:
+        return raw
+
+
+def parse_overrides(items: list[str]) -> dict[str, object]:
+    overrides: dict[str, object] = {}
+    for item in items:
+        if "=" not in item:
+            raise ValueError(f"expected KEY=VALUE, got {item!r}")
+        key, raw_value = item.split("=", 1)
+        overrides[key.strip().upper()] = coerce_value(raw_value.strip())
+    return overrides
+
+
+def parse_space_overrides(items: list[str]) -> dict[str, list[object]]:
+    overrides: dict[str, list[object]] = {}
+    for item in items:
+        if "=" not in item:
+            raise ValueError(f"expected KEY=V1,V2,V3, got {item!r}")
+        key, raw_values = item.split("=", 1)
+        values = [coerce_value(part.strip()) for part in raw_values.split(",") if part.strip()]
+        if not values:
+            raise ValueError(f"space override for {key.strip().upper()} must include at least one value")
+        overrides[key.strip().upper()] = values
+    return overrides
+
+
+def value_key(value: object) -> tuple[int, object]:
+    if isinstance(value, (int, float)):
+        return (0, float(value))
+    return (1, str(value))
+
+
+def normalize_signature(candidate: dict[str, object]) -> tuple[tuple[str, object], ...]:
+    effective = dict(ARCH_BASELINE)
+    effective.update(BASELINE)
+    effective.update(candidate)
+    return tuple(sorted(effective.items()))
+
+
+def make_session_dir(root: Path, session_name: str) -> Path:
+    if session_name:
+        name = session_name
+    else:
+        name = time.strftime("local_search_%Y%m%d_%H%M%S")
+    session_dir = root / name
+    session_dir.mkdir(parents=True, exist_ok=True)
+    return session_dir
+
+
+def candidate_name(prefix: str, idx: int) -> str:
+    return f"{prefix}_{idx:03d}"
+
+
+def generate_grid(space: dict[str, list[object]]) -> list[dict[str, object]]:
+    keys = list(space)
+    values = [space[key] for key in keys]
+    return [dict(zip(keys, combo)) for combo in itertools.product(*values)]
+
+
+def merged_arch(candidate: dict[str, object]) -> dict[str, object]:
+    arch = dict(ARCH_BASELINE)
+    arch.update({key: value for key, value in candidate.items() if key in ARCH_BASELINE})
+    return arch
+
+
+def estimate_model_params(candidate: dict[str, object]) -> int | None:
+    arch = merged_arch(candidate)
+    try:
+        tie_embeddings = int(arch["TIE_EMBEDDINGS"])
+        vocab_size = int(arch["VOCAB_SIZE"])
+        num_layers = int(arch["NUM_LAYERS"])
+        model_dim = int(arch["MODEL_DIM"])
+        num_heads = int(arch["NUM_HEADS"])
+        num_kv_heads = int(arch["NUM_KV_HEADS"])
+        mlp_mult = int(arch["MLP_MULT"])
+    except (TypeError, ValueError):
+        return None
+
+    if tie_embeddings != 1:
+        return None
+    if min(vocab_size, num_layers, model_dim, num_heads, num_kv_heads, mlp_mult) <= 0:
+        return None
+    if model_dim % num_heads != 0:
+        return None
+    head_dim = model_dim // num_heads
+    if head_dim % 2 != 0:
+        return None
+    if num_heads % num_kv_heads != 0:
+        return None
+
+    kv_dim = num_kv_heads * head_dim
+    per_block_matrix = (
+        model_dim * model_dim
+        + model_dim * kv_dim
+        + model_dim * kv_dim
+        + model_dim * model_dim
+        + model_dim * (model_dim * mlp_mult)
+        + (model_dim * mlp_mult) * model_dim
+    )
+    per_block_control = 4 * model_dim + num_heads
+    skip_params = (num_layers // 2) * model_dim
+    return (
+        vocab_size * model_dim
+        + num_layers * per_block_matrix
+        + num_layers * per_block_control
+        + skip_params
+    )
+
+
+def validate_candidate(candidate: dict[str, object]) -> str | None:
+    estimated = estimate_model_params(candidate)
+    if estimated is None:
+        return "invalid_architecture"
+    return None
+
+
+def within_budget(result: dict[str, object], args: argparse.Namespace) -> bool:
+    if args.max_param_count > 0:
+        model_params = result.get("model_params") or result.get("estimated_model_params")
+        if model_params is not None and int(model_params) > args.max_param_count:
+            return False
+    if args.max_int8_zlib_bytes > 0:
+        int8_zlib_bytes = result.get("int8_zlib_bytes")
+        if int8_zlib_bytes is not None and int(int8_zlib_bytes) > args.max_int8_zlib_bytes:
+            return False
+    return True
+
+
+def rankable_results(results: list[dict[str, object]], args: argparse.Namespace, *, full_val: bool) -> list[dict[str, object]]:
+    return [
+        result
+        for result in results
+        if result.get("status") == "ok" and bool(result.get("full_val")) == full_val and within_budget(result, args)
+    ]
+
+
+def sample_random(
+    space: dict[str, list[object]],
+    rng: random.Random,
+    budget: int,
+    seen: set[tuple[tuple[str, object], ...]],
+) -> list[dict[str, object]]:
+    keys = list(space)
+    candidates: list[dict[str, object]] = []
+    attempts = 0
+    max_attempts = max(100, budget * 20)
+    while len(candidates) < budget and attempts < max_attempts:
+        attempts += 1
+        candidate = {key: rng.choice(space[key]) for key in keys}
+        sig = normalize_signature(candidate)
+        if sig in seen:
+            continue
+        seen.add(sig)
+        candidates.append(candidate)
+    return candidates
+
+
+def promote_neighbors(
+    results: list[dict[str, object]],
+    space: dict[str, list[object]],
+    promote_top_k: int,
+    budget: int,
+    args: argparse.Namespace,
+    seen: set[tuple[tuple[str, object], ...]],
+) -> list[dict[str, object]]:
+    ranked = rankable_results(results, args, full_val=False)
+    ranked.sort(key=lambda item: item["val_bpb"])
+    promoted: list[dict[str, object]] = []
+    for result in ranked[:promote_top_k]:
+        base = dict(result["candidate"])
+        for key, values in space.items():
+            ordered = sorted(values, key=value_key)
+            current = base[key]
+            try:
+                idx = ordered.index(current)
+            except ValueError:
+                continue
+            for neighbor_idx in (idx - 1, idx + 1):
+                if not (0 <= neighbor_idx < len(ordered)):
+                    continue
+                candidate = dict(base)
+                candidate[key] = ordered[neighbor_idx]
+                sig = normalize_signature(candidate)
+                if sig in seen:
+                    continue
+                seen.add(sig)
+                promoted.append(candidate)
+                if len(promoted) >= budget:
+                    return promoted
+    return promoted
+
+
+def parse_metrics(log_path: Path) -> dict[str, object]:
+    text = log_path.read_text(encoding="utf-8")
+    final_matches = list(FINAL_METRIC_RE.finditer(text))
+    if not final_matches:
+        raise ValueError(f"missing final roundtrip metric in {log_path}")
+    final = final_matches[-1]
+    train_matches = list(TRAIN_LINE_RE.finditer(text))
+    train_line = train_matches[-1] if train_matches else None
+    model_params_match = MODEL_PARAMS_RE.search(text)
+    int8_match = INT8_ZLIB_RE.search(text)
+    payload_ratio = float(int8_match.group("payload_ratio")) if int8_match else None
+    return {
+        "val_loss": float(final.group("val_loss")),
+        "val_bpb": float(final.group("val_bpb")),
+        "step": int(train_line.group("step")) if train_line else None,
+        "train_loss": float(train_line.group("train_loss")) if train_line else None,
+        "train_time_ms": float(train_line.group("train_time_ms")) if train_line else None,
+        "step_avg_ms": float(train_line.group("step_avg_ms")) if train_line else None,
+        "model_params": int(model_params_match.group("model_params")) if model_params_match else None,
+        "int8_zlib_bytes": int(int8_match.group("int8_zlib_bytes")) if int8_match else None,
+        "int8_payload_bytes": int(int8_match.group("int8_payload_bytes")) if int8_match else None,
+        "int8_raw_bytes": int(int8_match.group("int8_raw_bytes")) if int8_match else None,
+        "payload_ratio": payload_ratio,
+    }
+
+
+def write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def write_markdown_report(
+    path: Path,
+    results: list[dict[str, object]],
+    session_dir: Path,
+    args: argparse.Namespace,
+) -> None:
+    ranked = sorted(
+        [result for result in results if result.get("status") == "ok"],
+        key=lambda item: (item["val_bpb"], item["name"]),
+    )
+    lines = [
+        "# Local Search Report",
+        "",
+        f"- Session: `{session_dir.name}`",
+        f"- Strategy: `{args.strategy}`",
+        f"- Search metric: `final_int8_zlib_roundtrip_exact val_bpb`",
+        f"- Proxy validation subset: `{args.val_max_seqs}` sequences",
+        f"- Full-val confirmations: `{args.full_val_top_k}`",
+        f"- Max param count: `{args.max_param_count or 'off'}`",
+        f"- Max int8+zlib bytes: `{args.max_int8_zlib_bytes or 'off'}`",
+        "",
+        "## Ranked Runs",
+        "",
+        "| Rank | Run | Score (val_bpb) | Params | Int8+zlib bytes | Budget | Full Val | Status | Candidate |",
+        "| ---: | --- | ---: | ---: | ---: | :---: | :---: | --- | --- |",
+    ]
+    for idx, result in enumerate(ranked, start=1):
+        model_params = result.get("model_params") or result.get("estimated_model_params")
+        int8_zlib_bytes = result.get("int8_zlib_bytes")
+        budget_ok = "yes" if within_budget(result, args) else "no"
+        lines.append(
+            "| "
+            f"{idx} | {result['name']} | {result['val_bpb']:.6f} | {model_params if model_params is not None else '-'} | "
+            f"{int8_zlib_bytes if int8_zlib_bytes is not None else '-'} | {budget_ok} | "
+            f"{'yes' if result.get('full_val') else 'no'} | {result['status']} | "
+            f"`{json.dumps(result['candidate'], sort_keys=True)}` |"
+        )
+    if not ranked:
+        lines.append("| - | - | - | - | - | - | - | no successful runs | - |")
+
+    skipped = [result for result in results if result.get("status") != "ok"]
+    if skipped:
+        lines.extend(["", "## Skipped / Failed", ""])
+        for result in skipped:
+            lines.append(
+                f"- `{result['name']}`: `{result['status']}` candidate=`{json.dumps(result['candidate'], sort_keys=True)}`"
+            )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def run_candidate(
+    *,
+    repo_root: Path,
+    session_dir: Path,
+    args: argparse.Namespace,
+    candidate: dict[str, object],
+    name: str,
+    full_val: bool,
+) -> dict[str, object]:
+    log_dir = session_dir / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    run_id = name if not full_val else f"{name}_fullval"
+    log_path = log_dir / f"{run_id}.txt"
+    launcher_path = log_dir / f"{run_id}.stdout.txt"
+    estimated_model_params = estimate_model_params(candidate)
+    invalid_reason = validate_candidate(candidate)
+    if invalid_reason is not None:
+        return {
+            "name": run_id,
+            "candidate": candidate,
+            "status": invalid_reason,
+            "returncode": None,
+            "full_val": full_val,
+            "duration_sec": 0.0,
+            "log_path": str(log_path),
+            "stdout_path": str(launcher_path),
+            "estimated_model_params": estimated_model_params,
+        }
+    if args.max_param_count > 0 and estimated_model_params is not None and estimated_model_params > args.max_param_count:
+        return {
+            "name": run_id,
+            "candidate": candidate,
+            "status": "skipped_param_budget",
+            "returncode": None,
+            "full_val": full_val,
+            "duration_sec": 0.0,
+            "log_path": str(log_path),
+            "stdout_path": str(launcher_path),
+            "estimated_model_params": estimated_model_params,
+        }
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "RUN_ID": run_id,
+            "OUT_DIR": str(log_dir),
+            "DATA_PATH": args.data_path,
+            "TOKENIZER_PATH": args.tokenizer_path,
+            "ITERATIONS": str(args.iterations),
+            "TRAIN_BATCH_TOKENS": str(args.train_batch_tokens),
+            "VAL_BATCH_SIZE": str(args.full_val_batch_size if full_val else args.val_batch_size),
+            "VAL_LOSS_EVERY": "0",
+            "TRAIN_LOG_EVERY": str(args.train_log_every),
+            "WARMUP_STEPS": str(args.warmup_steps),
+            "TRAIN_MAX_SHARDS": str(args.train_max_shards),
+            "VAL_MAX_SEQS": "0" if full_val else str(args.val_max_seqs),
+            "GRAD_ACCUM_STEPS": str(args.grad_accum_steps),
+            "MLX_MAX_MICROBATCH_TOKENS": str(args.mlx_max_microbatch_tokens),
+            "MAX_WALLCLOCK_SECONDS": "0",
+        }
+    )
+    for key, value in candidate.items():
+        env[key] = str(value)
+
+    cmd = [args.python, args.train_script]
+    started_at = time.time()
+    proc = subprocess.run(
+        cmd,
+        cwd=repo_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    launcher_path.write_text(proc.stdout, encoding="utf-8")
+    result = {
+        "name": run_id,
+        "candidate": candidate,
+        "status": "ok" if proc.returncode == 0 and log_path.is_file() else "failed",
+        "returncode": proc.returncode,
+        "full_val": full_val,
+        "duration_sec": round(time.time() - started_at, 3),
+        "log_path": str(log_path),
+        "stdout_path": str(launcher_path),
+        "estimated_model_params": estimated_model_params,
+    }
+    if result["status"] == "ok":
+        result.update(parse_metrics(log_path))
+    return result
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    session_root = Path(args.out_dir).resolve()
+    session_dir = make_session_dir(session_root, args.session_name)
+    baseline = dict(BASELINE)
+    overrides = parse_overrides(args.set)
+    space_overrides = parse_space_overrides(args.space)
+    space = {} if args.space_only else {key: list(values) for key, values in DEFAULT_SPACE.items()}
+    for key, values in space_overrides.items():
+        space[key] = values
+    for key, value in overrides.items():
+        baseline[key] = value
+        if key not in space:
+            space[key] = [value]
+        elif value not in space[key]:
+            space[key] = sorted(space[key] + [value], key=value_key)
+
+    rng = random.Random(args.seed)
+    results: list[dict[str, object]] = []
+    seen: set[tuple[tuple[str, object], ...]] = {normalize_signature(baseline)}
+    queue: list[dict[str, object]] = [dict(baseline)]
+
+    if args.strategy == "grid":
+        for candidate in generate_grid(space):
+            sig = normalize_signature(candidate)
+            if sig in seen:
+                continue
+            seen.add(sig)
+            queue.append(candidate)
+    elif args.strategy == "random":
+        queue.extend(sample_random(space, rng, max(args.max_runs - 1, 0), seen))
+    else:
+        queue.extend(sample_random(space, rng, max(args.max_runs - 1, 0), seen))
+
+    queue = queue[: args.max_runs]
+    for idx, candidate in enumerate(queue, start=1):
+        result = run_candidate(
+            repo_root=repo_root,
+            session_dir=session_dir,
+            args=args,
+            candidate=candidate,
+            name=candidate_name("search", idx),
+            full_val=False,
+        )
+        results.append(result)
+        write_json(session_dir / "results.json", results)
+        write_markdown_report(session_dir / "REPORT.md", results, session_dir, args)
+
+    if args.strategy == "hybrid":
+        promoted = promote_neighbors(results, space, args.promote_top_k, args.promote_budget, args, seen)
+        for idx, candidate in enumerate(promoted, start=1):
+            result = run_candidate(
+                repo_root=repo_root,
+                session_dir=session_dir,
+                args=args,
+                candidate=candidate,
+                name=candidate_name("promote", idx),
+                full_val=False,
+            )
+            results.append(result)
+            write_json(session_dir / "results.json", results)
+            write_markdown_report(session_dir / "REPORT.md", results, session_dir, args)
+
+    ranked = sorted(
+        [result for result in results if result.get("status") == "ok" and not result.get("full_val")],
+        key=lambda item: item["val_bpb"],
+    )
+    for idx, result in enumerate(ranked[: args.full_val_top_k], start=1):
+        full_val_result = run_candidate(
+            repo_root=repo_root,
+            session_dir=session_dir,
+            args=args,
+            candidate=dict(result["candidate"]),
+            name=candidate_name("confirm", idx),
+            full_val=True,
+        )
+        results.append(full_val_result)
+        write_json(session_dir / "results.json", results)
+        write_markdown_report(session_dir / "REPORT.md", results, session_dir, args)
+
+    summary = {
+        "session_dir": str(session_dir),
+        "best_proxy": min(
+            rankable_results(results, args, full_val=False),
+            key=lambda item: item["val_bpb"],
+            default=None,
+        ),
+        "best_proxy_any": min(
+            (result for result in results if result.get("status") == "ok" and not result.get("full_val")),
+            key=lambda item: item["val_bpb"],
+            default=None,
+        ),
+        "best_full_val": min(
+            rankable_results(results, args, full_val=True),
+            key=lambda item: item["val_bpb"],
+            default=None,
+        ),
+        "best_full_val_any": min(
+            (result for result in results if result.get("status") == "ok" and result.get("full_val")),
+            key=lambda item: item["val_bpb"],
+            default=None,
+        ),
+        "run_count": len(results),
+    }
+    write_json(session_dir / "summary.json", summary)
+    write_markdown_report(session_dir / "REPORT.md", results, session_dir, args)
+    print(session_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -44,6 +44,8 @@ class Hyperparameters:
     tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
     run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
     seed = int(os.environ.get("SEED", 1337))
+    train_max_shards = int(os.environ.get("TRAIN_MAX_SHARDS", 0))
+    val_max_seqs = int(os.environ.get("VAL_MAX_SEQS", 0))
 
     # Validation cadence and batch size. Validation always uses the full fineweb_val split.
     val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
@@ -204,13 +206,23 @@ def build_sentencepiece_luts(
     )
 
 
-def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+def resolve_shard_files(pattern: str, max_files: int = 0) -> list[Path]:
     files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if max_files > 0:
+        files = files[:max_files]
     if not files:
-        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        limit = f" with max_files={max_files}" if max_files > 0 else ""
+        raise FileNotFoundError(f"No files found for pattern: {pattern}{limit}")
+    return files
+
+
+def load_validation_tokens(pattern: str, seq_len: int, max_seqs: int = 0) -> Tensor:
+    files = resolve_shard_files(pattern)
     # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
     tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
     usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if max_seqs > 0:
+        usable = min(usable, max_seqs * seq_len)
     if usable <= 0:
         raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
     return tokens[: usable + 1]
@@ -446,10 +458,8 @@ def load_data_shard(file: Path) -> Tensor:
 class TokenStream:
     # Reads shards sequentially and wraps around forever. The training loop therefore
     # has deterministic, simple streaming behavior with no sampling or workers.
-    def __init__(self, pattern: str):
-        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
-        if not self.files:
-            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    def __init__(self, pattern: str, max_files: int = 0):
+        self.files = resolve_shard_files(pattern, max_files=max_files)
         self.file_idx = 0
         self.tokens = load_data_shard(self.files[0])
         self.pos = 0
@@ -477,11 +487,11 @@ class TokenStream:
 class DistributedTokenLoader:
     # Each call consumes a contiguous chunk from the shared token stream, then slices out
     # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
-    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device, max_files: int = 0):
         self.rank = rank
         self.world_size = world_size
         self.device = device
-        self.stream = TokenStream(pattern)
+        self.stream = TokenStream(pattern, max_files=max_files)
 
     def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
         local_tokens = global_tokens // (self.world_size * grad_accum_steps)
@@ -749,6 +759,13 @@ def main() -> None:
         raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
     grad_accum_steps = 8 // world_size
     grad_scale = 1.0 / grad_accum_steps
+    local_batch_tokens = args.train_batch_tokens // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "TRAIN_BATCH_TOKENS must provide at least one sequence per rank per microstep; "
+            f"got TRAIN_BATCH_TOKENS={args.train_batch_tokens}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
     if not torch.cuda.is_available():
         raise RuntimeError("CUDA is required")
     device = torch.device("cuda", local_rank)
@@ -810,14 +827,19 @@ def main() -> None:
             f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
         )
     dataset_dir = Path(args.data_path).resolve()
-    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
-    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    available_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    selected_train_files = min(available_train_files, args.train_max_shards) if args.train_max_shards > 0 else available_train_files
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len, args.val_max_seqs)
     base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
         sp, args.vocab_size, device
     )
     log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
-    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{selected_train_files}")
+    if args.train_max_shards > 0 and selected_train_files < available_train_files:
+        log0(f"train_loader:runtime_limit train_shards:{selected_train_files}/{available_train_files}")
     log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+    if args.val_max_seqs > 0:
+        log0(f"val_loader:runtime_limit seqs:{(val_tokens.numel() - 1) // args.train_seq_len}")
 
     # -----------------------------
     # MODEL + OPTIMIZER SETUP
@@ -913,7 +935,13 @@ def main() -> None:
     # DATA LOADER & MODEL WARMUP
     # -----------------------------
 
-    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    train_loader = DistributedTokenLoader(
+        args.train_files,
+        rank,
+        world_size,
+        device,
+        max_files=args.train_max_shards,
+    )
 
     def zero_grad_all() -> None:
         for opt in optimizers:
@@ -958,7 +986,13 @@ def main() -> None:
         zero_grad_all()
         if distributed:
             model.require_backward_grad_sync = True
-        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+        train_loader = DistributedTokenLoader(
+            args.train_files,
+            rank,
+            world_size,
+            device,
+            max_files=args.train_max_shards,
+        )
 
     # -----------------------------
     # MAIN TRAINING LOOP

--- a/train_gpt_mlx.py
+++ b/train_gpt_mlx.py
@@ -46,6 +46,8 @@ class Hyperparameters:
     tokenizer_path: str = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
     run_id: str = os.environ.get("RUN_ID", str(uuid.uuid4()))
     seed: int = int(os.environ.get("SEED", 1337))
+    train_max_shards: int = int(os.environ.get("TRAIN_MAX_SHARDS", 0))
+    val_max_seqs: int = int(os.environ.get("VAL_MAX_SEQS", 0))
 
     # Training loop. These defaults now mirror train_gpt.py on a single process.
     iterations: int = int(os.environ.get("ITERATIONS", 20_000))
@@ -203,6 +205,16 @@ def load_data_shard(path: Path) -> np.ndarray:
     return tokens.astype(np.int32, copy=False)
 
 
+def resolve_shard_files(pattern: str, max_files: int = 0) -> list[Path]:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if max_files > 0:
+        files = files[:max_files]
+    if not files:
+        limit = f" with max_files={max_files}" if max_files > 0 else ""
+        raise FileNotFoundError(f"No files found for pattern: {pattern}{limit}")
+    return files
+
+
 # ==============================================================================
 # TOKEN STREAMING / BATCHING
 # ==============================================================================
@@ -214,10 +226,9 @@ class TokenStream:
         pattern: str,
         log_fn: Callable[[str], None] | None = None,
         dataset_name: str = "",
+        max_files: int = 0,
     ):
-        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
-        if not self.files:
-            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.files = resolve_shard_files(pattern, max_files=max_files)
         self.epoch = 1
         self.file_idx = 0
         self.log_fn = log_fn
@@ -256,8 +267,9 @@ class TokenLoader:
         pattern: str,
         log_fn: Callable[[str], None] | None = None,
         dataset_name: str = "",
+        max_files: int = 0,
     ):
-        self.stream = TokenStream(pattern, log_fn=log_fn, dataset_name=dataset_name)
+        self.stream = TokenStream(pattern, log_fn=log_fn, dataset_name=dataset_name, max_files=max_files)
 
     def next_batch(self, batch_tokens: int, seq_len: int) -> tuple[mx.array, mx.array]:
         usable = (batch_tokens // seq_len) * seq_len
@@ -685,22 +697,27 @@ def build_sentencepiece_luts(
     return base_bytes_lut, has_leading_space_lut, is_boundary_token_lut
 
 
-def validate_dataset_tokenizer_pair(data_path: str, tokenizer_path: str) -> tuple[str, int, int | None]:
+def validate_dataset_tokenizer_pair(
+    data_path: str,
+    tokenizer_path: str,
+    train_max_shards: int = 0,
+) -> tuple[str, int, int | None, int]:
     # The shard directory and tokenizer are coupled: val_bpb is only meaningful if we
     # decode bytes with the exact tokenizer that produced the shards. The manifest
     # lets the training script fail fast on accidental dataset/tokenizer mismatches.
     dataset_dir = Path(data_path).resolve()
-    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    available_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    selected_train_files = min(available_train_files, train_max_shards) if train_max_shards > 0 else available_train_files
     if len(dataset_dir.parents) < 2:
-        return dataset_dir.name, actual_train_files, None
+        return dataset_dir.name, selected_train_files, None, available_train_files
     manifest_path = dataset_dir.parents[1] / "manifest.json"
     if not manifest_path.is_file():
-        return dataset_dir.name, actual_train_files, None
+        return dataset_dir.name, selected_train_files, None, available_train_files
 
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     dataset_entry = next((x for x in manifest.get("datasets", []) if x.get("name") == dataset_dir.name), None)
     if dataset_entry is None:
-        return dataset_dir.name, actual_train_files, None
+        return dataset_dir.name, selected_train_files, None, available_train_files
 
     tokenizer_name = dataset_entry.get("tokenizer_name")
     tokenizer_entry = (
@@ -714,21 +731,21 @@ def validate_dataset_tokenizer_pair(data_path: str, tokenizer_path: str) -> tupl
     expected_train_files = (dataset_entry.get("stats") or {}).get("files_train")
     if expected_train_files is not None:
         expected_train_files = int(expected_train_files)
-        if actual_train_files > expected_train_files:
+        if available_train_files > expected_train_files:
             raise ValueError(
-                f"{dataset_dir.name} has more train shards than expected: found {actual_train_files}, "
+                f"{dataset_dir.name} has more train shards than expected: found {available_train_files}, "
                 f"manifest says {expected_train_files}"
             )
-    return dataset_dir.name, actual_train_files, expected_train_files
+    return dataset_dir.name, selected_train_files, expected_train_files, available_train_files
 
 
-def load_validation_tokens(pattern: str, seq_len: int) -> np.ndarray:
-    files = [Path(p) for p in sorted(glob.glob(pattern))]
-    if not files:
-        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+def load_validation_tokens(pattern: str, seq_len: int, max_seqs: int = 0) -> np.ndarray:
+    files = resolve_shard_files(pattern)
     # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
     tokens = np.ascontiguousarray(np.concatenate([load_data_shard(file) for file in files], axis=0))
     usable = ((tokens.size - 1) // seq_len) * seq_len
+    if max_seqs > 0:
+        usable = min(usable, max_seqs * seq_len)
     if usable <= 0:
         raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
     return tokens[: usable + 1]
@@ -859,11 +876,19 @@ def main() -> None:
         raise ValueError(
             f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
         )
-    dataset_name, actual_train_files, expected_train_files = validate_dataset_tokenizer_pair(
+    dataset_name, selected_train_files, expected_train_files, available_train_files = validate_dataset_tokenizer_pair(
         args.data_path,
         args.tokenizer_path,
+        train_max_shards=args.train_max_shards,
     )
-    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len, args.val_max_seqs)
+
+    if args.microbatch_tokens < args.train_seq_len:
+        raise ValueError(
+            "TRAIN_BATCH_TOKENS / GRAD_ACCUM_STEPS must provide at least one sequence; "
+            f"got TRAIN_BATCH_TOKENS={args.train_batch_tokens}, "
+            f"GRAD_ACCUM_STEPS={args.grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
 
     base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
         sp, args.vocab_size
@@ -874,7 +899,12 @@ def main() -> None:
     # ==============================================================================
     mx.random.seed(args.seed)
 
-    train_loader = TokenLoader(args.train_files, log_fn=log, dataset_name=dataset_name)
+    train_loader = TokenLoader(
+        args.train_files,
+        log_fn=log,
+        dataset_name=dataset_name,
+        max_files=args.train_max_shards,
+    )
 
     # ==============================================================================
     # MODEL + OPTIMIZER SETUP
@@ -915,15 +945,17 @@ def main() -> None:
     log(f"train_loader:shards pattern={args.train_files}")
     log(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.size - 1}")
     if expected_train_files is None:
-        log(f"train_loader:dataset:{dataset_name} train_shards:{actual_train_files}")
-    elif actual_train_files < expected_train_files:
+        log(f"train_loader:dataset:{dataset_name} train_shards:{selected_train_files}")
+    elif selected_train_files < expected_train_files:
         log(
             f"WARNING: train_loader:subset dataset:{dataset_name} "
-            f"train_shards:{actual_train_files}/{expected_train_files} "
+            f"train_shards:{selected_train_files}/{expected_train_files} "
             f"new epochs will arrive sooner than the full dataset"
         )
     else:
-        log(f"train_loader:dataset:{dataset_name} train_shards:{actual_train_files}/{expected_train_files}")
+        log(f"train_loader:dataset:{dataset_name} train_shards:{selected_train_files}/{expected_train_files}")
+    if args.train_max_shards > 0 and selected_train_files < available_train_files:
+        log(f"train_loader:runtime_limit train_shards:{selected_train_files}/{available_train_files}")
     log(f"tokenizer_path:{args.tokenizer_path}")
     log(
         f"model_params:{n_params} vocab_size:{args.vocab_size} layers:{args.num_layers} "
@@ -944,6 +976,8 @@ def main() -> None:
         f"muon_momentum:{args.muon_momentum} muon_steps:{args.muon_backend_steps}"
     )
     log(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    if args.val_max_seqs > 0:
+        log(f"val_loader:runtime_limit seqs:{(val_tokens.size - 1) // args.train_seq_len}")
     log(f"compute_dtype:{COMPUTE_DTYPE} compile:True")
     log(
         f"dtypes tok_emb:{model.tok_emb.weight.dtype} "
@@ -987,7 +1021,12 @@ def main() -> None:
         mx.eval(warm_val_loss)
         mx.synchronize()
 
-        train_loader = TokenLoader(args.train_files, log_fn=log, dataset_name=dataset_name)
+        train_loader = TokenLoader(
+            args.train_files,
+            log_fn=log,
+            dataset_name=dataset_name,
+            max_files=args.train_max_shards,
+        )
 
     train_time_ms = 0.0
     max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None


### PR DESCRIPTION
## Summary
- add runtime shard and validation-sequence limits for local proxy iteration without changing the default challenge path
- add a local MLX sweep harness with proxy/full-val modes and budget-aware architecture filtering
- document the Apple Silicon local search workflow in the README and a dedicated playbook

## Why
Local Apple Silicon iteration was bottlenecked by full validation on every run and by fully manual hyperparameter sweeps. This patch keeps the default challenge behavior intact while making local search substantially faster and easier to compare.

## Validation
- python3 -m py_compile train_gpt.py train_gpt_mlx.py tools/local_search.py
- exercised tools/local_search.py on Apple Silicon with proxy-search sessions
