### PR TITLE
Record: 11L Full GPTQ + Multi-Order N-gram Backoff (fixed-alpha 0.9757 / entropy-adaptive 0.9605, 3-seed)

### DIFF
--- a/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/README.md
+++ b/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/README.md
@@ -1,40 +1,60 @@
 # Record: 11L Full GPTQ + Multi-Order N-gram Backoff Cache
 
-**3-seed mean val_bpb = 0.9757** (std=0.0002) | 15.92 MB | 8xH100 SXM, 600s training + 258s eval
+**Fixed alpha: 3-seed mean val_bpb = 0.9757** (std=0.0002)
+**Entropy-adaptive alpha: 3-seed mean val_bpb = 0.9605** (std=0.0002)
+
+15.92 MB | 8xH100 SXM, 596s training + ~258s eval
 
 ## 3-Seed Results
 
-| Seed | Steps | ms/step | Neural-only BPB | N-gram BPB (fixed alpha) | Artifact | GPTQ Budget |
-|------|-------|---------|-----------------|--------------------------|----------|-------------|
-| 1337 | ~6500 | 87 | 1.1172 | **0.9756** | 15,929,323 B | 596s/600s |
-| 42 | ~6500 | 87 | 1.1171 | **0.9756** | 15,929,323 B | 596s/600s |
-| 7 | ~6500 | 87 | 1.1179 | **0.9760** | 15,922,059 B | 596s/600s |
+| Seed | Neural-only | Fixed alpha (a=0.40) | Entropy-adaptive | Artifact | GPTQ Budget |
+|------|-------------|----------------------|-----------------|----------|-------------|
+| 1337 | 1.11719 | **0.97558** | **0.96027** | 15,921,027 B | 596s/600s |
+| 42 | 1.11715 | **0.97562** | **0.96029** | 15,929,323 B | 596s/600s |
+| 7 | 1.11787 | **0.97602** | **0.96082** | 15,922,059 B | 596s/600s |
+| **Mean** | **1.11740** | **0.97574** | **0.96046** | | |
+| **Std** | 0.00033 | 0.00020 | 0.00025 | | |
 
-**Mean: 0.9757 | Std: 0.0002**
+## Two Variants
+
+### Variant 1: Fixed alpha (safest legal)
+
+- `NGRAM_ENTROPY=0`, `NGRAM_ALPHA=0.40`
+- Probability blend: `p = 0.60 * model + 0.40 * ngram` (constant for all tokens)
+- **3-seed mean: 0.9757**
+
+### Variant 2: Entropy-adaptive alpha
+
+- `NGRAM_ENTROPY=1`, `alpha = 0.05 + 0.55 * sigmoid(2 * (H - 4.0))`
+- Alpha depends on model output entropy H (high entropy = trust ngram more, low = trust model)
+- Alpha is computed from the model's own output distribution ONLY, never from the true token
+- **3-seed mean: 0.9605**
 
 ## Compliance
 
 ### Training (600s budget)
 - Training stops at ~586s to reserve 14s for GPTQ calibration
-- GPTQ Hessian calibration uses training data (`fineweb_train_*`) within the reserved budget
+- GPTQ Hessian calibration uses training data within the reserved budget
 - Total: train 586s + GPTQ 10s = **596s** (within 600s)
 - Budget check logged: `gptq:budget_check train:586069ms + gptq:9839ms = 595908ms (budget:600000ms)`
-- No training data is accessed during evaluation
+- **No training data is accessed during evaluation**
 
 ### Evaluation (600s budget)
 - Sliding window eval (stride=64): ~86s
-- N-gram cached eval: ~130s
-- Total eval: **~258s** (within 600s)
+- N-gram cached eval (fixed alpha): ~130s
+- N-gram cached eval (entropy-adaptive): ~140s
+- Total eval (both variants): **~356s** (within 600s)
 
 ### N-gram Cache Legality
-- **Backward-looking only**: n-gram count tables are updated AFTER each window is scored, never before
-- **Fixed-weight blend**: `mixed = (1 - 0.40) * model_prob + 0.40 * ngram_prob` — alpha is constant, not adaptive
+- **Backward-looking only**: n-gram count tables updated AFTER each window is scored, never before
 - **No oracle selection**: probabilities are blended before seeing the true token; no min(NLL) picking
 - **No training data access**: cache is built entirely from validation tokens during eval
-- **Score-first protocol**: each sliding window's tokens are scored by the model first, then the n-gram tables are updated with those tokens for future windows
+- **Score-first protocol**: each sliding window's tokens are scored by the model first, then cache is updated
+- **Fixed alpha variant**: constant alpha=0.40, no data-dependent weighting whatsoever
+- **Entropy-adaptive variant**: alpha depends on model output distribution entropy only, never on the true token
 
 ### Artifact
-- All seeds under 16,000,000 bytes
+- All seeds under 16,000,000 bytes (TARGET_MB=15.8 for seed 7)
 - int6 per-row quantization + LZMA compression
 
 ## Architecture
@@ -46,40 +66,42 @@
 Multi-order backward-looking n-gram cache with backoff from order 7 down to order 2:
 - For each token being scored, attempt the highest n-gram order first (7-gram context)
 - If context has fewer than `min_count=2` occurrences in the cache, back off to a lower order
-- Probability blend: `p_mixed = 0.60 * p_model + 0.40 * p_ngram`
 - Hash table: 4M buckets per order, XOR-shift hashing
-- Cache update happens AFTER scoring (backward-looking)
+- Cache update happens strictly AFTER scoring (backward-looking)
 
 ## Ablation (seed 1337)
 
 | Configuration | val_bpb | Delta |
 |---------------|---------|-------|
 | Neural-only (no cache) | 1.1172 | baseline |
-| Fixed 7-gram, alpha=0.40 | 1.0258 | -0.0914 |
-| **Multi-order backoff (2-7), alpha=0.40** | **0.9756** | **-0.1416** |
+| Fixed 7-gram only, alpha=0.40 | 1.0258 | -0.0914 |
+| Multi-order backoff (2-7), fixed alpha=0.40 | 0.9756 | -0.1416 |
+| Multi-order backoff (2-7), entropy-adaptive | 0.9603 | -0.1569 |
 
 ## Credits
 
 - Base architecture: PR #609 by @saml212 (XSA-all + selective pruning)
 - Parallel Muon: PR #593 by @abaybektursun
-- GPTQ budget fix: PR #535 by @raahilshah (reserved calibration time within training budget)
+- GPTQ budget fix: PR #535 by @raahilshah
 - N-gram cache concept: PR #715, PR #727
 
 ## Run Command
 
 ```bash
+# Fixed alpha variant (safest)
 DATA_PATH=./data/datasets/fineweb10B_sp1024 \
 TOKENIZER_PATH=./data/tokenizers/fineweb_1024_bpe.model \
-VOCAB_SIZE=1024 \
-MAX_WALLCLOCK_SECONDS=600 \
-TARGET_MB=15.8 \
-NGRAM_CACHE=1 \
-NGRAM_ORDER=7 \
-NGRAM_MIN_ORDER=2 \
-NGRAM_ALPHA=0.40 \
-NGRAM_MIN_COUNT=2 \
-NGRAM_BUCKETS=4194304 \
-NGRAM_ENTROPY=0 \
-SEED=1337 \
-torchrun --standalone --nproc_per_node=8 train_gpt.py
+VOCAB_SIZE=1024 MAX_WALLCLOCK_SECONDS=600 TARGET_MB=15.8 \
+NGRAM_CACHE=1 NGRAM_ORDER=7 NGRAM_MIN_ORDER=2 NGRAM_ALPHA=0.40 \
+NGRAM_MIN_COUNT=2 NGRAM_BUCKETS=4194304 NGRAM_ENTROPY=0 \
+SEED=1337 torchrun --standalone --nproc_per_node=8 train_gpt.py
+
+# Entropy-adaptive variant
+DATA_PATH=./data/datasets/fineweb10B_sp1024 \
+TOKENIZER_PATH=./data/tokenizers/fineweb_1024_bpe.model \
+VOCAB_SIZE=1024 MAX_WALLCLOCK_SECONDS=600 TARGET_MB=15.8 \
+NGRAM_CACHE=1 NGRAM_ORDER=7 NGRAM_MIN_ORDER=2 NGRAM_ALPHA=0.40 \
+NGRAM_MIN_COUNT=2 NGRAM_BUCKETS=4194304 NGRAM_ENTROPY=1 \
+NGRAM_ENT_BASE=0.05 NGRAM_ENT_RANGE=0.55 NGRAM_ENT_SCALE=2.0 NGRAM_ENT_THRESH=4.0 \
+SEED=1337 torchrun --standalone --nproc_per_node=8 train_gpt.py
 ```

--- a/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/README.md
+++ b/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/README.md
@@ -1,7 +1,7 @@
 # Record: 11L Full GPTQ + Multi-Order N-gram Backoff Cache
 
 **Fixed alpha: 3-seed mean val_bpb = 0.9757** (std=0.0002)
-**Entropy-adaptive alpha: 3-seed mean val_bpb = 0.9605** (std=0.0002)
+**Entropy-adaptive alpha: 3-seed mean val_bpb = 0.9605** (std=0.0003)
 
 15.92 MB | 8xH100 SXM, 596s training + ~258s eval
 
@@ -13,7 +13,7 @@
 | 42 | 1.11715 | **0.97562** | **0.96029** | 15,929,323 B | 596s/600s |
 | 7 | 1.11787 | **0.97602** | **0.96082** | 15,922,059 B | 596s/600s |
 | **Mean** | **1.11740** | **0.97574** | **0.96046** | | |
-| **Std** | 0.00033 | 0.00020 | 0.00025 | | |
+| **Std** | 0.00041 | 0.00024 | 0.00031 | | |
 
 ## Two Variants
 

--- a/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/README.md
+++ b/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/README.md
@@ -1,0 +1,85 @@
+# Record: 11L Full GPTQ + Multi-Order N-gram Backoff Cache
+
+**3-seed mean val_bpb = 0.9757** (std=0.0002) | 15.92 MB | 8xH100 SXM, 600s training + 258s eval
+
+## 3-Seed Results
+
+| Seed | Steps | ms/step | Neural-only BPB | N-gram BPB (fixed alpha) | Artifact | GPTQ Budget |
+|------|-------|---------|-----------------|--------------------------|----------|-------------|
+| 1337 | ~6500 | 87 | 1.1172 | **0.9756** | 15,929,323 B | 596s/600s |
+| 42 | ~6500 | 87 | 1.1171 | **0.9756** | 15,929,323 B | 596s/600s |
+| 7 | ~6500 | 87 | 1.1179 | **0.9760** | 15,922,059 B | 596s/600s |
+
+**Mean: 0.9757 | Std: 0.0002**
+
+## Compliance
+
+### Training (600s budget)
+- Training stops at ~586s to reserve 14s for GPTQ calibration
+- GPTQ Hessian calibration uses training data (`fineweb_train_*`) within the reserved budget
+- Total: train 586s + GPTQ 10s = **596s** (within 600s)
+- Budget check logged: `gptq:budget_check train:586069ms + gptq:9839ms = 595908ms (budget:600000ms)`
+- No training data is accessed during evaluation
+
+### Evaluation (600s budget)
+- Sliding window eval (stride=64): ~86s
+- N-gram cached eval: ~130s
+- Total eval: **~258s** (within 600s)
+
+### N-gram Cache Legality
+- **Backward-looking only**: n-gram count tables are updated AFTER each window is scored, never before
+- **Fixed-weight blend**: `mixed = (1 - 0.40) * model_prob + 0.40 * ngram_prob` — alpha is constant, not adaptive
+- **No oracle selection**: probabilities are blended before seeing the true token; no min(NLL) picking
+- **No training data access**: cache is built entirely from validation tokens during eval
+- **Score-first protocol**: each sliding window's tokens are scored by the model first, then the n-gram tables are updated with those tokens for future windows
+
+### Artifact
+- All seeds under 16,000,000 bytes
+- int6 per-row quantization + LZMA compression
+
+## Architecture
+
+11L, 512d, GQA 8H/4KV, LeakyReLU(0.5)^2 MLP 3x, XSA on all 11 layers, VE128, BigramHash(2048), Partial RoPE 16/64, LN Scale, SmearGate, U-Net skip connections, EMA(0.997), Parallel Muon optimizer, Full Hessian GPTQ int6.
+
+## N-gram Cache Details
+
+Multi-order backward-looking n-gram cache with backoff from order 7 down to order 2:
+- For each token being scored, attempt the highest n-gram order first (7-gram context)
+- If context has fewer than `min_count=2` occurrences in the cache, back off to a lower order
+- Probability blend: `p_mixed = 0.60 * p_model + 0.40 * p_ngram`
+- Hash table: 4M buckets per order, XOR-shift hashing
+- Cache update happens AFTER scoring (backward-looking)
+
+## Ablation (seed 1337)
+
+| Configuration | val_bpb | Delta |
+|---------------|---------|-------|
+| Neural-only (no cache) | 1.1172 | baseline |
+| Fixed 7-gram, alpha=0.40 | 1.0258 | -0.0914 |
+| **Multi-order backoff (2-7), alpha=0.40** | **0.9756** | **-0.1416** |
+
+## Credits
+
+- Base architecture: PR #609 by @saml212 (XSA-all + selective pruning)
+- Parallel Muon: PR #593 by @abaybektursun
+- GPTQ budget fix: PR #535 by @raahilshah (reserved calibration time within training budget)
+- N-gram cache concept: PR #715, PR #727
+
+## Run Command
+
+```bash
+DATA_PATH=./data/datasets/fineweb10B_sp1024 \
+TOKENIZER_PATH=./data/tokenizers/fineweb_1024_bpe.model \
+VOCAB_SIZE=1024 \
+MAX_WALLCLOCK_SECONDS=600 \
+TARGET_MB=15.8 \
+NGRAM_CACHE=1 \
+NGRAM_ORDER=7 \
+NGRAM_MIN_ORDER=2 \
+NGRAM_ALPHA=0.40 \
+NGRAM_MIN_COUNT=2 \
+NGRAM_BUCKETS=4194304 \
+NGRAM_ENTROPY=0 \
+SEED=1337 \
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```

--- a/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/submission.json
+++ b/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/submission.json
@@ -2,7 +2,7 @@
   "name": "11L Full GPTQ + Multi-Order N-gram Backoff Cache",
   "val_bpb": 0.9757,
   "bytes_total": 15929323,
-  "blurb": "11L LeakyReLU(0.5)^2 + Full Hessian GPTQ (within 600s budget) + multi-order backward-looking n-gram cache (orders 2-7, fixed alpha=0.40, min_count=2). GPTQ calibration reserved within training budget (train 586s + GPTQ 10s = 596s). N-gram cache is purely eval-time: counts built from already-scored tokens only, fixed-weight probability blend, no oracle selection. 3-seed mean: 0.9757 (std 0.0002).",
+  "blurb": "11L LeakyReLU(0.5)^2 + Full Hessian GPTQ (within 600s budget) + multi-order backward-looking n-gram cache (orders 2-7). Fixed alpha=0.40 variant: 0.9757 (3-seed mean). Entropy-adaptive alpha variant: 0.9605 (3-seed mean). GPTQ calibration reserved within training budget (train 586s + GPTQ 10s = 596s). N-gram cache is purely eval-time, backward-looking, no oracle selection.",
   "author": "Raahil Shah",
   "github_id": "raahilshah",
   "date": "2026-03-25"

--- a/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/submission.json
+++ b/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/submission.json
@@ -1,0 +1,9 @@
+{
+  "name": "11L Full GPTQ + Multi-Order N-gram Backoff Cache",
+  "val_bpb": 0.9757,
+  "bytes_total": 15929323,
+  "blurb": "11L LeakyReLU(0.5)^2 + Full Hessian GPTQ (within 600s budget) + multi-order backward-looking n-gram cache (orders 2-7, fixed alpha=0.40, min_count=2). GPTQ calibration reserved within training budget (train 586s + GPTQ 10s = 596s). N-gram cache is purely eval-time: counts built from already-scored tokens only, fixed-weight probability blend, no oracle selection. 3-seed mean: 0.9757 (std 0.0002).",
+  "author": "Raahil Shah",
+  "github_id": "raahilshah",
+  "date": "2026-03-25"
+}

--- a/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/submission.json
+++ b/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/submission.json
@@ -2,7 +2,7 @@
   "name": "11L Full GPTQ + Multi-Order N-gram Backoff Cache",
   "val_bpb": 0.9757,
   "bytes_total": 15929323,
-  "blurb": "11L LeakyReLU(0.5)^2 + Full Hessian GPTQ (within 600s budget) + multi-order backward-looking n-gram cache (orders 2-7). Fixed alpha=0.40 variant: 0.9757 (3-seed mean). Entropy-adaptive alpha variant: 0.9605 (3-seed mean). GPTQ calibration reserved within training budget (train 586s + GPTQ 10s = 596s). N-gram cache is purely eval-time, backward-looking, no oracle selection.",
+  "blurb": "11L LeakyReLU(0.5)^2 + Full Hessian GPTQ (within 600s budget) + multi-order backward-looking n-gram cache (orders 2-7). Fixed alpha=0.40 variant: 0.9757 (3-seed mean, std 0.0002). Entropy-adaptive alpha variant: 0.9605 (3-seed mean, std 0.0003). GPTQ calibration reserved within training budget (train 586s + GPTQ 10s = 596s). N-gram cache is purely eval-time, backward-looking, no oracle selection.",
   "author": "Raahil Shah",
   "github_id": "raahilshah",
   "date": "2026-03-25"

--- a/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/train_gpt.py
@@ -1,0 +1,1950 @@
+from __future__ import annotations
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import lzma
+import zlib
+from pathlib import Path
+try:
+    import zstandard
+except ImportError:
+    pass
+_COMPRESSOR = "lzma"
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from flash_attn_interface import flash_attn_func as flash_attn_3_func
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3500))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 3.0))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.035))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.025))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.025))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    mtp_num_heads = int(os.environ.get("MTP_NUM_HEADS", 0))
+    mtp_loss_weight = float(os.environ.get("MTP_LOSS_WEIGHT", 0.2))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))  # tighter: collect more recent checkpoints
+    muon_wd = float(os.environ.get("MUON_WD", 0.04))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.04))
+    qat_enabled = bool(int(os.environ.get("QAT_ENABLED", "0")))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 2048))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))  # XSA on all layers (PR #609: -0.0016 BPB)
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    dtg_enabled = bool(int(os.environ.get("DTG_ENABLED", "0")))
+    late_qat_threshold = float(os.environ.get("LATE_QAT_THRESHOLD", 0.15))
+    ve_enabled = bool(int(os.environ.get("VE_ENABLED", "1")))
+    ve_dim = int(os.environ.get("VE_DIM", 128))
+    ve_layers = os.environ.get("VE_LAYERS", "9,10")
+    ngram_cache = bool(int(os.environ.get("NGRAM_CACHE", "0")))
+    ngram_alpha = float(os.environ.get("NGRAM_ALPHA", "0.40"))
+    ngram_order = int(os.environ.get("NGRAM_ORDER", "7"))
+    ngram_min_count = int(os.environ.get("NGRAM_MIN_COUNT", "2"))
+    ngram_buckets = int(os.environ.get("NGRAM_BUCKETS", "4194304"))
+    ngram_min_order = int(os.environ.get("NGRAM_MIN_ORDER", "7"))
+    ngram_entropy = bool(int(os.environ.get("NGRAM_ENTROPY", "0")))
+    ngram_ent_base = float(os.environ.get("NGRAM_ENT_BASE", "0.05"))
+    ngram_ent_range = float(os.environ.get("NGRAM_ENT_RANGE", "0.55"))
+    ngram_ent_scale = float(os.environ.get("NGRAM_ENT_SCALE", "2.0"))
+    ngram_ent_thresh = float(os.environ.get("NGRAM_ENT_THRESH", "4.0"))
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    """Batched Newton-Schulz orthogonalization. G: (B,M,N) or (M,N)."""
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+class Muon(torch.optim.Optimizer):
+    """Parallel Muon: reduce-scatter -> local batched NS5 -> all-gather.
+    Each param is a 3D bank tensor (B, M, N)."""
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay),
+        )
+        self._built = False
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append({
+                    'p': p, 'B': B,
+                    'padded_grad': torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'shard': torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'shard_mom': torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'full_update': torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'scale': max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                })
+        self._bank_meta.sort(key=lambda m: -m['p'].numel())
+        self._built = True
+    def launch_reduce_scatters(self):
+        """Phase 1: launch async reduce-scatter for all banks."""
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m['p']
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m['padded_grad']
+            pg[:m['B']].copy_(p.grad.bfloat16())
+            if pg.shape[0] > m['B']:
+                pg[m['B']:].zero_()
+            fut = dist.reduce_scatter_tensor(m['shard'], pg, op=dist.ReduceOp.AVG, async_op=True)
+            self._rs_futures.append(fut)
+    @torch.no_grad()
+    def step(self, closure=None):
+        """Phase 3: wait for RS, local NS5, all-gather."""
+        if not self._built:
+            self._build()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+        sharded = self._distributed and hasattr(self, '_rs_futures')
+        prev_ag_handle, prev_m = None, None
+        for i, m in enumerate(self._bank_meta):
+            p = m['p']
+            if p.grad is None:
+                continue
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m['p']
+                upd = prev_m['full_update'][:prev_m['B']]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m['scale'])
+            if sharded and self._rs_futures[i] is not None:
+                self._rs_futures[i].wait()
+                g = m['shard']
+                buf = m['shard_mom']
+            else:
+                g = p.grad.bfloat16()
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+            buf.mul_(momentum).add_(g)
+            update = g.add(buf, alpha=momentum) if nesterov else buf.clone()
+            update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+            if sharded:
+                prev_ag_handle = dist.all_gather_into_tensor(
+                    m['full_update'], update, async_op=True)
+                prev_m = m
+            else:
+                if wd > 0.0:
+                    p.data.mul_(1.0 - lr * wd)
+                p.add_(update.to(dtype=p.dtype), alpha=-lr * m['scale'])
+        if prev_ag_handle is not None:
+            prev_ag_handle.wait()
+            pp = prev_m['p']
+            upd = prev_m['full_update'][:prev_m['B']]
+            if wd > 0.0:
+                pp.data.mul_(1.0 - lr * wd)
+            pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m['scale'])
+        if hasattr(self, '_rs_futures'):
+            del self._rs_futures
+        return None
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    seq_len = eval_seq_len or args.train_seq_len
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,dtg_gate,ve_layer_scales,ve_shared.scale",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        shard_order = os.environ.get("SHARD_ORDER", "")
+        if shard_order:
+            order = [int(x) for x in shard_order.split(",")]
+            reordered = [self.files[i] for i in order if i < len(self.files)]
+            remaining = [f for i, f in enumerate(self.files) if i not in set(order)]
+            self.files = reordered + remaining
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            w32 = self.weight.float()
+            with torch.no_grad():
+                row_max = w32.abs().amax(dim=1)
+                scale = (row_max / 31.0).clamp_min(1.0 / 31.0)
+            x_norm = w32 / scale[:, None]
+            q_hard = torch.clamp(torch.round(x_norm), -32, 31)
+            w_q = (q_hard.detach() * scale[:, None]).to(x.dtype)
+            w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024, rope_dims: int = 0):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / (base ** (torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (rd / (rd - 2)))
+                inv_freq = 1.0 / (new_base ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd))
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int = 0) -> Tensor:
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        use_banks: bool = True,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        if not use_banks:
+            kv_dim = num_kv_heads * self.head_dim
+            self.c_q = CastedLinear(dim, dim, bias=False)
+            self.c_k = CastedLinear(dim, kv_dim, bias=False)
+            self.c_v = CastedLinear(dim, kv_dim, bias=False)
+            self.proj = CastedLinear(dim, dim, bias=False)
+            self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rope_dims = 0  # set by GPT.__init__ for partial RoPE
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False  # set by GPT.__init__ for deep layers only
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        """Efficient XSA: subtract self-value projection via GQA-aware reshape (no repeat_interleave).
+        y: [B, T, H, D], v: [B, T, Hkv, D]. H must be divisible by Hkv."""
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)        # [B, T, Hkv, group, D]
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)    # [B, T, Hkv, 1, D] — broadcast ready
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+    def forward(self, x: Tensor, q_w: Tensor | None = None, k_w: Tensor | None = None, v_w: Tensor | None = None, out_w: Tensor | None = None, v_embed: Tensor | None = None) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        if q_w is not None:
+            q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+            k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+            v = F.linear(x, v_w.to(x.dtype))
+        else:
+            q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+            k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+            v = self.c_v(x)
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        return F.linear(y, out_w.to(x.dtype)) if out_w is not None else self.proj(y)
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+class ValueEmbedding(nn.Module):
+    """Reinject token identity into attention values at specific layers.
+    Each table maps vocab tokens to a low-dim embedding, projected to model_dim."""
+    def __init__(self, vocab_size: int, ve_dim: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, ve_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(ve_dim, model_dim, bias=False) if ve_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(token_ids)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int, use_banks: bool = True):
+        super().__init__()
+        if not use_banks:
+            hidden = int(mlp_mult * dim)
+            self.fc = CastedLinear(dim, hidden, bias=False)
+            self.proj = CastedLinear(hidden, dim, bias=False)
+            self.proj._zero_init = True
+    def forward(self, x: Tensor, up_w: Tensor | None = None, down_w: Tensor | None = None) -> Tensor:
+        if up_w is not None:
+            x = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5)
+            return F.linear(x.square(), down_w.to(x.dtype))
+        x = F.leaky_relu(self.fc(x), negative_slope=0.5)
+        return self.proj(x.square())
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        layer_idx: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        use_banks: bool = True,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init, use_banks=use_banks)
+        self.mlp = MLP(dim, mlp_mult, use_banks=use_banks)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+        if dtg:
+            self.dtg_gate = nn.Linear(dim, 1, bias=True)
+            nn.init.zeros_(self.dtg_gate.weight)
+            nn.init.constant_(self.dtg_gate.bias, 2.0)
+        else:
+            self.dtg_gate = None
+    def forward(self, x: Tensor, x0: Tensor, q_w: Tensor | None = None, k_w: Tensor | None = None, v_w: Tensor | None = None, out_w: Tensor | None = None, up_w: Tensor | None = None, down_w: Tensor | None = None, v_embed: Tensor | None = None) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x_in) * self.ln_scale_factor, q_w, k_w, v_w, out_w, v_embed=v_embed)
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        if self.dtg_gate is not None:
+            gate = torch.sigmoid(self.dtg_gate(x_in.detach()))
+            x_out = x_in + gate * (x_out - x_in)
+        return x_out
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        mtp_num_heads: int = 0,
+        mtp_loss_weight: float = 0.1,
+        bigram_vocab_size: int = 0,
+        bigram_dim: int = 128,
+        xsa_last_n: int = 0,
+        rope_dims: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        ve_enabled: bool = False,
+        ve_dim: int = 128,
+        ve_layers: str = "9,10",
+        use_banks: bool = True,
+    ):
+        super().__init__()
+        self.use_banks = use_banks
+        self._ve_target_dim = num_kv_heads * (model_dim // num_heads)  # kv_dim for value projection
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.mtp_num_heads = mtp_num_heads
+        self.mtp_loss_weight = mtp_loss_weight
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.smear = SmearGate(model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.num_layers = num_layers
+        if use_banks:
+            # Parameter banks: contiguous 3D tensors for batched optimizer
+            head_dim = model_dim // num_heads
+            kv_dim = num_kv_heads * head_dim
+            mlp_dim = int(mlp_mult * model_dim)
+            self.qo_bank = nn.Parameter(torch.empty(2 * num_layers, model_dim, model_dim))
+            self.kv_bank = nn.Parameter(torch.empty(2 * num_layers, kv_dim, model_dim))
+            self.mlp_up_bank = nn.Parameter(torch.empty(num_layers, mlp_dim, model_dim))
+            self.mlp_down_bank = nn.Parameter(torch.empty(num_layers, model_dim, mlp_dim))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                    layer_idx=i,
+                    ln_scale=ln_scale,
+                    dtg=dtg,
+                    use_banks=use_banks,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        if rope_dims > 0:
+            head_dim = model_dim // num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = rope_dims
+                block.attn.rotary = Rotary(head_dim, base=rope_base, train_seq_len=1024, rope_dims=rope_dims)
+        self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+        kv_dim = self._ve_target_dim
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim)
+            self.ve_layer_scales = nn.ParameterList(
+                [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices]
+            )
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.value_embeds = nn.ModuleList()  # keep empty for compat
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.mtp_heads = nn.ModuleList(
+            [CastedLinear(model_dim, vocab_size, bias=False) for _ in range(mtp_num_heads)]
+        )
+        for head in self.mtp_heads:
+            head._zero_init = True
+        if xsa_last_n > 0:
+            for i in range(max(0, num_layers - xsa_last_n), num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self._init_weights()
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        # Init bank parameters (only when using banked architecture)
+        if self.use_banks:
+            for i in range(n):
+                nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)        # Q
+                nn.init.zeros_(self.qo_bank.data[n + i])                    # Out (zero init)
+                nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)        # K
+                nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)    # V
+                nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)    # MLP up
+                nn.init.zeros_(self.mlp_down_bank.data[i])                  # MLP down (zero init)
+        # Init remaining non-bank modules
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj." in name or name.endswith(".proj"):
+                        with torch.no_grad():
+                            module.weight.mul_(proj_scale)
+    def _get_ve(self, layer_idx: int, input_ids: Tensor, ve_cache: dict | None = None) -> Tensor | None:
+        """Get value embedding for a specific layer using shared table + per-layer scale."""
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if ve_cache is not None and 've' not in ve_cache:
+            ve_cache['ve'] = self.ve_shared(input_ids)
+        ve_base = ve_cache['ve'] if ve_cache is not None else self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_base * self.ve_layer_scales[ve_idx].to(dtype=ve_base.dtype)
+    def _run_blocks(self, x: Tensor, x0: Tensor, input_ids: Tensor) -> Tensor:
+        n = self.num_layers
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            if self.use_banks:
+                x = self.blocks[i](x, x0,
+                    self.qo_bank[i], self.kv_bank[i], self.kv_bank[n + i],
+                    self.qo_bank[n + i], self.mlp_up_bank[i], self.mlp_down_bank[i],
+                    v_embed=ve)
+            else:
+                x = self.blocks[i](x, x0, v_embed=ve)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            if self.use_banks:
+                x = self.blocks[bi](x, x0,
+                    self.qo_bank[bi], self.kv_bank[bi], self.kv_bank[n + bi],
+                    self.qo_bank[n + bi], self.mlp_up_bank[bi], self.mlp_down_bank[bi],
+                    v_embed=ve)
+            else:
+                x = self.blocks[bi](x, x0, v_embed=ve)
+        return x
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        x = self._run_blocks(x, x0, input_ids)
+        x = self.final_norm(x)
+        x_flat = x.reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x_flat, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x_flat)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        main_loss = F.cross_entropy(logits.float(), targets, reduction="mean")
+        if self.training and self.mtp_num_heads > 0 and self.mtp_loss_weight > 0.0:
+            _, seqlen, dim = x.shape
+            mtp_loss_sum = x.new_zeros(())
+            mtp_loss_count = 0
+            for k, mtp_head in enumerate(self.mtp_heads):
+                valid_t = seqlen - (k + 1)
+                if valid_t <= 0:
+                    continue
+                mtp_hidden = x[:, :valid_t, :].reshape(-1, dim)
+                mtp_targets = target_ids[:, k + 1 :].reshape(-1)
+                mtp_logits_proj = mtp_head(mtp_hidden)
+                mtp_logits = self.logit_softcap * torch.tanh(mtp_logits_proj / self.logit_softcap)
+                mtp_loss_sum = mtp_loss_sum + F.cross_entropy(mtp_logits.float(), mtp_targets, reduction="mean")
+                mtp_loss_count += 1
+            if mtp_loss_count > 0:
+                main_loss = main_loss + self.mtp_loss_weight * (mtp_loss_sum / mtp_loss_count)
+        return main_loss
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Return logits (bsz, seq_len, vocab) without computing loss."""
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        x = self._run_blocks(x, x0, input_ids)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+    eval_seq_len: int | None = None,
+    use_ngram: bool = False,
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context."""
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= 1]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    if use_ngram:
+        assert 2 <= args.ngram_min_order <= args.ngram_order
+        assert args.ngram_buckets > 0 and (args.ngram_buckets & (args.ngram_buckets - 1)) == 0, "ngram_buckets must be power of two"
+        val_np = val_tokens.cpu().numpy()
+        n_orders = args.ngram_order - args.ngram_min_order + 1
+        ctx_tables = [np.zeros((args.ngram_buckets,), dtype=np.uint32) for _ in range(n_orders)]
+        full_tables = [np.zeros((args.ngram_buckets,), dtype=np.uint32) for _ in range(n_orders)]
+        ng_mask = np.uint64(args.ngram_buckets - 1)
+        ng_primes = np.array(
+            [36313, 27191, 51647, 81929, 131071, 175447, 209591],
+            dtype=np.uint64,
+        )
+        if rank == 0:
+            print(
+                f"ngram_cache:enabled orders={args.ngram_min_order}-{args.ngram_order} "
+                f"entropy={int(args.ngram_entropy)} alpha={args.ngram_alpha} "
+                f"ent_base={args.ngram_ent_base} ent_range={args.ngram_ent_range} "
+                f"ent_scale={args.ngram_ent_scale} ent_thresh={args.ngram_ent_thresh} "
+                f"min_count={args.ngram_min_count} buckets={args.ngram_buckets}",
+                flush=True,
+            )
+    base_model.eval()
+    compiled_logits = torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = compiled_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                seg_len = wlen - s
+                if seg_len <= 0:
+                    continue
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                if use_ngram:
+                    seg_nll_np = scored_nll.cpu().numpy()
+                    seg_model_p = np.exp(-seg_nll_np)
+                    global_j = np.arange(ws + s + 1, ws + wlen + 1, dtype=np.int64)
+
+                    if args.ngram_entropy:
+                        lp = F.log_softmax(logits[i, s:wlen].float(), dim=-1)
+                        seg_ent = -(lp.exp() * lp).sum(dim=-1).cpu().numpy()
+                        alpha_per_tok = args.ngram_ent_base + args.ngram_ent_range / (
+                            1.0 + np.exp(-args.ngram_ent_scale * (seg_ent - args.ngram_ent_thresh))
+                        )
+
+                    order_data = []
+                    for oi in range(n_orders):
+                        ctx_w = args.ngram_min_order + oi - 1
+                        valid = global_j >= ctx_w
+                        if not valid.any():
+                            order_data.append(None)
+                            continue
+                        v_idx = np.nonzero(valid)[0]
+                        jv = global_j[v_idx]
+                        ctx_hash = np.zeros(len(jv), dtype=np.uint64)
+                        for k in range(ctx_w):
+                            tok = val_np[jv - (ctx_w - k)].astype(np.uint64)
+                            ctx_hash ^= tok * ng_primes[k % len(ng_primes)]
+                        ctx_key = (ctx_hash & ng_mask).astype(np.int64)
+                        tgt_np = val_np[jv].astype(np.uint64)
+                        full_key = (
+                            (ctx_hash ^ (tgt_np * ng_primes[ctx_w % len(ng_primes)])) & ng_mask
+                        ).astype(np.int64)
+                        order_data.append((v_idx, ctx_key, full_key))
+
+                    best_p_ng = np.full(seg_len, -1.0, dtype=np.float64)
+                    for oi in range(n_orders - 1, -1, -1):
+                        data = order_data[oi]
+                        if data is None:
+                            continue
+                        v_idx, ctx_key, full_key = data
+                        ctx_counts = ctx_tables[oi][ctx_key].astype(np.float64)
+                        full_counts = full_tables[oi][full_key].astype(np.float64)
+                        has_match = ctx_counts >= float(args.ngram_min_count)
+                        needs_fill = has_match & (best_p_ng[v_idx] < 0.0)
+                        if needs_fill.any():
+                            fill_idx = v_idx[needs_fill]
+                            p = np.minimum(full_counts[needs_fill], ctx_counts[needs_fill]) / np.maximum(ctx_counts[needs_fill], 1.0)
+                            best_p_ng[fill_idx] = np.clip(p, 0.0, 1.0)
+
+                    has_match = best_p_ng >= 0.0
+                    if has_match.any():
+                        alpha = alpha_per_tok[has_match] if args.ngram_entropy else args.ngram_alpha
+                        seg_model_p[has_match] = (1.0 - alpha) * seg_model_p[has_match] + alpha * best_p_ng[has_match]
+                    seg_nll_np = -np.log(np.clip(seg_model_p, 1e-12, 1.0))
+
+                    # Legal score-first update: update every order only after scoring.
+                    for oi in range(n_orders):
+                        data = order_data[oi]
+                        if data is None:
+                            continue
+                        _, ctx_key, full_key = data
+                        np.add.at(ctx_tables[oi], ctx_key, 1)
+                        np.add.at(full_tables[oi], full_key, 1)
+
+                    scored_nll = torch.from_numpy(seg_nll_np).to(dtype=torch.float64, device=device)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+def _unbank_state_dict(banked_sd: dict[str, Tensor], num_layers: int) -> dict[str, Tensor]:
+    """Convert banked 3D params to per-layer 2D params for GPTQ/serialization."""
+    out = {}
+    n = num_layers
+    for name, t in banked_sd.items():
+        if name == "qo_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_q.weight"] = t[i]
+                out[f"blocks.{i}.attn.proj.weight"] = t[n + i]
+        elif name == "kv_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_k.weight"] = t[i]
+                out[f"blocks.{i}.attn.c_v.weight"] = t[n + i]
+        elif name == "mlp_up_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.fc.weight"] = t[i]
+        elif name == "mlp_down_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.proj.weight"] = t[i]
+        else:
+            out[name] = t
+    return out
+def _rebank_state_dict(unbanked_sd: dict[str, Tensor], num_layers: int) -> dict[str, Tensor]:
+    """Convert per-layer 2D params back to banked 3D params."""
+    out = {}
+    n = num_layers
+    qo_slices, kv_slices, up_slices, down_slices = [], [], [], []
+    for name, t in unbanked_sd.items():
+        if ".attn.c_q.weight" in name or ".attn.c_k.weight" in name or \
+           ".attn.c_v.weight" in name or ".attn.proj.weight" in name or \
+           ".mlp.fc.weight" in name or ".mlp.proj.weight" in name:
+            continue  # handled below
+        out[name] = t
+    for i in range(n):
+        qo_slices.append(unbanked_sd[f"blocks.{i}.attn.c_q.weight"])
+    for i in range(n):
+        qo_slices.append(unbanked_sd[f"blocks.{i}.attn.proj.weight"])
+    for i in range(n):
+        kv_slices.append(unbanked_sd[f"blocks.{i}.attn.c_k.weight"])
+    for i in range(n):
+        kv_slices.append(unbanked_sd[f"blocks.{i}.attn.c_v.weight"])
+    for i in range(n):
+        up_slices.append(unbanked_sd[f"blocks.{i}.mlp.fc.weight"])
+    for i in range(n):
+        down_slices.append(unbanked_sd[f"blocks.{i}.mlp.proj.weight"])
+    out["qo_bank"] = torch.stack(qo_slices)
+    out["kv_bank"] = torch.stack(kv_slices)
+    out["mlp_up_bank"] = torch.stack(up_slices)
+    out["mlp_down_bank"] = torch.stack(down_slices)
+    return out
+def gptq_calibrate(calib_model: nn.Module, train_pattern: str, rank: int, world_size: int,
+                   device: torch.device, num_batches: int = 256,
+                   batch_tokens: int = 786432, seq_len: int = 2048) -> dict[str, Tensor]:
+    """Collect Hessian H = X^T X using training batches. Accumulates on GPU for speed."""
+    hessians: dict[str, Tensor] = {}
+    hooks = []
+    grad_accum_steps = max(1, 8 // world_size)
+    # Pre-initialize Hessians on GPU for fast accumulation
+    for name, module in calib_model.named_modules():
+        if isinstance(module, (nn.Linear, CastedLinear)):
+            cols = module.weight.shape[1]
+            hessians[name] = torch.zeros(cols, cols, dtype=torch.float32, device=device)
+    def make_hook(name: str):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            hessians[name] += x.t() @ x
+        return hook_fn
+    for name, module in calib_model.named_modules():
+        if isinstance(module, (nn.Linear, CastedLinear)):
+            hooks.append(module.register_forward_hook(make_hook(name)))
+    loader = DistributedTokenLoader(train_pattern, rank, world_size, device)
+    calib_model.eval()
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        for _ in range(num_batches):
+            x, y = loader.next_batch(batch_tokens, seq_len, grad_accum_steps)
+            calib_model(x, y)
+    for h in hooks:
+        h.remove()
+    # Move to CPU, normalize, and add damping
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / num_batches
+        damp = 0.01 * torch.diag(hessians[name]).mean().clamp_min(1e-6)
+        hessians[name] += damp * torch.eye(hessians[name].shape[0])
+    calib_model.train()
+    return hessians
+def gptq_quantize_weight(W: Tensor, H: Tensor, clip_range: int = 31,
+                          block_size: int = 128, percdamp: float = 0.01) -> tuple[Tensor, Tensor]:
+    """GPTQ quantize weight W using Hessian H — reference implementation.
+    Uses actorder (descending Hessian diagonal), Cholesky of H^{-1}, and multi-scale search."""
+    W_orig = W.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+    # Kill dead columns
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    # Damping
+    damp = percdamp * H.diag().mean()
+    H.diagonal().add_(damp)
+    # Actorder: process most important (highest activation) columns first
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    # Cholesky of H^{-1} (per GPTQ Algorithm 1)
+    try:
+        Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+        Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    except torch.linalg.LinAlgError:
+        return quantize_int6_per_row(W_orig, clip_range)
+    best_q, best_scale, best_err = None, None, float('inf')
+    for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+        if pct < 1.0:
+            row_clip = torch.quantile(W_orig.abs(), pct, dim=1)
+        else:
+            row_clip = W_orig.abs().amax(dim=1)
+        s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+        sf = s.float()
+        Q = torch.zeros(rows, cols, dtype=torch.int8)
+        W_work = W_perm.clone()
+        for i1 in range(0, cols, block_size):
+            i2 = min(i1 + block_size, cols)
+            W_block = W_work[:, i1:i2].clone()
+            Hinv_block = Hinv[i1:i2, i1:i2]
+            Err = torch.zeros(rows, i2 - i1)
+            for j in range(i2 - i1):
+                w_col = W_block[:, j]
+                d = Hinv_block[j, j]
+                q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+                Q[:, i1 + j] = q_col.to(torch.int8)
+                err = (w_col - q_col.float() * sf) / d
+                Err[:, j] = err
+                W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+            if i2 < cols:
+                W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+        recon = Q.float() * sf[:, None]
+        mse = (W_perm - recon).pow(2).mean().item()
+        if mse < best_err:
+            best_q, best_scale, best_err = Q, s, mse
+    best_q = best_q[:, invperm]
+    return best_q, best_scale
+def _find_best_row_scales(W: Tensor, clip_range: int = 31) -> Tensor:
+    t32 = W.float()
+    best_s = t32.abs().amax(dim=1) / clip_range
+    best_s = best_s.clamp_min(1.0 / clip_range)
+    best_err = torch.full((t32.shape[0],), float('inf'))
+    for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+        if pct < 1.0:
+            row_clip = torch.quantile(t32.abs(), pct, dim=1)
+        else:
+            row_clip = t32.abs().amax(dim=1)
+        s = (row_clip / clip_range).clamp_min(1.0 / clip_range)
+        q = torch.clamp(torch.round(t32 / s[:, None]), -clip_range, clip_range)
+        recon = q * s[:, None]
+        err = (t32 - recon).pow(2).mean(dim=1)
+        improved = err < best_err
+        best_s[improved] = s[improved]
+        best_err[improved] = err[improved]
+    return best_s
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+def quantize_int6_per_row(t: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        best_q, best_s, best_err = None, None, float('inf')
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            if pct < 1.0:
+                row_clip = torch.quantile(t32.abs(), pct, dim=1)
+            else:
+                row_clip = t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+            recon = q.float() * s.float()[:, None]
+            err = (t32 - recon).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_s, best_err = q, s, err
+        return best_q, best_s
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str],
+                        hessians: dict[str, Tensor] | None = None):
+    num_layers_total = max(
+        (int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")),
+        default=0,
+    ) + 1
+    late_k_layers = set(range(num_layers_total - 2, num_layers_total))
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    gptq_count, naive_count = 0, 0
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            # Try GPTQ if Hessian available for this layer
+            module_name = name.rsplit(".weight", 1)[0] if name.endswith(".weight") else name
+            H = hessians.get(module_name) if hessians else None
+            if H is not None and t.ndim == 2:
+                q, s = gptq_quantize_weight(t, H.cpu())
+                gptq_count += 1
+            else:
+                q, s = quantize_int6_per_row(t)
+                naive_count += 1
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    print(f"gptq_quantize: {gptq_count} GPTQ layers, {naive_count} naive layers", flush=True)
+    return result, meta
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+def main() -> None:
+    global zeropower_via_newtonschulz5
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    effective_eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+    CastedLinear._qat_enabled = args.qat_enabled
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=args.mtp_num_heads,
+        mtp_loss_weight=args.mtp_loss_weight,
+        bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims,
+        ln_scale=args.ln_scale,
+        dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled,
+        ve_dim=args.ve_dim,
+        ve_layers=args.ve_layers,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    # Bank parameters in float32 for optimizer
+    base_model.qo_bank.data = base_model.qo_bank.data.float()
+    base_model.kv_bank.data = base_model.kv_bank.data.float()
+    base_model.mlp_up_bank.data = base_model.mlp_up_bank.data.float()
+    base_model.mlp_down_bank.data = base_model.mlp_down_bank.data.float()
+    restore_low_dim_params_to_fp32(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    # No DDP — Parallel Muon handles bank communication via reduce-scatter,
+    # non-bank grads are manually all-reduced before Adam steps.
+    model = compiled_model
+    block_named_params = list(base_model.blocks.named_parameters())
+    # 4 bank parameters -> Muon (batched Newton-Schulz)
+    matrix_params = [
+        base_model.qo_bank, base_model.kv_bank,
+        base_model.mlp_up_bank, base_model.mlp_down_bank,
+    ]
+    # Everything else in blocks -> Adam (all block params are scalar/control now)
+    extra_adam_2d = []
+    if base_model.mtp_num_heads > 0:
+        extra_adam_2d.extend([p for p in base_model.mtp_heads.parameters() if p.ndim == 2])
+    scalar_params = [p for _, p in block_named_params]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_params.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None:
+            extra_adam_2d.append(base_model.bigram.proj.weight)
+    if base_model.ve_shared is not None:
+        tok_params.append({"params": [base_model.ve_shared.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.ve_shared.proj is not None:
+            extra_adam_2d.append(base_model.ve_shared.proj.weight)
+        scalar_params.append(base_model.ve_shared.scale)
+        for s in base_model.ve_layer_scales:
+            scalar_params.append(s)
+    scalar_params.extend(extra_adam_2d)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    optimizer_head = None
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+    # Non-bank params that need manual all-reduce (no DDP)
+    replicated_params: list[nn.Parameter] = []
+    for pg in optimizer_tok.param_groups:
+        replicated_params.extend(pg["params"])
+    replicated_params.extend(scalar_params)
+    if base_model.lm_head is not None:
+        replicated_params.append(base_model.lm_head.weight)
+    # Pre-allocate flat buffer for single all-reduce (avoids 60+ per-param calls)
+    rep_total = sum(p.numel() for p in replicated_params)
+    rep_grad_buf = torch.zeros(rep_total, device=device, dtype=torch.bfloat16) if distributed else None
+    n_params = sum(p.numel() for p in base_model.parameters())
+    mtp_params = sum(p.numel() for p in base_model.mtp_heads.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"mtp_num_heads:{args.mtp_num_heads} mtp_loss_weight:{args.mtp_loss_weight} mtp_params:{mtp_params}")
+    xsa_layers = [i for i, b in enumerate(base_model.blocks) if b.attn.use_xsa]
+    log0(f"XSA:last_{args.xsa_last_n} active_layers:{xsa_layers}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    # Reserve time within training budget for GPTQ calibration (must fit in 600s total)
+    gptq_reserve_ms = 14000.0
+    train_budget_ms = (max_wallclock_ms - gptq_reserve_ms) if max_wallclock_ms else None
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if train_budget_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        if step < 50:
+            step_ms = min(step_ms, 150.0)  # protect against first-step compilation spike
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(train_budget_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            # Warmup: simple all-reduce for all grads (not optimized)
+            if distributed:
+                for p in base_model.parameters():
+                    if p.grad is not None:
+                        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    ema_decay = 0.997
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        if args.late_qat_threshold > 0 and scale < args.late_qat_threshold and not CastedLinear._qat_enabled:
+            CastedLinear._qat_enabled = True
+            log0(f"late_qat:enabled step:{step} scale:{scale:.4f}")
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        # === 3-phase overlapped optimizer step ===
+        # Phase 1: Launch async reduce-scatter for Muon banks
+        optimizer_muon.launch_reduce_scatters()
+        # Phase 2: All-reduce non-bank grads + step Adam (while RS is in-flight)
+        if distributed:
+            off = 0
+            for p in replicated_params:
+                n = p.numel()
+                rep_grad_buf[off:off+n].copy_(p.grad.reshape(-1).bfloat16() if p.grad is not None else rep_grad_buf[off:off+n].zero_())
+                off += n
+            dist.all_reduce(rep_grad_buf, op=dist.ReduceOp.AVG)
+            off = 0
+            for p in replicated_params:
+                n = p.numel()
+                if p.grad is not None:
+                    p.grad.copy_(rep_grad_buf[off:off+n].reshape(p.shape).to(dtype=p.dtype))
+                off += n
+        optimizer_tok.step()
+        optimizer_scalar.step()
+        if optimizer_head is not None:
+            optimizer_head.step()
+        # Phase 3: Wait for RS, local batched NS5, all-gather (banks last)
+        optimizer_muon.step()
+        zero_grad_all()
+        # EMA update
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(t.detach().float(), alpha=1.0 - ema_decay)
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        if args.swa_enabled and scale < 0.2 and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+        reached_cap = train_budget_ms is not None and approx_training_time_ms >= train_budget_ms
+        if distributed and train_budget_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+    # Apply EMA weights (better than SWA alone per PR#401)
+    log0("ema:applying EMA weights")
+    current_state = base_model.state_dict()
+    avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+    base_model.load_state_dict(avg_state, strict=True)
+    torch.cuda.synchronize()
+    t_diag = time.perf_counter()
+    diag_val_loss, diag_val_bpb = eval_val(
+        args, compiled_model, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"DIAGNOSTIC post_ema val_loss:{diag_val_loss:.4f} val_bpb:{diag_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_diag):.0f}ms"
+    )
+    full_state_dict = base_model.state_dict()
+    export_sd = {k: v for k, v in full_state_dict.items() if "mtp_heads" not in k}
+    excluded_mtp = sum(int(t.numel()) for k, t in full_state_dict.items() if "mtp_heads" in k)
+    if excluded_mtp > 0:
+        log0(f"export_excluding_mtp_params:{excluded_mtp}")
+    if master_process:
+        torch.save(export_sd, "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    # Unbank state dict for GPTQ and serialization
+    unbanked_sd = _unbank_state_dict(sd_cpu, args.num_layers)
+    # GPTQ calibration: build non-banked model for Hessian collection
+    log0("gptq:building calibration model...")
+    t_gptq = time.perf_counter()
+    calib_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n, rope_dims=args.rope_dims, ln_scale=args.ln_scale,
+        ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+        use_banks=False,
+    ).to(device).bfloat16()
+    for m in calib_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(calib_model)
+    calib_model.load_state_dict(
+        {k: v.to(device) for k, v in unbanked_sd.items() if k in calib_model.state_dict()},
+        strict=False,
+    )
+    log0("gptq:calibrating with 64 training batches...")
+    gptq_hessians = gptq_calibrate(calib_model, args.train_files, rank, world_size, device,
+                                    num_batches=64, batch_tokens=args.train_batch_tokens, seq_len=args.train_seq_len)
+    gptq_elapsed_s = time.perf_counter() - t_gptq
+    log0(f"gptq:calibrated {len(gptq_hessians)} layers in {gptq_elapsed_s:.1f}s")
+    total_compute_ms = training_time_ms + gptq_elapsed_s * 1000.0
+    log0(f"gptq:budget_check train:{training_time_ms:.0f}ms + gptq:{gptq_elapsed_s*1000:.0f}ms = {total_compute_ms:.0f}ms (budget:{max_wallclock_ms:.0f}ms)")
+    del calib_model
+    torch.cuda.empty_cache()
+    quant_result, quant_meta = mixed_quantize_int6(unbanked_sd, {"mlp", "attn"}, gptq_hessians)
+    code_bytes = len(code.encode("utf-8"))
+    target_mb = float(os.environ.get("TARGET_MB", "15.9"))
+    target_bytes = int(target_mb * 1024 * 1024)
+    # Selective ±1 pruning: zero least-impactful |q|=1 entries to fit target (PR #609)
+    ones_info = []  # (tensor_key, flat_idx, error=scale²)
+    for name, info in quant_meta.items():
+        if not (isinstance(info, dict) and info.get("type") == "int6"):
+            continue
+        qk, sk = name + ".q", name + ".scale"
+        if qk not in quant_result or sk not in quant_result:
+            continue
+        q, s = quant_result[qk], quant_result[sk]
+        if s.ndim > 0:
+            ones_mask = (q.abs() == 1)
+            if ones_mask.any():
+                row_idx = torch.arange(q.shape[0]).unsqueeze(1).expand_as(q)[ones_mask]
+                flat_idx = torch.arange(q.numel()).reshape(q.shape)[ones_mask]
+                errors = s.float()[row_idx].pow(2)
+                for fi, err in zip(flat_idx.tolist(), errors.tolist()):
+                    ones_info.append((qk, fi, err))
+    ones_info.sort(key=lambda x: x[2])  # sort by error ascending (prune least impactful first)
+    def _compress_artifact(qr):
+        buf = io.BytesIO()
+        torch.save({"w": qr, "m": quant_meta}, buf)
+        raw = buf.getvalue()
+        blob = lzma.compress(raw, preset=6)
+        return len(blob) + code_bytes, blob
+    def _try_prune(n):
+        tmp = {k: v.clone() for k, v in quant_result.items()}
+        for i in range(min(n, len(ones_info))):
+            tmp[ones_info[i][0]].view(-1)[ones_info[i][1]] = 0
+        return _compress_artifact(tmp)
+    unpruned_size, quant_blob = _compress_artifact(quant_result)
+    log0(f"selective_prune: {len(ones_info)} ±1 candidates, unpruned={unpruned_size/(1024*1024):.2f}MB target={target_mb}MB")
+    if unpruned_size > target_bytes and ones_info:
+        full_size, _ = _try_prune(len(ones_info))
+        log0(f"selective_prune: full ±1 prune={full_size/(1024*1024):.2f}MB")
+        if full_size > target_bytes:
+            log0("selective_prune: even full prune not enough, applying all")
+            _, quant_blob = _try_prune(len(ones_info))
+            for i in range(len(ones_info)):
+                quant_result[ones_info[i][0]].view(-1)[ones_info[i][1]] = 0
+        else:
+            lo, hi = 0, len(ones_info)
+            while lo < hi:
+                mid = (lo + hi) // 2
+                sz, _ = _try_prune(mid)
+                if sz <= target_bytes:
+                    hi = mid
+                else:
+                    lo = mid + 1
+            log0(f"selective_prune: pruning {lo}/{len(ones_info)} ±1 values ({100*lo/len(ones_info):.1f}%) to fit {target_mb}MB")
+            _, quant_blob = _try_prune(lo)
+            for i in range(lo):
+                quant_result[ones_info[i][0]].view(-1)[ones_info[i][1]] = 0
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = len(quant_blob)
+        log0(f"Serialized model int6+lzma: {quant_file_bytes} bytes")
+        log0(f"Total submission size int6+lzma: {quant_file_bytes + code_bytes} bytes")
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(lzma.decompress(quant_blob_disk)),
+        map_location="cpu",
+    )
+    deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], unbanked_sd)
+    eval_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=0, mtp_loss_weight=0.0,
+        bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,  # must match training model
+        rope_dims=args.rope_dims, ln_scale=args.ln_scale, dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+        use_banks=False,  # eval uses non-banked (per-layer) weights from quantized artifact
+    ).to(device).bfloat16()
+    for m in eval_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(eval_model)
+    eval_model.load_state_dict(deq_state, strict=True)
+    compiled_eval = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args, compiled_eval, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        eval_seq_len=effective_eval_seq_len,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+    sw_seq_len = effective_eval_seq_len
+    if args.eval_stride > 0 and args.eval_stride < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride,
+            eval_seq_len=sw_seq_len,
+            use_ngram=False,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+        if not args.ngram_cache:
+            log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+        if args.ngram_cache:
+            # Run 1: Multi-order backoff with FIXED alpha (safest legal variant)
+            saved_entropy = args.ngram_entropy
+            args.ngram_entropy = False
+            torch.cuda.synchronize()
+            t_ng_fixed = time.perf_counter()
+            ng_fixed_loss, ng_fixed_bpb = eval_val_sliding(
+                args, eval_model, rank, world_size, device,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+                stride=args.eval_stride,
+                eval_seq_len=sw_seq_len,
+                use_ngram=True,
+            )
+            torch.cuda.synchronize()
+            log0(
+                f"final_ngram_fixed_alpha val_loss:{ng_fixed_loss:.4f} val_bpb:{ng_fixed_bpb:.4f} "
+                f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_ng_fixed):.0f}ms"
+            )
+            log0(f"final_ngram_fixed_alpha_exact val_loss:{ng_fixed_loss:.8f} val_bpb:{ng_fixed_bpb:.8f}")
+            # Run 2: Multi-order backoff with ENTROPY-ADAPTIVE alpha (strongest variant)
+            args.ngram_entropy = True
+            torch.cuda.synchronize()
+            t_ng_ent = time.perf_counter()
+            ng_ent_loss, ng_ent_bpb = eval_val_sliding(
+                args, eval_model, rank, world_size, device,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+                stride=args.eval_stride,
+                eval_seq_len=sw_seq_len,
+                use_ngram=True,
+            )
+            torch.cuda.synchronize()
+            log0(
+                f"final_ngram_entropy_adaptive val_loss:{ng_ent_loss:.4f} val_bpb:{ng_ent_bpb:.4f} "
+                f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_ng_ent):.0f}ms"
+            )
+            log0(f"final_ngram_entropy_adaptive_exact val_loss:{ng_ent_loss:.8f} val_bpb:{ng_ent_bpb:.8f}")
+            args.ngram_entropy = saved_entropy
+            # Use best legal result for the canonical score
+            log0(f"final_int8_zlib_roundtrip_exact val_loss:{ng_fixed_loss:.8f} val_bpb:{ng_fixed_bpb:.8f}")
+    if args.eval_stride != 64 and 64 < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide64 = time.perf_counter()
+        sw64_val_loss, sw64_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=64,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window_s64 val_loss:{sw64_val_loss:.4f} val_bpb:{sw64_val_bpb:.4f} "
+            f"stride:64 eval_time:{1000.0 * (time.perf_counter() - t_slide64):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_s64_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+    if distributed:
+        dist.destroy_process_group()
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/train_seed1337.log
+++ b/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/train_seed1337.log
@@ -1,0 +1,94 @@
+logs/5ebcee5a-6195-44fd-ac97-96392552391b.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26993756
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_11 active_layers:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9309 val_bpb:4.1049 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9317 train_time:4378ms step_avg:4377.60ms
+step:2/20000 train_loss:8.6935 train_time:4424ms step_avg:2211.78ms
+step:3/20000 train_loss:7.5958 train_time:4542ms step_avg:1513.93ms
+step:4/20000 train_loss:7.3348 train_time:4622ms step_avg:1155.57ms
+step:5/20000 train_loss:7.2638 train_time:4706ms step_avg:941.22ms
+step:6/20000 train_loss:7.1177 train_time:4791ms step_avg:798.46ms
+step:7/20000 train_loss:6.9212 train_time:4875ms step_avg:696.43ms
+step:8/20000 train_loss:6.8020 train_time:4959ms step_avg:619.90ms
+step:9/20000 train_loss:6.4158 train_time:5043ms step_avg:560.33ms
+step:10/20000 train_loss:6.0441 train_time:5128ms step_avg:512.78ms
+step:500/20000 train_loss:2.3826 train_time:47394ms step_avg:94.79ms
+step:1000/20000 train_loss:2.2593 train_time:90773ms step_avg:90.77ms
+step:1500/20000 train_loss:2.2041 train_time:134284ms step_avg:89.52ms
+step:2000/20000 train_loss:2.0490 train_time:177859ms step_avg:88.93ms
+step:2500/20000 train_loss:2.1522 train_time:221478ms step_avg:88.59ms
+step:3000/20000 train_loss:2.1448 train_time:265083ms step_avg:88.36ms
+step:3500/20000 train_loss:2.1576 train_time:308683ms step_avg:88.20ms
+step:4000/20000 train_loss:1.9478 train_time:352270ms step_avg:88.07ms
+step:4000/20000 val_loss:2.0396 val_bpb:1.2080 train_time:352313ms step_avg:88.08ms
+step:4500/20000 train_loss:2.1001 train_time:395874ms step_avg:87.97ms
+step:5000/20000 train_loss:2.0820 train_time:439428ms step_avg:87.89ms
+step:5500/20000 train_loss:1.9947 train_time:482922ms step_avg:87.80ms
+swa:start step:6000
+step:6000/20000 train_loss:1.9147 train_time:526465ms step_avg:87.74ms
+late_qat:enabled step:6151 scale:0.1499
+step:6500/20000 train_loss:2.0553 train_time:570713ms step_avg:87.80ms
+step:6673/20000 val_loss:1.9219 val_bpb:1.1383 train_time:586069ms step_avg:87.83ms
+stopping_early: wallclock_cap train_time:586069ms step:6673/20000
+peak memory allocated: 22861 MiB reserved: 23032 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9203 val_bpb:1.1373 eval_time:2089ms
+Serialized model: 106158518 bytes
+Code size: 95919 bytes
+gptq:building calibration model...
+gptq:calibrating with 64 training batches...
+gptq:calibrated 68 layers in 9.8s
+gptq:budget_check train:586069ms + gptq:9839ms = 595908ms (budget:600000ms)
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+selective_prune: 4105230 ±1 candidates, unpruned=15.18MB target=15.9MB
+Serialized model int6+lzma: 15825108 bytes
+Total submission size int6+lzma: 15921027 bytes
+Total submission size int8+zlib: 15921027 bytes
+final_int6_roundtrip val_loss:1.9260 val_bpb:1.1407 eval_time:47093ms
+final_int6_roundtrip_exact val_loss:1.92601076 val_bpb:1.14069206
+final_int6_sliding_window val_loss:1.8863 val_bpb:1.1172 stride:64 eval_time:101066ms
+final_int6_sliding_window_exact val_loss:1.88632453 val_bpb:1.11719060
+ngram_cache:enabled orders=2-7 entropy=0 alpha=0.4 ent_base=0.05 ent_range=0.55 ent_scale=2.0 ent_thresh=4.0 min_count=2 buckets=4194304
+final_ngram_fixed_alpha val_loss:1.6472 val_bpb:0.9756 stride:64 eval_time:127851ms
+final_ngram_fixed_alpha_exact val_loss:1.64722756 val_bpb:0.97558353
+ngram_cache:enabled orders=2-7 entropy=1 alpha=0.4 ent_base=0.05 ent_range=0.55 ent_scale=2.0 ent_thresh=4.0 min_count=2 buckets=4194304
+final_ngram_entropy_adaptive val_loss:1.6214 val_bpb:0.9603 stride:64 eval_time:138425ms
+final_ngram_entropy_adaptive_exact val_loss:1.62136782 val_bpb:0.96026789
+final_int8_zlib_roundtrip_exact val_loss:1.64722756 val_bpb:0.97558353

--- a/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/train_seed42.log
+++ b/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/train_seed42.log
@@ -1,0 +1,94 @@
+logs/47dfee25-7a9b-45f7-a238-2fe14d29a6c3.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26993756
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_11 active_layers:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:42
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9297 val_bpb:4.1042 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9319 train_time:546ms step_avg:546.24ms
+step:2/20000 train_loss:8.6636 train_time:591ms step_avg:295.59ms
+step:3/20000 train_loss:7.6340 train_time:675ms step_avg:225.12ms
+step:4/20000 train_loss:7.3769 train_time:759ms step_avg:189.66ms
+step:5/20000 train_loss:7.2664 train_time:843ms step_avg:168.59ms
+step:6/20000 train_loss:7.0296 train_time:927ms step_avg:154.44ms
+step:7/20000 train_loss:6.8710 train_time:1011ms step_avg:144.38ms
+step:8/20000 train_loss:6.8219 train_time:1094ms step_avg:136.75ms
+step:9/20000 train_loss:6.4674 train_time:1178ms step_avg:130.86ms
+step:10/20000 train_loss:6.0497 train_time:1262ms step_avg:126.17ms
+step:500/20000 train_loss:2.4032 train_time:43523ms step_avg:87.05ms
+step:1000/20000 train_loss:2.2646 train_time:86926ms step_avg:86.93ms
+step:1500/20000 train_loss:2.2106 train_time:130404ms step_avg:86.94ms
+step:2000/20000 train_loss:2.0506 train_time:173958ms step_avg:86.98ms
+step:2500/20000 train_loss:2.1566 train_time:217506ms step_avg:87.00ms
+step:3000/20000 train_loss:2.1446 train_time:261073ms step_avg:87.02ms
+step:3500/20000 train_loss:2.1607 train_time:304636ms step_avg:87.04ms
+step:4000/20000 train_loss:1.9533 train_time:348146ms step_avg:87.04ms
+step:4000/20000 val_loss:2.0423 val_bpb:1.2095 train_time:348190ms step_avg:87.05ms
+step:4500/20000 train_loss:2.1023 train_time:391670ms step_avg:87.04ms
+step:5000/20000 train_loss:2.0821 train_time:435221ms step_avg:87.04ms
+step:5500/20000 train_loss:1.9951 train_time:478743ms step_avg:87.04ms
+step:6000/20000 train_loss:1.9215 train_time:522270ms step_avg:87.04ms
+swa:start step:6050
+late_qat:enabled step:6204 scale:0.1498
+step:6500/20000 train_loss:2.0558 train_time:566428ms step_avg:87.14ms
+step:6722/20000 val_loss:1.9218 val_bpb:1.1382 train_time:586067ms step_avg:87.19ms
+stopping_early: wallclock_cap train_time:586067ms step:6722/20000
+peak memory allocated: 22851 MiB reserved: 23004 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9202 val_bpb:1.1373 eval_time:2088ms
+Serialized model: 106158518 bytes
+Code size: 95919 bytes
+gptq:building calibration model...
+gptq:calibrating with 64 training batches...
+gptq:calibrated 68 layers in 9.8s
+gptq:budget_check train:586067ms + gptq:9815ms = 595882ms (budget:600000ms)
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+selective_prune: 4079908 ±1 candidates, unpruned=15.19MB target=15.9MB
+Serialized model int6+lzma: 15833404 bytes
+Total submission size int6+lzma: 15929323 bytes
+Total submission size int8+zlib: 15929323 bytes
+final_int6_roundtrip val_loss:1.9259 val_bpb:1.1406 eval_time:16638ms
+final_int6_roundtrip_exact val_loss:1.92589138 val_bpb:1.14062136
+final_int6_sliding_window val_loss:1.8863 val_bpb:1.1171 stride:64 eval_time:86479ms
+final_int6_sliding_window_exact val_loss:1.88625472 val_bpb:1.11714925
+ngram_cache:enabled orders=2-7 entropy=0 alpha=0.4 ent_base=0.05 ent_range=0.55 ent_scale=2.0 ent_thresh=4.0 min_count=2 buckets=4194304
+final_ngram_fixed_alpha val_loss:1.6473 val_bpb:0.9756 stride:64 eval_time:130376ms
+final_ngram_fixed_alpha_exact val_loss:1.64728810 val_bpb:0.97561938
+ngram_cache:enabled orders=2-7 entropy=1 alpha=0.4 ent_base=0.05 ent_range=0.55 ent_scale=2.0 ent_thresh=4.0 min_count=2 buckets=4194304
+final_ngram_entropy_adaptive val_loss:1.6214 val_bpb:0.9603 stride:64 eval_time:141580ms
+final_ngram_entropy_adaptive_exact val_loss:1.62140537 val_bpb:0.96029013
+final_int8_zlib_roundtrip_exact val_loss:1.64728810 val_bpb:0.97561938

--- a/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/train_seed7.log
+++ b/records/track_10min_16mb/2026-03-25_11L_FullGPTQ_NgramBackoff_0.9757/train_seed7.log
@@ -1,0 +1,98 @@
+W0325 18:20:30.790000 137733 torch/distributed/run.py:766] 
+W0325 18:20:30.790000 137733 torch/distributed/run.py:766] *****************************************
+W0325 18:20:30.790000 137733 torch/distributed/run.py:766] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0325 18:20:30.790000 137733 torch/distributed/run.py:766] *****************************************
+logs/f86a9d98-ef2b-41f9-9313-75b18db528df.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26993756
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_11 active_layers:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:7
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9296 val_bpb:4.1041 train_time:0ms step_avg:0.03ms
+step:1/20000 train_loss:6.9310 train_time:553ms step_avg:552.56ms
+step:2/20000 train_loss:8.7435 train_time:597ms step_avg:298.72ms
+step:3/20000 train_loss:7.6071 train_time:681ms step_avg:227.10ms
+step:4/20000 train_loss:7.2511 train_time:765ms step_avg:191.23ms
+step:5/20000 train_loss:7.0886 train_time:849ms step_avg:169.85ms
+step:6/20000 train_loss:7.0709 train_time:933ms step_avg:155.56ms
+step:7/20000 train_loss:6.9929 train_time:1017ms step_avg:145.28ms
+step:8/20000 train_loss:6.8866 train_time:1101ms step_avg:137.60ms
+step:9/20000 train_loss:6.4402 train_time:1185ms step_avg:131.69ms
+step:10/20000 train_loss:6.0426 train_time:1270ms step_avg:127.00ms
+step:500/20000 train_loss:2.3933 train_time:43557ms step_avg:87.11ms
+step:1000/20000 train_loss:2.2587 train_time:87067ms step_avg:87.07ms
+step:1500/20000 train_loss:2.2064 train_time:130684ms step_avg:87.12ms
+step:2000/20000 train_loss:2.0486 train_time:174399ms step_avg:87.20ms
+step:2500/20000 train_loss:2.1528 train_time:218079ms step_avg:87.23ms
+step:3000/20000 train_loss:2.1458 train_time:261765ms step_avg:87.26ms
+step:3500/20000 train_loss:2.1630 train_time:305465ms step_avg:87.28ms
+step:4000/20000 train_loss:1.9508 train_time:349178ms step_avg:87.29ms
+step:4000/20000 val_loss:2.0420 val_bpb:1.2094 train_time:349220ms step_avg:87.31ms
+step:4500/20000 train_loss:2.1009 train_time:392860ms step_avg:87.30ms
+step:5000/20000 train_loss:2.0832 train_time:436554ms step_avg:87.31ms
+step:5500/20000 train_loss:1.9976 train_time:480203ms step_avg:87.31ms
+step:6000/20000 train_loss:1.9201 train_time:523829ms step_avg:87.30ms
+swa:start step:6050
+late_qat:enabled step:6184 scale:0.1499
+step:6500/20000 train_loss:2.0558 train_time:568122ms step_avg:87.40ms
+step:6702/20000 val_loss:1.9229 val_bpb:1.1388 train_time:586082ms step_avg:87.45ms
+stopping_early: wallclock_cap train_time:586082ms step:6702/20000
+peak memory allocated: 22851 MiB reserved: 23004 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9212 val_bpb:1.1378 eval_time:2090ms
+Serialized model: 106158518 bytes
+Code size: 95919 bytes
+gptq:building calibration model...
+gptq:calibrating with 64 training batches...
+gptq:calibrated 68 layers in 10.2s
+gptq:budget_check train:586082ms + gptq:10180ms = 596262ms (budget:600000ms)
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+selective_prune: 4080784 ±1 candidates, unpruned=15.18MB target=15.8MB
+Serialized model int6+lzma: 15826140 bytes
+Total submission size int6+lzma: 15922059 bytes
+Total submission size int8+zlib: 15922059 bytes
+final_int6_roundtrip val_loss:1.9270 val_bpb:1.1413 eval_time:16053ms
+final_int6_roundtrip_exact val_loss:1.92697384 val_bpb:1.14126245
+final_int6_sliding_window val_loss:1.8875 val_bpb:1.1179 stride:64 eval_time:86176ms
+final_int6_sliding_window_exact val_loss:1.88747642 val_bpb:1.11787281
+ngram_cache:enabled orders=2-7 entropy=0 alpha=0.4 ent_base=0.05 ent_range=0.55 ent_scale=2.0 ent_thresh=4.0 min_count=2 buckets=4194304
+final_ngram_fixed_alpha val_loss:1.6480 val_bpb:0.9760 stride:64 eval_time:129603ms
+final_ngram_fixed_alpha_exact val_loss:1.64796347 val_bpb:0.97601938
+ngram_cache:enabled orders=2-7 entropy=1 alpha=0.4 ent_base=0.05 ent_range=0.55 ent_scale=2.0 ent_thresh=4.0 min_count=2 buckets=4194304
+final_ngram_entropy_adaptive val_loss:1.6223 val_bpb:0.9608 stride:64 eval_time:140036ms
+final_ngram_entropy_adaptive_exact val_loss:1.62229332 val_bpb:0.96081603
+final_int8_zlib_roundtrip_exact val_loss:1.64796347 val_bpb:0.97601938


### PR DESCRIPTION
## Summary

**Fixed alpha (safest): 3-seed mean val_bpb = 0.9757** (std=0.0002)
**Entropy-adaptive alpha: 3-seed mean val_bpb = 0.9605** (std=0.0003)

15.92 MB | 8xH100 SXM | Training 596s/600s

## 3-Seed Results

| Seed | Neural-only | Fixed alpha (a=0.40) | Entropy-adaptive | Artifact | GPTQ Budget |
|------|-------------|----------------------|-----------------|----------|-------------|
| 1337 | 1.11719 | **0.97558** | **0.96027** | 15,921,027 B | 596s/600s |
| 42 | 1.11715 | **0.97562** | **0.96029** | 15,929,323 B | 596s/600s |
| 7 | 1.11787 | **0.97602** | **0.96082** | 15,922,059 B | 596s/600s |
| **Mean** | **1.11740** | **0.97574** | **0.96046** | | |
| **Std** | 0.00041 | 0.00024 | 0.00031 | | |

## Two Variants

### Variant 1: Fixed alpha (safest legal)
- `NGRAM_ENTROPY=0`, constant `alpha=0.40`
- Blend: `p = 0.60 * model + 0.40 * ngram` — same weight for every token
- **3-seed mean: 0.9757**

### Variant 2: Entropy-adaptive alpha
- `NGRAM_ENTROPY=1`, `alpha = 0.05 + 0.55 * sigmoid(2 * (H - 4.0))`
- Alpha depends on model output entropy H only (never on the true token)
- **3-seed mean: 0.9605**

## Key Techniques

| Technique | Description |
|-----------|-------------|
| Full Hessian GPTQ | 64-batch calibration within 600s training budget (reserved 14s) |
| Multi-order n-gram backoff | Orders 2-7, highest available order used first |
| Fixed/entropy-adaptive blend | Model + n-gram probability interpolation |
| Backward-looking cache | Counts updated AFTER scoring each window |

## Compliance

- **Training**: 586s training + 10s GPTQ = 596s (within 600s). No training data accessed during eval.
- **GPTQ calibration**: Uses training data within reserved training budget, NOT during eval
- **Eval**: ~86s sliding + ~130s cached = ~216s (within 600s)
- **N-gram cache**: Backward-looking only, no oracle selection, no true-token peeking
- **Fixed alpha**: No data-dependent weighting whatsoever
- **Entropy-adaptive**: Depends on model output distribution only, not ground truth
- **Artifacts**: All seeds under 16,000,000 bytes

## Architecture

11L, 512d, GQA 8H/4KV, LeakyReLU(0.5)^2 MLP 3x, XSA-all, VE128, BigramHash(2048), Partial RoPE 16/64, LN Scale, SmearGate, U-Net skips, EMA(0.997), Parallel Muon, Full Hessian GPTQ int6 + LZMA.

## Ablation (seed 1337)

| Configuration | val_bpb | Delta |
|---------------|---------|-------|
| Neural-only (no cache) | 1.1172 | baseline |
| Fixed 7-gram only, alpha=0.40 | 1.0258 | -0.0914 |
| Multi-order backoff (2-7), fixed alpha | 0.9756 | -0.1416 |
| Multi-order backoff (2-7), entropy-adaptive | 0.9603 | -0.1569 |

## Credits

- Base: PR #609 @saml212, PR #593 @abaybektursun
- N-gram cache: PR #715, PR #727