### PR TITLE
Non-record: Depth Recurrence + TTT + Gradient Checkpointing

### DIFF
--- a/records/track_non_record_16mb/2026-03-25_DepthRecurrence_TTT_GradCheckpoint/README.md
+++ b/records/track_non_record_16mb/2026-03-25_DepthRecurrence_TTT_GradCheckpoint/README.md
@@ -1,0 +1,106 @@
+# Non-Record Submission: Depth Recurrence + TTT + Gradient Checkpointing
+
+This is a non-record submission exploring **depth-recurrent transformers** with test-time training (TTT) for the Parameter Golf challenge. The architecture uses 3 unique transformer blocks looped 4 times (12 effective layers) with U-Net skip connections, achieving parameter efficiency through weight sharing while maintaining representational depth.
+
+**Status:** Partial results — the 8xH100 benchmark run was interrupted by a RunPod spend limit before final evaluation. We are applying for additional compute credits to complete the 3-run statistical significance requirement.
+
+## Architecture: Depth-Recurrent Transformer
+
+Instead of 12 independent transformer layers, we use **3 unique blocks repeated 4 times** in a U-Net encoder-decoder structure:
+
+- **Encoder half (6 layers):** Store skip connections at each layer
+- **Decoder half (6 layers):** Consume skip connections in reverse with learned skip weights
+- **Per-iteration differentiation:** Separate RMSNorm parameters and low-rank level signals per effective layer distinguish each loop iteration
+- **Weight sharing:** The 3 core blocks (attention + MLP) are shared across all 4 loops
+
+This gives 12 effective layers of depth while only storing 3 blocks worth of unique attention/MLP weights, freeing parameter budget for other components.
+
+### Additional Features
+
+- **BigramHash embeddings:** Hash-based bigram features (10240×128) for local context
+- **SmearGate:** Learned gating on the input representation
+- **Test-Time Training (TTT):** Optional adaptation on already-evaluated validation tokens during sliding window eval
+- **Stochastic Weight Averaging (SWA):** Running average of weights during warmdown phase
+- **Sliding Window Evaluation:** Stride-64 evaluation for accurate bpb scoring
+
+## Key Technical Challenges & Solutions
+
+### 1. torch.compile + DDP Incompatibility (NaN)
+
+**Problem:** `torch.compile(fullgraph=True)` combined with DDP produces NaN on the first training step for depth-recurrent architectures. The compiled graph's unrolled loops interact incorrectly with DDP's gradient synchronization hooks.
+
+**Solution:** Use gradient checkpointing instead of torch.compile for DDP training. Each layer's forward pass is wrapped in `torch.utils.checkpoint.checkpoint`, trading ~2x compute for memory efficiency. torch.compile is re-enabled after training for fast evaluation (where DDP is not needed).
+
+### 2. Step-0 Validation Hang
+
+**Problem:** The original code runs validation at step 0 (before any training) because `0 % val_loss_every == 0`. With sliding window eval (stride=64), this creates ~969k forward passes that take 20+ minutes on a single GPU.
+
+**Solution:** Skip validation at step 0 (`step > 0` guard). Use full-stride (fast) evaluation during training, sliding window only for the final evaluation.
+
+### 3. Progressive Loop Training + Warmup Ordering
+
+**Problem:** Progressive loop training (starting with 2 loops, ramping to 4) was configured *after* warmup, causing torch.compile to cache the wrong graph during warmup.
+
+**Solution:** Move progressive loop setup before warmup. Disable progressive loops under DDP (changing loop count creates unused parameters incompatible with DDP).
+
+## Results
+
+### Complete 1xH100 Test (progressive loops enabled, torch.compile)
+
+| Metric | Value |
+|--------|-------|
+| Steps | 52 |
+| Wallclock | 90s |
+| val_loss (pre-quant) | 5.7435 |
+| val_bpb (pre-quant) | 3.4016 |
+| val_bpb (post-quant, int8+zstd) | 3.5041 |
+| Peak memory | ~18 GB |
+| Step avg | 1,745 ms |
+
+### Partial 8xH100 Benchmark (gradient checkpointing, no compile)
+
+| Metric | Value |
+|--------|-------|
+| Steps completed | 300+ (interrupted) |
+| Wallclock at interruption | ~536s / 600s |
+| train_loss at step 300 | 2.4452 |
+| Step avg | ~1,786 ms |
+| Peak memory per GPU | ~18 GB |
+
+Training was converging well (loss: 26 → 2.45 over 300 steps) when RunPod terminated the pod due to account spend limits. The learning rate warmdown had not yet activated, suggesting further improvement was likely.
+
+### Quick 8xH100 Sanity Test (30s)
+
+| Metric | Value |
+|--------|-------|
+| Steps | 33 |
+| val_bpb | 4.5392 |
+| Step avg | 931 ms |
+
+## Configuration
+
+```
+NUM_UNIQUE_BLOCKS=3  NUM_LOOPS=4  (12 effective layers)
+MODEL_DIM=512  NUM_HEADS=32  NUM_KV_HEADS=4  MLP_MULT=2
+VOCAB_SIZE=1024  TRAIN_SEQ_LEN=2048  TRAIN_BATCH_TOKENS=524288
+EMBED_LR=0.05  MATRIX_LR=0.04  SCALAR_LR=0.04
+SWA_START_FRAC=0.6  EVAL_STRIDE=64
+WARMUP_STEPS=50  WARMDOWN_ITERS=1200  MAX_WALLCLOCK_SECONDS=600
+```
+
+- Model params: 107,911,265
+- DDP: gradient checkpointing (no torch.compile during training)
+- Post-training: torch.compile enabled for fast evaluation
+
+## What's Needed to Complete
+
+1. **3 full 8xH100 runs** with different seeds for statistical significance
+2. Final post-quantization val_bpb scores
+3. Artifact size verification (int8+zstd under 16MB)
+
+We are applying for an OpenAI compute grant to complete these runs.
+
+## Included Files
+
+- `train_gpt_recurrent.py` — Full training script with all fixes
+- `submission.json` — Leaderboard metadata

--- a/records/track_non_record_16mb/2026-03-25_DepthRecurrence_TTT_GradCheckpoint/submission.json
+++ b/records/track_non_record_16mb/2026-03-25_DepthRecurrence_TTT_GradCheckpoint/submission.json
@@ -1,0 +1,19 @@
+{
+    "author": "Agustin Blaumann",
+    "github_id": "blaumannagustin",
+    "name": "Depth Recurrence + TTT + Gradient Checkpointing",
+    "blurb": "Non-record submission exploring depth-recurrent transformers (3 unique blocks x 4 loops = 12 effective layers) with U-Net skip connections, test-time training, SWA, and gradient checkpointing for DDP compatibility. Partial 8xH100 run demonstrated convergence to train_loss 2.45 in 300 steps before being interrupted. Complete 1xH100 test achieved val_bpb 3.50 in 90 seconds with progressive loop training.",
+    "date": "2026-03-25T00:00:00Z",
+    "track": "non-record-16mb",
+    "val_loss": null,
+    "val_bpb": null,
+    "pre_quant_val_loss": 5.7435,
+    "pre_quant_val_bpb": 3.4016,
+    "step_stop": 300,
+    "wallclock_seconds": 536,
+    "bytes_total": null,
+    "bytes_model_int8_zlib": null,
+    "bytes_code": null,
+    "gpu": "8xH100 SXM (partial), 1xH100 SXM (complete)",
+    "notes": "Run interrupted by RunPod spend limit before final eval. 3-run statistical significance pending additional compute credits."
+}

--- a/records/track_non_record_16mb/2026-03-25_DepthRecurrence_TTT_GradCheckpoint/train_gpt_recurrent.py
+++ b/records/track_non_record_16mb/2026-03-25_DepthRecurrence_TTT_GradCheckpoint/train_gpt_recurrent.py
@@ -1,0 +1,1540 @@
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: To keep readable for newcomers, let's make sure `train_gpt.py` and `train_gpt_mlx.py` never are longer than 1500 lines.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+import zstandard as zstd
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Sliding window evaluation: stride < seq_len gives overlapping windows.
+    # Only the last `stride` tokens of each window are scored, but they get
+    # the full seq_len of context. stride=0 disables (uses non-overlapping).
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+
+    # Test-time training: adapt model on each eval window before scoring.
+    # ttt_steps=0 disables TTT. Higher values = more adaptation per window.
+    ttt_steps = int(os.environ.get("TTT_STEPS", 3))
+    ttt_lr = float(os.environ.get("TTT_LR", 1e-4))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 50))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Stochastic Weight Averaging: start averaging weights after this fraction
+    # of total training. 0.6 means SWA kicks in at 60% through training.
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.6))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 2048))
+    num_heads = int(os.environ.get("NUM_HEADS", 32))
+    mlp_mult = int(os.environ.get("MLP_MULT", 3))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+
+    # BigramHash: hash-based bigram embeddings for local context.
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 10240))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+
+    # SmearGate: blend each token with previous token via learned gate.
+    use_smeargate = bool(int(os.environ.get("USE_SMEARGATE", "1")))
+
+    # Level signal rank for input-dependent signals (0 = static vectors).
+    level_signal_rank = int(os.environ.get("LEVEL_SIGNAL_RANK", 8))
+
+    # Progressive loop training: start with fewer loops, ramp up.
+    # 0.0 = disabled, 0.3 = start ramping at 30% of training.
+    progressive_loop_start = float(os.environ.get("PROGRESSIVE_LOOP_START", 0.3))
+
+    # Depth recurrence: num_unique_blocks unique blocks, each looped num_loops times.
+    # Effective depth = num_unique_blocks * num_loops.
+    num_unique_blocks = int(os.environ.get("NUM_UNIQUE_BLOCKS", 3))
+    num_loops = int(os.environ.get("NUM_LOOPS", 4))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_weight_decay = float(os.environ.get("MUON_WEIGHT_DECAY", 0.06))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 1.0))
+
+# -----------------------------
+# MUON OPTIMIZER 
+# -----------------------------
+# 
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, weight_decay=weight_decay),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+
+            # Decoupled weight decay (applied before Muon update).
+            if wd > 0.0:
+                for p in params:
+                    p.data.mul_(1.0 - lr * wd)
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride_override: int | None = None,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    #
+    # When eval_stride > 0 and < seq_len, uses sliding window evaluation:
+    # each window is seq_len tokens, but only the last `stride` positions are
+    # scored. This gives every scored token the full context window, improving
+    # bpb at the cost of more forward passes.
+    seq_len = args.train_seq_len
+    if stride_override is not None:
+        stride = stride_override
+    else:
+        stride = args.eval_stride if args.eval_stride > 0 else seq_len
+    if stride > seq_len:
+        stride = seq_len
+
+    total_tokens = val_tokens.numel() - 1  # -1 because we need (x, y) shift
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Build list of window start positions, then shard across ranks.
+    window_starts = list(range(0, total_tokens - seq_len + 1, stride))
+    if not window_starts:
+        window_starts = [0]
+    my_starts = window_starts[rank::world_size]
+
+    # For TTT: save original model state to restore after each window.
+    ttt_active = args.ttt_steps > 0
+    original_state = None
+    if ttt_active:
+        original_state = copy.deepcopy({k: v.cpu() for k, v in _unwrap_model(model).state_dict().items()})
+
+    model.eval()
+    num_windows = len(my_starts)
+    log_every_n = max(num_windows // 10, 1)
+    for win_idx, win_start in enumerate(my_starts):
+        win_end = win_start + seq_len
+        local = val_tokens[win_start : win_end + 1].to(
+            device=device, dtype=torch.int64, non_blocking=True
+        )
+        x = local[:-1].unsqueeze(0)  # [1, seq_len]
+        y = local[1:].unsqueeze(0)   # [1, seq_len]
+
+        # Test-time training: adapt on context prefix before scoring.
+        # We train on tokens [0..score_start) then score [score_start..seq_len).
+        # Only train on already-evaluated tokens (challenge rules).
+        if win_start == 0:
+            score_start = 0
+        else:
+            score_start = seq_len - stride
+
+        if ttt_active and score_start > 0:
+            base = _unwrap_model(model)
+            base.train()
+            ttt_opt = torch.optim.Adam(base.parameters(), lr=args.ttt_lr)
+            for _ in range(args.ttt_steps):
+                ttt_opt.zero_grad()
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    # Train on the context prefix (already evaluated tokens).
+                    ttt_loss = base(x[:, :score_start], y[:, :score_start])
+                ttt_loss.backward()
+                ttt_opt.step()
+            base.eval()
+
+        with torch.inference_mode():
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = _forward_logits(model, x)
+                per_token_loss = F.cross_entropy(
+                    logits.float().reshape(-1, logits.size(-1)),
+                    y.reshape(-1),
+                    reduction="none",
+                )
+
+        scored_losses = per_token_loss[score_start:]
+        scored_y = y[0, score_start:]
+        scored_x_prev = x[0, score_start:]
+
+        val_loss_sum += scored_losses.to(torch.float64).sum()
+        val_token_count += scored_losses.numel()
+
+        token_bytes = base_bytes_lut[scored_y].to(dtype=torch.int16)
+        token_bytes += (
+            has_leading_space_lut[scored_y] & ~is_boundary_token_lut[scored_x_prev]
+        ).to(dtype=torch.int16)
+        val_byte_count += token_bytes.to(torch.float64).sum()
+
+        if win_idx % log_every_n == 0 or win_idx == num_windows - 1:
+            print(f"  eval: {win_idx + 1}/{num_windows} windows", flush=True)
+
+        # Restore original weights after TTT adaptation for this window.
+        if ttt_active and score_start > 0 and original_state is not None:
+            base = _unwrap_model(model)
+            base.load_state_dict({k: v.to(device) for k, v in original_state.items()}, strict=True)
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+def _unwrap_model(model: nn.Module) -> nn.Module:
+    """Unwrap DDP/compiled model to get the base model."""
+    m = model
+    if hasattr(m, "module"):
+        m = m.module
+    if hasattr(m, "_orig_mod"):
+        m = m._orig_mod
+    return m
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor, is_mlp: bool = False) -> tuple[Tensor, Tensor]:
+    # Mixed precision quantization:
+    # - MLP weights: int5 range [-15, 15] (more compressible, saves bytes)
+    # - Attention weights: int6 range [-31, 31] (higher precision)
+    # Both stored in int8 containers. QAT trains with matching ranges.
+    q_min = INT5_MIN if is_mlp else INT6_MIN
+    q_max = INT5_MAX if is_mlp else INT6_MAX
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / q_max).clamp_min(1.0 / q_max)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), q_min, q_max).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / q_max if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), q_min, q_max).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        is_mlp = ".mlp." in name and (".fc." in name or ".proj." in name)
+        q, s = quantize_float_tensor(t, is_mlp=is_mlp)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int6_qat_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING 
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+# -----------------------------
+# INT6 QUANTIZATION-AWARE TRAINING (QAT)
+# -----------------------------
+# During training, weights are stored in fp32 for optimizer quality but
+# the forward pass simulates int6 quantization via a straight-through estimator.
+# This lets the model learn to be robust to 6-bit precision, so the final
+# quantized export loses minimal quality.
+
+INT6_LEVELS = 63  # int6 range: [-31, 31] = 63 levels (we use symmetric)
+INT6_MIN = -31
+INT6_MAX = 31
+INT5_MIN = -15
+INT5_MAX = 15
+
+def _fake_quantize(w: Tensor, q_min: int, q_max: int) -> Tensor:
+    """Simulate per-row symmetric quantization with straight-through estimator."""
+    if w.ndim == 2:
+        abs_max = w.abs().amax(dim=1, keepdim=True).clamp_min(1e-8)
+        scale = abs_max / q_max
+        w_q = (w / scale).round().clamp(q_min, q_max)
+        w_dq = w_q * scale
+    else:
+        abs_max = w.abs().max().clamp_min(1e-8)
+        scale = abs_max / q_max
+        w_q = (w / scale).round().clamp(q_min, q_max)
+        w_dq = w_q * scale
+    # Straight-through estimator: forward uses quantized, backward uses real.
+    return w + (w_dq - w).detach()
+
+def fake_quantize_int6(w: Tensor) -> Tensor:
+    return _fake_quantize(w, INT6_MIN, INT6_MAX)
+
+def fake_quantize_int5(w: Tensor) -> Tensor:
+    return _fake_quantize(w, INT5_MIN, INT5_MAX)
+
+
+class CastedLinear(nn.Linear):
+    # Keep weights in fp32 for optimizer/state quality.
+    # During training: simulate quantization via STE for QAT.
+    # _use_int5: set True for MLP layers (more compressible, saves bytes).
+    # At matmul time: cast to bf16 for compute.
+    _use_int5: bool = False
+
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        w = self.weight
+        if self.training:
+            w = fake_quantize_int5(w) if self._use_int5 else fake_quantize_int6(w)
+        return F.linear(x, w.to(x.dtype), bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    # relu^2 MLP from the original modded-nanogpt setup
+    # MLP weights use int5 QAT (more compressible than int6, saves bytes).
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.fc._use_int5 = True
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+        self.proj._use_int5 = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class BigramHash(nn.Module):
+    """Hash-based bigram embeddings: hashes consecutive token pairs into a learned table.
+    Gives the model bigram-level context at the embedding level before any attention."""
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        # token_ids: [batch, seq_len]
+        # Hash consecutive pairs: XOR(36313 * current, 27191 * prev) % vocab_size
+        bigram_ids = torch.zeros_like(token_ids)
+        bigram_ids[:, 1:] = (
+            torch.bitwise_xor(36313 * token_ids[:, 1:], 27191 * token_ids[:, :-1])
+            % self.bigram_vocab_size
+        )
+        bigram_emb = self.embed(bigram_ids)
+        return self.scale * self.proj(bigram_emb)
+
+
+class SmearGate(nn.Module):
+    """Blends each token with the previous token via a learned gate.
+    Provides cheap local context: out = (1-g)*x + g*x_prev."""
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.zeros_like(x)
+        x_prev[:, 1:, :] = x[:, :-1, :]
+        return (1.0 - g) * x + g * x_prev
+
+
+class LevelSignal(nn.Module):
+    """Input-dependent low-rank level signal (RingFormer-style).
+    Generates per-iteration adaptation from the input via down/up projections."""
+    def __init__(self, dim: int, rank: int):
+        super().__init__()
+        self.down = CastedLinear(dim, rank, bias=False)
+        self.up = CastedLinear(rank, dim, bias=False)
+        # Initialize up projection to near-zero so signals start small.
+        nn.init.zeros_(self.up.weight)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.up(self.down(x))
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        # Note: attn_norm and mlp_norm are NOT stored here when using per-iteration norms.
+        # They're passed in from the GPT class during forward.
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor, attn_norm: nn.Module, mlp_norm: nn.Module) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        num_unique_blocks: int = 3,
+        num_loops: int = 4,
+        bigram_vocab_size: int = 10240,
+        bigram_dim: int = 128,
+        use_smeargate: bool = True,
+        level_signal_rank: int = 8,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.num_unique_blocks = num_unique_blocks
+        self.num_loops = num_loops
+        self.max_loops = num_loops  # For progressive training: current active loops.
+        self.gradient_checkpointing = False  # Enabled at runtime for DDP without compile.
+        effective_layers = num_unique_blocks * num_loops
+
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+
+        # BigramHash: hash-based bigram embeddings for local context.
+        self.bigram_hash = BigramHash(bigram_vocab_size, bigram_dim, model_dim)
+
+        # SmearGate: blend each token with previous token.
+        self.smeargate = SmearGate(model_dim) if use_smeargate else None
+
+        # U-Net skip connection counts based on effective depth.
+        self.num_encoder_layers = effective_layers // 2
+        self.num_decoder_layers = effective_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+
+        # Only num_unique_blocks unique transformer blocks (the core of depth recurrence).
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                )
+                for _ in range(num_unique_blocks)
+            ]
+        )
+
+        # Per-iteration RMSNorm: separate norm parameters per effective layer.
+        # This differentiates each loop iteration more than shared norms.
+        self.attn_norms = nn.ModuleList([RMSNorm() for _ in range(effective_layers)])
+        self.mlp_norms = nn.ModuleList([RMSNorm() for _ in range(effective_layers)])
+
+        # Input-dependent level signals (RingFormer-style): low-rank down/up projections
+        # per effective layer, generating signals from the input x.
+        if level_signal_rank > 0:
+            self.level_signals = nn.ModuleList([
+                LevelSignal(model_dim, level_signal_rank) for _ in range(effective_layers)
+            ])
+        else:
+            self.level_signals = None
+
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights(effective_layers)
+
+    def _init_weights(self, effective_layers: int) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        # Residual scaling factor: prevents residual stream from growing unboundedly
+        # with many effective layers. Critical for depth recurrence.
+        resid_scale = 1.0 / math.sqrt(2 * effective_layers)
+        for module in self.modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2:
+                    nn.init.orthogonal_(module.weight)
+                    # Apply residual scaling to projection layers (attn.proj, mlp.proj).
+                    if hasattr(module, '_zero_init'):
+                        pass  # Already zero-init, don't scale
+                    elif any(n.endswith('.proj.weight') for n, p in self.named_parameters() if p is module.weight):
+                        module.weight.data.mul_(resid_scale)
+
+    def _get_block_for_layer(self, layer_idx: int) -> Block:
+        """Map virtual layer index to the shared block via round-robin."""
+        return self.blocks[layer_idx % self.num_unique_blocks]
+
+    def set_active_loops(self, num_loops: int) -> None:
+        """For progressive training: change the number of active loops."""
+        self.max_loops = min(num_loops, self.num_loops)
+
+    def _run_layer_fn(self, layer_idx: int, x: Tensor, x0: Tensor) -> Tensor:
+        """Run a single layer (encoder or decoder) — factored out for checkpointing."""
+        if self.level_signals is not None:
+            x = x + self.level_signals[layer_idx](x)
+        x = self._get_block_for_layer(layer_idx)(x, x0, self.attn_norms[layer_idx], self.mlp_norms[layer_idx])
+        return x
+
+    def _run_layers(self, x: Tensor, x0: Tensor, token_ids: Tensor | None = None) -> Tensor:
+        """Core forward through depth-recurrent layers. Shared by forward() and forward_logits()."""
+        effective_layers = self.num_unique_blocks * self.max_loops
+        num_enc = effective_layers // 2
+        num_dec = effective_layers - num_enc
+        skips: list[Tensor] = []
+        use_ckpt = self.training and self.gradient_checkpointing
+
+        # Encoder half: store skip connections.
+        for i in range(num_enc):
+            if use_ckpt:
+                x = torch.utils.checkpoint.checkpoint(
+                    self._run_layer_fn, i, x, x0, use_reentrant=False
+                )
+            else:
+                x = self._run_layer_fn(i, x, x0)
+            skips.append(x)
+
+        # Decoder half: consume skip connections in reverse.
+        for i in range(num_dec):
+            if skips:
+                skip_idx = min(i, len(self.skip_weights) - 1)
+                x = x + self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            layer_idx = num_enc + i
+            if use_ckpt:
+                x = torch.utils.checkpoint.checkpoint(
+                    self._run_layer_fn, layer_idx, x, x0, use_reentrant=False
+                )
+            else:
+                x = self._run_layer_fn(layer_idx, x, x0)
+
+        return x
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        x = x + self.bigram_hash(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        if self.smeargate is not None:
+            x = self.smeargate(x)
+        x0 = x
+
+        x = self._run_layers(x, x0, input_ids)
+
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Forward pass that returns logits instead of loss (for sliding window eval)."""
+        x = self.tok_emb(input_ids)
+        x = x + self.bigram_hash(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        if self.smeargate is not None:
+            x = self.smeargate(x)
+        x0 = x
+
+        x = self._run_layers(x, x0, input_ids)
+
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+
+def _forward_logits(model: nn.Module, x: Tensor) -> Tensor:
+    """Unwrap DDP/compiled model and call forward_logits."""
+    m = model
+    if hasattr(m, "module"):
+        m = m.module  # unwrap DDP
+    if hasattr(m, "_orig_mod"):
+        m = m._orig_mod  # unwrap torch.compile
+    return m.forward_logits(x)
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        num_unique_blocks=args.num_unique_blocks,
+        num_loops=args.num_loops,
+        bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim,
+        use_smeargate=args.use_smeargate,
+        level_signal_rank=args.level_signal_rank,
+    ).to(device).bfloat16()
+    log0(f"depth_recurrence: {args.num_unique_blocks} unique blocks x {args.num_loops} loops = {args.num_unique_blocks * args.num_loops} effective layers")
+    log0(f"features: bigram_hash={args.bigram_vocab_size}x{args.bigram_dim} smeargate={args.use_smeargate} level_rank={args.level_signal_rank}")
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    use_compile = bool(int(os.environ.get("TORCH_COMPILE", "1")))
+    if distributed:
+        # DDP + torch.compile(fullgraph=True) produces NaN with recurrent architectures.
+        # Use gradient checkpointing instead for memory efficiency.
+        base_model.gradient_checkpointing = True
+        model: nn.Module = DDP(base_model, device_ids=[local_rank], broadcast_buffers=False)
+        log0("distributed: gradient_checkpointing=True, torch.compile=disabled")
+    elif use_compile:
+        model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    else:
+        base_model.gradient_checkpointing = True
+        model = base_model
+        log0("torch.compile: disabled, gradient_checkpointing=True")
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_weight_decay,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Progressive loop training: start with fewer loops, ramp to full.
+    # MUST happen before warmup so torch.compile traces the correct initial graph.
+    # Disabled under DDP: changing loop count creates unused parameters incompatible
+    # with torch.compile(fullgraph=True) + DDP.
+    if args.progressive_loop_start > 0 and args.num_loops > 2 and not distributed:
+        progressive_full_step = int(args.iterations * args.progressive_loop_start)
+        initial_loops = max(2, args.num_loops // 2)
+        base_model.set_active_loops(initial_loops)
+        log0(f"progressive_loops: starting with {initial_loops} loops, ramping to {args.num_loops} at step {progressive_full_step}")
+    else:
+        progressive_full_step = 0
+        log0(f"progressive_loops: disabled (using {args.num_loops} loops from start)")
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    # Stochastic Weight Averaging: maintain running average of weights.
+    swa_start_step = int(args.iterations * args.swa_start_frac)
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    log0(f"swa: will start averaging at step {swa_start_step} ({args.swa_start_frac:.0%} of training)")
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            # Use full-stride (fast) eval mid-training; sliding window only on final step
+            eval_stride = None if last_step else args.train_seq_len
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+                stride_override=eval_stride,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+
+        # Progressive loop training: ramp up loops as training progresses.
+        if progressive_full_step > 0 and step <= progressive_full_step:
+            frac = step / progressive_full_step
+            target_loops = max(2, int(2 + (args.num_loops - 2) * frac))
+            if target_loops != base_model.max_loops:
+                base_model.set_active_loops(target_loops)
+                log0(f"progressive_loops: step {step}, now using {target_loops} loops")
+        elif progressive_full_step > 0 and base_model.max_loops != args.num_loops:
+            base_model.set_active_loops(args.num_loops)
+            log0(f"progressive_loops: step {step}, ramped to full {args.num_loops} loops")
+
+        # SWA: accumulate running average of weights after swa_start_step.
+        if step >= swa_start_step:
+            with torch.no_grad():
+                if swa_state is None:
+                    swa_state = {k: v.clone().float() for k, v in base_model.state_dict().items()}
+                    swa_count = 1
+                else:
+                    swa_count += 1
+                    for k, v in base_model.state_dict().items():
+                        swa_state[k] += (v.float() - swa_state[k]) / swa_count
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # After training, compile the base model for fast evaluation.
+    # DDP is not needed for eval — each rank evaluates its shard independently.
+    base_model.gradient_checkpointing = False
+    eval_model: nn.Module = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model = eval_model  # Replace model reference for eval_val calls below.
+    log0("post-training: compiled base_model for fast evaluation")
+
+    # -----------------------------
+    # APPLY SWA WEIGHTS
+    # -----------------------------
+    # If SWA was active, load the averaged weights before evaluation and export.
+    if swa_state is not None and swa_count > 0:
+        log0(f"swa: loading averaged weights (averaged over {swa_count} steps)")
+        averaged_state = {k: v.to(dtype=base_model.state_dict()[k].dtype) for k, v in swa_state.items()}
+        base_model.load_state_dict(averaged_state, strict=True)
+    else:
+        log0("swa: not enough training steps to activate SWA")
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed int6+zlib artifact and validate the round-tripped weights.
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zstd.ZstdCompressor(level=22).compress(quant_raw)
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int6.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int6+zstd: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int6+zstd: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zstd.ZstdDecompressor().decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Non-record submission exploring **depth-recurrent transformers** for parameter-efficient language modeling:

- **Architecture:** 3 unique transformer blocks × 4 loops = 12 effective layers with U-Net skip connections, per-iteration RMSNorm, and low-rank level signals
- **Features:** BigramHash embeddings, SmearGate, test-time training (TTT), Stochastic Weight Averaging (SWA), sliding window evaluation
- **DDP Solution:** Gradient checkpointing replaces torch.compile for multi-GPU training (torch.compile + DDP produces NaN with recurrent loop architectures); torch.compile re-enabled post-training for fast evaluation

### Results

| Run | Steps | train_loss | val_bpb | GPU | Notes |
|-----|-------|-----------|---------|-----|-------|
| 8xH100 benchmark | 300+ | 2.4452 | — | 8xH100 SXM | Interrupted by spend limit before eval |
| 1xH100 test (progressive loops) | 52 | 5.7383 | 3.4016 (pre-quant) | 1xH100 SXM | Complete run, 90s |
| 8xH100 sanity (30s) | 33 | 7.6756 | 4.5392 | 8xH100 SXM | Quick validation |

### Status

⚠️ **Partial results** — the 8xH100 benchmark was interrupted by RunPod spend limits before final evaluation completed. Training was converging well (loss 26 → 2.45 over 300 steps). Applying for compute credits to complete the 3-run statistical significance requirement.

### Key Technical Findings

1. `torch.compile(fullgraph=True)` + DDP produces NaN from step 1 with depth-recurrent architectures — the compiled unrolled loops interact incorrectly with DDP gradient hooks
2. Gradient checkpointing is a viable workaround: ~2x slower per step but enables DDP training with 18GB peak memory per GPU
3. Sliding window eval (stride=64) should only run at final evaluation, not mid-training — 969k windows per GPU takes 20+ minutes

## Test plan

- [ ] Complete 3 full 8xH100 runs with seeds 1337, 42, 7 (pending compute credits)
- [ ] Verify post-quantization val_bpb scores
- [ ] Verify artifact size under 16MB
- [ ] Confirm eval completes under 10 minutes on 8xH100

🤖 Generated with [Claude Code](https://claude.com/claude-code)