### PR TITLE
[Non-Record] Hymba-LongContext: 32K context training and eval via hybrid SSM (1.1873 BPB)

### DIFF
--- a/records/track_10min_16mb/2026-03-26-hymba_long_context_32k/README.md
+++ b/records/track_10min_16mb/2026-03-26-hymba_long_context_32k/README.md
@@ -1,0 +1,97 @@
+# [Non-Record] Hymba-LongContext: 32K Context Training via Hybrid SSM + Sliding Window Attention (1.1873 BPB)
+
+## Summary
+
+This submission demonstrates that hybrid SSM architectures can train at **32x longer context** (32,768 tokens) than the standard baseline (1,024 tokens) with **near-constant cost as context length increases**. By combining Mamba (selective state space model) with sliding window attention (SWA-512), both branches have constant per-token cost, going from 8K to 64K context adds virtually no overhead (~80-83 ms/step). This enables ultra-long context training within the 10-minute wall-clock budget.
+
+## Results
+
+| Seed | val_bpb | val_loss | Steps | Artifact Size |
+|------|---------|----------|-------|---------------|
+| 1337 | 1.1866  | 2.0036   | 7,334 | 14.3 MB       |
+| 42   | 1.1881  | 2.0061   | 7,139 | 14.6 MB       |
+| 7    | 1.1873  | 2.0048   | 7,176 | 14.5 MB       |
+| **Mean** | **1.1873 +/- 0.0008** | | | |
+
+- Training: 600s on 8xH100 SXM, ~82-88 ms/step
+- Evaluation: Score-first TTT, ~67-74s
+- Artifact: int6 + zstd-22, under 16 MB
+
+## Key Innovations
+
+### 1. Ultra-Long Context Training (32K tokens)
+The naive transformer baseline trains at 1,024 token context. We train at **32,768 tokens** — a 32x increase. Increasing context from 8K to 64K adds virtually no overhead (~80-83 ms/step across that range). This is because both SWA and Mamba have constant per-token cost as SWA attends to a fixed 512-token window regardless of sequence length, and Mamba's recurrent scan processes each token in O(1). Since the total tokens per batch is fixed (524K), the step time stays roughly constant regardless of how those tokens are divided into sequences.
+
+This is made possible by two architectural choices:
+- **Mamba SSM** processes sequences via selective scan with O(1) per-token cost (recurrent state)
+- **Sliding Window Attention (SWA-512)** on all layers limits attention to a fixed 512-token local window, also O(1) per token
+
+The Mamba branch handles global context (full sequence memory via recurrent state), while SWA handles local pattern matching.
+
+### 2. Hymba Hybrid Architecture
+Based on the Hymba paper (arXiv:2411.13676), each block runs attention and Mamba **in parallel** within a single layer:
+- Attention branch: Q projection + shared KV projection, GQA (8 heads, 4 KV heads), RoPE, QK-norm
+- Mamba branch: Selective scan with causal 1D convolution, gated output
+- Learned merge: sigmoid-gated weighted sum of both branches
+- Post-merge: output projection + residual with learned scale
+
+Architecture: 7 layers, 512 dim, MLP 4x with LeakyReLU(0.9)^2, U-Net skip connections, SmearGate + BigramHash embedding, EMA (0.997).
+
+### 3. Score-First Test-Time Training (TTT)
+Legal TTT following the PR #461 recipe:
+1. **Score** each 524K-token chunk under `inference_mode` (no gradient)
+2. **Train** on the already-scored chunk with SGD (lr=0.002, momentum=0.9)
+3. First 2 blocks frozen to prevent catastrophic forgetting
+4. 3 epochs per chunk with cosine LR decay
+5. Total eval time: ~67-74s
+
+TTT improves post-quantization BPB by adapting the quantized model to validation data patterns.
+
+### 4. Context Length Scaling Results
+We systematically evaluated training context length while keeping all other hyperparameters fixed:
+
+| Train Seq Len | ms/step | Pre-quant BPB (13,780 steps) |
+|---------------|---------|------------------------------|
+| 8,192         | 79.0    | 1.1507                       |
+| 16,384        | 80.1    | 1.1491                       |
+| 32,768        | 80.6    | 1.1478                       |
+| 65,536        | 82.8    | 1.1477                       |
+
+Per-step cost is nearly constant from 8K to 64K context because the per-token cost of both SWA and Mamba is independent of sequence length (see above). Quality improves with longer context up to ~32K, then plateaus.
+
+## Why This Matters
+
+With constant per-token cost, our architecture can train and evaluate at long context without the quadratic overhead that full attention would incur. This frees the eval time budget for TTT adaptation rather than expensive sliding window overlap.
+
+The competition README specifically requests "state-space models" and "super long context for evaluation or training" as novel directions. This submission demonstrates both, showing that hybrid SSM architectures naturally enable ultra-long context training regimes.
+
+## Run Command
+
+```bash
+SEED=1337 SLIDING_WINDOW=512 SWA_GLOBAL_LAYERS=none TRAIN_SEQ_LEN=32768 \
+NUM_LAYERS=7 MLP_MULT=4 MODEL_DIM=512 NUM_HEADS=8 NUM_KV_HEADS=4 \
+MATRIX_LR=0.02 SCALAR_LR=0.02 WARMDOWN_ITERS=3000 WARMDOWN_SHAPE=cosine \
+EVAL_STRIDE=0 EVAL_BATCH_SEQS=4 QUANT_BITS=6 GPTQ_LITE=1 \
+HYMBA_EXPAND=1 HYMBA_SSM_STATE=8 \
+TTT_ENABLED=1 TTT_LR=0.002 TTT_EPOCHS=3 TTT_CHUNK_TOKENS=524288 \
+TTT_FREEZE_BLOCKS=2 TTT_BATCH_SEQS=4 \
+MAX_WALLCLOCK_SECONDS=600 \
+torchrun --standalone --nproc_per_node=8 records/track_10min_16mb/hymba_long_context/train_gpt.py
+```
+
+## Dependencies
+
+```bash
+pip install --no-build-isolation mamba-ssm causal-conv1d
+pip install zstandard
+```
+
+## Setup
+
+Requires PyTorch >= 2.5 for flex_attention (sliding window). Tested on PyTorch 2.8.0+cu128.
+
+```bash
+pip install --no-build-isolation --break-system-packages mamba-ssm causal-conv1d
+```
+
+Note: `--no-build-isolation` is critical to avoid CUDA version mismatch during the mamba-ssm/causal-conv1d CUDA kernel builds.

--- a/records/track_10min_16mb/2026-03-26-hymba_long_context_32k/log_seed1337.txt
+++ b/records/track_10min_16mb/2026-03-26-hymba_long_context_32k/log_seed1337.txt
@@ -1,0 +1,1837 @@
+"""Hymba: Hybrid Attention + Mamba SSM for Parameter Golf."""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+try:
+    import zstandard as zstd
+    HAS_ZSTD = True
+except ImportError:
+    HAS_ZSTD = False
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# Flex attention for sliding window (PyTorch >= 2.5)
+try:
+    from torch.nn.attention.flex_attention import flex_attention, create_block_mask, and_masks
+    HAS_FLEX_ATTENTION = True
+except ImportError:
+    HAS_FLEX_ATTENTION = False
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmdown_shape = os.environ.get("WARMDOWN_SHAPE", "cosine")  # "linear" or "cosine"
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Evaluation.
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))  # sliding window stride (0 = disabled)
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 0))  # eval sequence length (0 = same as train_seq_len)
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))  # batch size for sliding eval
+    # Test-Time Training (TTT): score-first online adaptation on val data
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.002))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 3))
+    ttt_chunk_tokens = int(os.environ.get("TTT_CHUNK_TOKENS", 32768))
+    ttt_freeze_blocks = int(os.environ.get("TTT_FREEZE_BLOCKS", 2))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+    ttt_batch_seqs = int(os.environ.get("TTT_BATCH_SEQS", 32))
+    ttt_grad_clip = float(os.environ.get("TTT_GRAD_CLIP", 1.0))
+
+    # Quantization.
+    fp16_embed = bool(int(os.environ.get("FP16_EMBED", "1")))  # keep embeddings in FP16
+    quant_bits = int(os.environ.get("QUANT_BITS", 6))  # quantization bit width for attention (6 or 8)
+    quant_bits_mlp = int(os.environ.get("QUANT_BITS_MLP", 0))  # MLP bit width (0 = same as quant_bits)
+    qat_start_frac = float(os.environ.get("QAT_START_FRAC", 0.0))  # QAT: start at this fraction of training (0 = disabled)
+    gptq_lite = bool(int(os.environ.get("GPTQ_LITE", "1")))  # search for optimal clip percentile per tensor
+    use_zstd = bool(int(os.environ.get("USE_ZSTD", "1")))  # use zstd instead of zlib
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 7))  # unique layers
+
+    # SmearGate + BigramHash.
+    use_smeargate = bool(int(os.environ.get("USE_SMEARGATE", "1")))
+    use_bigram_hash = bool(int(os.environ.get("USE_BIGRAM_HASH", "1")))
+    bigram_buckets = int(os.environ.get("BIGRAM_BUCKETS", 4096))
+    bigram_hash_dim = int(os.environ.get("BIGRAM_HASH_DIM", 128))
+
+    # OrthoInit + SWA.
+    use_ortho_init = bool(int(os.environ.get("USE_ORTHO_INIT", "1")))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.4))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 4))
+    hymba_expand = int(os.environ.get("HYMBA_EXPAND", 1))
+    hymba_conv_kernel = int(os.environ.get("HYMBA_CONV_KERNEL", 4))
+    hymba_dt_rank = int(os.environ.get("HYMBA_DT_RANK", 0))
+    hymba_ssm_state = int(os.environ.get("HYMBA_SSM_STATE", 8))
+    kv_share_every = int(os.environ.get("KV_SHARE_EVERY", 1))  # share KV every N layers (1 = no sharing, 2 = paper default)
+    meta_tokens = int(os.environ.get("META_TOKENS", 0))  # learnable register tokens for attention (0 = disabled)
+    sliding_window = int(os.environ.get("SLIDING_WINDOW", 0))  # attention window size (0 = full attention everywhere)
+    swa_global_layers = os.environ.get("SWA_GLOBAL_LAYERS", "auto")  # "auto" = first/mid/last, "none" = all SWA, or comma-separated indices
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    weight_decay = float(os.environ.get("WEIGHT_DECAY", 0.02))
+    ema_enabled = bool(int(os.environ.get("EMA_ENABLED", "1")))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+    grad_checkpoint = bool(int(os.environ.get("GRAD_CHECKPOINT", "0")))
+
+# MUON OPTIMIZER
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, weight_decay=weight_decay),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            weight_decay = group.get("weight_decay", 0.0)
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                if weight_decay > 0:
+                    p.data.mul_(1.0 - lr * weight_decay)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# TOKENIZER + EVALUATION
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters, model: nn.Module, rank: int, world_size: int,
+    device: torch.device, grad_accum_steps: int, val_tokens: Tensor,
+    base_bytes_lut: Tensor, has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+def eval_val_sliding(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    """Sliding window evaluation: score each token with maximal left-context."""
+    seq_len = args.train_seq_len
+    stride = args.eval_stride
+    batch_size = args.eval_batch_seqs
+    total_tokens = val_tokens.numel() - 1
+
+    window_starts = [ws for ws in range(0, total_tokens - seq_len + 1, stride)]
+    if window_starts[-1] + seq_len < total_tokens:
+        window_starts.append(total_tokens - seq_len)
+
+    my_starts = window_starts[rank::world_size]
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    with torch.inference_mode():
+        for batch_start in range(0, len(my_starts), batch_size):
+            batch_ws = my_starts[batch_start:batch_start + batch_size]
+            bsz = len(batch_ws)
+
+            x_list, y_list = [], []
+            for ws in batch_ws:
+                chunk = val_tokens[ws:ws + seq_len + 1].to(dtype=torch.int64)
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            x_batch = torch.stack(x_list).to(device=device, non_blocking=True)
+            y_batch = torch.stack(y_list).to(device=device, non_blocking=True)
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = base_model.forward_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+
+            for i, ws in enumerate(batch_ws):
+                wlen = min(seq_len, total_tokens - ws)
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+
+                prev_ids = x_batch[i, s:wlen]
+                tgt_ids = y_batch[i, s:wlen]
+                tbytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                tbytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+                byte_count += tbytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return float(val_loss), float(bits_per_token * tokens_per_byte)
+
+
+def eval_val_score_first_ttt(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    log0=print,
+) -> tuple[float, float]:
+    """Legal score-first TTT: score each chunk FIRST, then train on it.
+    Every token is scored BEFORE any update that could use it."""
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = args.ttt_chunk_tokens
+
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+
+    log0(f"ttt:start chunks={num_chunks} chunk_tokens={ttt_chunk} seq_len={seq_len} "
+         f"ttt_lr={args.ttt_lr} ttt_epochs={args.ttt_epochs} "
+         f"freeze_blocks={args.ttt_freeze_blocks}")
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Freeze first N blocks
+    frozen_block_ids = set(range(min(args.ttt_freeze_blocks, len(base_model.blocks))))
+    ttt_params = []
+    for name, p in base_model.named_parameters():
+        freeze = False
+        for bi in frozen_block_ids:
+            if f"blocks.{bi}." in name:
+                freeze = True
+                break
+        if freeze:
+            p.requires_grad_(False)
+        else:
+            p.requires_grad_(True)
+            ttt_params.append(p)
+
+    log0(f"ttt:params unfrozen={sum(p.numel() for p in ttt_params)} "
+         f"frozen={sum(p.numel() for p in base_model.parameters() if not p.requires_grad)}")
+
+    optimizer = torch.optim.SGD(ttt_params, lr=args.ttt_lr, momentum=args.ttt_momentum)
+    t0 = time.perf_counter()
+
+    for ci in range(num_chunks):
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+        chunk_seqs = (chunk_end - chunk_start) // seq_len
+        if chunk_seqs == 0:
+            continue
+
+        # Distribute sequences across ranks
+        my_seq_s = (chunk_seqs * rank) // world_size
+        my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+        my_chunk_seqs = my_seq_e - my_seq_s
+
+        # --- Phase 1: SCORE this chunk (inference_mode) ---
+        base_model.eval()
+        with torch.inference_mode():
+            for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                actual_bs = my_seq_s + bs
+                start_tok = chunk_start + actual_bs * seq_len
+                end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                if end_tok > val_tokens.numel():
+                    continue
+                local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                x = local[:-1].reshape(-1, seq_len)
+                y = local[1:].reshape(-1, seq_len)
+                bsz = x.size(0)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model.forward_logits(x)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y.reshape(-1), reduction="none",
+                ).reshape(bsz, seq_len)
+                loss_sum += nll.to(torch.float64).sum()
+                token_count += float(y.numel())
+                prev_ids = x.reshape(-1)
+                tgt_ids = y.reshape(-1)
+                tb = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                tb += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+                byte_count += tb.to(torch.float64).sum()
+
+        # --- Phase 2: TRAIN on this chunk (already scored = legal) ---
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and args.ttt_epochs > 0 and my_chunk_seqs > 0:
+            base_model.train()
+            cos_lr = args.ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+            for pg in optimizer.param_groups:
+                pg['lr'] = cos_lr
+            for _ep in range(args.ttt_epochs):
+                for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                    be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                    actual_bs = my_seq_s + bs
+                    start_tok = chunk_start + actual_bs * seq_len
+                    end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                    if end_tok > val_tokens.numel():
+                        continue
+                    local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                    x = local[:-1].reshape(-1, seq_len)
+                    y = local[1:].reshape(-1, seq_len)
+                    optimizer.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        loss = base_model(x, y)
+                    loss.backward()
+                    if world_size > 1:
+                        for p in ttt_params:
+                            if p.grad is not None:
+                                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                    torch.nn.utils.clip_grad_norm_(ttt_params, args.ttt_grad_clip)
+                    optimizer.step()
+
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            log0(f"  ttt_chunk [{ci+1}/{num_chunks}] bpb={rbpb:.6f} time={elapsed:.1f}s")
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+    log0(f"ttt:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+         f"elapsed={time.perf_counter() - t0:.1f}s")
+    return float(val_loss), float(val_bpb)
+
+
+# QUANTIZATION
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smeargate,merge_alpha",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def _quantize_with_clip(t32: Tensor, clip_abs: Tensor | float, qmax: int) -> tuple[Tensor, Tensor, Tensor]:
+    if t32.ndim == 2 and isinstance(clip_abs, Tensor):
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / qmax).clamp_min(1.0 / qmax)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -qmax, qmax).to(torch.int8)
+        recon = q.float() * scale[:, None]
+        return q.contiguous(), scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous(), recon
+    clip_abs_f = float(clip_abs) if isinstance(clip_abs, Tensor) else clip_abs
+    scale_f = clip_abs_f / qmax if clip_abs_f > 0 else 1.0
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs_f, clip_abs_f) / scale_f), -qmax, qmax).to(torch.int8)
+    recon = q.float() * scale_f
+    return q.contiguous(), torch.tensor(scale_f, dtype=torch.float32), recon
+
+def quantize_float_tensor(t: Tensor, bits: int = 8, search_clip: bool = False) -> tuple[Tensor, Tensor]:
+    qmax = (1 << (bits - 1)) - 1
+    t32 = t.float()
+
+    if not search_clip:
+        if t32.ndim == 2:
+            clip_abs = (
+                torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+                if t32.numel()
+                else torch.empty((t32.shape[0],), dtype=torch.float32)
+            )
+            q, scale, _ = _quantize_with_clip(t32, clip_abs, qmax)
+            return q, scale
+        clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+        q, scale, _ = _quantize_with_clip(t32, clip_abs, qmax)
+        return q, scale
+
+    candidates = [0.999, 0.9995, 0.9999, 0.99995, 0.99999, 0.999999, 1.0]
+    best_q, best_scale, best_mse = None, None, float("inf")
+
+    for pct in candidates:
+        if t32.ndim == 2:
+            if pct >= 1.0:
+                clip_abs = t32.abs().amax(dim=1)
+            else:
+                clip_abs = torch.quantile(t32.abs(), pct, dim=1)
+            q, scale, recon = _quantize_with_clip(t32, clip_abs, qmax)
+        else:
+            if pct >= 1.0:
+                clip_abs = float(t32.abs().max().item())
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), pct).item()) if t32.numel() else 0.0
+            q, scale, recon = _quantize_with_clip(t32, clip_abs, qmax)
+        mse = (t32 - recon).pow(2).mean().item()
+        if mse < best_mse:
+            best_mse = mse
+            best_q, best_scale = q, scale
+
+    return best_q, best_scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor], fp16_embed: bool = False, quant_bits: int = 8, quant_bits_mlp: int = 0, search_clip: bool = False):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        if fp16_embed and "tok_emb" in name:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        bits = quant_bits
+        if quant_bits_mlp > 0 and "mlp" in name:
+            bits = quant_bits_mlp
+        q, s = quantize_float_tensor(t, bits=bits, search_clip=search_clip)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class FakeQuantizeSTE(torch.autograd.Function):
+    """Simulated quantization with Straight-Through Estimator for QAT."""
+    @staticmethod
+    def forward(ctx, w: Tensor, bits: int) -> Tensor:
+        qmax = (1 << (bits - 1)) - 1
+        if w.ndim == 2:
+            scale = w.detach().abs().amax(dim=1, keepdim=True) / qmax
+            scale = scale.clamp_min(1.0 / qmax)
+            return (torch.clamp(torch.round(w / scale), -qmax, qmax) * scale).to(w.dtype)
+        scale = w.detach().abs().amax() / qmax
+        scale = scale.clamp_min(1.0 / qmax)
+        return (torch.clamp(torch.round(w / scale), -qmax, qmax) * scale).to(w.dtype)
+
+    @staticmethod
+    def backward(ctx, grad: Tensor) -> tuple[Tensor, None]:
+        return grad, None
+
+
+class CastedLinear(nn.Linear):
+    _qat_bits: int = 0
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if self._qat_bits > 0 and self.weight.numel() > 65536:
+            w = FakeQuantizeSTE.apply(w, self._qat_bits)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.full((dim,), 3.0, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate).to(dtype=x.dtype)
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return g * x + (1.0 - g) * x_prev
+
+
+class BigramHash(nn.Module):
+    def __init__(self, num_buckets: int, hash_dim: int, model_dim: int):
+        super().__init__()
+        self.num_buckets = num_buckets
+        self.table = nn.Embedding(num_buckets, hash_dim)
+        self.proj = CastedLinear(hash_dim, model_dim, bias=False)
+        self.proj._zero_init = True
+        nn.init.normal_(self.table.weight, std=0.01)
+
+    def forward(self, input_ids: Tensor) -> Tensor:
+        bsz, seqlen = input_ids.shape
+        prev_ids = torch.cat([torch.zeros(bsz, 1, dtype=input_ids.dtype, device=input_ids.device),
+                              input_ids[:, :-1]], dim=1)
+        h = ((prev_ids.long() * 92821 + input_ids.long()) % self.num_buckets).long()
+        return self.proj(self.table(h))
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class HymbaAttention(nn.Module):
+    """Hymba-style hybrid: attention + Mamba SSM in parallel within one block."""
+    def __init__(
+        self, dim: int, num_heads: int, num_kv_heads: int, rope_base: float,
+        qk_gain_init: float, mamba_expand: int = 2, conv_kernel_size: int = 4,
+        dt_rank: int = 0, ssm_state_size: int = 16, shared_kv_proj=None,
+        sliding_window: int = 0,
+    ):
+        super().__init__()
+        from mamba_ssm.ops.selective_scan_interface import selective_scan_fn
+        from causal_conv1d import causal_conv1d_fn
+        self._selective_scan_fn = selective_scan_fn
+        self._causal_conv1d_fn = causal_conv1d_fn
+        self.sliding_window = sliding_window
+
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        self.intermediate_size = mamba_expand * dim
+        self.ssm_state_size = ssm_state_size
+        self.dt_rank = dt_rank if dt_rank > 0 else max(dim // 16, 1)
+
+        kv_dim = num_kv_heads * self.head_dim
+        self.q_dim = dim
+        self.kv_dim = kv_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+
+        # Cross-layer KV sharing: if shared_kv_proj provided, reuse it
+        if shared_kv_proj is not None:
+            self.kv_proj = shared_kv_proj
+        else:
+            self.kv_proj = CastedLinear(dim, kv_dim * 2, bias=False)
+
+        # Mamba projections (always per-layer)
+        self.mamba_proj = CastedLinear(dim, self.intermediate_size * 2, bias=False)
+
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+        self.conv1d = nn.Conv1d(
+            self.intermediate_size, self.intermediate_size, bias=True,
+            kernel_size=conv_kernel_size, groups=self.intermediate_size,
+            padding=conv_kernel_size - 1,
+        )
+        self.x_proj = CastedLinear(self.intermediate_size, self.dt_rank + ssm_state_size * 2, bias=False)
+        self.dt_proj = nn.Linear(self.dt_rank, self.intermediate_size, bias=True)
+
+        A = torch.arange(1, ssm_state_size + 1, dtype=torch.float32)[None, :].expand(self.intermediate_size, -1).contiguous()
+        self.A_log = nn.Parameter(torch.log(A))
+        self.D = nn.Parameter(torch.ones(self.intermediate_size))
+
+        self.mamba_out_proj = CastedLinear(self.intermediate_size, dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.merge_alpha = nn.Parameter(torch.zeros(1, dtype=torch.float32))
+
+        # Pre-compile flex_attention for sliding window
+        if sliding_window > 0 and HAS_FLEX_ATTENTION:
+            window = sliding_window
+            def swa_mask(b, h, q_idx, kv_idx):
+                causal = q_idx >= kv_idx
+                in_window = (q_idx - kv_idx) < window
+                return causal & in_window
+            self._swa_mask_fn = swa_mask
+            self._swa_block_mask = None  # lazily created on first forward
+            self._flex_attention = torch.compile(flex_attention)
+
+    def _sliding_window_attn(self, q: Tensor, k: Tensor, v: Tensor, seqlen: int) -> Tensor:
+        """Sliding window attention using flex_attention with GQA support."""
+        # Expand KV heads for flex_attention (doesn't support GQA natively)
+        if self.num_kv_heads != self.num_heads:
+            n_rep = self.num_heads // self.num_kv_heads
+            k = k[:, :, None, :, :].expand(-1, -1, n_rep, -1, -1).reshape(
+                k.size(0), self.num_heads, seqlen, self.head_dim
+            )
+            v = v[:, :, None, :, :].expand(-1, -1, n_rep, -1, -1).reshape(
+                v.size(0), self.num_heads, seqlen, self.head_dim
+            )
+        # Lazily create block mask on first call (needs to know seq_len and device)
+        if self._swa_block_mask is None or self._swa_block_mask.shape[-1] != seqlen:
+            self._swa_block_mask = create_block_mask(
+                self._swa_mask_fn, B=None, H=None, Q_LEN=seqlen, KV_LEN=seqlen,
+                device=q.device,
+            )
+        return self._flex_attention(q, k, v, block_mask=self._swa_block_mask)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+
+        q_out = self.c_q(x)
+
+        kv_out = self.kv_proj(x)
+        k_out, v_out = kv_out.split([self.kv_dim, self.kv_dim], dim=-1)
+
+        mamba_out_proj = self.mamba_proj(x)
+        x_ssm, gate = mamba_out_proj.split([self.intermediate_size, self.intermediate_size], dim=-1)
+
+        q = q_out.reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k_out.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = v_out.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+
+        if self.sliding_window > 0 and seqlen > self.sliding_window:
+            y = self._sliding_window_attn(q, k, v, seqlen)
+        else:
+            y = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=None, is_causal=True,
+                enable_gqa=(self.num_kv_heads != self.num_heads),
+            )
+        attn_out = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+
+        x_ssm = x_ssm.transpose(1, 2)
+        gate = gate.transpose(1, 2)
+
+        _conv_dtype = x_ssm.dtype
+        conv_weights = self.conv1d.weight.view(self.conv1d.weight.size(0), self.conv1d.weight.size(2)).to(_conv_dtype)
+        conv_bias = self.conv1d.bias.to(_conv_dtype) if self.conv1d.bias is not None else None
+        x_ssm = self._causal_conv1d_fn(x_ssm, conv_weights, conv_bias, activation="silu")
+
+        ssm_params = self.x_proj(x_ssm.transpose(1, 2))
+        dt, B_ssm, C_ssm = torch.split(
+            ssm_params, [self.dt_rank, self.ssm_state_size, self.ssm_state_size], dim=-1
+        )
+
+        dt_proj_bias = self.dt_proj.bias
+        self.dt_proj.bias = None
+        dt = self.dt_proj(dt).transpose(1, 2)
+        self.dt_proj.bias = dt_proj_bias
+
+        A = -torch.exp(self.A_log.float())
+        dt_proj_bias_f = dt_proj_bias.float() if dt_proj_bias is not None else None
+
+        scan_out = self._selective_scan_fn(
+            x_ssm, dt, A,
+            B_ssm.transpose(1, 2), C_ssm.transpose(1, 2),
+            self.D.float(), z=gate,
+            delta_bias=dt_proj_bias_f,
+            delta_softplus=True,
+            return_last_state=False,
+        )
+        mamba_out = self.mamba_out_proj(scan_out.transpose(1, 2))
+
+        w = torch.sigmoid(self.merge_alpha).to(dtype=x.dtype)
+        merged = w * attn_out + (1.0 - w) * mamba_out
+        return self.proj(merged)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = F.leaky_relu(self.fc(x), negative_slope=0.9)
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int,
+        rope_base: float, qk_gain_init: float, hymba_expand: int = 2,
+        hymba_conv_kernel: int = 4, hymba_dt_rank: int = 0, hymba_ssm_state: int = 16,
+        shared_kv_proj=None, sliding_window: int = 0,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = HymbaAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+            mamba_expand=hymba_expand, conv_kernel_size=hymba_conv_kernel,
+            dt_rank=hymba_dt_rank, ssm_state_size=hymba_ssm_state,
+            shared_kv_proj=shared_kv_proj, sliding_window=sliding_window,
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self, vocab_size: int, num_layers: int, model_dim: int, num_heads: int,
+        num_kv_heads: int, mlp_mult: int, tie_embeddings: bool, tied_embed_init_std: float,
+        logit_softcap: float, rope_base: float, qk_gain_init: float,
+        use_smeargate: bool = False, use_bigram_hash: bool = False,
+        bigram_buckets: int = 4096, bigram_hash_dim: int = 128,
+        use_ortho_init: bool = False, hymba_expand: int = 2, hymba_conv_kernel: int = 4,
+        hymba_dt_rank: int = 0, hymba_ssm_state: int = 16, kv_share_every: int = 1,
+        meta_tokens: int = 0, sliding_window: int = 0, swa_global_layers: str = "auto",
+        grad_checkpoint: bool = False,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.use_ortho_init = use_ortho_init
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+
+        self.smeargate = SmearGate(model_dim) if use_smeargate else None
+        self.bigram_hash = BigramHash(bigram_buckets, bigram_hash_dim, model_dim) if use_bigram_hash else None
+
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+
+        self.skip_weights = nn.Parameter(
+            torch.ones(1, self.num_skip_weights, model_dim, dtype=torch.float32)
+        )
+
+        # Shared meta tokens (one set of learnable embeddings, per-layer KV projection)
+        self._meta_tokens_param = nn.Parameter(
+            torch.randn(1, meta_tokens, model_dim) * 0.02
+        ) if meta_tokens > 0 else None
+
+        # Determine which layers get full attention vs sliding window
+        if sliding_window > 0:
+            if swa_global_layers == "none":
+                global_layers = set()
+            elif swa_global_layers == "auto":
+                # Paper default: first, middle, and last layers
+                global_layers = {0, num_layers // 2, num_layers - 1}
+            else:
+                global_layers = {int(x) for x in swa_global_layers.split(",") if x.strip()}
+        else:
+            global_layers = set(range(num_layers))  # all full attention
+
+        # Build blocks with cross-layer KV sharing
+        blocks = []
+        for i in range(num_layers):
+            # Share KV projections: layer i shares with layer (i // kv_share_every) * kv_share_every
+            shared_kv = None
+            if kv_share_every > 1 and (i % kv_share_every) != 0:
+                # Reuse KV proj from the group leader
+                leader_idx = (i // kv_share_every) * kv_share_every
+                shared_kv = blocks[leader_idx].attn.kv_proj
+            layer_window = 0 if i in global_layers else sliding_window
+            blocks.append(Block(
+                model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init,
+                hymba_expand=hymba_expand, hymba_conv_kernel=hymba_conv_kernel,
+                hymba_dt_rank=hymba_dt_rank, hymba_ssm_state=hymba_ssm_state,
+                shared_kv_proj=shared_kv, sliding_window=layer_window,
+            ))
+        self.blocks = nn.ModuleList(blocks)
+
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.grad_checkpoint = grad_checkpoint
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        num_layers = len(self.blocks)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif self.use_ortho_init and module.weight.ndim == 2 and min(module.weight.shape) >= 16:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj" in name and name.split(".")[-1] in ("proj", "proj_D"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+
+    def _compute_logits_and_loss(self, x: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def _embed(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram_hash is not None:
+            x = x + self.bigram_hash(input_ids)
+        if self.smeargate is not None:
+            x = self.smeargate(x)
+        return F.rms_norm(x, (x.size(-1),))
+
+    def _block_forward(self, block: nn.Module, x: Tensor, x0: Tensor) -> Tensor:
+        if self.grad_checkpoint and self.training:
+            return torch.utils.checkpoint.checkpoint(block, x, x0, use_reentrant=False)
+        return block(x, x0)
+
+    def _prepend_meta(self, x: Tensor) -> Tensor:
+        """Prepend learnable meta tokens to the sequence."""
+        if self._meta_tokens_param is not None:
+            meta = self._meta_tokens_param.expand(x.size(0), -1, -1).to(dtype=x.dtype)
+            x = torch.cat([meta, x], dim=1)
+        return x
+
+    def _strip_meta(self, x: Tensor) -> Tensor:
+        """Remove meta token positions from the output."""
+        if self._meta_tokens_param is not None:
+            x = x[:, self._meta_tokens_param.size(1):]
+        return x
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self._embed(input_ids)
+        x = self._prepend_meta(x)
+        x0 = x
+        skips: list[Tensor] = []
+
+        for i in range(self.num_encoder_layers):
+            x = self._block_forward(self.blocks[i], x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[0, i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self._block_forward(self.blocks[self.num_encoder_layers + i], x, x0)
+
+        x = self._strip_meta(x)
+        return self._compute_logits_and_loss(x, target_ids)
+
+    def _run_blocks(self, x: Tensor, x0: Tensor) -> Tensor:
+        skips: list[Tensor] = []
+        for i in range(self.num_encoder_layers):
+            x = self._block_forward(self.blocks[i], x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[0, i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self._block_forward(self.blocks[self.num_encoder_layers + i], x, x0)
+        return x
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        bsz, seqlen = input_ids.shape
+        x = self._embed(input_ids)
+        x = self._prepend_meta(x)
+        x = self._run_blocks(x, x)
+        x = self._strip_meta(x)
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        w = self.tok_emb.weight if self.tie_embeddings else self.lm_head.weight
+        logits = self.logit_softcap * torch.tanh(F.linear(x, w) / self.logit_softcap)
+        return logits.reshape(bsz, seqlen, -1)
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = int(os.environ.get("GRAD_ACCUM_STEPS", 8 // world_size))
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    base_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        use_smeargate=args.use_smeargate, use_bigram_hash=args.use_bigram_hash,
+        bigram_buckets=args.bigram_buckets, bigram_hash_dim=args.bigram_hash_dim,
+        use_ortho_init=args.use_ortho_init, hymba_expand=args.hymba_expand,
+        hymba_conv_kernel=args.hymba_conv_kernel, hymba_dt_rank=args.hymba_dt_rank,
+        hymba_ssm_state=args.hymba_ssm_state, kv_share_every=args.kv_share_every,
+        meta_tokens=args.meta_tokens, sliding_window=args.sliding_window,
+        swa_global_layers=args.swa_global_layers, grad_checkpoint=args.grad_checkpoint,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    if bool(int(os.environ.get("NO_COMPILE", "0"))):
+        compiled_model = base_model
+    else:
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=False)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if hasattr(base_model, 'skip_weights') and base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    if base_model.smeargate is not None:
+        scalar_params.append(base_model.smeargate.gate)
+    if base_model.bigram_hash is not None:
+        scalar_params.append(base_model.bigram_hash.table.weight)
+        matrix_params.append(base_model.bigram_hash.proj.weight)
+    if base_model._meta_tokens_param is not None:
+        scalar_params.append(base_model._meta_tokens_param)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params, lr=args.matrix_lr, momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps, weight_decay=args.weight_decay,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(f"num_layers:{args.num_layers} mlp_mult:{args.mlp_mult} kv_share_every:{args.kv_share_every} meta_tokens:{args.meta_tokens} sliding_window:{args.sliding_window}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            frac = max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        else:
+            step_ms = elapsed_ms / max(step, 1)
+            warmdown_ms = args.warmdown_iters * step_ms
+            remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+            frac = remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+        if args.warmdown_shape == "cosine" and frac < 1.0:
+            return 0.5 * (1.0 + math.cos(math.pi * (1.0 - frac)))
+        return frac
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+
+    ema_state: dict[str, Tensor] | None = None
+    if args.ema_enabled:
+        ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+
+        if args.qat_start_frac > 0 and max_wallclock_ms:
+            elapsed_frac_qat = elapsed_ms / max_wallclock_ms
+            qat_active = elapsed_frac_qat >= args.qat_start_frac
+            qat_bits = args.quant_bits if qat_active else 0
+            if qat_active and any(m._qat_bits == 0 for m in base_model.modules() if isinstance(m, CastedLinear)):
+                log0(f"qat:enabled bits={qat_bits} at step {step} frac={elapsed_frac_qat:.2f}")
+                for m in base_model.modules():
+                    if isinstance(m, CastedLinear):
+                        m._qat_bits = qat_bits
+
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        cur_seq_len = args.train_seq_len
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, cur_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+
+        if ema_state is not None:
+            d = args.ema_decay
+            with torch.no_grad():
+                for name, t in base_model.state_dict().items():
+                    ema_state[name].mul_(d).add_(t.detach().float(), alpha=1.0 - d)
+
+        if args.swa_enabled and scale < args.swa_start_frac and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone().float() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu().float()
+                swa_count += 1
+
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    for m in base_model.modules():
+        if isinstance(m, CastedLinear):
+            m._qat_bits = 0
+
+    if ema_state is not None:
+        log0("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+        del ema_state
+        base_model.load_state_dict(avg_state, strict=True)
+    elif args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"swa:applying averaged {swa_count} checkpoints")
+        current_state = base_model.state_dict()
+        avg_state = {
+            name: (tensor / swa_count).to(dtype=current_state[name].dtype)
+            for name, tensor in swa_state.items()
+        }
+        del swa_state
+        base_model.load_state_dict(avg_state, strict=True)
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    mlp_bits = args.quant_bits_mlp if args.quant_bits_mlp > 0 else args.quant_bits
+    quant_obj, quant_stats = quantize_state_dict_int8(
+        base_model.state_dict(), fp16_embed=args.fp16_embed, quant_bits=args.quant_bits,
+        quant_bits_mlp=args.quant_bits_mlp, search_clip=args.gptq_lite,
+    )
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    if args.use_zstd and HAS_ZSTD:
+        cctx = zstd.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+        compress_fmt = "zstd-22"
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+        compress_fmt = "zlib-9"
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int{args.quant_bits}+{compress_fmt}: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int{args.quant_bits}+{compress_fmt}: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    if args.use_zstd and HAS_ZSTD:
+        dctx = zstd.ZstdDecompressor()
+        quant_decompressed = dctx.decompress(quant_blob_disk)
+    else:
+        quant_decompressed = zlib.decompress(quant_blob_disk)
+    quant_state = torch.load(io.BytesIO(quant_decompressed), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+
+    # Override seq_len for eval if EVAL_SEQ_LEN is set
+    eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    if eval_seq_len != args.train_seq_len:
+        val_tokens = load_validation_tokens(args.val_files, eval_seq_len)
+    original_train_seq_len = args.train_seq_len
+    args.train_seq_len = eval_seq_len
+
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+
+    if args.ttt_enabled:
+        q_val_loss, q_val_bpb = eval_val_score_first_ttt(
+            args, base_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            log0=log0,
+        )
+        eval_mode = "score_first_ttt"
+    else:
+        use_sliding = args.eval_stride > 0 and args.eval_stride < args.train_seq_len
+        if use_sliding:
+            q_val_loss, q_val_bpb = eval_val_sliding(
+                args, base_model, rank, world_size, device,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            eval_mode = "sliding"
+        else:
+            q_val_loss, q_val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            eval_mode = "standard"
+    torch.cuda.synchronize()
+    args.train_seq_len = original_train_seq_len
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_mode:{eval_mode} eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
+Running Python 3.12.3 (main, Aug 14 2025, 17:47:21) [GCC 13.3.0]
+Running PyTorch 2.8.0+cu128
+Thu Mar 26 15:17:26 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.195.03             Driver Version: 570.195.03     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:18:00.0 Off |                    0 |
+| N/A   24C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:2A:00.0 Off |                    0 |
+| N/A   27C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:3A:00.0 Off |                    0 |
+| N/A   28C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   24C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9A:00.0 Off |                    0 |
+| N/A   24C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:AB:00.0 Off |                    0 |
+| N/A   27C    P0            113W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:BA:00.0 Off |                    0 |
+| N/A   26C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   25C    P0            112W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A           32324      C   /usr/local/bin/python                  1510MiB |
+|    1   N/A  N/A           32325      C   /usr/local/bin/python                  1510MiB |
+|    2   N/A  N/A           32326      C   /usr/local/bin/python                  1510MiB |
+|    3   N/A  N/A           32327      C   /usr/local/bin/python                  1510MiB |
+|    4   N/A  N/A           32328      C   /usr/local/bin/python                  1510MiB |
+|    5   N/A  N/A           32329      C   /usr/local/bin/python                  1510MiB |
+|    6   N/A  N/A           32330      C   /usr/local/bin/python                  1510MiB |
+|    7   N/A  N/A           32331      C   /usr/local/bin/python                  1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:10
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:61997056
+model_params:27161151
+world_size:8 grad_accum_steps:1
+attention_mode:gqa num_heads:8 num_kv_heads:4
+num_layers:7 mlp_mult:4 kv_share_every:1 meta_tokens:0 sliding_window:512
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:524288 train_seq_len:32768 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9383 val_bpb:4.1091 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9378 train_time:82ms step_avg:81.65ms
+step:2/20000 train_loss:17.7766 train_time:168ms step_avg:84.03ms
+step:3/20000 train_loss:9.3470 train_time:255ms step_avg:85.05ms
+step:4/20000 train_loss:6.5580 train_time:342ms step_avg:85.61ms
+step:5/20000 train_loss:6.2287 train_time:429ms step_avg:85.89ms
+step:6/20000 train_loss:7.1237 train_time:516ms step_avg:86.04ms
+step:7/20000 train_loss:6.1243 train_time:603ms step_avg:86.10ms
+step:8/20000 train_loss:6.0306 train_time:690ms step_avg:86.19ms
+step:9/20000 train_loss:5.9906 train_time:777ms step_avg:86.30ms
+step:10/20000 train_loss:5.9371 train_time:864ms step_avg:86.38ms
+step:200/20000 train_loss:2.8898 train_time:16389ms step_avg:81.94ms
+step:400/20000 train_loss:2.2888 train_time:32720ms step_avg:81.80ms
+step:600/20000 train_loss:2.4771 train_time:49051ms step_avg:81.75ms
+step:800/20000 train_loss:2.2114 train_time:65391ms step_avg:81.74ms
+step:1000/20000 train_loss:2.3132 train_time:81720ms step_avg:81.72ms
+step:1000/20000 val_loss:2.2606 val_bpb:1.3388 train_time:81731ms step_avg:81.73ms
+step:1200/20000 train_loss:2.3159 train_time:98052ms step_avg:81.71ms
+step:1400/20000 train_loss:2.3589 train_time:114380ms step_avg:81.70ms
+step:1600/20000 train_loss:2.0172 train_time:130729ms step_avg:81.71ms
+step:1800/20000 train_loss:2.1183 train_time:147059ms step_avg:81.70ms
+step:2000/20000 train_loss:2.1504 train_time:163399ms step_avg:81.70ms
+step:2000/20000 val_loss:2.1595 val_bpb:1.2789 train_time:163411ms step_avg:81.71ms
+step:2200/20000 train_loss:2.2664 train_time:179727ms step_avg:81.69ms
+step:2400/20000 train_loss:2.2750 train_time:196057ms step_avg:81.69ms
+step:2600/20000 train_loss:2.1437 train_time:212386ms step_avg:81.69ms
+step:2800/20000 train_loss:2.0962 train_time:228769ms step_avg:81.70ms
+step:3000/20000 train_loss:3.1429 train_time:245084ms step_avg:81.69ms
+step:3000/20000 val_loss:2.1210 val_bpb:1.2562 train_time:245096ms step_avg:81.70ms
+step:3200/20000 train_loss:2.1934 train_time:261411ms step_avg:81.69ms
+step:3400/20000 train_loss:2.0173 train_time:277741ms step_avg:81.69ms
+step:3600/20000 train_loss:2.1398 train_time:294076ms step_avg:81.69ms
+step:3800/20000 train_loss:2.0816 train_time:310416ms step_avg:81.69ms
+step:4000/20000 train_loss:2.1968 train_time:326741ms step_avg:81.69ms
+step:4000/20000 val_loss:2.0965 val_bpb:1.2417 train_time:326753ms step_avg:81.69ms
+step:4200/20000 train_loss:2.1436 train_time:343168ms step_avg:81.71ms
+step:4400/20000 train_loss:2.0937 train_time:359494ms step_avg:81.70ms
+step:4600/20000 train_loss:2.1332 train_time:375822ms step_avg:81.70ms
+step:4800/20000 train_loss:2.0637 train_time:392147ms step_avg:81.70ms
+step:5000/20000 train_loss:2.1467 train_time:408473ms step_avg:81.69ms
+step:5000/20000 val_loss:2.0755 val_bpb:1.2292 train_time:408485ms step_avg:81.70ms
+step:5200/20000 train_loss:2.1999 train_time:424815ms step_avg:81.70ms
+step:5400/20000 train_loss:2.1517 train_time:441147ms step_avg:81.69ms
+step:5600/20000 train_loss:2.0346 train_time:457477ms step_avg:81.69ms
+step:5800/20000 train_loss:2.0832 train_time:473812ms step_avg:81.69ms
+step:6000/20000 train_loss:1.9876 train_time:490146ms step_avg:81.69ms
+step:6000/20000 val_loss:2.0198 val_bpb:1.1962 train_time:490158ms step_avg:81.69ms
+step:6200/20000 train_loss:1.9594 train_time:506650ms step_avg:81.72ms
+step:6400/20000 train_loss:1.7219 train_time:523094ms step_avg:81.73ms
+step:6600/20000 train_loss:1.9349 train_time:539548ms step_avg:81.75ms
+step:6800/20000 train_loss:1.9749 train_time:555997ms step_avg:81.76ms
+step:7000/20000 train_loss:1.9234 train_time:572483ms step_avg:81.78ms
+step:7000/20000 val_loss:1.9732 val_bpb:1.1686 train_time:572491ms step_avg:81.78ms
+step:7200/20000 train_loss:1.8141 train_time:588972ms step_avg:81.80ms
+step:7334/20000 val_loss:1.9708 val_bpb:1.1672 train_time:600025ms step_avg:81.81ms
+stopping_early: wallclock_cap train_time:600025ms step:7334/20000
+peak memory allocated: 16142 MiB reserved: 16578 MiB
+ema:applying EMA weights
+Serialized model: 106281387 bytes
+Code size: 74979 bytes
+Total submission size: 106356366 bytes
+Serialized model int6+zstd-22: 14290148 bytes (payload:28227836 raw_torch:28286663 payload_ratio:3.76x)
+Total submission size int6+zstd-22: 14365127 bytes
+ttt:start chunks=119 chunk_tokens=524288 seq_len=32768 ttt_lr=0.002 ttt_epochs=3 freeze_blocks=2
+ttt:params unfrozen=19719725 frozen=7441426
+  ttt_chunk [1/119] bpb=1.231864 time=7.2s
+  ttt_chunk [11/119] bpb=1.190547 time=12.8s
+  ttt_chunk [21/119] bpb=1.197110 time=18.3s
+  ttt_chunk [31/119] bpb=1.191980 time=23.8s
+  ttt_chunk [41/119] bpb=1.196191 time=29.3s
+  ttt_chunk [51/119] bpb=1.189535 time=34.9s
+  ttt_chunk [61/119] bpb=1.188398 time=40.4s
+  ttt_chunk [71/119] bpb=1.188142 time=46.0s
+  ttt_chunk [81/119] bpb=1.184994 time=51.5s
+  ttt_chunk [91/119] bpb=1.183932 time=57.0s
+  ttt_chunk [101/119] bpb=1.184429 time=62.6s
+  ttt_chunk [111/119] bpb=1.183912 time=68.1s
+  ttt_chunk [119/119] bpb=1.182637 time=72.0s
+ttt:done val_loss=2.003629 val_bpb=1.186634 elapsed=74.0s
+final_int8_zlib_roundtrip val_loss:2.0036 val_bpb:1.1866 eval_mode:score_first_ttt eval_time:74040ms
+final_int8_zlib_roundtrip_exact val_loss:2.00362894 val_bpb:1.18663362

--- a/records/track_10min_16mb/2026-03-26-hymba_long_context_32k/log_seed42.txt
+++ b/records/track_10min_16mb/2026-03-26-hymba_long_context_32k/log_seed42.txt
@@ -1,0 +1,1835 @@
+"""Hymba: Hybrid Attention + Mamba SSM for Parameter Golf."""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+try:
+    import zstandard as zstd
+    HAS_ZSTD = True
+except ImportError:
+    HAS_ZSTD = False
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# Flex attention for sliding window (PyTorch >= 2.5)
+try:
+    from torch.nn.attention.flex_attention import flex_attention, create_block_mask
+    HAS_FLEX_ATTENTION = True
+except ImportError:
+    HAS_FLEX_ATTENTION = False
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmdown_shape = os.environ.get("WARMDOWN_SHAPE", "cosine")  # "linear" or "cosine"
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Evaluation.
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))  # sliding window stride (0 = disabled)
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 0))  # eval sequence length (0 = same as train_seq_len)
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))  # batch size for sliding eval
+    # Test-Time Training (TTT): score-first online adaptation on val data
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.002))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 3))
+    ttt_chunk_tokens = int(os.environ.get("TTT_CHUNK_TOKENS", 524288))
+    ttt_freeze_blocks = int(os.environ.get("TTT_FREEZE_BLOCKS", 0))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+    ttt_batch_seqs = int(os.environ.get("TTT_BATCH_SEQS", 4))
+    ttt_grad_clip = float(os.environ.get("TTT_GRAD_CLIP", 1.0))
+
+    # Quantization.
+    fp16_embed = bool(int(os.environ.get("FP16_EMBED", "1")))  # keep embeddings in FP16
+    quant_bits = int(os.environ.get("QUANT_BITS", 6))  # quantization bit width for attention (6 or 8)
+    quant_bits_mlp = int(os.environ.get("QUANT_BITS_MLP", 0))  # MLP bit width (0 = same as quant_bits)
+    qat_start_frac = float(os.environ.get("QAT_START_FRAC", 0.0))  # QAT: start at this fraction of training (0 = disabled)
+    gptq_lite = bool(int(os.environ.get("GPTQ_LITE", "1")))  # search for optimal clip percentile per tensor
+    use_zstd = bool(int(os.environ.get("USE_ZSTD", "1")))  # use zstd instead of zlib
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 7))  # unique layers
+
+    # SmearGate + BigramHash.
+    use_smeargate = bool(int(os.environ.get("USE_SMEARGATE", "1")))
+    use_bigram_hash = bool(int(os.environ.get("USE_BIGRAM_HASH", "1")))
+    bigram_buckets = int(os.environ.get("BIGRAM_BUCKETS", 4096))
+    bigram_hash_dim = int(os.environ.get("BIGRAM_HASH_DIM", 128))
+
+    # OrthoInit + SWA.
+    use_ortho_init = bool(int(os.environ.get("USE_ORTHO_INIT", "1")))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.4))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 4))
+    hymba_expand = int(os.environ.get("HYMBA_EXPAND", 1))
+    hymba_conv_kernel = int(os.environ.get("HYMBA_CONV_KERNEL", 4))
+    hymba_dt_rank = int(os.environ.get("HYMBA_DT_RANK", 0))
+    hymba_ssm_state = int(os.environ.get("HYMBA_SSM_STATE", 8))
+    kv_share_every = int(os.environ.get("KV_SHARE_EVERY", 1))  # share KV every N layers (1 = no sharing, 2 = paper default)
+    meta_tokens = int(os.environ.get("META_TOKENS", 0))  # learnable register tokens for attention (0 = disabled)
+    sliding_window = int(os.environ.get("SLIDING_WINDOW", 0))  # attention window size (0 = full attention everywhere)
+    swa_global_layers = os.environ.get("SWA_GLOBAL_LAYERS", "auto")  # "auto" = first/mid/last, "none" = all SWA, or comma-separated indices
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    weight_decay = float(os.environ.get("WEIGHT_DECAY", 0.02))
+    ema_enabled = bool(int(os.environ.get("EMA_ENABLED", "1")))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+    grad_checkpoint = bool(int(os.environ.get("GRAD_CHECKPOINT", "0")))
+
+# MUON OPTIMIZER
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, weight_decay=weight_decay),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            weight_decay = group.get("weight_decay", 0.0)
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                if weight_decay > 0:
+                    p.data.mul_(1.0 - lr * weight_decay)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# TOKENIZER + EVALUATION
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters, model: nn.Module, rank: int, world_size: int,
+    device: torch.device, grad_accum_steps: int, val_tokens: Tensor,
+    base_bytes_lut: Tensor, has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+def eval_val_sliding(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    """Sliding window evaluation: score each token with maximal left-context."""
+    seq_len = args.train_seq_len
+    stride = args.eval_stride
+    batch_size = args.eval_batch_seqs
+    total_tokens = val_tokens.numel() - 1
+
+    window_starts = [ws for ws in range(0, total_tokens - seq_len + 1, stride)]
+    if window_starts[-1] + seq_len < total_tokens:
+        window_starts.append(total_tokens - seq_len)
+
+    my_starts = window_starts[rank::world_size]
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    with torch.inference_mode():
+        for batch_start in range(0, len(my_starts), batch_size):
+            batch_ws = my_starts[batch_start:batch_start + batch_size]
+            bsz = len(batch_ws)
+
+            x_list, y_list = [], []
+            for ws in batch_ws:
+                chunk = val_tokens[ws:ws + seq_len + 1].to(dtype=torch.int64)
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            x_batch = torch.stack(x_list).to(device=device, non_blocking=True)
+            y_batch = torch.stack(y_list).to(device=device, non_blocking=True)
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = base_model.forward_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+
+            for i, ws in enumerate(batch_ws):
+                wlen = min(seq_len, total_tokens - ws)
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+
+                prev_ids = x_batch[i, s:wlen]
+                tgt_ids = y_batch[i, s:wlen]
+                tbytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                tbytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+                byte_count += tbytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return float(val_loss), float(bits_per_token * tokens_per_byte)
+
+
+def eval_val_score_first_ttt(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    log0=print,
+) -> tuple[float, float]:
+    """Legal score-first TTT: score each chunk FIRST, then train on it.
+    Every token is scored BEFORE any update that could use it."""
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = args.ttt_chunk_tokens
+
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+
+    log0(f"ttt:start chunks={num_chunks} chunk_tokens={ttt_chunk} seq_len={seq_len} "
+         f"ttt_lr={args.ttt_lr} ttt_epochs={args.ttt_epochs} "
+         f"freeze_blocks={args.ttt_freeze_blocks}")
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Freeze first N blocks
+    frozen_block_ids = set(range(min(args.ttt_freeze_blocks, len(base_model.blocks))))
+    ttt_params = []
+    for name, p in base_model.named_parameters():
+        freeze = False
+        for bi in frozen_block_ids:
+            if f"blocks.{bi}." in name:
+                freeze = True
+                break
+        if freeze:
+            p.requires_grad_(False)
+        else:
+            p.requires_grad_(True)
+            ttt_params.append(p)
+
+    log0(f"ttt:params unfrozen={sum(p.numel() for p in ttt_params)} "
+         f"frozen={sum(p.numel() for p in base_model.parameters() if not p.requires_grad)}")
+
+    optimizer = torch.optim.SGD(ttt_params, lr=args.ttt_lr, momentum=args.ttt_momentum)
+    t0 = time.perf_counter()
+
+    for ci in range(num_chunks):
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+        chunk_seqs = (chunk_end - chunk_start) // seq_len
+        if chunk_seqs == 0:
+            continue
+
+        # Distribute sequences across ranks
+        my_seq_s = (chunk_seqs * rank) // world_size
+        my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+        my_chunk_seqs = my_seq_e - my_seq_s
+
+        # --- Phase 1: SCORE this chunk (inference_mode) ---
+        base_model.eval()
+        with torch.inference_mode():
+            for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                actual_bs = my_seq_s + bs
+                start_tok = chunk_start + actual_bs * seq_len
+                end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                if end_tok > val_tokens.numel():
+                    continue
+                local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                x = local[:-1].reshape(-1, seq_len)
+                y = local[1:].reshape(-1, seq_len)
+                bsz = x.size(0)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model.forward_logits(x)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y.reshape(-1), reduction="none",
+                ).reshape(bsz, seq_len)
+                loss_sum += nll.to(torch.float64).sum()
+                token_count += float(y.numel())
+                prev_ids = x.reshape(-1)
+                tgt_ids = y.reshape(-1)
+                tb = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                tb += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+                byte_count += tb.to(torch.float64).sum()
+
+        # --- Phase 2: TRAIN on this chunk (already scored = legal) ---
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and args.ttt_epochs > 0 and my_chunk_seqs > 0:
+            base_model.train()
+            cos_lr = args.ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+            for pg in optimizer.param_groups:
+                pg['lr'] = cos_lr
+            for _ep in range(args.ttt_epochs):
+                for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                    be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                    actual_bs = my_seq_s + bs
+                    start_tok = chunk_start + actual_bs * seq_len
+                    end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                    if end_tok > val_tokens.numel():
+                        continue
+                    local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                    x = local[:-1].reshape(-1, seq_len)
+                    y = local[1:].reshape(-1, seq_len)
+                    optimizer.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        loss = base_model(x, y)
+                    loss.backward()
+                    if world_size > 1:
+                        for p in ttt_params:
+                            if p.grad is not None:
+                                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                    torch.nn.utils.clip_grad_norm_(ttt_params, args.ttt_grad_clip)
+                    optimizer.step()
+
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            log0(f"  ttt_chunk [{ci+1}/{num_chunks}] bpb={rbpb:.6f} time={elapsed:.1f}s")
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+    log0(f"ttt:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+         f"elapsed={time.perf_counter() - t0:.1f}s")
+    return float(val_loss), float(val_bpb)
+
+
+# QUANTIZATION
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smeargate,merge_alpha",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def _quantize_with_clip(t32: Tensor, clip_abs: Tensor | float, qmax: int) -> tuple[Tensor, Tensor, Tensor]:
+    if t32.ndim == 2 and isinstance(clip_abs, Tensor):
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / qmax).clamp_min(1.0 / qmax)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -qmax, qmax).to(torch.int8)
+        recon = q.float() * scale[:, None]
+        return q.contiguous(), scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous(), recon
+    clip_abs_f = float(clip_abs) if isinstance(clip_abs, Tensor) else clip_abs
+    scale_f = clip_abs_f / qmax if clip_abs_f > 0 else 1.0
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs_f, clip_abs_f) / scale_f), -qmax, qmax).to(torch.int8)
+    recon = q.float() * scale_f
+    return q.contiguous(), torch.tensor(scale_f, dtype=torch.float32), recon
+
+def quantize_float_tensor(t: Tensor, bits: int = 8, search_clip: bool = False) -> tuple[Tensor, Tensor]:
+    qmax = (1 << (bits - 1)) - 1
+    t32 = t.float()
+
+    if not search_clip:
+        if t32.ndim == 2:
+            clip_abs = (
+                torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+                if t32.numel()
+                else torch.empty((t32.shape[0],), dtype=torch.float32)
+            )
+            q, scale, _ = _quantize_with_clip(t32, clip_abs, qmax)
+            return q, scale
+        clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+        q, scale, _ = _quantize_with_clip(t32, clip_abs, qmax)
+        return q, scale
+
+    candidates = [0.999, 0.9995, 0.9999, 0.99995, 0.99999, 0.999999, 1.0]
+    best_q, best_scale, best_mse = None, None, float("inf")
+
+    for pct in candidates:
+        if t32.ndim == 2:
+            if pct >= 1.0:
+                clip_abs = t32.abs().amax(dim=1)
+            else:
+                clip_abs = torch.quantile(t32.abs(), pct, dim=1)
+            q, scale, recon = _quantize_with_clip(t32, clip_abs, qmax)
+        else:
+            if pct >= 1.0:
+                clip_abs = float(t32.abs().max().item())
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), pct).item()) if t32.numel() else 0.0
+            q, scale, recon = _quantize_with_clip(t32, clip_abs, qmax)
+        mse = (t32 - recon).pow(2).mean().item()
+        if mse < best_mse:
+            best_mse = mse
+            best_q, best_scale = q, scale
+
+    return best_q, best_scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor], fp16_embed: bool = False, quant_bits: int = 8, quant_bits_mlp: int = 0, search_clip: bool = False):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        if fp16_embed and "tok_emb" in name:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        bits = quant_bits
+        if quant_bits_mlp > 0 and "mlp" in name:
+            bits = quant_bits_mlp
+        q, s = quantize_float_tensor(t, bits=bits, search_clip=search_clip)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class FakeQuantizeSTE(torch.autograd.Function):
+    """Simulated quantization with Straight-Through Estimator for QAT."""
+    @staticmethod
+    def forward(ctx, w: Tensor, bits: int) -> Tensor:
+        qmax = (1 << (bits - 1)) - 1
+        if w.ndim == 2:
+            scale = w.detach().abs().amax(dim=1, keepdim=True) / qmax
+            scale = scale.clamp_min(1.0 / qmax)
+            return (torch.clamp(torch.round(w / scale), -qmax, qmax) * scale).to(w.dtype)
+        scale = w.detach().abs().amax() / qmax
+        scale = scale.clamp_min(1.0 / qmax)
+        return (torch.clamp(torch.round(w / scale), -qmax, qmax) * scale).to(w.dtype)
+
+    @staticmethod
+    def backward(ctx, grad: Tensor) -> tuple[Tensor, None]:
+        return grad, None
+
+
+class CastedLinear(nn.Linear):
+    _qat_bits: int = 0
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if self._qat_bits > 0 and self.weight.numel() > 65536:
+            w = FakeQuantizeSTE.apply(w, self._qat_bits)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.full((dim,), 3.0, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate).to(dtype=x.dtype)
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return g * x + (1.0 - g) * x_prev
+
+
+class BigramHash(nn.Module):
+    def __init__(self, num_buckets: int, hash_dim: int, model_dim: int):
+        super().__init__()
+        self.num_buckets = num_buckets
+        self.table = nn.Embedding(num_buckets, hash_dim)
+        self.proj = CastedLinear(hash_dim, model_dim, bias=False)
+        self.proj._zero_init = True
+        nn.init.normal_(self.table.weight, std=0.01)
+
+    def forward(self, input_ids: Tensor) -> Tensor:
+        bsz, seqlen = input_ids.shape
+        prev_ids = torch.cat([torch.zeros(bsz, 1, dtype=input_ids.dtype, device=input_ids.device),
+                              input_ids[:, :-1]], dim=1)
+        h = ((prev_ids.long() * 92821 + input_ids.long()) % self.num_buckets).long()
+        return self.proj(self.table(h))
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class HymbaAttention(nn.Module):
+    """Hymba-style hybrid: attention + Mamba SSM in parallel within one block."""
+    def __init__(
+        self, dim: int, num_heads: int, num_kv_heads: int, rope_base: float,
+        qk_gain_init: float, mamba_expand: int = 2, conv_kernel_size: int = 4,
+        dt_rank: int = 0, ssm_state_size: int = 16, shared_kv_proj=None,
+        sliding_window: int = 0,
+    ):
+        super().__init__()
+        from mamba_ssm.ops.selective_scan_interface import selective_scan_fn
+        from causal_conv1d import causal_conv1d_fn
+        self._selective_scan_fn = selective_scan_fn
+        self._causal_conv1d_fn = causal_conv1d_fn
+        self.sliding_window = sliding_window
+
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        self.intermediate_size = mamba_expand * dim
+        self.ssm_state_size = ssm_state_size
+        self.dt_rank = dt_rank if dt_rank > 0 else max(dim // 16, 1)
+
+        kv_dim = num_kv_heads * self.head_dim
+        self.q_dim = dim
+        self.kv_dim = kv_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+
+        # Cross-layer KV sharing: if shared_kv_proj provided, reuse it
+        if shared_kv_proj is not None:
+            self.kv_proj = shared_kv_proj
+        else:
+            self.kv_proj = CastedLinear(dim, kv_dim * 2, bias=False)
+
+        # Mamba projections (always per-layer)
+        self.mamba_proj = CastedLinear(dim, self.intermediate_size * 2, bias=False)
+
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+        self.conv1d = nn.Conv1d(
+            self.intermediate_size, self.intermediate_size, bias=True,
+            kernel_size=conv_kernel_size, groups=self.intermediate_size,
+            padding=conv_kernel_size - 1,
+        )
+        self.x_proj = CastedLinear(self.intermediate_size, self.dt_rank + ssm_state_size * 2, bias=False)
+        self.dt_proj = nn.Linear(self.dt_rank, self.intermediate_size, bias=True)
+
+        A = torch.arange(1, ssm_state_size + 1, dtype=torch.float32)[None, :].expand(self.intermediate_size, -1).contiguous()
+        self.A_log = nn.Parameter(torch.log(A))
+        self.D = nn.Parameter(torch.ones(self.intermediate_size))
+
+        self.mamba_out_proj = CastedLinear(self.intermediate_size, dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.merge_alpha = nn.Parameter(torch.zeros(1, dtype=torch.float32))
+
+        # Pre-compile flex_attention for sliding window
+        if sliding_window > 0 and HAS_FLEX_ATTENTION:
+            window = sliding_window
+            def swa_mask(b, h, q_idx, kv_idx):
+                causal = q_idx >= kv_idx
+                in_window = (q_idx - kv_idx) < window
+                return causal & in_window
+            self._swa_mask_fn = swa_mask
+            self._swa_block_mask = None  # lazily created on first forward
+            self._flex_attention = torch.compile(flex_attention)
+
+    def _sliding_window_attn(self, q: Tensor, k: Tensor, v: Tensor, seqlen: int) -> Tensor:
+        """Sliding window attention using flex_attention with GQA support."""
+        # Expand KV heads for flex_attention (doesn't support GQA natively)
+        if self.num_kv_heads != self.num_heads:
+            n_rep = self.num_heads // self.num_kv_heads
+            k = k[:, :, None, :, :].expand(-1, -1, n_rep, -1, -1).reshape(
+                k.size(0), self.num_heads, seqlen, self.head_dim
+            )
+            v = v[:, :, None, :, :].expand(-1, -1, n_rep, -1, -1).reshape(
+                v.size(0), self.num_heads, seqlen, self.head_dim
+            )
+        # Lazily create block mask on first call (needs to know seq_len and device)
+        if self._swa_block_mask is None or self._swa_block_mask.shape[-1] != seqlen:
+            self._swa_block_mask = create_block_mask(
+                self._swa_mask_fn, B=None, H=None, Q_LEN=seqlen, KV_LEN=seqlen,
+                device=q.device,
+            )
+        return self._flex_attention(q, k, v, block_mask=self._swa_block_mask)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+
+        q_out = self.c_q(x)
+
+        kv_out = self.kv_proj(x)
+        k_out, v_out = kv_out.split([self.kv_dim, self.kv_dim], dim=-1)
+
+        mamba_out_proj = self.mamba_proj(x)
+        x_ssm, gate = mamba_out_proj.split([self.intermediate_size, self.intermediate_size], dim=-1)
+
+        q = q_out.reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k_out.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = v_out.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+
+        if self.sliding_window > 0 and seqlen > self.sliding_window:
+            y = self._sliding_window_attn(q, k, v, seqlen)
+        else:
+            y = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=None, is_causal=True,
+                enable_gqa=(self.num_kv_heads != self.num_heads),
+            )
+        attn_out = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+
+        x_ssm = x_ssm.transpose(1, 2)
+        gate = gate.transpose(1, 2)
+
+        _conv_dtype = x_ssm.dtype
+        conv_weights = self.conv1d.weight.view(self.conv1d.weight.size(0), self.conv1d.weight.size(2)).to(_conv_dtype)
+        conv_bias = self.conv1d.bias.to(_conv_dtype) if self.conv1d.bias is not None else None
+        x_ssm = self._causal_conv1d_fn(x_ssm, conv_weights, conv_bias, activation="silu")
+
+        ssm_params = self.x_proj(x_ssm.transpose(1, 2))
+        dt, B_ssm, C_ssm = torch.split(
+            ssm_params, [self.dt_rank, self.ssm_state_size, self.ssm_state_size], dim=-1
+        )
+
+        dt_proj_bias = self.dt_proj.bias
+        self.dt_proj.bias = None
+        dt = self.dt_proj(dt).transpose(1, 2)
+        self.dt_proj.bias = dt_proj_bias
+
+        A = -torch.exp(self.A_log.float())
+        dt_proj_bias_f = dt_proj_bias.float() if dt_proj_bias is not None else None
+
+        scan_out = self._selective_scan_fn(
+            x_ssm, dt, A,
+            B_ssm.transpose(1, 2), C_ssm.transpose(1, 2),
+            self.D.float(), z=gate,
+            delta_bias=dt_proj_bias_f,
+            delta_softplus=True,
+            return_last_state=False,
+        )
+        mamba_out = self.mamba_out_proj(scan_out.transpose(1, 2))
+
+        w = torch.sigmoid(self.merge_alpha).to(dtype=x.dtype)
+        merged = w * attn_out + (1.0 - w) * mamba_out
+        return self.proj(merged)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = F.leaky_relu(self.fc(x), negative_slope=0.9)
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int,
+        rope_base: float, qk_gain_init: float, hymba_expand: int = 2,
+        hymba_conv_kernel: int = 4, hymba_dt_rank: int = 0, hymba_ssm_state: int = 16,
+        shared_kv_proj=None, sliding_window: int = 0,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = HymbaAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+            mamba_expand=hymba_expand, conv_kernel_size=hymba_conv_kernel,
+            dt_rank=hymba_dt_rank, ssm_state_size=hymba_ssm_state,
+            shared_kv_proj=shared_kv_proj, sliding_window=sliding_window,
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self, vocab_size: int, num_layers: int, model_dim: int, num_heads: int,
+        num_kv_heads: int, mlp_mult: int, tie_embeddings: bool, tied_embed_init_std: float,
+        logit_softcap: float, rope_base: float, qk_gain_init: float,
+        use_smeargate: bool = False, use_bigram_hash: bool = False,
+        bigram_buckets: int = 4096, bigram_hash_dim: int = 128,
+        use_ortho_init: bool = False, hymba_expand: int = 2, hymba_conv_kernel: int = 4,
+        hymba_dt_rank: int = 0, hymba_ssm_state: int = 16, kv_share_every: int = 1,
+        meta_tokens: int = 0, sliding_window: int = 0, swa_global_layers: str = "auto",
+        grad_checkpoint: bool = False,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.use_ortho_init = use_ortho_init
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+
+        self.smeargate = SmearGate(model_dim) if use_smeargate else None
+        self.bigram_hash = BigramHash(bigram_buckets, bigram_hash_dim, model_dim) if use_bigram_hash else None
+
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+
+        self.skip_weights = nn.Parameter(
+            torch.ones(1, self.num_skip_weights, model_dim, dtype=torch.float32)
+        )
+
+        # Shared meta tokens (one set of learnable embeddings, per-layer KV projection)
+        self._meta_tokens_param = nn.Parameter(
+            torch.randn(1, meta_tokens, model_dim) * 0.02
+        ) if meta_tokens > 0 else None
+
+        # Determine which layers get full attention vs sliding window
+        if sliding_window > 0:
+            if swa_global_layers == "none":
+                global_layers = set()
+            elif swa_global_layers == "auto":
+                # Paper default: first, middle, and last layers
+                global_layers = {0, num_layers // 2, num_layers - 1}
+            else:
+                global_layers = {int(x) for x in swa_global_layers.split(",") if x.strip()}
+        else:
+            global_layers = set(range(num_layers))  # all full attention
+
+        # Build blocks with cross-layer KV sharing
+        blocks = []
+        for i in range(num_layers):
+            # Share KV projections: layer i shares with layer (i // kv_share_every) * kv_share_every
+            shared_kv = None
+            if kv_share_every > 1 and (i % kv_share_every) != 0:
+                # Reuse KV proj from the group leader
+                leader_idx = (i // kv_share_every) * kv_share_every
+                shared_kv = blocks[leader_idx].attn.kv_proj
+            layer_window = 0 if i in global_layers else sliding_window
+            blocks.append(Block(
+                model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init,
+                hymba_expand=hymba_expand, hymba_conv_kernel=hymba_conv_kernel,
+                hymba_dt_rank=hymba_dt_rank, hymba_ssm_state=hymba_ssm_state,
+                shared_kv_proj=shared_kv, sliding_window=layer_window,
+            ))
+        self.blocks = nn.ModuleList(blocks)
+
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.grad_checkpoint = grad_checkpoint
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        num_layers = len(self.blocks)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif self.use_ortho_init and module.weight.ndim == 2 and min(module.weight.shape) >= 16:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj" in name and name.split(".")[-1] in ("proj", "proj_D"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+
+    def _compute_logits_and_loss(self, x: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def _embed(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram_hash is not None:
+            x = x + self.bigram_hash(input_ids)
+        if self.smeargate is not None:
+            x = self.smeargate(x)
+        return F.rms_norm(x, (x.size(-1),))
+
+    def _block_forward(self, block: nn.Module, x: Tensor, x0: Tensor) -> Tensor:
+        if self.grad_checkpoint and self.training:
+            return torch.utils.checkpoint.checkpoint(block, x, x0, use_reentrant=False)
+        return block(x, x0)
+
+    def _prepend_meta(self, x: Tensor) -> Tensor:
+        """Prepend learnable meta tokens to the sequence."""
+        if self._meta_tokens_param is not None:
+            meta = self._meta_tokens_param.expand(x.size(0), -1, -1).to(dtype=x.dtype)
+            x = torch.cat([meta, x], dim=1)
+        return x
+
+    def _strip_meta(self, x: Tensor) -> Tensor:
+        """Remove meta token positions from the output."""
+        if self._meta_tokens_param is not None:
+            x = x[:, self._meta_tokens_param.size(1):]
+        return x
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self._embed(input_ids)
+        x = self._prepend_meta(x)
+        x0 = x
+        skips: list[Tensor] = []
+
+        for i in range(self.num_encoder_layers):
+            x = self._block_forward(self.blocks[i], x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[0, i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self._block_forward(self.blocks[self.num_encoder_layers + i], x, x0)
+
+        x = self._strip_meta(x)
+        return self._compute_logits_and_loss(x, target_ids)
+
+    def _run_blocks(self, x: Tensor, x0: Tensor) -> Tensor:
+        skips: list[Tensor] = []
+        for i in range(self.num_encoder_layers):
+            x = self._block_forward(self.blocks[i], x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[0, i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self._block_forward(self.blocks[self.num_encoder_layers + i], x, x0)
+        return x
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        bsz, seqlen = input_ids.shape
+        x = self._embed(input_ids)
+        x = self._prepend_meta(x)
+        x = self._run_blocks(x, x)
+        x = self._strip_meta(x)
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        w = self.tok_emb.weight if self.tie_embeddings else self.lm_head.weight
+        logits = self.logit_softcap * torch.tanh(F.linear(x, w) / self.logit_softcap)
+        return logits.reshape(bsz, seqlen, -1)
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = int(os.environ.get("GRAD_ACCUM_STEPS", 8 // world_size))
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    base_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        use_smeargate=args.use_smeargate, use_bigram_hash=args.use_bigram_hash,
+        bigram_buckets=args.bigram_buckets, bigram_hash_dim=args.bigram_hash_dim,
+        use_ortho_init=args.use_ortho_init, hymba_expand=args.hymba_expand,
+        hymba_conv_kernel=args.hymba_conv_kernel, hymba_dt_rank=args.hymba_dt_rank,
+        hymba_ssm_state=args.hymba_ssm_state, kv_share_every=args.kv_share_every,
+        meta_tokens=args.meta_tokens, sliding_window=args.sliding_window,
+        swa_global_layers=args.swa_global_layers, grad_checkpoint=args.grad_checkpoint,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    if bool(int(os.environ.get("NO_COMPILE", "0"))):
+        compiled_model = base_model
+    else:
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=False)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if hasattr(base_model, 'skip_weights') and base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    if base_model.smeargate is not None:
+        scalar_params.append(base_model.smeargate.gate)
+    if base_model.bigram_hash is not None:
+        scalar_params.append(base_model.bigram_hash.table.weight)
+        matrix_params.append(base_model.bigram_hash.proj.weight)
+    if base_model._meta_tokens_param is not None:
+        scalar_params.append(base_model._meta_tokens_param)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params, lr=args.matrix_lr, momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps, weight_decay=args.weight_decay,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(f"num_layers:{args.num_layers} mlp_mult:{args.mlp_mult} kv_share_every:{args.kv_share_every} meta_tokens:{args.meta_tokens} sliding_window:{args.sliding_window}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            frac = max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        else:
+            step_ms = elapsed_ms / max(step, 1)
+            warmdown_ms = args.warmdown_iters * step_ms
+            remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+            frac = remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+        if args.warmdown_shape == "cosine" and frac < 1.0:
+            return 0.5 * (1.0 + math.cos(math.pi * (1.0 - frac)))
+        return frac
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+
+    ema_state: dict[str, Tensor] | None = None
+    if args.ema_enabled:
+        ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+
+        if args.qat_start_frac > 0 and max_wallclock_ms:
+            elapsed_frac_qat = elapsed_ms / max_wallclock_ms
+            qat_active = elapsed_frac_qat >= args.qat_start_frac
+            qat_bits = args.quant_bits if qat_active else 0
+            if qat_active and any(m._qat_bits == 0 for m in base_model.modules() if isinstance(m, CastedLinear)):
+                log0(f"qat:enabled bits={qat_bits} at step {step} frac={elapsed_frac_qat:.2f}")
+                for m in base_model.modules():
+                    if isinstance(m, CastedLinear):
+                        m._qat_bits = qat_bits
+
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        cur_seq_len = args.train_seq_len
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, cur_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+
+        if ema_state is not None:
+            d = args.ema_decay
+            with torch.no_grad():
+                for name, t in base_model.state_dict().items():
+                    ema_state[name].mul_(d).add_(t.detach().float(), alpha=1.0 - d)
+
+        if args.swa_enabled and scale < args.swa_start_frac and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone().float() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu().float()
+                swa_count += 1
+
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    for m in base_model.modules():
+        if isinstance(m, CastedLinear):
+            m._qat_bits = 0
+
+    if ema_state is not None:
+        log0("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+        del ema_state
+        base_model.load_state_dict(avg_state, strict=True)
+    elif args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"swa:applying averaged {swa_count} checkpoints")
+        current_state = base_model.state_dict()
+        avg_state = {
+            name: (tensor / swa_count).to(dtype=current_state[name].dtype)
+            for name, tensor in swa_state.items()
+        }
+        del swa_state
+        base_model.load_state_dict(avg_state, strict=True)
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(
+        base_model.state_dict(), fp16_embed=args.fp16_embed, quant_bits=args.quant_bits,
+        quant_bits_mlp=args.quant_bits_mlp, search_clip=args.gptq_lite,
+    )
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    if args.use_zstd and HAS_ZSTD:
+        cctx = zstd.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+        compress_fmt = "zstd-22"
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+        compress_fmt = "zlib-9"
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int{args.quant_bits}+{compress_fmt}: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int{args.quant_bits}+{compress_fmt}: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    if args.use_zstd and HAS_ZSTD:
+        dctx = zstd.ZstdDecompressor()
+        quant_decompressed = dctx.decompress(quant_blob_disk)
+    else:
+        quant_decompressed = zlib.decompress(quant_blob_disk)
+    quant_state = torch.load(io.BytesIO(quant_decompressed), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+
+    # Override seq_len for eval if EVAL_SEQ_LEN is set
+    eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    if eval_seq_len != args.train_seq_len:
+        val_tokens = load_validation_tokens(args.val_files, eval_seq_len)
+    original_train_seq_len = args.train_seq_len
+    args.train_seq_len = eval_seq_len
+
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+
+    if args.ttt_enabled:
+        q_val_loss, q_val_bpb = eval_val_score_first_ttt(
+            args, base_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            log0=log0,
+        )
+        eval_mode = "score_first_ttt"
+    else:
+        use_sliding = args.eval_stride > 0 and args.eval_stride < args.train_seq_len
+        if use_sliding:
+            q_val_loss, q_val_bpb = eval_val_sliding(
+                args, base_model, rank, world_size, device,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            eval_mode = "sliding"
+        else:
+            q_val_loss, q_val_bpb = eval_val(
+                args, base_model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            eval_mode = "standard"
+    torch.cuda.synchronize()
+    args.train_seq_len = original_train_seq_len
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_mode:{eval_mode} eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
+Running Python 3.12.3 (main, Aug 14 2025, 17:47:21) [GCC 13.3.0]
+Running PyTorch 2.8.0+cu128
+Thu Mar 26 23:37:17 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.195.03             Driver Version: 570.195.03     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   41C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:06:00.0 Off |                    0 |
+| N/A   32C    P0            117W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:07:00.0 Off |                    0 |
+| N/A   41C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:08:00.0 Off |                    0 |
+| N/A   41C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:09:00.0 Off |                    0 |
+| N/A   41C    P0            125W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   33C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   32C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:0C:00.0 Off |                    0 |
+| N/A   40C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A           36130      C   /usr/local/bin/python                  1510MiB |
+|    1   N/A  N/A           36131      C   /usr/local/bin/python                  1510MiB |
+|    2   N/A  N/A           36132      C   /usr/local/bin/python                  1510MiB |
+|    3   N/A  N/A           36133      C   /usr/local/bin/python                  1510MiB |
+|    4   N/A  N/A           36134      C   /usr/local/bin/python                  1510MiB |
+|    5   N/A  N/A           36135      C   /usr/local/bin/python                  1510MiB |
+|    6   N/A  N/A           36136      C   /usr/local/bin/python                  1510MiB |
+|    7   N/A  N/A           36137      C   /usr/local/bin/python                  1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:10
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:61997056
+model_params:27161151
+world_size:8 grad_accum_steps:1
+attention_mode:gqa num_heads:8 num_kv_heads:4
+num_layers:7 mlp_mult:4 kv_share_every:1 meta_tokens:0 sliding_window:512
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:524288 train_seq_len:32768 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:42
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9348 val_bpb:4.1071 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9363 train_time:84ms step_avg:83.62ms
+step:2/20000 train_loss:17.8080 train_time:171ms step_avg:85.39ms
+step:3/20000 train_loss:9.4447 train_time:260ms step_avg:86.64ms
+step:4/20000 train_loss:6.5102 train_time:349ms step_avg:87.23ms
+step:5/20000 train_loss:6.1565 train_time:438ms step_avg:87.58ms
+step:6/20000 train_loss:7.0715 train_time:527ms step_avg:87.76ms
+step:7/20000 train_loss:6.0782 train_time:616ms step_avg:87.95ms
+step:8/20000 train_loss:6.0054 train_time:705ms step_avg:88.14ms
+step:9/20000 train_loss:5.9825 train_time:794ms step_avg:88.21ms
+step:10/20000 train_loss:5.9381 train_time:883ms step_avg:88.28ms
+step:200/20000 train_loss:2.8946 train_time:16581ms step_avg:82.91ms
+step:400/20000 train_loss:2.3005 train_time:33205ms step_avg:83.01ms
+step:600/20000 train_loss:2.4803 train_time:49913ms step_avg:83.19ms
+step:800/20000 train_loss:2.2105 train_time:66620ms step_avg:83.28ms
+step:1000/20000 train_loss:2.3114 train_time:83458ms step_avg:83.46ms
+step:1000/20000 val_loss:2.2603 val_bpb:1.3387 train_time:83472ms step_avg:83.47ms
+step:1200/20000 train_loss:2.3159 train_time:100206ms step_avg:83.50ms
+step:1400/20000 train_loss:2.3552 train_time:116999ms step_avg:83.57ms
+step:1600/20000 train_loss:2.0155 train_time:133779ms step_avg:83.61ms
+step:1800/20000 train_loss:2.1173 train_time:150585ms step_avg:83.66ms
+step:2000/20000 train_loss:2.1493 train_time:167368ms step_avg:83.68ms
+step:2000/20000 val_loss:2.1583 val_bpb:1.2782 train_time:167381ms step_avg:83.69ms
+step:2200/20000 train_loss:2.2639 train_time:184154ms step_avg:83.71ms
+step:2400/20000 train_loss:2.2771 train_time:200971ms step_avg:83.74ms
+step:2600/20000 train_loss:2.1464 train_time:217762ms step_avg:83.75ms
+step:2800/20000 train_loss:2.0940 train_time:234557ms step_avg:83.77ms
+step:3000/20000 train_loss:3.1276 train_time:251362ms step_avg:83.79ms
+step:3000/20000 val_loss:2.1209 val_bpb:1.2561 train_time:251375ms step_avg:83.79ms
+step:3200/20000 train_loss:2.1912 train_time:268143ms step_avg:83.79ms
+step:3400/20000 train_loss:2.0212 train_time:284948ms step_avg:83.81ms
+step:3600/20000 train_loss:2.1390 train_time:301743ms step_avg:83.82ms
+step:3800/20000 train_loss:2.0825 train_time:318518ms step_avg:83.82ms
+step:4000/20000 train_loss:2.1989 train_time:335302ms step_avg:83.83ms
+step:4000/20000 val_loss:2.0963 val_bpb:1.2415 train_time:335317ms step_avg:83.83ms
+step:4200/20000 train_loss:2.1538 train_time:352189ms step_avg:83.85ms
+step:4400/20000 train_loss:2.0956 train_time:369033ms step_avg:83.87ms
+step:4600/20000 train_loss:2.1340 train_time:385863ms step_avg:83.88ms
+step:4800/20000 train_loss:2.0606 train_time:402730ms step_avg:83.90ms
+step:5000/20000 train_loss:2.1397 train_time:419564ms step_avg:83.91ms
+step:5000/20000 val_loss:2.0697 val_bpb:1.2257 train_time:419579ms step_avg:83.92ms
+step:5200/20000 train_loss:2.1896 train_time:436327ms step_avg:83.91ms
+step:5400/20000 train_loss:2.1407 train_time:453094ms step_avg:83.91ms
+step:5600/20000 train_loss:2.0256 train_time:469887ms step_avg:83.91ms
+step:5800/20000 train_loss:2.0697 train_time:486722ms step_avg:83.92ms
+step:6000/20000 train_loss:1.9759 train_time:503773ms step_avg:83.96ms
+step:6000/20000 val_loss:2.0094 val_bpb:1.1901 train_time:503782ms step_avg:83.96ms
+step:6200/20000 train_loss:1.9507 train_time:520765ms step_avg:83.99ms
+step:6400/20000 train_loss:1.7149 train_time:537734ms step_avg:84.02ms
+step:6600/20000 train_loss:1.9271 train_time:554666ms step_avg:84.04ms
+step:6800/20000 train_loss:1.9699 train_time:571546ms step_avg:84.05ms
+step:7000/20000 train_loss:1.9164 train_time:588368ms step_avg:84.05ms
+step:7000/20000 val_loss:1.9723 val_bpb:1.1681 train_time:588380ms step_avg:84.05ms
+step:7139/20000 val_loss:1.9721 val_bpb:1.1680 train_time:600003ms step_avg:84.05ms
+stopping_early: wallclock_cap train_time:600003ms step:7139/20000
+peak memory allocated: 16142 MiB reserved: 16578 MiB
+ema:applying EMA weights
+Serialized model: 106281387 bytes
+Code size: 74890 bytes
+Total submission size: 106356277 bytes
+Serialized model int6+zstd-22: 14555318 bytes (payload:28227836 raw_torch:28286663 payload_ratio:3.76x)
+Total submission size int6+zstd-22: 14630208 bytes
+ttt:start chunks=119 chunk_tokens=524288 seq_len=32768 ttt_lr=0.002 ttt_epochs=3 freeze_blocks=2
+ttt:params unfrozen=19719725 frozen=7441426
+  ttt_chunk [1/119] bpb=1.234057 time=1.4s
+  ttt_chunk [11/119] bpb=1.193707 time=7.0s
+  ttt_chunk [21/119] bpb=1.199437 time=12.5s
+  ttt_chunk [31/119] bpb=1.194089 time=18.1s
+  ttt_chunk [41/119] bpb=1.198068 time=23.6s
+  ttt_chunk [51/119] bpb=1.191268 time=29.2s
+  ttt_chunk [61/119] bpb=1.189980 time=34.7s
+  ttt_chunk [71/119] bpb=1.189589 time=40.2s
+  ttt_chunk [81/119] bpb=1.186446 time=45.8s
+  ttt_chunk [91/119] bpb=1.185287 time=51.3s
+  ttt_chunk [101/119] bpb=1.185762 time=56.9s
+  ttt_chunk [111/119] bpb=1.185304 time=62.5s
+  ttt_chunk [119/119] bpb=1.184001 time=66.3s
+ttt:done val_loss=2.006066 val_bpb=1.188077 elapsed=66.7s
+final_int8_zlib_roundtrip val_loss:2.0061 val_bpb:1.1881 eval_mode:score_first_ttt eval_time:66674ms
+final_int8_zlib_roundtrip_exact val_loss:2.00606628 val_bpb:1.18807711

--- a/records/track_10min_16mb/2026-03-26-hymba_long_context_32k/log_seed7.txt
+++ b/records/track_10min_16mb/2026-03-26-hymba_long_context_32k/log_seed7.txt
@@ -1,0 +1,1835 @@
+"""Hymba: Hybrid Attention + Mamba SSM for Parameter Golf."""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+try:
+    import zstandard as zstd
+    HAS_ZSTD = True
+except ImportError:
+    HAS_ZSTD = False
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# Flex attention for sliding window (PyTorch >= 2.5)
+try:
+    from torch.nn.attention.flex_attention import flex_attention, create_block_mask
+    HAS_FLEX_ATTENTION = True
+except ImportError:
+    HAS_FLEX_ATTENTION = False
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmdown_shape = os.environ.get("WARMDOWN_SHAPE", "cosine")  # "linear" or "cosine"
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Evaluation.
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))  # sliding window stride (0 = disabled)
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 0))  # eval sequence length (0 = same as train_seq_len)
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))  # batch size for sliding eval
+    # Test-Time Training (TTT): score-first online adaptation on val data
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.002))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 3))
+    ttt_chunk_tokens = int(os.environ.get("TTT_CHUNK_TOKENS", 524288))
+    ttt_freeze_blocks = int(os.environ.get("TTT_FREEZE_BLOCKS", 0))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+    ttt_batch_seqs = int(os.environ.get("TTT_BATCH_SEQS", 4))
+    ttt_grad_clip = float(os.environ.get("TTT_GRAD_CLIP", 1.0))
+
+    # Quantization.
+    fp16_embed = bool(int(os.environ.get("FP16_EMBED", "1")))  # keep embeddings in FP16
+    quant_bits = int(os.environ.get("QUANT_BITS", 6))  # quantization bit width for attention (6 or 8)
+    quant_bits_mlp = int(os.environ.get("QUANT_BITS_MLP", 0))  # MLP bit width (0 = same as quant_bits)
+    qat_start_frac = float(os.environ.get("QAT_START_FRAC", 0.0))  # QAT: start at this fraction of training (0 = disabled)
+    gptq_lite = bool(int(os.environ.get("GPTQ_LITE", "1")))  # search for optimal clip percentile per tensor
+    use_zstd = bool(int(os.environ.get("USE_ZSTD", "1")))  # use zstd instead of zlib
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 7))  # unique layers
+
+    # SmearGate + BigramHash.
+    use_smeargate = bool(int(os.environ.get("USE_SMEARGATE", "1")))
+    use_bigram_hash = bool(int(os.environ.get("USE_BIGRAM_HASH", "1")))
+    bigram_buckets = int(os.environ.get("BIGRAM_BUCKETS", 4096))
+    bigram_hash_dim = int(os.environ.get("BIGRAM_HASH_DIM", 128))
+
+    # OrthoInit + SWA.
+    use_ortho_init = bool(int(os.environ.get("USE_ORTHO_INIT", "1")))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.4))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 4))
+    hymba_expand = int(os.environ.get("HYMBA_EXPAND", 1))
+    hymba_conv_kernel = int(os.environ.get("HYMBA_CONV_KERNEL", 4))
+    hymba_dt_rank = int(os.environ.get("HYMBA_DT_RANK", 0))
+    hymba_ssm_state = int(os.environ.get("HYMBA_SSM_STATE", 8))
+    kv_share_every = int(os.environ.get("KV_SHARE_EVERY", 1))  # share KV every N layers (1 = no sharing, 2 = paper default)
+    meta_tokens = int(os.environ.get("META_TOKENS", 0))  # learnable register tokens for attention (0 = disabled)
+    sliding_window = int(os.environ.get("SLIDING_WINDOW", 0))  # attention window size (0 = full attention everywhere)
+    swa_global_layers = os.environ.get("SWA_GLOBAL_LAYERS", "auto")  # "auto" = first/mid/last, "none" = all SWA, or comma-separated indices
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    weight_decay = float(os.environ.get("WEIGHT_DECAY", 0.02))
+    ema_enabled = bool(int(os.environ.get("EMA_ENABLED", "1")))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+    grad_checkpoint = bool(int(os.environ.get("GRAD_CHECKPOINT", "0")))
+
+# MUON OPTIMIZER
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, weight_decay=weight_decay),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            weight_decay = group.get("weight_decay", 0.0)
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                if weight_decay > 0:
+                    p.data.mul_(1.0 - lr * weight_decay)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# TOKENIZER + EVALUATION
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters, model: nn.Module, rank: int, world_size: int,
+    device: torch.device, grad_accum_steps: int, val_tokens: Tensor,
+    base_bytes_lut: Tensor, has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+def eval_val_sliding(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    """Sliding window evaluation: score each token with maximal left-context."""
+    seq_len = args.train_seq_len
+    stride = args.eval_stride
+    batch_size = args.eval_batch_seqs
+    total_tokens = val_tokens.numel() - 1
+
+    window_starts = [ws for ws in range(0, total_tokens - seq_len + 1, stride)]
+    if window_starts[-1] + seq_len < total_tokens:
+        window_starts.append(total_tokens - seq_len)
+
+    my_starts = window_starts[rank::world_size]
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    with torch.inference_mode():
+        for batch_start in range(0, len(my_starts), batch_size):
+            batch_ws = my_starts[batch_start:batch_start + batch_size]
+            bsz = len(batch_ws)
+
+            x_list, y_list = [], []
+            for ws in batch_ws:
+                chunk = val_tokens[ws:ws + seq_len + 1].to(dtype=torch.int64)
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            x_batch = torch.stack(x_list).to(device=device, non_blocking=True)
+            y_batch = torch.stack(y_list).to(device=device, non_blocking=True)
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = base_model.forward_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+
+            for i, ws in enumerate(batch_ws):
+                wlen = min(seq_len, total_tokens - ws)
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+
+                prev_ids = x_batch[i, s:wlen]
+                tgt_ids = y_batch[i, s:wlen]
+                tbytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                tbytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+                byte_count += tbytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return float(val_loss), float(bits_per_token * tokens_per_byte)
+
+
+def eval_val_score_first_ttt(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    log0=print,
+) -> tuple[float, float]:
+    """Legal score-first TTT: score each chunk FIRST, then train on it.
+    Every token is scored BEFORE any update that could use it."""
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = args.ttt_chunk_tokens
+
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+
+    log0(f"ttt:start chunks={num_chunks} chunk_tokens={ttt_chunk} seq_len={seq_len} "
+         f"ttt_lr={args.ttt_lr} ttt_epochs={args.ttt_epochs} "
+         f"freeze_blocks={args.ttt_freeze_blocks}")
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Freeze first N blocks
+    frozen_block_ids = set(range(min(args.ttt_freeze_blocks, len(base_model.blocks))))
+    ttt_params = []
+    for name, p in base_model.named_parameters():
+        freeze = False
+        for bi in frozen_block_ids:
+            if f"blocks.{bi}." in name:
+                freeze = True
+                break
+        if freeze:
+            p.requires_grad_(False)
+        else:
+            p.requires_grad_(True)
+            ttt_params.append(p)
+
+    log0(f"ttt:params unfrozen={sum(p.numel() for p in ttt_params)} "
+         f"frozen={sum(p.numel() for p in base_model.parameters() if not p.requires_grad)}")
+
+    optimizer = torch.optim.SGD(ttt_params, lr=args.ttt_lr, momentum=args.ttt_momentum)
+    t0 = time.perf_counter()
+
+    for ci in range(num_chunks):
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+        chunk_seqs = (chunk_end - chunk_start) // seq_len
+        if chunk_seqs == 0:
+            continue
+
+        # Distribute sequences across ranks
+        my_seq_s = (chunk_seqs * rank) // world_size
+        my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+        my_chunk_seqs = my_seq_e - my_seq_s
+
+        # --- Phase 1: SCORE this chunk (inference_mode) ---
+        base_model.eval()
+        with torch.inference_mode():
+            for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                actual_bs = my_seq_s + bs
+                start_tok = chunk_start + actual_bs * seq_len
+                end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                if end_tok > val_tokens.numel():
+                    continue
+                local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                x = local[:-1].reshape(-1, seq_len)
+                y = local[1:].reshape(-1, seq_len)
+                bsz = x.size(0)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model.forward_logits(x)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y.reshape(-1), reduction="none",
+                ).reshape(bsz, seq_len)
+                loss_sum += nll.to(torch.float64).sum()
+                token_count += float(y.numel())
+                prev_ids = x.reshape(-1)
+                tgt_ids = y.reshape(-1)
+                tb = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                tb += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+                byte_count += tb.to(torch.float64).sum()
+
+        # --- Phase 2: TRAIN on this chunk (already scored = legal) ---
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and args.ttt_epochs > 0 and my_chunk_seqs > 0:
+            base_model.train()
+            cos_lr = args.ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+            for pg in optimizer.param_groups:
+                pg['lr'] = cos_lr
+            for _ep in range(args.ttt_epochs):
+                for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                    be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                    actual_bs = my_seq_s + bs
+                    start_tok = chunk_start + actual_bs * seq_len
+                    end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                    if end_tok > val_tokens.numel():
+                        continue
+                    local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                    x = local[:-1].reshape(-1, seq_len)
+                    y = local[1:].reshape(-1, seq_len)
+                    optimizer.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        loss = base_model(x, y)
+                    loss.backward()
+                    if world_size > 1:
+                        for p in ttt_params:
+                            if p.grad is not None:
+                                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                    torch.nn.utils.clip_grad_norm_(ttt_params, args.ttt_grad_clip)
+                    optimizer.step()
+
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            log0(f"  ttt_chunk [{ci+1}/{num_chunks}] bpb={rbpb:.6f} time={elapsed:.1f}s")
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+    log0(f"ttt:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+         f"elapsed={time.perf_counter() - t0:.1f}s")
+    return float(val_loss), float(val_bpb)
+
+
+# QUANTIZATION
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smeargate,merge_alpha",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def _quantize_with_clip(t32: Tensor, clip_abs: Tensor | float, qmax: int) -> tuple[Tensor, Tensor, Tensor]:
+    if t32.ndim == 2 and isinstance(clip_abs, Tensor):
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / qmax).clamp_min(1.0 / qmax)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -qmax, qmax).to(torch.int8)
+        recon = q.float() * scale[:, None]
+        return q.contiguous(), scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous(), recon
+    clip_abs_f = float(clip_abs) if isinstance(clip_abs, Tensor) else clip_abs
+    scale_f = clip_abs_f / qmax if clip_abs_f > 0 else 1.0
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs_f, clip_abs_f) / scale_f), -qmax, qmax).to(torch.int8)
+    recon = q.float() * scale_f
+    return q.contiguous(), torch.tensor(scale_f, dtype=torch.float32), recon
+
+def quantize_float_tensor(t: Tensor, bits: int = 8, search_clip: bool = False) -> tuple[Tensor, Tensor]:
+    qmax = (1 << (bits - 1)) - 1
+    t32 = t.float()
+
+    if not search_clip:
+        if t32.ndim == 2:
+            clip_abs = (
+                torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+                if t32.numel()
+                else torch.empty((t32.shape[0],), dtype=torch.float32)
+            )
+            q, scale, _ = _quantize_with_clip(t32, clip_abs, qmax)
+            return q, scale
+        clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+        q, scale, _ = _quantize_with_clip(t32, clip_abs, qmax)
+        return q, scale
+
+    candidates = [0.999, 0.9995, 0.9999, 0.99995, 0.99999, 0.999999, 1.0]
+    best_q, best_scale, best_mse = None, None, float("inf")
+
+    for pct in candidates:
+        if t32.ndim == 2:
+            if pct >= 1.0:
+                clip_abs = t32.abs().amax(dim=1)
+            else:
+                clip_abs = torch.quantile(t32.abs(), pct, dim=1)
+            q, scale, recon = _quantize_with_clip(t32, clip_abs, qmax)
+        else:
+            if pct >= 1.0:
+                clip_abs = float(t32.abs().max().item())
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), pct).item()) if t32.numel() else 0.0
+            q, scale, recon = _quantize_with_clip(t32, clip_abs, qmax)
+        mse = (t32 - recon).pow(2).mean().item()
+        if mse < best_mse:
+            best_mse = mse
+            best_q, best_scale = q, scale
+
+    return best_q, best_scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor], fp16_embed: bool = False, quant_bits: int = 8, quant_bits_mlp: int = 0, search_clip: bool = False):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        if fp16_embed and "tok_emb" in name:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        bits = quant_bits
+        if quant_bits_mlp > 0 and "mlp" in name:
+            bits = quant_bits_mlp
+        q, s = quantize_float_tensor(t, bits=bits, search_clip=search_clip)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class FakeQuantizeSTE(torch.autograd.Function):
+    """Simulated quantization with Straight-Through Estimator for QAT."""
+    @staticmethod
+    def forward(ctx, w: Tensor, bits: int) -> Tensor:
+        qmax = (1 << (bits - 1)) - 1
+        if w.ndim == 2:
+            scale = w.detach().abs().amax(dim=1, keepdim=True) / qmax
+            scale = scale.clamp_min(1.0 / qmax)
+            return (torch.clamp(torch.round(w / scale), -qmax, qmax) * scale).to(w.dtype)
+        scale = w.detach().abs().amax() / qmax
+        scale = scale.clamp_min(1.0 / qmax)
+        return (torch.clamp(torch.round(w / scale), -qmax, qmax) * scale).to(w.dtype)
+
+    @staticmethod
+    def backward(ctx, grad: Tensor) -> tuple[Tensor, None]:
+        return grad, None
+
+
+class CastedLinear(nn.Linear):
+    _qat_bits: int = 0
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if self._qat_bits > 0 and self.weight.numel() > 65536:
+            w = FakeQuantizeSTE.apply(w, self._qat_bits)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.full((dim,), 3.0, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate).to(dtype=x.dtype)
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return g * x + (1.0 - g) * x_prev
+
+
+class BigramHash(nn.Module):
+    def __init__(self, num_buckets: int, hash_dim: int, model_dim: int):
+        super().__init__()
+        self.num_buckets = num_buckets
+        self.table = nn.Embedding(num_buckets, hash_dim)
+        self.proj = CastedLinear(hash_dim, model_dim, bias=False)
+        self.proj._zero_init = True
+        nn.init.normal_(self.table.weight, std=0.01)
+
+    def forward(self, input_ids: Tensor) -> Tensor:
+        bsz, seqlen = input_ids.shape
+        prev_ids = torch.cat([torch.zeros(bsz, 1, dtype=input_ids.dtype, device=input_ids.device),
+                              input_ids[:, :-1]], dim=1)
+        h = ((prev_ids.long() * 92821 + input_ids.long()) % self.num_buckets).long()
+        return self.proj(self.table(h))
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class HymbaAttention(nn.Module):
+    """Hymba-style hybrid: attention + Mamba SSM in parallel within one block."""
+    def __init__(
+        self, dim: int, num_heads: int, num_kv_heads: int, rope_base: float,
+        qk_gain_init: float, mamba_expand: int = 2, conv_kernel_size: int = 4,
+        dt_rank: int = 0, ssm_state_size: int = 16, shared_kv_proj=None,
+        sliding_window: int = 0,
+    ):
+        super().__init__()
+        from mamba_ssm.ops.selective_scan_interface import selective_scan_fn
+        from causal_conv1d import causal_conv1d_fn
+        self._selective_scan_fn = selective_scan_fn
+        self._causal_conv1d_fn = causal_conv1d_fn
+        self.sliding_window = sliding_window
+
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        self.intermediate_size = mamba_expand * dim
+        self.ssm_state_size = ssm_state_size
+        self.dt_rank = dt_rank if dt_rank > 0 else max(dim // 16, 1)
+
+        kv_dim = num_kv_heads * self.head_dim
+        self.q_dim = dim
+        self.kv_dim = kv_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+
+        # Cross-layer KV sharing: if shared_kv_proj provided, reuse it
+        if shared_kv_proj is not None:
+            self.kv_proj = shared_kv_proj
+        else:
+            self.kv_proj = CastedLinear(dim, kv_dim * 2, bias=False)
+
+        # Mamba projections (always per-layer)
+        self.mamba_proj = CastedLinear(dim, self.intermediate_size * 2, bias=False)
+
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+        self.conv1d = nn.Conv1d(
+            self.intermediate_size, self.intermediate_size, bias=True,
+            kernel_size=conv_kernel_size, groups=self.intermediate_size,
+            padding=conv_kernel_size - 1,
+        )
+        self.x_proj = CastedLinear(self.intermediate_size, self.dt_rank + ssm_state_size * 2, bias=False)
+        self.dt_proj = nn.Linear(self.dt_rank, self.intermediate_size, bias=True)
+
+        A = torch.arange(1, ssm_state_size + 1, dtype=torch.float32)[None, :].expand(self.intermediate_size, -1).contiguous()
+        self.A_log = nn.Parameter(torch.log(A))
+        self.D = nn.Parameter(torch.ones(self.intermediate_size))
+
+        self.mamba_out_proj = CastedLinear(self.intermediate_size, dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.merge_alpha = nn.Parameter(torch.zeros(1, dtype=torch.float32))
+
+        # Pre-compile flex_attention for sliding window
+        if sliding_window > 0 and HAS_FLEX_ATTENTION:
+            window = sliding_window
+            def swa_mask(b, h, q_idx, kv_idx):
+                causal = q_idx >= kv_idx
+                in_window = (q_idx - kv_idx) < window
+                return causal & in_window
+            self._swa_mask_fn = swa_mask
+            self._swa_block_mask = None  # lazily created on first forward
+            self._flex_attention = torch.compile(flex_attention)
+
+    def _sliding_window_attn(self, q: Tensor, k: Tensor, v: Tensor, seqlen: int) -> Tensor:
+        """Sliding window attention using flex_attention with GQA support."""
+        # Expand KV heads for flex_attention (doesn't support GQA natively)
+        if self.num_kv_heads != self.num_heads:
+            n_rep = self.num_heads // self.num_kv_heads
+            k = k[:, :, None, :, :].expand(-1, -1, n_rep, -1, -1).reshape(
+                k.size(0), self.num_heads, seqlen, self.head_dim
+            )
+            v = v[:, :, None, :, :].expand(-1, -1, n_rep, -1, -1).reshape(
+                v.size(0), self.num_heads, seqlen, self.head_dim
+            )
+        # Lazily create block mask on first call (needs to know seq_len and device)
+        if self._swa_block_mask is None or self._swa_block_mask.shape[-1] != seqlen:
+            self._swa_block_mask = create_block_mask(
+                self._swa_mask_fn, B=None, H=None, Q_LEN=seqlen, KV_LEN=seqlen,
+                device=q.device,
+            )
+        return self._flex_attention(q, k, v, block_mask=self._swa_block_mask)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+
+        q_out = self.c_q(x)
+
+        kv_out = self.kv_proj(x)
+        k_out, v_out = kv_out.split([self.kv_dim, self.kv_dim], dim=-1)
+
+        mamba_out_proj = self.mamba_proj(x)
+        x_ssm, gate = mamba_out_proj.split([self.intermediate_size, self.intermediate_size], dim=-1)
+
+        q = q_out.reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k_out.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = v_out.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+
+        if self.sliding_window > 0 and seqlen > self.sliding_window:
+            y = self._sliding_window_attn(q, k, v, seqlen)
+        else:
+            y = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=None, is_causal=True,
+                enable_gqa=(self.num_kv_heads != self.num_heads),
+            )
+        attn_out = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+
+        x_ssm = x_ssm.transpose(1, 2)
+        gate = gate.transpose(1, 2)
+
+        _conv_dtype = x_ssm.dtype
+        conv_weights = self.conv1d.weight.view(self.conv1d.weight.size(0), self.conv1d.weight.size(2)).to(_conv_dtype)
+        conv_bias = self.conv1d.bias.to(_conv_dtype) if self.conv1d.bias is not None else None
+        x_ssm = self._causal_conv1d_fn(x_ssm, conv_weights, conv_bias, activation="silu")
+
+        ssm_params = self.x_proj(x_ssm.transpose(1, 2))
+        dt, B_ssm, C_ssm = torch.split(
+            ssm_params, [self.dt_rank, self.ssm_state_size, self.ssm_state_size], dim=-1
+        )
+
+        dt_proj_bias = self.dt_proj.bias
+        self.dt_proj.bias = None
+        dt = self.dt_proj(dt).transpose(1, 2)
+        self.dt_proj.bias = dt_proj_bias
+
+        A = -torch.exp(self.A_log.float())
+        dt_proj_bias_f = dt_proj_bias.float() if dt_proj_bias is not None else None
+
+        scan_out = self._selective_scan_fn(
+            x_ssm, dt, A,
+            B_ssm.transpose(1, 2), C_ssm.transpose(1, 2),
+            self.D.float(), z=gate,
+            delta_bias=dt_proj_bias_f,
+            delta_softplus=True,
+            return_last_state=False,
+        )
+        mamba_out = self.mamba_out_proj(scan_out.transpose(1, 2))
+
+        w = torch.sigmoid(self.merge_alpha).to(dtype=x.dtype)
+        merged = w * attn_out + (1.0 - w) * mamba_out
+        return self.proj(merged)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = F.leaky_relu(self.fc(x), negative_slope=0.9)
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int,
+        rope_base: float, qk_gain_init: float, hymba_expand: int = 2,
+        hymba_conv_kernel: int = 4, hymba_dt_rank: int = 0, hymba_ssm_state: int = 16,
+        shared_kv_proj=None, sliding_window: int = 0,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = HymbaAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+            mamba_expand=hymba_expand, conv_kernel_size=hymba_conv_kernel,
+            dt_rank=hymba_dt_rank, ssm_state_size=hymba_ssm_state,
+            shared_kv_proj=shared_kv_proj, sliding_window=sliding_window,
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self, vocab_size: int, num_layers: int, model_dim: int, num_heads: int,
+        num_kv_heads: int, mlp_mult: int, tie_embeddings: bool, tied_embed_init_std: float,
+        logit_softcap: float, rope_base: float, qk_gain_init: float,
+        use_smeargate: bool = False, use_bigram_hash: bool = False,
+        bigram_buckets: int = 4096, bigram_hash_dim: int = 128,
+        use_ortho_init: bool = False, hymba_expand: int = 2, hymba_conv_kernel: int = 4,
+        hymba_dt_rank: int = 0, hymba_ssm_state: int = 16, kv_share_every: int = 1,
+        meta_tokens: int = 0, sliding_window: int = 0, swa_global_layers: str = "auto",
+        grad_checkpoint: bool = False,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.use_ortho_init = use_ortho_init
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+
+        self.smeargate = SmearGate(model_dim) if use_smeargate else None
+        self.bigram_hash = BigramHash(bigram_buckets, bigram_hash_dim, model_dim) if use_bigram_hash else None
+
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+
+        self.skip_weights = nn.Parameter(
+            torch.ones(1, self.num_skip_weights, model_dim, dtype=torch.float32)
+        )
+
+        # Shared meta tokens (one set of learnable embeddings, per-layer KV projection)
+        self._meta_tokens_param = nn.Parameter(
+            torch.randn(1, meta_tokens, model_dim) * 0.02
+        ) if meta_tokens > 0 else None
+
+        # Determine which layers get full attention vs sliding window
+        if sliding_window > 0:
+            if swa_global_layers == "none":
+                global_layers = set()
+            elif swa_global_layers == "auto":
+                # Paper default: first, middle, and last layers
+                global_layers = {0, num_layers // 2, num_layers - 1}
+            else:
+                global_layers = {int(x) for x in swa_global_layers.split(",") if x.strip()}
+        else:
+            global_layers = set(range(num_layers))  # all full attention
+
+        # Build blocks with cross-layer KV sharing
+        blocks = []
+        for i in range(num_layers):
+            # Share KV projections: layer i shares with layer (i // kv_share_every) * kv_share_every
+            shared_kv = None
+            if kv_share_every > 1 and (i % kv_share_every) != 0:
+                # Reuse KV proj from the group leader
+                leader_idx = (i // kv_share_every) * kv_share_every
+                shared_kv = blocks[leader_idx].attn.kv_proj
+            layer_window = 0 if i in global_layers else sliding_window
+            blocks.append(Block(
+                model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init,
+                hymba_expand=hymba_expand, hymba_conv_kernel=hymba_conv_kernel,
+                hymba_dt_rank=hymba_dt_rank, hymba_ssm_state=hymba_ssm_state,
+                shared_kv_proj=shared_kv, sliding_window=layer_window,
+            ))
+        self.blocks = nn.ModuleList(blocks)
+
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.grad_checkpoint = grad_checkpoint
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        num_layers = len(self.blocks)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif self.use_ortho_init and module.weight.ndim == 2 and min(module.weight.shape) >= 16:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj" in name and name.split(".")[-1] in ("proj", "proj_D"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+
+    def _compute_logits_and_loss(self, x: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def _embed(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram_hash is not None:
+            x = x + self.bigram_hash(input_ids)
+        if self.smeargate is not None:
+            x = self.smeargate(x)
+        return F.rms_norm(x, (x.size(-1),))
+
+    def _block_forward(self, block: nn.Module, x: Tensor, x0: Tensor) -> Tensor:
+        if self.grad_checkpoint and self.training:
+            return torch.utils.checkpoint.checkpoint(block, x, x0, use_reentrant=False)
+        return block(x, x0)
+
+    def _prepend_meta(self, x: Tensor) -> Tensor:
+        """Prepend learnable meta tokens to the sequence."""
+        if self._meta_tokens_param is not None:
+            meta = self._meta_tokens_param.expand(x.size(0), -1, -1).to(dtype=x.dtype)
+            x = torch.cat([meta, x], dim=1)
+        return x
+
+    def _strip_meta(self, x: Tensor) -> Tensor:
+        """Remove meta token positions from the output."""
+        if self._meta_tokens_param is not None:
+            x = x[:, self._meta_tokens_param.size(1):]
+        return x
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self._embed(input_ids)
+        x = self._prepend_meta(x)
+        x0 = x
+        skips: list[Tensor] = []
+
+        for i in range(self.num_encoder_layers):
+            x = self._block_forward(self.blocks[i], x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[0, i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self._block_forward(self.blocks[self.num_encoder_layers + i], x, x0)
+
+        x = self._strip_meta(x)
+        return self._compute_logits_and_loss(x, target_ids)
+
+    def _run_blocks(self, x: Tensor, x0: Tensor) -> Tensor:
+        skips: list[Tensor] = []
+        for i in range(self.num_encoder_layers):
+            x = self._block_forward(self.blocks[i], x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[0, i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self._block_forward(self.blocks[self.num_encoder_layers + i], x, x0)
+        return x
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        bsz, seqlen = input_ids.shape
+        x = self._embed(input_ids)
+        x = self._prepend_meta(x)
+        x = self._run_blocks(x, x)
+        x = self._strip_meta(x)
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        w = self.tok_emb.weight if self.tie_embeddings else self.lm_head.weight
+        logits = self.logit_softcap * torch.tanh(F.linear(x, w) / self.logit_softcap)
+        return logits.reshape(bsz, seqlen, -1)
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = int(os.environ.get("GRAD_ACCUM_STEPS", 8 // world_size))
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    base_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        use_smeargate=args.use_smeargate, use_bigram_hash=args.use_bigram_hash,
+        bigram_buckets=args.bigram_buckets, bigram_hash_dim=args.bigram_hash_dim,
+        use_ortho_init=args.use_ortho_init, hymba_expand=args.hymba_expand,
+        hymba_conv_kernel=args.hymba_conv_kernel, hymba_dt_rank=args.hymba_dt_rank,
+        hymba_ssm_state=args.hymba_ssm_state, kv_share_every=args.kv_share_every,
+        meta_tokens=args.meta_tokens, sliding_window=args.sliding_window,
+        swa_global_layers=args.swa_global_layers, grad_checkpoint=args.grad_checkpoint,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    if bool(int(os.environ.get("NO_COMPILE", "0"))):
+        compiled_model = base_model
+    else:
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=False)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if hasattr(base_model, 'skip_weights') and base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    if base_model.smeargate is not None:
+        scalar_params.append(base_model.smeargate.gate)
+    if base_model.bigram_hash is not None:
+        scalar_params.append(base_model.bigram_hash.table.weight)
+        matrix_params.append(base_model.bigram_hash.proj.weight)
+    if base_model._meta_tokens_param is not None:
+        scalar_params.append(base_model._meta_tokens_param)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params, lr=args.matrix_lr, momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps, weight_decay=args.weight_decay,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(f"num_layers:{args.num_layers} mlp_mult:{args.mlp_mult} kv_share_every:{args.kv_share_every} meta_tokens:{args.meta_tokens} sliding_window:{args.sliding_window}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            frac = max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        else:
+            step_ms = elapsed_ms / max(step, 1)
+            warmdown_ms = args.warmdown_iters * step_ms
+            remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+            frac = remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+        if args.warmdown_shape == "cosine" and frac < 1.0:
+            return 0.5 * (1.0 + math.cos(math.pi * (1.0 - frac)))
+        return frac
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+
+    ema_state: dict[str, Tensor] | None = None
+    if args.ema_enabled:
+        ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+
+        if args.qat_start_frac > 0 and max_wallclock_ms:
+            elapsed_frac_qat = elapsed_ms / max_wallclock_ms
+            qat_active = elapsed_frac_qat >= args.qat_start_frac
+            qat_bits = args.quant_bits if qat_active else 0
+            if qat_active and any(m._qat_bits == 0 for m in base_model.modules() if isinstance(m, CastedLinear)):
+                log0(f"qat:enabled bits={qat_bits} at step {step} frac={elapsed_frac_qat:.2f}")
+                for m in base_model.modules():
+                    if isinstance(m, CastedLinear):
+                        m._qat_bits = qat_bits
+
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        cur_seq_len = args.train_seq_len
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, cur_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+
+        if ema_state is not None:
+            d = args.ema_decay
+            with torch.no_grad():
+                for name, t in base_model.state_dict().items():
+                    ema_state[name].mul_(d).add_(t.detach().float(), alpha=1.0 - d)
+
+        if args.swa_enabled and scale < args.swa_start_frac and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone().float() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu().float()
+                swa_count += 1
+
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    for m in base_model.modules():
+        if isinstance(m, CastedLinear):
+            m._qat_bits = 0
+
+    if ema_state is not None:
+        log0("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+        del ema_state
+        base_model.load_state_dict(avg_state, strict=True)
+    elif args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"swa:applying averaged {swa_count} checkpoints")
+        current_state = base_model.state_dict()
+        avg_state = {
+            name: (tensor / swa_count).to(dtype=current_state[name].dtype)
+            for name, tensor in swa_state.items()
+        }
+        del swa_state
+        base_model.load_state_dict(avg_state, strict=True)
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(
+        base_model.state_dict(), fp16_embed=args.fp16_embed, quant_bits=args.quant_bits,
+        quant_bits_mlp=args.quant_bits_mlp, search_clip=args.gptq_lite,
+    )
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    if args.use_zstd and HAS_ZSTD:
+        cctx = zstd.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+        compress_fmt = "zstd-22"
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+        compress_fmt = "zlib-9"
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int{args.quant_bits}+{compress_fmt}: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int{args.quant_bits}+{compress_fmt}: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    if args.use_zstd and HAS_ZSTD:
+        dctx = zstd.ZstdDecompressor()
+        quant_decompressed = dctx.decompress(quant_blob_disk)
+    else:
+        quant_decompressed = zlib.decompress(quant_blob_disk)
+    quant_state = torch.load(io.BytesIO(quant_decompressed), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+
+    # Override seq_len for eval if EVAL_SEQ_LEN is set
+    eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    if eval_seq_len != args.train_seq_len:
+        val_tokens = load_validation_tokens(args.val_files, eval_seq_len)
+    original_train_seq_len = args.train_seq_len
+    args.train_seq_len = eval_seq_len
+
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+
+    if args.ttt_enabled:
+        q_val_loss, q_val_bpb = eval_val_score_first_ttt(
+            args, base_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            log0=log0,
+        )
+        eval_mode = "score_first_ttt"
+    else:
+        use_sliding = args.eval_stride > 0 and args.eval_stride < args.train_seq_len
+        if use_sliding:
+            q_val_loss, q_val_bpb = eval_val_sliding(
+                args, base_model, rank, world_size, device,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            eval_mode = "sliding"
+        else:
+            q_val_loss, q_val_bpb = eval_val(
+                args, base_model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            eval_mode = "standard"
+    torch.cuda.synchronize()
+    args.train_seq_len = original_train_seq_len
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_mode:{eval_mode} eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
+Running Python 3.12.3 (main, Aug 14 2025, 17:47:21) [GCC 13.3.0]
+Running PyTorch 2.8.0+cu128
+Thu Mar 26 23:50:41 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.195.03             Driver Version: 570.195.03     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   41C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:06:00.0 Off |                    0 |
+| N/A   32C    P0            117W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:07:00.0 Off |                    0 |
+| N/A   41C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:08:00.0 Off |                    0 |
+| N/A   41C    P0            124W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:09:00.0 Off |                    0 |
+| N/A   41C    P0            125W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   33C    P0            116W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   31C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:0C:00.0 Off |                    0 |
+| N/A   40C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A           38394      C   /usr/local/bin/python                  1510MiB |
+|    1   N/A  N/A           38395      C   /usr/local/bin/python                  1510MiB |
+|    2   N/A  N/A           38396      C   /usr/local/bin/python                  1510MiB |
+|    3   N/A  N/A           38397      C   /usr/local/bin/python                  1510MiB |
+|    4   N/A  N/A           38398      C   /usr/local/bin/python                  1510MiB |
+|    5   N/A  N/A           38399      C   /usr/local/bin/python                  1510MiB |
+|    6   N/A  N/A           38400      C   /usr/local/bin/python                  1510MiB |
+|    7   N/A  N/A           38401      C   /usr/local/bin/python                  1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:10
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:61997056
+model_params:27161151
+world_size:8 grad_accum_steps:1
+attention_mode:gqa num_heads:8 num_kv_heads:4
+num_layers:7 mlp_mult:4 kv_share_every:1 meta_tokens:0 sliding_window:512
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.02 scalar_lr:0.02
+train_batch_tokens:524288 train_seq_len:32768 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:7
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9377 val_bpb:4.1088 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9380 train_time:80ms step_avg:80.39ms
+step:2/20000 train_loss:17.6497 train_time:167ms step_avg:83.62ms
+step:3/20000 train_loss:9.2552 train_time:256ms step_avg:85.31ms
+step:4/20000 train_loss:6.6352 train_time:344ms step_avg:86.09ms
+step:5/20000 train_loss:6.2494 train_time:434ms step_avg:86.71ms
+step:6/20000 train_loss:7.1248 train_time:522ms step_avg:87.04ms
+step:7/20000 train_loss:6.1403 train_time:610ms step_avg:87.15ms
+step:8/20000 train_loss:6.0311 train_time:698ms step_avg:87.19ms
+step:9/20000 train_loss:5.9794 train_time:786ms step_avg:87.35ms
+step:10/20000 train_loss:5.9322 train_time:874ms step_avg:87.41ms
+step:200/20000 train_loss:2.8858 train_time:16520ms step_avg:82.60ms
+step:400/20000 train_loss:2.2903 train_time:33157ms step_avg:82.89ms
+step:600/20000 train_loss:2.4790 train_time:49781ms step_avg:82.97ms
+step:800/20000 train_loss:2.2108 train_time:66418ms step_avg:83.02ms
+step:1000/20000 train_loss:2.3121 train_time:83106ms step_avg:83.11ms
+step:1000/20000 val_loss:2.2575 val_bpb:1.3370 train_time:83120ms step_avg:83.12ms
+step:1200/20000 train_loss:2.3169 train_time:99516ms step_avg:82.93ms
+step:1400/20000 train_loss:2.3538 train_time:115926ms step_avg:82.80ms
+step:1600/20000 train_loss:2.0193 train_time:132615ms step_avg:82.88ms
+step:1800/20000 train_loss:2.1186 train_time:149335ms step_avg:82.96ms
+step:2000/20000 train_loss:2.1502 train_time:166063ms step_avg:83.03ms
+step:2000/20000 val_loss:2.1591 val_bpb:1.2787 train_time:166077ms step_avg:83.04ms
+step:2200/20000 train_loss:2.2612 train_time:182775ms step_avg:83.08ms
+step:2400/20000 train_loss:2.2774 train_time:199471ms step_avg:83.11ms
+step:2600/20000 train_loss:2.1490 train_time:216188ms step_avg:83.15ms
+step:2800/20000 train_loss:2.0936 train_time:232890ms step_avg:83.17ms
+step:3000/20000 train_loss:3.1210 train_time:249598ms step_avg:83.20ms
+step:3000/20000 val_loss:2.1209 val_bpb:1.2561 train_time:249616ms step_avg:83.21ms
+step:3200/20000 train_loss:2.1905 train_time:266311ms step_avg:83.22ms
+step:3400/20000 train_loss:2.0191 train_time:283023ms step_avg:83.24ms
+step:3600/20000 train_loss:2.1439 train_time:299716ms step_avg:83.25ms
+step:3800/20000 train_loss:2.0817 train_time:316419ms step_avg:83.27ms
+step:4000/20000 train_loss:2.2030 train_time:333157ms step_avg:83.29ms
+step:4000/20000 val_loss:2.0978 val_bpb:1.2424 train_time:333181ms step_avg:83.30ms
+step:4200/20000 train_loss:2.1435 train_time:350029ms step_avg:83.34ms
+step:4400/20000 train_loss:2.0931 train_time:366781ms step_avg:83.36ms
+step:4600/20000 train_loss:2.1315 train_time:383552ms step_avg:83.38ms
+step:4800/20000 train_loss:2.0649 train_time:400346ms step_avg:83.41ms
+step:5000/20000 train_loss:2.1389 train_time:417082ms step_avg:83.42ms
+step:5000/20000 val_loss:2.0723 val_bpb:1.2273 train_time:417102ms step_avg:83.42ms
+step:5200/20000 train_loss:2.1904 train_time:433590ms step_avg:83.38ms
+step:5400/20000 train_loss:2.1468 train_time:450262ms step_avg:83.38ms
+step:5600/20000 train_loss:2.0312 train_time:466987ms step_avg:83.39ms
+step:5800/20000 train_loss:2.0734 train_time:483745ms step_avg:83.40ms
+step:6000/20000 train_loss:1.9813 train_time:500712ms step_avg:83.45ms
+step:6000/20000 val_loss:2.0121 val_bpb:1.1917 train_time:500721ms step_avg:83.45ms
+step:6200/20000 train_loss:1.9494 train_time:517687ms step_avg:83.50ms
+step:6400/20000 train_loss:1.7153 train_time:534580ms step_avg:83.53ms
+step:6600/20000 train_loss:1.9281 train_time:551479ms step_avg:83.56ms
+step:6800/20000 train_loss:1.9733 train_time:568374ms step_avg:83.58ms
+step:7000/20000 train_loss:1.9198 train_time:585225ms step_avg:83.60ms
+step:7000/20000 val_loss:1.9725 val_bpb:1.1682 train_time:585242ms step_avg:83.61ms
+step:7176/20000 val_loss:1.9721 val_bpb:1.1680 train_time:599993ms step_avg:83.61ms
+stopping_early: wallclock_cap train_time:599993ms step:7176/20000
+peak memory allocated: 16142 MiB reserved: 16578 MiB
+ema:applying EMA weights
+Serialized model: 106281387 bytes
+Code size: 74890 bytes
+Total submission size: 106356277 bytes
+Serialized model int6+zstd-22: 14397340 bytes (payload:28227836 raw_torch:28286663 payload_ratio:3.76x)
+Total submission size int6+zstd-22: 14472230 bytes
+ttt:start chunks=119 chunk_tokens=524288 seq_len=32768 ttt_lr=0.002 ttt_epochs=3 freeze_blocks=2
+ttt:params unfrozen=19719725 frozen=7441426
+  ttt_chunk [1/119] bpb=1.229938 time=1.4s
+  ttt_chunk [11/119] bpb=1.191202 time=6.9s
+  ttt_chunk [21/119] bpb=1.198010 time=12.4s
+  ttt_chunk [31/119] bpb=1.192702 time=18.0s
+  ttt_chunk [41/119] bpb=1.196907 time=23.5s
+  ttt_chunk [51/119] bpb=1.190183 time=29.1s
+  ttt_chunk [61/119] bpb=1.188934 time=34.6s
+  ttt_chunk [71/119] bpb=1.188663 time=40.2s
+  ttt_chunk [81/119] bpb=1.185535 time=45.8s
+  ttt_chunk [91/119] bpb=1.184421 time=51.3s
+  ttt_chunk [101/119] bpb=1.184889 time=56.9s
+  ttt_chunk [111/119] bpb=1.184478 time=62.4s
+  ttt_chunk [119/119] bpb=1.183171 time=66.3s
+ttt:done val_loss=2.004767 val_bpb=1.187308 elapsed=66.6s
+final_int8_zlib_roundtrip val_loss:2.0048 val_bpb:1.1873 eval_mode:score_first_ttt eval_time:66636ms
+final_int8_zlib_roundtrip_exact val_loss:2.00476736 val_bpb:1.18730784

--- a/records/track_10min_16mb/2026-03-26-hymba_long_context_32k/submission.json
+++ b/records/track_10min_16mb/2026-03-26-hymba_long_context_32k/submission.json
@@ -1,0 +1,17 @@
+{
+  "submission_name": "Hymba-LongContext",
+  "description": "Hybrid Mamba+SWA architecture enabling 32K context training at the same per-step cost as 1K, with score-first TTT evaluation",
+  "track": "10min_16mb",
+  "train_script": "train_gpt.py",
+  "seeds": [1337, 42, 7],
+  "results": {
+    "1337": {"val_bpb": 1.1866, "val_loss": 2.0036, "steps": 7334, "artifact_bytes": 14290148, "eval_time_s": 74.0},
+    "42": {"val_bpb": 1.1881, "val_loss": 2.0061, "steps": 7139, "artifact_bytes": 14555318, "eval_time_s": 66.7},
+    "7": {"val_bpb": 1.1873, "val_loss": 2.0048, "steps": 7176, "artifact_bytes": 14397340, "eval_time_s": 66.6}
+  },
+  "mean_val_bpb": 1.1873,
+  "std_val_bpb": 0.0008,
+  "hardware": "8xH100 SXM 80GB",
+  "training_time_s": 600,
+  "dependencies": ["mamba-ssm", "causal-conv1d", "zstandard"]
+}

--- a/records/track_10min_16mb/2026-03-26-hymba_long_context_32k/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-26-hymba_long_context_32k/train_gpt.py
@@ -1,0 +1,1664 @@
+"""Hymba: Hybrid Attention + Mamba SSM for Parameter Golf."""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+try:
+    import zstandard as zstd
+    HAS_ZSTD = True
+except ImportError:
+    HAS_ZSTD = False
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# Flex attention for sliding window (PyTorch >= 2.5)
+try:
+    from torch.nn.attention.flex_attention import flex_attention, create_block_mask
+    HAS_FLEX_ATTENTION = True
+except ImportError:
+    HAS_FLEX_ATTENTION = False
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmdown_shape = os.environ.get("WARMDOWN_SHAPE", "cosine")  # "linear" or "cosine"
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Evaluation.
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))  # sliding window stride (0 = disabled)
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 0))  # eval sequence length (0 = same as train_seq_len)
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))  # batch size for sliding eval
+    # Test-Time Training (TTT): score-first online adaptation on val data
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.002))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 3))
+    ttt_chunk_tokens = int(os.environ.get("TTT_CHUNK_TOKENS", 524288))
+    ttt_freeze_blocks = int(os.environ.get("TTT_FREEZE_BLOCKS", 0))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+    ttt_batch_seqs = int(os.environ.get("TTT_BATCH_SEQS", 4))
+    ttt_grad_clip = float(os.environ.get("TTT_GRAD_CLIP", 1.0))
+
+    # Quantization.
+    fp16_embed = bool(int(os.environ.get("FP16_EMBED", "1")))  # keep embeddings in FP16
+    quant_bits = int(os.environ.get("QUANT_BITS", 6))  # quantization bit width for attention (6 or 8)
+    quant_bits_mlp = int(os.environ.get("QUANT_BITS_MLP", 0))  # MLP bit width (0 = same as quant_bits)
+    qat_start_frac = float(os.environ.get("QAT_START_FRAC", 0.0))  # QAT: start at this fraction of training (0 = disabled)
+    gptq_lite = bool(int(os.environ.get("GPTQ_LITE", "1")))  # search for optimal clip percentile per tensor
+    use_zstd = bool(int(os.environ.get("USE_ZSTD", "1")))  # use zstd instead of zlib
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 7))  # unique layers
+
+    # SmearGate + BigramHash.
+    use_smeargate = bool(int(os.environ.get("USE_SMEARGATE", "1")))
+    use_bigram_hash = bool(int(os.environ.get("USE_BIGRAM_HASH", "1")))
+    bigram_buckets = int(os.environ.get("BIGRAM_BUCKETS", 4096))
+    bigram_hash_dim = int(os.environ.get("BIGRAM_HASH_DIM", 128))
+
+    # OrthoInit + SWA.
+    use_ortho_init = bool(int(os.environ.get("USE_ORTHO_INIT", "1")))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.4))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 4))
+    hymba_expand = int(os.environ.get("HYMBA_EXPAND", 1))
+    hymba_conv_kernel = int(os.environ.get("HYMBA_CONV_KERNEL", 4))
+    hymba_dt_rank = int(os.environ.get("HYMBA_DT_RANK", 0))
+    hymba_ssm_state = int(os.environ.get("HYMBA_SSM_STATE", 8))
+    kv_share_every = int(os.environ.get("KV_SHARE_EVERY", 1))  # share KV every N layers (1 = no sharing, 2 = paper default)
+    meta_tokens = int(os.environ.get("META_TOKENS", 0))  # learnable register tokens for attention (0 = disabled)
+    sliding_window = int(os.environ.get("SLIDING_WINDOW", 0))  # attention window size (0 = full attention everywhere)
+    swa_global_layers = os.environ.get("SWA_GLOBAL_LAYERS", "auto")  # "auto" = first/mid/last, "none" = all SWA, or comma-separated indices
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    weight_decay = float(os.environ.get("WEIGHT_DECAY", 0.02))
+    ema_enabled = bool(int(os.environ.get("EMA_ENABLED", "1")))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+    grad_checkpoint = bool(int(os.environ.get("GRAD_CHECKPOINT", "0")))
+
+# MUON OPTIMIZER
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, weight_decay=weight_decay),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            weight_decay = group.get("weight_decay", 0.0)
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                if weight_decay > 0:
+                    p.data.mul_(1.0 - lr * weight_decay)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# TOKENIZER + EVALUATION
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters, model: nn.Module, rank: int, world_size: int,
+    device: torch.device, grad_accum_steps: int, val_tokens: Tensor,
+    base_bytes_lut: Tensor, has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+def eval_val_sliding(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    """Sliding window evaluation: score each token with maximal left-context."""
+    seq_len = args.train_seq_len
+    stride = args.eval_stride
+    batch_size = args.eval_batch_seqs
+    total_tokens = val_tokens.numel() - 1
+
+    window_starts = [ws for ws in range(0, total_tokens - seq_len + 1, stride)]
+    if window_starts[-1] + seq_len < total_tokens:
+        window_starts.append(total_tokens - seq_len)
+
+    my_starts = window_starts[rank::world_size]
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    with torch.inference_mode():
+        for batch_start in range(0, len(my_starts), batch_size):
+            batch_ws = my_starts[batch_start:batch_start + batch_size]
+            bsz = len(batch_ws)
+
+            x_list, y_list = [], []
+            for ws in batch_ws:
+                chunk = val_tokens[ws:ws + seq_len + 1].to(dtype=torch.int64)
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            x_batch = torch.stack(x_list).to(device=device, non_blocking=True)
+            y_batch = torch.stack(y_list).to(device=device, non_blocking=True)
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = base_model.forward_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+
+            for i, ws in enumerate(batch_ws):
+                wlen = min(seq_len, total_tokens - ws)
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+
+                prev_ids = x_batch[i, s:wlen]
+                tgt_ids = y_batch[i, s:wlen]
+                tbytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                tbytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+                byte_count += tbytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return float(val_loss), float(bits_per_token * tokens_per_byte)
+
+
+def eval_val_score_first_ttt(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    log0=print,
+) -> tuple[float, float]:
+    """Legal score-first TTT: score each chunk FIRST, then train on it.
+    Every token is scored BEFORE any update that could use it."""
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = args.ttt_chunk_tokens
+
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+
+    log0(f"ttt:start chunks={num_chunks} chunk_tokens={ttt_chunk} seq_len={seq_len} "
+         f"ttt_lr={args.ttt_lr} ttt_epochs={args.ttt_epochs} "
+         f"freeze_blocks={args.ttt_freeze_blocks}")
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Freeze first N blocks
+    frozen_block_ids = set(range(min(args.ttt_freeze_blocks, len(base_model.blocks))))
+    ttt_params = []
+    for name, p in base_model.named_parameters():
+        freeze = False
+        for bi in frozen_block_ids:
+            if f"blocks.{bi}." in name:
+                freeze = True
+                break
+        if freeze:
+            p.requires_grad_(False)
+        else:
+            p.requires_grad_(True)
+            ttt_params.append(p)
+
+    log0(f"ttt:params unfrozen={sum(p.numel() for p in ttt_params)} "
+         f"frozen={sum(p.numel() for p in base_model.parameters() if not p.requires_grad)}")
+
+    optimizer = torch.optim.SGD(ttt_params, lr=args.ttt_lr, momentum=args.ttt_momentum)
+    t0 = time.perf_counter()
+
+    for ci in range(num_chunks):
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+        chunk_seqs = (chunk_end - chunk_start) // seq_len
+        if chunk_seqs == 0:
+            continue
+
+        # Distribute sequences across ranks
+        my_seq_s = (chunk_seqs * rank) // world_size
+        my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+        my_chunk_seqs = my_seq_e - my_seq_s
+
+        # --- Phase 1: SCORE this chunk (inference_mode) ---
+        base_model.eval()
+        with torch.inference_mode():
+            for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                actual_bs = my_seq_s + bs
+                start_tok = chunk_start + actual_bs * seq_len
+                end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                if end_tok > val_tokens.numel():
+                    continue
+                local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                x = local[:-1].reshape(-1, seq_len)
+                y = local[1:].reshape(-1, seq_len)
+                bsz = x.size(0)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model.forward_logits(x)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y.reshape(-1), reduction="none",
+                ).reshape(bsz, seq_len)
+                loss_sum += nll.to(torch.float64).sum()
+                token_count += float(y.numel())
+                prev_ids = x.reshape(-1)
+                tgt_ids = y.reshape(-1)
+                tb = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                tb += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+                byte_count += tb.to(torch.float64).sum()
+
+        # --- Phase 2: TRAIN on this chunk (already scored = legal) ---
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and args.ttt_epochs > 0 and my_chunk_seqs > 0:
+            base_model.train()
+            cos_lr = args.ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+            for pg in optimizer.param_groups:
+                pg['lr'] = cos_lr
+            for _ep in range(args.ttt_epochs):
+                for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                    be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                    actual_bs = my_seq_s + bs
+                    start_tok = chunk_start + actual_bs * seq_len
+                    end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                    if end_tok > val_tokens.numel():
+                        continue
+                    local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                    x = local[:-1].reshape(-1, seq_len)
+                    y = local[1:].reshape(-1, seq_len)
+                    optimizer.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        loss = base_model(x, y)
+                    loss.backward()
+                    if world_size > 1:
+                        for p in ttt_params:
+                            if p.grad is not None:
+                                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                    torch.nn.utils.clip_grad_norm_(ttt_params, args.ttt_grad_clip)
+                    optimizer.step()
+
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            log0(f"  ttt_chunk [{ci+1}/{num_chunks}] bpb={rbpb:.6f} time={elapsed:.1f}s")
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+    log0(f"ttt:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+         f"elapsed={time.perf_counter() - t0:.1f}s")
+    return float(val_loss), float(val_bpb)
+
+
+# QUANTIZATION
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smeargate,merge_alpha",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def _quantize_with_clip(t32: Tensor, clip_abs: Tensor | float, qmax: int) -> tuple[Tensor, Tensor, Tensor]:
+    if t32.ndim == 2 and isinstance(clip_abs, Tensor):
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / qmax).clamp_min(1.0 / qmax)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -qmax, qmax).to(torch.int8)
+        recon = q.float() * scale[:, None]
+        return q.contiguous(), scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous(), recon
+    clip_abs_f = float(clip_abs) if isinstance(clip_abs, Tensor) else clip_abs
+    scale_f = clip_abs_f / qmax if clip_abs_f > 0 else 1.0
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs_f, clip_abs_f) / scale_f), -qmax, qmax).to(torch.int8)
+    recon = q.float() * scale_f
+    return q.contiguous(), torch.tensor(scale_f, dtype=torch.float32), recon
+
+def quantize_float_tensor(t: Tensor, bits: int = 8, search_clip: bool = False) -> tuple[Tensor, Tensor]:
+    qmax = (1 << (bits - 1)) - 1
+    t32 = t.float()
+
+    if not search_clip:
+        if t32.ndim == 2:
+            clip_abs = (
+                torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+                if t32.numel()
+                else torch.empty((t32.shape[0],), dtype=torch.float32)
+            )
+            q, scale, _ = _quantize_with_clip(t32, clip_abs, qmax)
+            return q, scale
+        clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+        q, scale, _ = _quantize_with_clip(t32, clip_abs, qmax)
+        return q, scale
+
+    candidates = [0.999, 0.9995, 0.9999, 0.99995, 0.99999, 0.999999, 1.0]
+    best_q, best_scale, best_mse = None, None, float("inf")
+
+    for pct in candidates:
+        if t32.ndim == 2:
+            if pct >= 1.0:
+                clip_abs = t32.abs().amax(dim=1)
+            else:
+                clip_abs = torch.quantile(t32.abs(), pct, dim=1)
+            q, scale, recon = _quantize_with_clip(t32, clip_abs, qmax)
+        else:
+            if pct >= 1.0:
+                clip_abs = float(t32.abs().max().item())
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), pct).item()) if t32.numel() else 0.0
+            q, scale, recon = _quantize_with_clip(t32, clip_abs, qmax)
+        mse = (t32 - recon).pow(2).mean().item()
+        if mse < best_mse:
+            best_mse = mse
+            best_q, best_scale = q, scale
+
+    return best_q, best_scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor], fp16_embed: bool = False, quant_bits: int = 8, quant_bits_mlp: int = 0, search_clip: bool = False):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        if fp16_embed and "tok_emb" in name:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        bits = quant_bits
+        if quant_bits_mlp > 0 and "mlp" in name:
+            bits = quant_bits_mlp
+        q, s = quantize_float_tensor(t, bits=bits, search_clip=search_clip)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class FakeQuantizeSTE(torch.autograd.Function):
+    """Simulated quantization with Straight-Through Estimator for QAT."""
+    @staticmethod
+    def forward(ctx, w: Tensor, bits: int) -> Tensor:
+        qmax = (1 << (bits - 1)) - 1
+        if w.ndim == 2:
+            scale = w.detach().abs().amax(dim=1, keepdim=True) / qmax
+            scale = scale.clamp_min(1.0 / qmax)
+            return (torch.clamp(torch.round(w / scale), -qmax, qmax) * scale).to(w.dtype)
+        scale = w.detach().abs().amax() / qmax
+        scale = scale.clamp_min(1.0 / qmax)
+        return (torch.clamp(torch.round(w / scale), -qmax, qmax) * scale).to(w.dtype)
+
+    @staticmethod
+    def backward(ctx, grad: Tensor) -> tuple[Tensor, None]:
+        return grad, None
+
+
+class CastedLinear(nn.Linear):
+    _qat_bits: int = 0
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if self._qat_bits > 0 and self.weight.numel() > 65536:
+            w = FakeQuantizeSTE.apply(w, self._qat_bits)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.full((dim,), 3.0, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate).to(dtype=x.dtype)
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return g * x + (1.0 - g) * x_prev
+
+
+class BigramHash(nn.Module):
+    def __init__(self, num_buckets: int, hash_dim: int, model_dim: int):
+        super().__init__()
+        self.num_buckets = num_buckets
+        self.table = nn.Embedding(num_buckets, hash_dim)
+        self.proj = CastedLinear(hash_dim, model_dim, bias=False)
+        self.proj._zero_init = True
+        nn.init.normal_(self.table.weight, std=0.01)
+
+    def forward(self, input_ids: Tensor) -> Tensor:
+        bsz, seqlen = input_ids.shape
+        prev_ids = torch.cat([torch.zeros(bsz, 1, dtype=input_ids.dtype, device=input_ids.device),
+                              input_ids[:, :-1]], dim=1)
+        h = ((prev_ids.long() * 92821 + input_ids.long()) % self.num_buckets).long()
+        return self.proj(self.table(h))
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class HymbaAttention(nn.Module):
+    """Hymba-style hybrid: attention + Mamba SSM in parallel within one block."""
+    def __init__(
+        self, dim: int, num_heads: int, num_kv_heads: int, rope_base: float,
+        qk_gain_init: float, mamba_expand: int = 2, conv_kernel_size: int = 4,
+        dt_rank: int = 0, ssm_state_size: int = 16, shared_kv_proj=None,
+        sliding_window: int = 0,
+    ):
+        super().__init__()
+        from mamba_ssm.ops.selective_scan_interface import selective_scan_fn
+        from causal_conv1d import causal_conv1d_fn
+        self._selective_scan_fn = selective_scan_fn
+        self._causal_conv1d_fn = causal_conv1d_fn
+        self.sliding_window = sliding_window
+
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        self.intermediate_size = mamba_expand * dim
+        self.ssm_state_size = ssm_state_size
+        self.dt_rank = dt_rank if dt_rank > 0 else max(dim // 16, 1)
+
+        kv_dim = num_kv_heads * self.head_dim
+        self.q_dim = dim
+        self.kv_dim = kv_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+
+        # Cross-layer KV sharing: if shared_kv_proj provided, reuse it
+        if shared_kv_proj is not None:
+            self.kv_proj = shared_kv_proj
+        else:
+            self.kv_proj = CastedLinear(dim, kv_dim * 2, bias=False)
+
+        # Mamba projections (always per-layer)
+        self.mamba_proj = CastedLinear(dim, self.intermediate_size * 2, bias=False)
+
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+        self.conv1d = nn.Conv1d(
+            self.intermediate_size, self.intermediate_size, bias=True,
+            kernel_size=conv_kernel_size, groups=self.intermediate_size,
+            padding=conv_kernel_size - 1,
+        )
+        self.x_proj = CastedLinear(self.intermediate_size, self.dt_rank + ssm_state_size * 2, bias=False)
+        self.dt_proj = nn.Linear(self.dt_rank, self.intermediate_size, bias=True)
+
+        A = torch.arange(1, ssm_state_size + 1, dtype=torch.float32)[None, :].expand(self.intermediate_size, -1).contiguous()
+        self.A_log = nn.Parameter(torch.log(A))
+        self.D = nn.Parameter(torch.ones(self.intermediate_size))
+
+        self.mamba_out_proj = CastedLinear(self.intermediate_size, dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.merge_alpha = nn.Parameter(torch.zeros(1, dtype=torch.float32))
+
+        # Pre-compile flex_attention for sliding window
+        if sliding_window > 0 and HAS_FLEX_ATTENTION:
+            window = sliding_window
+            def swa_mask(b, h, q_idx, kv_idx):
+                causal = q_idx >= kv_idx
+                in_window = (q_idx - kv_idx) < window
+                return causal & in_window
+            self._swa_mask_fn = swa_mask
+            self._swa_block_mask = None  # lazily created on first forward
+            self._flex_attention = torch.compile(flex_attention)
+
+    def _sliding_window_attn(self, q: Tensor, k: Tensor, v: Tensor, seqlen: int) -> Tensor:
+        """Sliding window attention using flex_attention with GQA support."""
+        # Expand KV heads for flex_attention (doesn't support GQA natively)
+        if self.num_kv_heads != self.num_heads:
+            n_rep = self.num_heads // self.num_kv_heads
+            k = k[:, :, None, :, :].expand(-1, -1, n_rep, -1, -1).reshape(
+                k.size(0), self.num_heads, seqlen, self.head_dim
+            )
+            v = v[:, :, None, :, :].expand(-1, -1, n_rep, -1, -1).reshape(
+                v.size(0), self.num_heads, seqlen, self.head_dim
+            )
+        # Lazily create block mask on first call (needs to know seq_len and device)
+        if self._swa_block_mask is None or self._swa_block_mask.shape[-1] != seqlen:
+            self._swa_block_mask = create_block_mask(
+                self._swa_mask_fn, B=None, H=None, Q_LEN=seqlen, KV_LEN=seqlen,
+                device=q.device,
+            )
+        return self._flex_attention(q, k, v, block_mask=self._swa_block_mask)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+
+        q_out = self.c_q(x)
+
+        kv_out = self.kv_proj(x)
+        k_out, v_out = kv_out.split([self.kv_dim, self.kv_dim], dim=-1)
+
+        mamba_out_proj = self.mamba_proj(x)
+        x_ssm, gate = mamba_out_proj.split([self.intermediate_size, self.intermediate_size], dim=-1)
+
+        q = q_out.reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k_out.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = v_out.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+
+        if self.sliding_window > 0 and seqlen > self.sliding_window:
+            y = self._sliding_window_attn(q, k, v, seqlen)
+        else:
+            y = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=None, is_causal=True,
+                enable_gqa=(self.num_kv_heads != self.num_heads),
+            )
+        attn_out = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+
+        x_ssm = x_ssm.transpose(1, 2)
+        gate = gate.transpose(1, 2)
+
+        _conv_dtype = x_ssm.dtype
+        conv_weights = self.conv1d.weight.view(self.conv1d.weight.size(0), self.conv1d.weight.size(2)).to(_conv_dtype)
+        conv_bias = self.conv1d.bias.to(_conv_dtype) if self.conv1d.bias is not None else None
+        x_ssm = self._causal_conv1d_fn(x_ssm, conv_weights, conv_bias, activation="silu")
+
+        ssm_params = self.x_proj(x_ssm.transpose(1, 2))
+        dt, B_ssm, C_ssm = torch.split(
+            ssm_params, [self.dt_rank, self.ssm_state_size, self.ssm_state_size], dim=-1
+        )
+
+        dt_proj_bias = self.dt_proj.bias
+        self.dt_proj.bias = None
+        dt = self.dt_proj(dt).transpose(1, 2)
+        self.dt_proj.bias = dt_proj_bias
+
+        A = -torch.exp(self.A_log.float())
+        dt_proj_bias_f = dt_proj_bias.float() if dt_proj_bias is not None else None
+
+        scan_out = self._selective_scan_fn(
+            x_ssm, dt, A,
+            B_ssm.transpose(1, 2), C_ssm.transpose(1, 2),
+            self.D.float(), z=gate,
+            delta_bias=dt_proj_bias_f,
+            delta_softplus=True,
+            return_last_state=False,
+        )
+        mamba_out = self.mamba_out_proj(scan_out.transpose(1, 2))
+
+        w = torch.sigmoid(self.merge_alpha).to(dtype=x.dtype)
+        merged = w * attn_out + (1.0 - w) * mamba_out
+        return self.proj(merged)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = F.leaky_relu(self.fc(x), negative_slope=0.9)
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int,
+        rope_base: float, qk_gain_init: float, hymba_expand: int = 2,
+        hymba_conv_kernel: int = 4, hymba_dt_rank: int = 0, hymba_ssm_state: int = 16,
+        shared_kv_proj=None, sliding_window: int = 0,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = HymbaAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+            mamba_expand=hymba_expand, conv_kernel_size=hymba_conv_kernel,
+            dt_rank=hymba_dt_rank, ssm_state_size=hymba_ssm_state,
+            shared_kv_proj=shared_kv_proj, sliding_window=sliding_window,
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self, vocab_size: int, num_layers: int, model_dim: int, num_heads: int,
+        num_kv_heads: int, mlp_mult: int, tie_embeddings: bool, tied_embed_init_std: float,
+        logit_softcap: float, rope_base: float, qk_gain_init: float,
+        use_smeargate: bool = False, use_bigram_hash: bool = False,
+        bigram_buckets: int = 4096, bigram_hash_dim: int = 128,
+        use_ortho_init: bool = False, hymba_expand: int = 2, hymba_conv_kernel: int = 4,
+        hymba_dt_rank: int = 0, hymba_ssm_state: int = 16, kv_share_every: int = 1,
+        meta_tokens: int = 0, sliding_window: int = 0, swa_global_layers: str = "auto",
+        grad_checkpoint: bool = False,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.use_ortho_init = use_ortho_init
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+
+        self.smeargate = SmearGate(model_dim) if use_smeargate else None
+        self.bigram_hash = BigramHash(bigram_buckets, bigram_hash_dim, model_dim) if use_bigram_hash else None
+
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+
+        self.skip_weights = nn.Parameter(
+            torch.ones(1, self.num_skip_weights, model_dim, dtype=torch.float32)
+        )
+
+        # Shared meta tokens (one set of learnable embeddings, per-layer KV projection)
+        self._meta_tokens_param = nn.Parameter(
+            torch.randn(1, meta_tokens, model_dim) * 0.02
+        ) if meta_tokens > 0 else None
+
+        # Determine which layers get full attention vs sliding window
+        if sliding_window > 0:
+            if swa_global_layers == "none":
+                global_layers = set()
+            elif swa_global_layers == "auto":
+                # Paper default: first, middle, and last layers
+                global_layers = {0, num_layers // 2, num_layers - 1}
+            else:
+                global_layers = {int(x) for x in swa_global_layers.split(",") if x.strip()}
+        else:
+            global_layers = set(range(num_layers))  # all full attention
+
+        # Build blocks with cross-layer KV sharing
+        blocks = []
+        for i in range(num_layers):
+            # Share KV projections: layer i shares with layer (i // kv_share_every) * kv_share_every
+            shared_kv = None
+            if kv_share_every > 1 and (i % kv_share_every) != 0:
+                # Reuse KV proj from the group leader
+                leader_idx = (i // kv_share_every) * kv_share_every
+                shared_kv = blocks[leader_idx].attn.kv_proj
+            layer_window = 0 if i in global_layers else sliding_window
+            blocks.append(Block(
+                model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init,
+                hymba_expand=hymba_expand, hymba_conv_kernel=hymba_conv_kernel,
+                hymba_dt_rank=hymba_dt_rank, hymba_ssm_state=hymba_ssm_state,
+                shared_kv_proj=shared_kv, sliding_window=layer_window,
+            ))
+        self.blocks = nn.ModuleList(blocks)
+
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.grad_checkpoint = grad_checkpoint
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        num_layers = len(self.blocks)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif self.use_ortho_init and module.weight.ndim == 2 and min(module.weight.shape) >= 16:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj" in name and name.split(".")[-1] in ("proj", "proj_D"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+
+    def _compute_logits_and_loss(self, x: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def _embed(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram_hash is not None:
+            x = x + self.bigram_hash(input_ids)
+        if self.smeargate is not None:
+            x = self.smeargate(x)
+        return F.rms_norm(x, (x.size(-1),))
+
+    def _block_forward(self, block: nn.Module, x: Tensor, x0: Tensor) -> Tensor:
+        if self.grad_checkpoint and self.training:
+            return torch.utils.checkpoint.checkpoint(block, x, x0, use_reentrant=False)
+        return block(x, x0)
+
+    def _prepend_meta(self, x: Tensor) -> Tensor:
+        """Prepend learnable meta tokens to the sequence."""
+        if self._meta_tokens_param is not None:
+            meta = self._meta_tokens_param.expand(x.size(0), -1, -1).to(dtype=x.dtype)
+            x = torch.cat([meta, x], dim=1)
+        return x
+
+    def _strip_meta(self, x: Tensor) -> Tensor:
+        """Remove meta token positions from the output."""
+        if self._meta_tokens_param is not None:
+            x = x[:, self._meta_tokens_param.size(1):]
+        return x
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self._embed(input_ids)
+        x = self._prepend_meta(x)
+        x0 = x
+        skips: list[Tensor] = []
+
+        for i in range(self.num_encoder_layers):
+            x = self._block_forward(self.blocks[i], x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[0, i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self._block_forward(self.blocks[self.num_encoder_layers + i], x, x0)
+
+        x = self._strip_meta(x)
+        return self._compute_logits_and_loss(x, target_ids)
+
+    def _run_blocks(self, x: Tensor, x0: Tensor) -> Tensor:
+        skips: list[Tensor] = []
+        for i in range(self.num_encoder_layers):
+            x = self._block_forward(self.blocks[i], x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[0, i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self._block_forward(self.blocks[self.num_encoder_layers + i], x, x0)
+        return x
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        bsz, seqlen = input_ids.shape
+        x = self._embed(input_ids)
+        x = self._prepend_meta(x)
+        x = self._run_blocks(x, x)
+        x = self._strip_meta(x)
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        w = self.tok_emb.weight if self.tie_embeddings else self.lm_head.weight
+        logits = self.logit_softcap * torch.tanh(F.linear(x, w) / self.logit_softcap)
+        return logits.reshape(bsz, seqlen, -1)
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = int(os.environ.get("GRAD_ACCUM_STEPS", 8 // world_size))
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    base_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        use_smeargate=args.use_smeargate, use_bigram_hash=args.use_bigram_hash,
+        bigram_buckets=args.bigram_buckets, bigram_hash_dim=args.bigram_hash_dim,
+        use_ortho_init=args.use_ortho_init, hymba_expand=args.hymba_expand,
+        hymba_conv_kernel=args.hymba_conv_kernel, hymba_dt_rank=args.hymba_dt_rank,
+        hymba_ssm_state=args.hymba_ssm_state, kv_share_every=args.kv_share_every,
+        meta_tokens=args.meta_tokens, sliding_window=args.sliding_window,
+        swa_global_layers=args.swa_global_layers, grad_checkpoint=args.grad_checkpoint,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    if bool(int(os.environ.get("NO_COMPILE", "0"))):
+        compiled_model = base_model
+    else:
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=False)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if hasattr(base_model, 'skip_weights') and base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    if base_model.smeargate is not None:
+        scalar_params.append(base_model.smeargate.gate)
+    if base_model.bigram_hash is not None:
+        scalar_params.append(base_model.bigram_hash.table.weight)
+        matrix_params.append(base_model.bigram_hash.proj.weight)
+    if base_model._meta_tokens_param is not None:
+        scalar_params.append(base_model._meta_tokens_param)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params, lr=args.matrix_lr, momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps, weight_decay=args.weight_decay,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(f"num_layers:{args.num_layers} mlp_mult:{args.mlp_mult} kv_share_every:{args.kv_share_every} meta_tokens:{args.meta_tokens} sliding_window:{args.sliding_window}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            frac = max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        else:
+            step_ms = elapsed_ms / max(step, 1)
+            warmdown_ms = args.warmdown_iters * step_ms
+            remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+            frac = remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+        if args.warmdown_shape == "cosine" and frac < 1.0:
+            return 0.5 * (1.0 + math.cos(math.pi * (1.0 - frac)))
+        return frac
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+
+    ema_state: dict[str, Tensor] | None = None
+    if args.ema_enabled:
+        ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+
+        if args.qat_start_frac > 0 and max_wallclock_ms:
+            elapsed_frac_qat = elapsed_ms / max_wallclock_ms
+            qat_active = elapsed_frac_qat >= args.qat_start_frac
+            qat_bits = args.quant_bits if qat_active else 0
+            if qat_active and any(m._qat_bits == 0 for m in base_model.modules() if isinstance(m, CastedLinear)):
+                log0(f"qat:enabled bits={qat_bits} at step {step} frac={elapsed_frac_qat:.2f}")
+                for m in base_model.modules():
+                    if isinstance(m, CastedLinear):
+                        m._qat_bits = qat_bits
+
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        cur_seq_len = args.train_seq_len
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, cur_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+
+        if ema_state is not None:
+            d = args.ema_decay
+            with torch.no_grad():
+                for name, t in base_model.state_dict().items():
+                    ema_state[name].mul_(d).add_(t.detach().float(), alpha=1.0 - d)
+
+        if args.swa_enabled and scale < args.swa_start_frac and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone().float() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu().float()
+                swa_count += 1
+
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    for m in base_model.modules():
+        if isinstance(m, CastedLinear):
+            m._qat_bits = 0
+
+    if ema_state is not None:
+        log0("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+        del ema_state
+        base_model.load_state_dict(avg_state, strict=True)
+    elif args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"swa:applying averaged {swa_count} checkpoints")
+        current_state = base_model.state_dict()
+        avg_state = {
+            name: (tensor / swa_count).to(dtype=current_state[name].dtype)
+            for name, tensor in swa_state.items()
+        }
+        del swa_state
+        base_model.load_state_dict(avg_state, strict=True)
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(
+        base_model.state_dict(), fp16_embed=args.fp16_embed, quant_bits=args.quant_bits,
+        quant_bits_mlp=args.quant_bits_mlp, search_clip=args.gptq_lite,
+    )
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    if args.use_zstd and HAS_ZSTD:
+        cctx = zstd.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+        compress_fmt = "zstd-22"
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+        compress_fmt = "zlib-9"
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int{args.quant_bits}+{compress_fmt}: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int{args.quant_bits}+{compress_fmt}: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    if args.use_zstd and HAS_ZSTD:
+        dctx = zstd.ZstdDecompressor()
+        quant_decompressed = dctx.decompress(quant_blob_disk)
+    else:
+        quant_decompressed = zlib.decompress(quant_blob_disk)
+    quant_state = torch.load(io.BytesIO(quant_decompressed), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+
+    # Override seq_len for eval if EVAL_SEQ_LEN is set
+    eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    if eval_seq_len != args.train_seq_len:
+        val_tokens = load_validation_tokens(args.val_files, eval_seq_len)
+    original_train_seq_len = args.train_seq_len
+    args.train_seq_len = eval_seq_len
+
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+
+    if args.ttt_enabled:
+        q_val_loss, q_val_bpb = eval_val_score_first_ttt(
+            args, base_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            log0=log0,
+        )
+        eval_mode = "score_first_ttt"
+    else:
+        use_sliding = args.eval_stride > 0 and args.eval_stride < args.train_seq_len
+        if use_sliding:
+            q_val_loss, q_val_bpb = eval_val_sliding(
+                args, base_model, rank, world_size, device,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            eval_mode = "sliding"
+        else:
+            q_val_loss, q_val_bpb = eval_val(
+                args, base_model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            eval_mode = "standard"
+    torch.cuda.synchronize()
+    args.train_seq_len = original_train_seq_len
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_mode:{eval_mode} eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This submission demonstrates that hybrid SSM architectures can train at **32x longer context** (32,768 tokens) than the standard baseline (1,024 tokens) with **near-constant cost as context length increases**. By combining Mamba (selective state space model) with sliding window attention (SWA-512), both branches have constant per-token cost, going from 8K to 64K context adds virtually no overhead (~80-83 ms/step). This enables ultra-long context training within the 10-minute wall-clock budget.

## Results

| Seed | val_bpb | val_loss | Steps | Artifact Size |
|------|---------|----------|-------|---------------|
| 1337 | 1.1866  | 2.0036   | 7,334 | 14.3 MB       |
| 42   | 1.1881  | 2.0061   | 7,139 | 14.6 MB       |
| 7    | 1.1873  | 2.0048   | 7,176 | 14.5 MB       |
| **Mean** | **1.1873 +/- 0.0008** | | | |

- Training: 600s on 8xH100 SXM, ~82-88 ms/step
- Evaluation: Score-first TTT, ~67-74s
- Artifact: int6 + zstd-22, under 16 MB

## Key Innovations

### 1. Ultra-Long Context Training (32K tokens)
The naive transformer baseline trains at 1,024 token context. We train at **32,768 tokens** — a 32x increase. Increasing context from 8K to 64K adds virtually no overhead (~80-83 ms/step across that range). This is because both SWA and Mamba have constant per-token cost as SWA attends to a fixed 512-token window regardless of sequence length, and Mamba's recurrent scan processes each token in O(1). Since the total tokens per batch is fixed (524K), the step time stays roughly constant regardless of how those tokens are divided into sequences.

This is made possible by two architectural choices:
- **Mamba SSM** processes sequences via selective scan with O(1) per-token cost (recurrent state)
- **Sliding Window Attention (SWA-512)** on all layers limits attention to a fixed 512-token local window, also O(1) per token

The Mamba branch handles global context (full sequence memory via recurrent state), while SWA handles local pattern matching.

### 2. Hymba Hybrid Architecture
Based on the Hymba paper (arXiv:2411.13676), each block runs attention and Mamba **in parallel** within a single layer:
- Attention branch: Q projection + shared KV projection, GQA (8 heads, 4 KV heads), RoPE, QK-norm
- Mamba branch: Selective scan with causal 1D convolution, gated output
- Learned merge: sigmoid-gated weighted sum of both branches
- Post-merge: output projection + residual with learned scale

Architecture: 7 layers, 512 dim, MLP 4x with LeakyReLU(0.9)^2, U-Net skip connections, SmearGate + BigramHash embedding, EMA (0.997).

### 3. Score-First Test-Time Training (TTT)
Legal TTT following the PR #461 recipe:
1. **Score** each 524K-token chunk under `inference_mode` (no gradient)
2. **Train** on the already-scored chunk with SGD (lr=0.002, momentum=0.9)
3. First 2 blocks frozen to prevent catastrophic forgetting
4. 3 epochs per chunk with cosine LR decay
5. Total eval time: ~67-74s

TTT improves post-quantization BPB by adapting the quantized model to validation data patterns.

### 4. Context Length Scaling Results
We systematically evaluated training context length while keeping all other hyperparameters fixed:

| Train Seq Len | ms/step | Pre-quant BPB (13,780 steps) |
|---------------|---------|------------------------------|
| 8,192         | 79.0    | 1.1507                       |
| 16,384        | 80.1    | 1.1491                       |
| 32,768        | 80.6    | 1.1478                       |
| 65,536        | 82.8    | 1.1477                       |

Per-step cost is nearly constant from 8K to 64K context because the per-token cost of both SWA and Mamba is independent of sequence length (see above). Quality improves with longer context up to ~32K, then plateaus.

## Why This Matters

With constant per-token cost, our architecture can train and evaluate at long context without the quadratic overhead that full attention would incur. This frees the eval time budget for TTT adaptation rather than expensive sliding window overlap.

The competition README specifically requests "state-space models" and "super long context for evaluation or training" as novel directions. This submission demonstrates both, showing that hybrid SSM architectures naturally enable ultra-long context training regimes.

## Run Command

```bash
SEED=1337 SLIDING_WINDOW=512 SWA_GLOBAL_LAYERS=none TRAIN_SEQ_LEN=32768 \
NUM_LAYERS=7 MLP_MULT=4 MODEL_DIM=512 NUM_HEADS=8 NUM_KV_HEADS=4 \
MATRIX_LR=0.02 SCALAR_LR=0.02 WARMDOWN_ITERS=3000 WARMDOWN_SHAPE=cosine \
EVAL_STRIDE=0 EVAL_BATCH_SEQS=4 QUANT_BITS=6 GPTQ_LITE=1 \
HYMBA_EXPAND=1 HYMBA_SSM_STATE=8 \
TTT_ENABLED=1 TTT_LR=0.002 TTT_EPOCHS=3 TTT_CHUNK_TOKENS=524288 \
TTT_FREEZE_BLOCKS=2 TTT_BATCH_SEQS=4 \
MAX_WALLCLOCK_SECONDS=600 \
torchrun --standalone --nproc_per_node=8 records/track_10min_16mb/hymba_long_context/train_gpt.py
```

## Dependencies

```bash
pip install --no-build-isolation mamba-ssm causal-conv1d
pip install zstandard
```

## Setup

Requires PyTorch >= 2.5 for flex_attention (sliding window). Tested on PyTorch 2.8.0+cu128.

```bash
pip install --no-build-isolation --break-system-packages mamba-ssm causal-conv1d
```

Note: `--no-build-isolation` is critical to avoid CUDA version mismatch during the mamba-ssm/causal-conv1d CUDA kernel builds.