### PR TITLE
Record: 1.0450 BPB — SGD TTT + HedgeMixer with Per-Layer LR Groups

### DIFF
--- a/records/track_10min_16mb/2026-03-27_SGD_TTT_HedgeMixer_PerLayerLR_1.0450/README.md
+++ b/records/track_10min_16mb/2026-03-27_SGD_TTT_HedgeMixer_PerLayerLR_1.0450/README.md
@@ -1,0 +1,71 @@
+# Record: 1.0450 BPB — SGD TTT + HedgeMixer with Per-Layer LR Groups
+
+**val_bpb: 1.0450** (3-seed mean, std 0.012) | 15.67 MB max artifact | 8xH100 SXM, <545s eval
+
+Built on PR #720 by @agalimova (XSA-all + HedgeMixer + legal TTT backbone).
+
+## Results
+
+| Seed | TTT BPB | Eval Time | Artifact Bytes |
+|------|---------|-----------|----------------|
+| 1337 | **1.0312** | 540s | 15,567,538 |
+| 42 | **1.0503** | 533s | 15,672,158 |
+| 2025 | **1.0535** | 544s | 15,152,756 |
+| **Mean** | **1.0450** | | |
+
+## What's New (vs PR #720)
+
+Two key changes to the TTT recipe, both producing large improvements:
+
+### 1. SGD Optimizer for TTT (main win: -0.041 BPB)
+Switched TTT from AdamW (lr=0.0005) to **SGD with momentum=0.9** (lr=0.002). SGD provides more aggressive, direct parameter updates that better exploit the short adaptation window. This single change accounts for most of the improvement.
+
+Run with: `TTT_OPTIMIZER=sgd TTT_LR=0.002`
+
+### 2. Per-Layer LR Groups + Cosine Schedule (from our earlier PR)
+- Output projections (`mlp.proj`, `attn.proj`): 3x base LR
+- Input projections (`mlp.fc`): 0.5x base LR
+- Cosine LR decay within TTT: `lr = base * 0.5 * (1 + cos(pi * chunk/total))`
+- 4 TTT epochs, zero frozen blocks
+- Skip standalone sliding eval to save time for TTT
+
+### Ablation: Mixer vs TTT Attribution
+
+| Config | BPB | Notes |
+|--------|-----|-------|
+| Full system (mixer + SGD TTT) | **1.0312** | Best (seed 1337) |
+| AdamW TTT + mixer (previous PR) | 1.0726 | AdamW is the bottleneck |
+| No mixer, AdamW TTT only | 1.1559 | TTT without mixer HURTS |
+| No TTT (sliding only) | 1.1210 | Pure neural baseline |
+
+Both mixer and TTT are necessary — the mixer provides the scoring framework that makes TTT adaptation effective.
+
+## Base Architecture (inherited from PR #720)
+
+- 11 layers, 512 dim, 8 heads, 8 KV heads (full MHA)
+- MLP 3.5x expansion, LeakyReLU(0.5)^2 activation
+- XSA on all 11 layers, BigramHash(6144, dim=128) + SmearGate
+- Partial RoPE (16/64 dims) + LN Scale + EMA(0.997)
+- Int5 GPTQ-lite + zstd compression, Parallel Muon optimizer
+- LogisticContextMixer: 5 backward-looking experts (Neural, Unigram, Bigram, Trigram, Entropy)
+
+## Setup and Run
+
+```bash
+export NCCL_NET=Socket
+export SKIP_SLIDING=1
+export TTT_OPTIMIZER=sgd
+export TTT_LR=0.002
+
+SEED=1337 torchrun --nproc_per_node=8 train_gpt.py
+```
+
+## Compliance
+
+- [x] 3 seeds on 8xH100 SXM (1337, 42, 2025)
+- [x] All train <=600s (582s)
+- [x] All eval <=600s (max 544s)
+- [x] All artifact <=16,000,000 bytes (max 15,672,158)
+- [x] Score-first TTT: every token scored BEFORE any update
+- [x] HedgeMixer: backward-looking n-gram counts from scored tokens only
+- [x] No network calls, external data, or validation leakage

--- a/records/track_10min_16mb/2026-03-27_SGD_TTT_HedgeMixer_PerLayerLR_1.0450/submission.json
+++ b/records/track_10min_16mb/2026-03-27_SGD_TTT_HedgeMixer_PerLayerLR_1.0450/submission.json
@@ -1,0 +1,11 @@
+{
+  "author": "dexhunter",
+  "github_id": "dexhunter",
+  "name": "SGD TTT + HedgeMixer: Per-Layer LR Groups on PR #720 Backbone",
+  "blurb": "Built on PR #720 by @agalimova. Switches TTT from AdamW to SGD (lr=0.002, momentum=0.9) with per-layer LR groups (3x proj, 0.5x fc), cosine schedule, and zero frozen blocks. 3-seed mean 1.0450 BPB on 8xH100 in under 600s eval.",
+  "date": "2026-03-27",
+  "val_loss": 1.76441249,
+  "val_bpb": 1.04498723,
+  "bytes_total": 15672158,
+  "bytes_code": 102023
+}

--- a/records/track_10min_16mb/2026-03-27_SGD_TTT_HedgeMixer_PerLayerLR_1.0450/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-27_SGD_TTT_HedgeMixer_PerLayerLR_1.0450/train_gpt.py
@@ -1,0 +1,2071 @@
+"""V27: CROWN-Q training + stride=64 + improved TTT recipe.
+
+TTT improvements over pr720_stride64:
+1. Per-layer LR groups (proj params 3x, fc params 0.5x)
+2. Cosine LR schedule within TTT (already present, kept)
+3. 4 epochs instead of 3
+4. Freeze only 1 block instead of 2
+5. Temperature calibration per-chunk after TTT
+"""
+from __future__ import annotations
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+try:
+    from flash_attn_interface import flash_attn_func as flash_attn_3_func
+    _HAS_FA3 = True
+except ImportError:
+    try:
+        from flash_attn import flash_attn_func as flash_attn_3_func
+        _HAS_FA3 = True
+    except ImportError:
+        _HAS_FA3 = False
+        flash_attn_3_func = None
+
+class LogisticContextMixer:
+    """GPU-vectorized logistic context mixing (inspired by PAQ compression).
+
+    Maintains GPU-resident n-gram count tables and learns online mixing weights
+    using the Hedge/multiplicative-weights algorithm.
+
+    Experts:
+      0: Neural model (logits passed in)
+      1: Unigram frequencies from scored tokens
+      2: Bigram frequencies (prev_token → next_token)
+      3: FastPPM (orders 0-4, CPU-side)
+      4: ExactMatchCache (high-order exact matches, CPU-side)
+    """
+
+    def __init__(self, vocab_size: int = 1024, device: str = 'cuda', eta: float = 0.1):
+        self.V = vocab_size
+        self.device = device
+        self.eta = eta  # Hedge learning rate
+        self.K = 5  # number of experts
+
+        # Expert weights (log-domain for numerical stability)
+        self.log_weights = torch.zeros(self.K, device=device)
+        # Bias toward neural model initially
+        self.log_weights[0] = 2.0
+
+        # N-gram count tables (GPU-resident)
+        self.uni_counts = torch.zeros(vocab_size, device=device)
+        self.bi_counts = torch.zeros(vocab_size, vocab_size, device=device)
+        self.total_tokens = 0
+
+        # GPU Trigram: hashed table [HASH_SIZE, V] to keep memory reasonable
+        self.TRI_HASH = 65536  # 64K hash buckets for (prev2, prev1) pairs
+        self.tri_counts = torch.zeros(self.TRI_HASH, vocab_size, device=device)
+        self.tri_row_totals = torch.zeros(self.TRI_HASH, device=device)
+
+    def update(self, tokens):
+        """Update all expert statistics with newly scored tokens."""
+        if hasattr(tokens, 'cpu'):
+            t = tokens.to(self.device).long()
+        else:
+            t = torch.tensor(tokens, device=self.device, dtype=torch.long)
+
+        n = t.numel()
+        if n == 0:
+            return
+        self.total_tokens += n
+
+        # Unigram: in-place scatter_add
+        ones = torch.ones(n, device=self.device)
+        self.uni_counts.scatter_add_(0, t, ones)
+
+        # Bigram: in-place scatter_add on flattened view (no temporary 1M tensor)
+        if n >= 2:
+            ctx = t[:-1]
+            nxt = t[1:]
+            bi_idx = ctx * self.V + nxt
+            ones_bi = torch.ones(n - 1, device=self.device)
+            self.bi_counts.reshape(-1).scatter_add_(0, bi_idx, ones_bi)
+
+        # Trigram: in-place scatter_add on flattened view (no temporary 67M tensor)
+        if n >= 3:
+            prev2 = t[:-2]
+            prev1 = t[1:-1]
+            nxt3 = t[2:]
+            tri_ctx = ((prev2 * 36313) ^ (prev1 * 27191)) % self.TRI_HASH
+            tri_idx = tri_ctx * self.V + nxt3
+            ones_tri = torch.ones(n - 2, device=self.device)
+            self.tri_counts.reshape(-1).scatter_add_(0, tri_idx, ones_tri)
+            self.tri_row_totals.scatter_add_(0, tri_ctx, ones_tri)
+
+    def get_expert_log_probs(self, neural_logits, x_batch, y_batch, wlens):
+        """Get log-probability of targets from each expert. All GPU-vectorized.
+
+        Args:
+            neural_logits: [bsz, seq_len, V] neural model logits
+            x_batch: [bsz, seq_len] input tokens (context)
+            y_batch: [bsz, seq_len] target tokens
+            wlens: list of actual lengths per sequence
+
+        Returns:
+            expert_nll: [bsz, seq_len, K] NLL from each expert
+        """
+        bsz, slen, V = neural_logits.shape
+        uniform_nll = math.log(self.V)
+        has_data = self.total_tokens > 0  # Python int — no GPU-CPU sync
+
+        # Expert 0: Neural model — compute log_softmax once, reuse for entropy
+        neural_lp = F.log_softmax(neural_logits, dim=-1)
+        neural_nll = -neural_lp.gather(2, y_batch.unsqueeze(2)).squeeze(2)  # [bsz, slen]
+
+        # Expert 1: Unigram
+        if has_data:
+            uni_probs = (self.uni_counts + 0.1) / (self.total_tokens + 0.1 * self.V)
+            uni_nll = -uni_probs.log()[y_batch]  # [bsz, slen]
+        else:
+            uni_nll = torch.full((bsz, slen), uniform_nll, device=self.device)
+
+        # Expert 2: Bigram P(next | prev)
+        if has_data:
+            bi_total = self.bi_counts.sum(dim=1, keepdim=True)  # [V, 1]
+            bi_probs = (self.bi_counts + 0.1) / (bi_total + 0.1 * self.V)  # [V, V]
+            prev_flat = x_batch.reshape(-1)
+            next_flat = y_batch.reshape(-1)
+            bi_nll = -bi_probs.log()[prev_flat, next_flat].reshape(bsz, slen)
+        else:
+            bi_nll = torch.full((bsz, slen), uniform_nll, device=self.device)
+
+        # Expert 3: GPU Trigram P(next | hash(prev2, prev1)) — vectorized
+        if has_data and slen >= 2:
+            prev2 = torch.zeros_like(x_batch)
+            prev2[:, 1:] = x_batch[:, :-1]
+            ctx_hash = ((prev2 * 36313) ^ (x_batch * 27191)) % self.TRI_HASH
+            ctx_flat = ctx_hash.reshape(-1).long()
+            next_flat = y_batch.reshape(-1).long()
+            tri_count = self.tri_counts[ctx_flat, next_flat]
+            tri_total = self.tri_row_totals[ctx_flat].clamp(min=1)
+            tri_prob = (tri_count + 0.01) / (tri_total + 0.01 * self.V)
+            tri_nll = -tri_prob.log().reshape(bsz, slen)
+        else:
+            tri_nll = torch.full((bsz, slen), uniform_nll, device=self.device)
+
+        # Expert 4: Neural entropy — reuse neural_lp (no redundant softmax)
+        entropy_nll = -(neural_lp.exp() * neural_lp).sum(-1)  # [bsz, slen]
+
+        # Stack: [bsz, slen, K]
+        return torch.stack([neural_nll, uni_nll, bi_nll, tri_nll, entropy_nll], dim=-1)
+
+    def mix_and_score(self, neural_logits, x_batch, y_batch, wlens):
+        """Compute mixed NLL using current expert weights.
+
+        Returns (mixed_nll [bsz, slen], expert_nll [bsz, slen, K] or None).
+        Caller should pass expert_nll to update_weights() to avoid recomputation.
+        """
+        if self.total_tokens < 10000:
+            # Not enough data for n-grams — just use neural
+            nll = F.cross_entropy(
+                neural_logits.reshape(-1, neural_logits.size(-1)),
+                y_batch.reshape(-1), reduction="none"
+            ).reshape(neural_logits.shape[0], neural_logits.shape[1])
+            return nll, None
+
+        expert_nll = self.get_expert_log_probs(neural_logits, x_batch, y_batch, wlens)  # [bsz, slen, K]
+
+        # Log-domain mixing: log(sum_k w_k * p_k) = logsumexp(log_w_k + log_p_k)
+        log_w = self.log_weights - self.log_weights.logsumexp(0)  # normalize
+        mixed_lp = (-expert_nll + log_w.unsqueeze(0).unsqueeze(0)).logsumexp(dim=-1)  # [bsz, slen]
+
+        return -mixed_lp, expert_nll  # mixed NLL + cached expert NLL
+
+    def update_weights(self, expert_nll, wlens):
+        """Update expert weights using Hedge algorithm on pre-computed expert NLLs."""
+        if expert_nll is None:
+            return
+
+        with torch.no_grad():
+            # Vectorized mask: compare position index against window lengths
+            bsz, slen = expert_nll.shape[0], expert_nll.shape[1]
+            wlens_t = torch.tensor(wlens, device=self.device, dtype=torch.long)
+            mask = torch.arange(slen, device=self.device).unsqueeze(0) < wlens_t.unsqueeze(1)  # [bsz, slen] bool
+
+            # Masked mean NLL per expert
+            masked_nll = expert_nll * mask.unsqueeze(-1).float()
+            expert_mean_loss = masked_nll.sum(dim=(0, 1)) / mask.sum().clamp(min=1)  # [K]
+
+            # Hedge update: log_w -= eta * loss
+            self.log_weights -= self.eta * expert_mean_loss
+
+
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3500))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 8))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 3.5))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.035))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.025))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.025))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    int6_last_n = int(os.environ.get("INT6_LAST_N", 0))  # all int5 (saves ~300KB vs int6 for last 2 blocks)
+    ttt_temperature = float(os.environ.get("TTT_TEMPERATURE", 0.98))  # post-TTT temperature calibration
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+
+    muon_wd = float(os.environ.get("MUON_WD", 0.04))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.04))
+    qat_enabled = bool(int(os.environ.get("QAT_ENABLED", "0")))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 6144))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    dtg_enabled = bool(int(os.environ.get("DTG_ENABLED", "0")))
+    late_qat_threshold = float(os.environ.get("LATE_QAT_THRESHOLD", 0.5))
+    ve_enabled = bool(int(os.environ.get("VE_ENABLED", "1")))
+    ve_dim = int(os.environ.get("VE_DIM", 128))
+    ve_layers = os.environ.get("VE_LAYERS", "9,10")
+    prune_pct = float(os.environ.get("PRUNE_PCT", 0.03))
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay),
+        )
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                if wd > 0.0:
+                    p.data.mul_(1.0 - lr * wd)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+        return loss
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+def eval_val(args: Hyperparameters, model: nn.Module, rank: int, world_size: int,
+             device: torch.device, grad_accum_steps: int, val_tokens: Tensor,
+             base_bytes_lut: Tensor, has_leading_space_lut: Tensor,
+             is_boundary_token_lut: Tensor, eval_seq_len: int | None = None) -> tuple[float, float]:
+    seq_len = eval_seq_len or args.train_seq_len
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,dtg_gate,ve_layer_scales,ve_shared.scale",
+    ).split(",")
+    if pattern
+)
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_Q = 0.9999984
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+    _soft_round_alpha: float = 1.0  # temperature for soft-round (annealed during training)
+    _use_soft_round: bool = False  # enable soft-round QAT instead of STE
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._clip_range = 15  # default int5, set to 31 for int6 layers
+
+    @staticmethod
+    def soft_round(y: Tensor, alpha: float) -> Tensor:
+        """Differentiable approximation to round() from Agustsson & Theis (NeurIPS 2020).
+        s_alpha(y) = floor(y) + 0.5 * tanh(alpha * r) / tanh(alpha/2) + 0.5
+        where r = y - floor(y) - 0.5 (centered fractional part)
+        """
+        fl = torch.floor(y)
+        r = y - fl - 0.5
+        return fl + 0.5 * torch.tanh(alpha * r) / (math.tanh(alpha / 2) + 1e-10) + 0.5
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        cr = self._clip_range
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            if CastedLinear._use_soft_round:
+                # Soft-Round QAT: differentiable rounding with temperature annealing
+                w32 = self.weight.float()
+                row_clip = torch.quantile(w32.abs(), 0.9995, dim=1)
+                scale = (row_clip / float(cr)).clamp_min(1.0 / float(cr))
+                w_scaled = w32 / scale[:, None]
+                w_rounded = CastedLinear.soft_round(w_scaled, CastedLinear._soft_round_alpha)
+                w_q = (torch.clamp(w_rounded, -(cr+1), cr) * scale[:, None]).to(x.dtype)
+                w = w_q  # fully differentiable path
+            else:
+                # Original STE QAT
+                with torch.no_grad():
+                    w32 = self.weight.float()
+                    row_clip = torch.quantile(w32.abs(), 0.9995, dim=1)
+                    scale = (row_clip / float(cr)).clamp_min(1.0 / float(cr))
+                    w_q = (torch.clamp(torch.round(w32 / scale[:, None]), -(cr+1), cr) * scale[:, None]).to(x.dtype)
+                w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024, rope_dims: int = 0):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / (base ** (torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (rd / (rd - 2)))
+                inv_freq = 1.0 / (new_base ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd))
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int = 0) -> Tensor:
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int,
+                 rope_base: float, qk_gain_init: float):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        y_g = y.reshape(B, T, Hkv, H // Hkv, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x: Tensor, v_embed: Tensor | None = None) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = self.c_v(x)
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if _HAS_FA3:
+            y = flash_attn_3_func(q, k, v, causal=True).contiguous()
+        else:
+            y = F.scaled_dot_product_attention(
+                q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
+                attn_mask=None, is_causal=True,
+                enable_gqa=(self.num_kv_heads != self.num_heads),
+            ).transpose(1, 2)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class ValueEmbedding(nn.Module):
+    def __init__(self, vocab_size: int, ve_dim: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, ve_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(ve_dim, model_dim, bias=False) if ve_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(token_ids)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.proj(F.leaky_relu(self.fc(x), negative_slope=0.5).square())
+
+class Block(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int,
+                 rope_base: float, qk_gain_init: float, layer_idx: int = 0,
+                 ln_scale: bool = False, dtg: bool = False):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+        if dtg:
+            self.dtg_gate = nn.Linear(dim, 1, bias=True)
+            nn.init.zeros_(self.dtg_gate.weight)
+            nn.init.constant_(self.dtg_gate.bias, 2.0)
+        else:
+            self.dtg_gate = None
+
+    def forward(self, x: Tensor, x0: Tensor, v_embed: Tensor | None = None) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x_in) * self.ln_scale_factor, v_embed=v_embed)
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor)
+        if self.dtg_gate is not None:
+            gate = torch.sigmoid(self.dtg_gate(x_in.detach()))
+            x_out = x_in + gate * (x_out - x_in)
+        return x_out
+
+class GPT(nn.Module):
+    def __init__(self, vocab_size: int, num_layers: int, model_dim: int, num_heads: int,
+                 num_kv_heads: int, mlp_mult: int, tie_embeddings: bool, tied_embed_init_std: float,
+                 logit_softcap: float, rope_base: float, qk_gain_init: float,
+                 bigram_vocab_size: int = 0, bigram_dim: int = 128, xsa_last_n: int = 0,
+                 rope_dims: int = 0, ln_scale: bool = False, dtg: bool = False,
+                 ve_enabled: bool = False, ve_dim: int = 128, ve_layers: str = "9,10"):
+        super().__init__()
+        self._ve_target_dim = num_kv_heads * (model_dim // num_heads)
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.smear = SmearGate(model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList([
+            Block(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base,
+                  qk_gain_init, layer_idx=i, ln_scale=ln_scale, dtg=dtg)
+            for i in range(num_layers)
+        ])
+        if rope_dims > 0:
+            head_dim = model_dim // num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = rope_dims
+                block.attn.rotary = Rotary(head_dim, base=rope_base, train_seq_len=1024, rope_dims=rope_dims)
+        self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+        kv_dim = self._ve_target_dim
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim)
+            self.ve_layer_scales = nn.ParameterList(
+                [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices]
+            )
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.value_embeds = nn.ModuleList()
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if xsa_last_n > 0:
+            for i in range(max(0, num_layers - xsa_last_n), num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        num_layers = len(self.blocks)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj." in name or name.endswith(".proj"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+
+    def _get_ve(self, layer_idx: int, input_ids: Tensor, ve_cache: dict | None = None) -> Tensor | None:
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if ve_cache is not None and 've' not in ve_cache:
+            ve_cache['ve'] = self.ve_shared(input_ids)
+        ve_base = ve_cache['ve'] if ve_cache is not None else self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_base * self.ve_layer_scales[ve_idx].to(dtype=ve_base.dtype)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x = self.blocks[i](x, x0, v_embed=ve)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x = self.blocks[bi](x, x0, v_embed=ve)
+        x = self.final_norm(x)
+        x_flat = x.reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x_flat, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x_flat)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x = self.blocks[i](x, x0, v_embed=ve)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x = self.blocks[bi](x, x0, v_embed=ve)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+def eval_val_sliding(args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+                     device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+                     has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+                     stride: int, batch_seqs: int = 32, eval_seq_len: int | None = None) -> tuple[float, float]:
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= 1]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    base_model.eval()
+    compiled_logits = torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+
+    # Pre-compile: dummy forward+backward with TTT shapes to warm the compile cache
+    if rank == 0:
+        print("  ttt: pre-compiling forward+backward kernels...", flush=True)
+    _dummy_x = torch.zeros(1, seq_len, dtype=torch.int64, device=device)
+    _dummy_y = torch.zeros(1, seq_len, dtype=torch.int64, device=device)
+    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        _dummy_logits = base_model.forward_logits(_dummy_x)
+        _dummy_loss = F.cross_entropy(_dummy_logits.reshape(-1, _dummy_logits.size(-1)), _dummy_y.reshape(-1))
+    _dummy_loss.backward()
+    base_model.zero_grad(set_to_none=True)
+    if rank == 0:
+        print("  ttt: pre-compile done", flush=True)
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = compiled_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+def eval_val_sliding_ttt(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    stride: int, ttt_epochs: int = 4, ttt_lr: float = 0.001,
+    ttt_momentum: float = 0.9, ttt_freeze_blocks: int = 1,
+    batch_seqs: int = 32, eval_seq_len: int | None = None,
+    ttt_chunk_tokens: int = 32768, ttt_optimizer: str = "adamw",
+    ttt_temp: float = 1.0,
+    ppm_alpha: float = 0.85,
+    byte_weighted_ttt: bool = True,
+    use_cache: bool = True,
+    cache_alpha: float = 0.3,
+    adaptive_lr: bool = True,
+    adaptive_lr_max_mult: float = 3.0,
+    calibrate_temp: bool = True,
+    calibrate_temp_range: tuple[float, float] = (0.85, 1.15),
+    calibrate_temp_steps: int = 7,
+) -> tuple[float, float]:
+    """Legal score-first TTT: score each chunk, then train on it.
+    Every token scored BEFORE any update that could use it."""
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+
+    # Initialize GPU-vectorized logistic context mixer
+    use_mixer = os.environ.get("USE_MIXER", "1") == "1"
+    mixer = LogisticContextMixer(
+        vocab_size=val_tokens.to(torch.int32).max().item() + 1,
+        device=device,
+        eta=float(os.environ.get("MIXER_ETA", "0.1")),
+    ) if use_mixer else None
+    if use_mixer and rank == 0:
+        print(f"  Logistic context mixer enabled: eta={mixer.eta}")
+    if adaptive_lr and rank == 0:
+        print(f"  Adaptive LR enabled: max_mult={adaptive_lr_max_mult}")
+
+    # Pre-compute all window starts
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+
+    # Assign each window to a chunk based on scored token position
+    num_chunks = (total_tokens + ttt_chunk_tokens - 1) // ttt_chunk_tokens
+    chunk_windows: list[list[int]] = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        end = min(ws + seq_len, total_tokens)
+        wlen = end - ws
+        s = 0 if ws == 0 else max(wlen - stride, 0)
+        scored_start = ws + s
+        ci = min(scored_start // ttt_chunk_tokens, num_chunks - 1)
+        chunk_windows[ci].append(ws)
+
+    if rank == 0:
+        print(f"ttt:start chunks={num_chunks} chunk_tokens={ttt_chunk_tokens} "
+              f"windows={len(window_starts)} stride={stride} "
+              f"lr={ttt_lr} epochs={ttt_epochs} opt={ttt_optimizer} "
+              f"freeze_first={ttt_freeze_blocks}")
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Freeze everything, then selectively unfreeze for TTT
+    num_blocks = len(base_model.blocks)
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+    ttt_params = []
+    ttt_param_ids = set()
+    # Track param names for per-layer LR groups
+    ttt_param_names: dict[int, str] = {}  # id(p) -> full_name
+    use_qttt = os.environ.get("QTTT", "0") == "1"
+    if use_qttt:
+        # qTTT: only unfreeze Q projections in last N blocks + norms + head
+        for i in range(max(0, num_blocks - ttt_freeze_blocks), num_blocks):
+            for name, p in base_model.blocks[i].named_parameters():
+                if "c_q" in name:
+                    p.requires_grad_(True)
+                    ttt_params.append(p)
+                    ttt_param_ids.add(id(p))
+                    ttt_param_names[id(p)] = f"blocks.{i}.{name}"
+    else:
+        # Standard: unfreeze all params in last N blocks
+        for i in range(max(0, num_blocks - ttt_freeze_blocks), num_blocks):
+            for name, p in base_model.blocks[i].named_parameters():
+                p.requires_grad_(True)
+                ttt_params.append(p)
+                ttt_param_ids.add(id(p))
+                ttt_param_names[id(p)] = f"blocks.{i}.{name}"
+    # Unfreeze norms, scales, lm_head
+    for name, p in base_model.named_parameters():
+        if "norm" in name or "scale" in name or "lm_head" in name:
+            p.requires_grad_(True)
+            if id(p) not in ttt_param_ids:
+                ttt_params.append(p)
+                ttt_param_ids.add(id(p))
+                ttt_param_names[id(p)] = name
+
+    if rank == 0:
+        n_unfrozen = sum(p.numel() for p in ttt_params)
+        n_frozen = sum(p.numel() for p in base_model.parameters() if not p.requires_grad)
+        print(f"ttt:params unfrozen={n_unfrozen} frozen={n_frozen}")
+
+    # Per-layer LR groups (PR #857 insight):
+    #   proj params (mlp.proj, attn.proj = output projections): lr * 3.0
+    #   fc params (mlp.fc = input projection): lr * 0.5
+    #   everything else (norms, scales, lm_head, q/k/v, etc.): lr * 1.0
+    proj_params = []
+    fc_params = []
+    other_params = []
+    for p in ttt_params:
+        pname = ttt_param_names.get(id(p), "")
+        if ".mlp.proj." in pname or ".attn.proj." in pname:
+            proj_params.append(p)
+        elif ".mlp.fc." in pname:
+            fc_params.append(p)
+        else:
+            other_params.append(p)
+
+    # LR multipliers (base LR will be set per-chunk via cosine schedule)
+    lr_mult_proj = float(os.environ.get("TTT_LR_MULT_PROJ", "3.0"))
+    lr_mult_fc = float(os.environ.get("TTT_LR_MULT_FC", "0.5"))
+    param_groups = [
+        {"params": proj_params, "lr": ttt_lr * lr_mult_proj, "_lr_mult": lr_mult_proj},
+        {"params": fc_params, "lr": ttt_lr * lr_mult_fc, "_lr_mult": lr_mult_fc},
+        {"params": other_params, "lr": ttt_lr, "_lr_mult": 1.0},
+    ]
+    # Filter out empty groups
+    param_groups = [pg for pg in param_groups if len(pg["params"]) > 0]
+
+    if rank == 0:
+        for pg in param_groups:
+            n = sum(p.numel() for p in pg["params"])
+            print(f"  ttt_lr_group: mult={pg['_lr_mult']:.1f} params={n} lr={pg['lr']:.6f}")
+
+    if ttt_optimizer == "adamw":
+        optimizer = torch.optim.AdamW(param_groups, lr=ttt_lr, weight_decay=0.0, betas=(0.9, 0.999))
+    else:
+        optimizer = torch.optim.SGD(param_groups, lr=ttt_lr, momentum=ttt_momentum)
+
+    # Polyak averaging (TTT weight EMA) for smoother scoring
+    use_polyak = os.environ.get("USE_POLYAK", "1") == "1"
+    polyak_decay = float(os.environ.get("POLYAK_DECAY", "0.998"))
+    if use_polyak:
+        polyak_state = {id(p): p.data.clone() for p in ttt_params}
+        if rank == 0:
+            print(f"  Polyak averaging enabled: decay={polyak_decay}")
+
+    t0 = time.perf_counter()
+
+    # Per-chunk calibrated temperature (starts at ttt_temp, updated after each TTT phase)
+    chunk_temp = ttt_temp
+    if calibrate_temp and rank == 0:
+        print(f"  Temperature calibration enabled: range={calibrate_temp_range} steps={calibrate_temp_steps}")
+
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows:
+            continue
+
+        # --- Phase 1: SCORE this chunk (inference_mode, no grad) ---
+        my_s = (len(windows) * rank) // world_size
+        my_e = (len(windows) * (rank + 1)) // world_size
+        my_windows = windows[my_s:my_e]
+
+        # Swap in Polyak-averaged weights for scoring
+        if use_polyak and ci > 0:
+            _saved_weights = {}
+            for p in ttt_params:
+                _saved_weights[id(p)] = p.data.clone()
+                p.data.copy_(polyak_state[id(p)])
+
+        base_model.eval()
+        with torch.inference_mode():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi:bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens: list[int] = []
+                for i, ws in enumerate(batch_ws):
+                    end = min(ws + seq_len, total_tokens)
+                    wlen = end - ws
+                    wlens.append(wlen)
+                    chunk_tok = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                    x_batch[i, :wlen] = chunk_tok[:-1]
+                    y_batch[i, :wlen] = chunk_tok[1:]
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model.forward_logits(x_batch)
+                logits_scaled = logits.float() / chunk_temp
+
+                # Adaptive temperature: sharpen confident predictions more
+                if chunk_temp != 1.0:
+                    with torch.no_grad():
+                        probs_for_entropy = F.softmax(logits.float(), dim=-1)
+                        token_entropy = -(probs_for_entropy * (probs_for_entropy + 1e-10).log()).sum(-1)
+                        max_ent = math.log(logits.size(-1))
+                        # Confident tokens (low entropy) get more sharpening
+                        adaptive_temp = 1.0 - (1.0 - chunk_temp) * (1.0 - token_entropy / max_ent)
+                        adaptive_temp = adaptive_temp.clamp(min=0.9, max=1.05)
+                        logits_scaled = logits.float() / adaptive_temp.unsqueeze(-1)
+
+                # Logistic context mixing (GPU-vectorized) or plain CE
+                if mixer is not None:
+                    nll, expert_nll = mixer.mix_and_score(logits_scaled, x_batch, y_batch, wlens)
+                    mixer.update_weights(expert_nll, wlens)
+                else:
+                    nll = F.cross_entropy(
+                        logits_scaled.reshape(-1, logits_scaled.size(-1)),
+                        y_batch.reshape(-1), reduction="none",
+                    ).reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]
+                    s = 0 if ws == 0 else max(wlen - stride, 0)
+                    scored_nll = nll[i, s:wlen].to(torch.float64)
+                    loss_sum += scored_nll.sum()
+                    token_count += float(wlen - s)
+                    tgt, prev = y_batch[i, s:wlen], x_batch[i, s:wlen]
+                    tb = base_bytes_lut[tgt].to(torch.float64)
+                    tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                    byte_count += tb.sum()
+
+        # --- Update context mixer with scored chunk tokens (GPU-vectorized) ---
+        chunk_start_tok = ci * ttt_chunk_tokens
+        chunk_end_tok = min((ci + 1) * ttt_chunk_tokens, total_tokens)
+        if mixer is not None:
+            mixer.update(val_tokens[chunk_start_tok:chunk_end_tok + 1])
+
+        # Swap back training weights after scoring
+        if use_polyak and ci > 0:
+            for p in ttt_params:
+                p.data.copy_(_saved_weights[id(p)])
+
+        # --- Phase 2: TRAIN on this chunk (already scored = legal) ---
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and ttt_epochs > 0:
+            chunk_start = ci * ttt_chunk_tokens
+            chunk_end = min((ci + 1) * ttt_chunk_tokens, total_tokens)
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if rank == 0 and ci < 3:
+                print(f"    ttt_train [{ci+1}] seqs={chunk_seqs} start_train...", flush=True)
+            if chunk_seqs > 0:
+                # Cosine LR across chunks + adaptive scaling
+                cos_lr = ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                if adaptive_lr:
+                    # Increase LR as we've seen more data (more confident adaptation)
+                    progress = min(ci / max(num_chunks * 0.3, 1), 1.0)  # ramp over first 30% of chunks
+                    lr_mult = 1.0 + (adaptive_lr_max_mult - 1.0) * progress
+                    cos_lr = cos_lr * lr_mult
+                # Apply per-group LR multipliers
+                for pg in optimizer.param_groups:
+                    group_mult = pg.get("_lr_mult", 1.0)
+                    pg["lr"] = cos_lr * group_mult
+                my_seq_s = (chunk_seqs * rank) // world_size
+                my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+                my_chunk_seqs = my_seq_e - my_seq_s
+                for _ep in range(ttt_epochs):
+                    if rank == 0 and ci < 3:
+                        print(f"    ttt_train [{ci+1}] epoch={_ep+1}/{ttt_epochs} batches={my_chunk_seqs} ...", flush=True)
+                    for bs in range(0, my_chunk_seqs, batch_seqs):
+                        be = min(bs + batch_seqs, my_chunk_seqs)
+                        actual_bs = my_seq_s + bs
+                        start_tok = chunk_start + actual_bs * seq_len
+                        end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                        if end_tok > val_tokens.numel():
+                            continue
+                        local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                        x = local[:-1].reshape(-1, seq_len)
+                        y = local[1:].reshape(-1, seq_len)
+                        optimizer.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            if byte_weighted_ttt:
+                                # Byte-weighted loss: tokens covering more bytes matter more
+                                ttt_logits = base_model.forward_logits(x)
+                                per_token_loss = F.cross_entropy(
+                                    ttt_logits.reshape(-1, ttt_logits.size(-1)),
+                                    y.reshape(-1), reduction='none'
+                                ).reshape(y.shape)
+                                byte_weights = base_bytes_lut[y].float()
+                                byte_weights = byte_weights + (has_leading_space_lut[y] & ~is_boundary_token_lut[x]).float()
+                                ttt_loss = (per_token_loss * byte_weights).sum() / byte_weights.sum()
+                            else:
+                                ttt_loss = base_model(x, y)
+                        ttt_loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        torch.nn.utils.clip_grad_norm_(ttt_params, 1.0)
+                        optimizer.step()
+                        # Update Polyak EMA after each step
+                        if use_polyak:
+                            for p in ttt_params:
+                                polyak_state[id(p)].lerp_(p.data, 1.0 - polyak_decay)
+                        if rank == 0 and ci < 3:
+                            print(f"      step done ep={_ep+1} bs={bs} loss={ttt_loss.item():.4f}", flush=True)
+
+        # --- Temperature calibration: find best temp on this chunk's data ---
+        if calibrate_temp and not is_last_chunk and ttt_epochs > 0:
+            chunk_start_cal = ci * ttt_chunk_tokens
+            chunk_end_cal = min((ci + 1) * ttt_chunk_tokens, total_tokens)
+            cal_seqs = (chunk_end_cal - chunk_start_cal) // seq_len
+            # Use up to 8 sequences for calibration (fast)
+            cal_seqs = min(cal_seqs, 8)
+            if cal_seqs > 0:
+                base_model.eval()
+                with torch.inference_mode():
+                    cal_start = chunk_start_cal
+                    cal_end = chunk_start_cal + cal_seqs * seq_len + 1
+                    if cal_end <= val_tokens.numel():
+                        cal_tok = val_tokens[cal_start:cal_end].to(device=device, dtype=torch.int64)
+                        cal_x = cal_tok[:-1].reshape(cal_seqs, seq_len)
+                        cal_y = cal_tok[1:].reshape(cal_seqs, seq_len)
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            cal_logits = base_model.forward_logits(cal_x)
+                        cal_logits_f = cal_logits.float()
+                        # Grid search over temperatures
+                        t_lo, t_hi = calibrate_temp_range
+                        best_temp = chunk_temp
+                        best_nll = float('inf')
+                        for ti in range(calibrate_temp_steps):
+                            t_cand = t_lo + (t_hi - t_lo) * ti / max(calibrate_temp_steps - 1, 1)
+                            nll_cand = F.cross_entropy(
+                                (cal_logits_f / t_cand).reshape(-1, cal_logits_f.size(-1)),
+                                cal_y.reshape(-1), reduction='mean',
+                            ).item()
+                            if nll_cand < best_nll:
+                                best_nll = nll_cand
+                                best_temp = t_cand
+                        chunk_temp = best_temp
+                        if rank == 0 and ci < 5:
+                            print(f"    temp_cal [{ci+1}] best_temp={chunk_temp:.4f} nll={best_nll:.6f}", flush=True)
+
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1 or ci < 5):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            print(f"  ttt_chunk [{ci+1}/{num_chunks}] bpb={rbpb:.6f} temp={chunk_temp:.4f} time={elapsed:.1f}s", flush=True)
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+    if rank == 0:
+        print(f"ttt:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+              f"elapsed={time.perf_counter() - t0:.1f}s")
+    return val_loss, val_bpb
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+
+def quantize_int6_per_row(t: Tensor, clip_range: int = 15) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        best_q, best_s, best_err = None, None, float('inf')
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            if pct < 1.0:
+                row_clip = torch.quantile(t32.abs(), pct, dim=1)
+            else:
+                row_clip = t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+            recon = q.float() * s.float()[:, None]
+            err = (t32 - recon).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_s, best_err = q, s, err
+        return best_q, best_s
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+
+
+def _find_best_row_scales(W: Tensor, clip_range: int = 15) -> Tensor:
+    """Find optimal per-row scales by searching percentile clipping thresholds."""
+    t32 = W.float()
+    best_s = t32.abs().amax(dim=1) / clip_range
+    best_s = best_s.clamp_min(1.0 / clip_range)
+    best_err = torch.full((t32.shape[0],), float('inf'))
+    for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+        if pct < 1.0:
+            row_clip = torch.quantile(t32.abs(), pct, dim=1)
+        else:
+            row_clip = t32.abs().amax(dim=1)
+        s = (row_clip / clip_range).clamp_min(1.0 / clip_range)
+        q = torch.clamp(torch.round(t32 / s[:, None]), -clip_range, clip_range)
+        recon = q * s[:, None]
+        err = (t32 - recon).pow(2).mean(dim=1)
+        improved = err < best_err
+        best_s[improved] = s[improved]
+        best_err[improved] = err[improved]
+    return best_s
+
+def gptq_quantize_weight(W: Tensor, H: Tensor, clip_range: int = 15,
+                          block_size: int = 128, percdamp: float = 0.01) -> tuple[Tensor, Tensor]:
+    """GPTQ: quantize weight matrix W using Hessian H = X^T X for error compensation."""
+    W = W.float().clone()
+    rows, cols = W.shape
+    row_scale = _find_best_row_scales(W, clip_range)
+    H = H.float().clone()
+    damp = percdamp * H.diag().mean()
+    H.diagonal().add_(damp)
+    perm = torch.argsort(H.diag())
+    invperm = torch.argsort(perm)
+    W = W[:, perm]
+    H = H[perm][:, perm]
+    try:
+        L = torch.linalg.cholesky(H)
+        Hinv = torch.cholesky_inverse(L)
+    except torch._C._LinAlgError:
+        Hinv = torch.diag(1.0 / H.diag().clamp_min(1e-6))
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros_like(W_block)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            h_inv_jj = Hinv_block[j, j].clamp_min(1e-8)
+            q_col = torch.clamp(torch.round(w_col / row_scale), -clip_range, clip_range)
+            deq_col = q_col * row_scale
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - deq_col) / h_inv_jj
+            Err[:, j] = err
+            if j + 1 < i2 - i1:
+                W_block[:, j + 1:] -= err.unsqueeze(1) * Hinv_block[j, j + 1:].unsqueeze(0)
+        if i2 < cols:
+            W[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+    Q = Q[:, invperm]
+    return Q, row_scale.to(torch.float16)
+
+def gptq_calibrate(model: nn.Module, train_pattern: str, device: torch.device,
+                   n_samples: int = 256, seq_len: int = 2048) -> dict[str, Tensor]:
+    """Collect Hessian H = X^T X for each linear layer using training data."""
+    hessians: dict[str, Tensor] = {}
+    n_seen: dict[str, int] = {}
+    hooks = []
+    def make_hook(name: str):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            if name not in hessians:
+                hessians[name] = torch.zeros(x.shape[1], x.shape[1], device=x.device, dtype=torch.float32)
+                n_seen[name] = 0
+            hessians[name].addmm_(x.t(), x)
+            n_seen[name] += x.shape[0]
+        return hook_fn
+    for name, module in model.named_modules():
+        if isinstance(module, (nn.Linear, CastedLinear)):
+            hooks.append(module.register_forward_hook(make_hook(name)))
+    stream = TokenStream(train_pattern)
+    model.eval()
+    with torch.no_grad():
+        for _ in range(n_samples):
+            tokens = stream.take(seq_len + 1).to(device=device, dtype=torch.int64)
+            x = tokens[:-1].unsqueeze(0)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                model.forward_logits(x)
+    for h in hooks:
+        h.remove()
+    for name in hessians:
+        hessians[name] /= max(n_seen[name], 1)
+    return hessians
+
+def _get_layer_clip_range(name: str, num_layers: int, int6_last_n: int) -> int:
+    """Return clip_range based on which layer the param belongs to."""
+    import re
+    m = re.search(r'blocks\.(\d+)\.', name)
+    if m:
+        layer_idx = int(m.group(1))
+        if layer_idx >= num_layers - int6_last_n:
+            return 31  # int6
+    return 15  # int5
+
+def mixed_quantize_int6_gptq(state_dict: dict[str, Tensor], int6_cats: set[str],
+                              hessians: dict[str, Tensor],
+                              num_layers: int = 11, int6_last_n: int = 2) -> tuple[dict, dict]:
+    """GPTQ quantization with mixed int5/int6 precision. int6 for last int6_last_n layers, int5 for rest."""
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    gptq_count, naive_count = 0, 0
+    int5_params, int6_params = 0, 0
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        cr = _get_layer_clip_range(name, num_layers, int6_last_n)
+        if cr == 31:
+            int6_params += t.numel()
+        else:
+            int5_params += t.numel()
+        if cat in int6_cats and t.ndim == 2:
+            module_name = name.rsplit(".weight", 1)[0] if name.endswith(".weight") else name
+            H = hessians.get(module_name)
+            if H is not None and H.shape[0] == t.shape[1]:
+                q, s = gptq_quantize_weight(t, H.cpu(), clip_range=cr)
+                gptq_count += 1
+            else:
+                q, s = quantize_int6_per_row(t, clip_range=cr)
+                naive_count += 1
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": f"int{'6' if cr == 31 else '5'}"}
+        elif cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t, clip_range=cr)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": f"int{'6' if cr == 31 else '5'}"}
+            naive_count += 1
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    print(f"gptq_quantize: {gptq_count} GPTQ layers, {naive_count} naive layers", flush=True)
+    print(f"mixed_precision: {int5_params} int5 params, {int6_params} int6 params", flush=True)
+    return result, meta
+
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+    log0(code, console=False)
+    log0(f"Python {sys.version} PyTorch {torch.__version__}", console=False)
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    effective_eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+    CastedLinear._qat_enabled = args.qat_enabled
+    base_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n, rope_dims=args.rope_dims, ln_scale=args.ln_scale,
+        dtg=args.dtg_enabled, ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_params.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None:
+            matrix_params.append(base_model.bigram.proj.weight)
+    if base_model.ve_shared is not None:
+        tok_params.append({"params": [base_model.ve_shared.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.ve_shared.proj is not None:
+            matrix_params.append(base_model.ve_shared.proj.weight)
+        scalar_params.append(base_model.ve_shared.scale)
+        for s in base_model.ve_layer_scales:
+            scalar_params.append(s)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    # Set int6 clip_range for last N layers (mixed precision)
+    int6_start = args.num_layers - args.int6_last_n
+    for i, block in enumerate(base_model.blocks):
+        if i >= int6_start:
+            for m in block.modules():
+                if isinstance(m, CastedLinear):
+                    m._clip_range = 31  # int6
+    if master_process:
+        int5_count = sum(1 for m in base_model.modules() if isinstance(m, CastedLinear) and m._clip_range == 15)
+        int6_count = sum(1 for m in base_model.modules() if isinstance(m, CastedLinear) and m._clip_range == 31)
+        log0(f"mixed_precision: {int5_count} int5 layers, {int6_count} int6 layers (last {args.int6_last_n} blocks)")
+    log0(f"model_params:{n_params}")
+    xsa_layers = [i for i, b in enumerate(base_model.blocks) if b.attn.use_xsa]
+    log0(f"XSA:{xsa_layers} ws:{world_size} gqa:{args.num_heads}/{args.num_kv_heads}")
+    log0(f"lr:embed={token_lr} matrix={args.matrix_lr} scalar={args.scalar_lr} batch:{args.train_batch_tokens} wall:{args.max_wallclock_seconds:.0f}s seed:{args.seed}")
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    train_reserve_ms = 18000  # reserve 18s for EMA + GPTQ calibration + quantization + save
+    effective_train_ms = (max_wallclock_ms - train_reserve_ms) if max_wallclock_ms is not None else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if effective_train_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(effective_train_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+    # TTT_ONLY mode: skip training, load saved model, run TTT eval
+    if os.environ.get("TTT_ONLY", "0") == "1":
+        log0("TTT_ONLY mode: skipping training, loading saved model...")
+        sd_cpu = {k: v.cpu() for k, v in torch.load("final_model.pt", map_location="cpu").items()}
+        if args.prune_pct > 0:
+            for k, v in sd_cpu.items():
+                if v.ndim == 2 and v.numel() > 65536:
+                    thresh = torch.quantile(v.abs().float(), args.prune_pct)
+                    v[v.abs() < thresh] = 0.0
+            log0(f"pruning:{args.prune_pct*100:.1f}% magnitude pruning applied")
+        with open("final_model.int6.ptz", "rb") as f:
+            quant_blob_disk = f.read()
+        quant_state = torch.load(
+            io.BytesIO(zstandard.ZstdDecompressor().decompress(quant_blob_disk) if _COMPRESSOR == "zstd" else zlib.decompress(quant_blob_disk)),
+            map_location="cpu",
+        )
+        deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], sd_cpu)
+        eval_model = GPT(
+            vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+            num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+            tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+            logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+            bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim, xsa_last_n=args.xsa_last_n,
+            rope_dims=args.rope_dims, ln_scale=args.ln_scale, dtg=args.dtg_enabled,
+            ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+        ).to(device).bfloat16()
+        for m in eval_model.modules():
+            if isinstance(m, CastedLinear):
+                m.float()
+        restore_low_dim_params_to_fp32(eval_model)
+        eval_model.load_state_dict(deq_state, strict=True)
+        sw_seq_len = int(os.environ.get("EVAL_SEQ_LEN", str(effective_eval_seq_len)))
+        log0(f"TTT_ONLY: model loaded, starting TTT eval...")
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_epochs = int(os.environ.get("TTT_EPOCHS", "4"))
+        ttt_lr = float(os.environ.get("TTT_LR", "0.0005"))
+        ttt_freeze = int(os.environ.get("TTT_FREEZE_BLOCKS", "1"))
+        ttt_chunk = int(os.environ.get("TTT_CHUNK_TOKENS", "32768"))
+        ttt_opt = os.environ.get("TTT_OPTIMIZER", "adamw")
+        log0(f"TTT: epochs={ttt_epochs} lr={ttt_lr} freeze_first={ttt_freeze} chunk={ttt_chunk} opt={ttt_opt}")
+        ttt_temp = args.ttt_temperature
+        log0(f"TTT temperature: {ttt_temp}")
+        ttt_val_loss, ttt_val_bpb = eval_val_sliding_ttt(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, ttt_epochs=ttt_epochs, ttt_lr=ttt_lr,
+            ttt_freeze_blocks=ttt_freeze, eval_seq_len=sw_seq_len,
+            ttt_chunk_tokens=ttt_chunk, ttt_optimizer=ttt_opt,
+            ttt_temp=ttt_temp,
+            ppm_alpha=float(os.environ.get("PPM_ALPHA", "0.85")),
+            byte_weighted_ttt=os.environ.get("BYTE_WEIGHTED_TTT", "1") == "1",
+            use_cache=os.environ.get("USE_CACHE", "1") == "1",
+            cache_alpha=float(os.environ.get("CACHE_ALPHA", "0.3")),
+            adaptive_lr=os.environ.get("ADAPTIVE_LR", "1") == "1",
+            adaptive_lr_max_mult=float(os.environ.get("ADAPTIVE_LR_MAX", "3.0")),
+            calibrate_temp=os.environ.get("CALIBRATE_TEMP", "1") == "1",
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_ttt val_loss:{ttt_val_loss:.4f} val_bpb:{ttt_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_ttt):.0f}ms"
+        )
+        log0(f"final_int6_ttt_exact val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f}")
+        if distributed:
+            dist.destroy_process_group()
+        return
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    ema_decay = float(os.environ.get("EMA_DECAY", "0.997"))
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        # Anneal soft-round alpha based on QAT progress
+        if CastedLinear._use_soft_round and CastedLinear._qat_enabled:
+            qat_progress = max(0.0, 1.0 - scale / max(args.late_qat_threshold, 0.01))
+            CastedLinear._soft_round_alpha = 1.0 + 15.0 * qat_progress
+        if args.late_qat_threshold > 0 and scale < args.late_qat_threshold and not CastedLinear._qat_enabled:
+            CastedLinear._qat_enabled = True
+            CastedLinear._use_soft_round = os.environ.get("SOFT_ROUND_QAT", "0") == "1"
+            if CastedLinear._use_soft_round and master_process:
+                log0(f"soft_round_qat:enabled initial_alpha=1.0")
+            log0(f"late_qat:enabled step:{step} scale:{scale:.4f}")
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            # CROWN-Q: penalize quantization-sensitive weights during warmdown
+            crownq_lambda = float(os.environ.get("CROWN_Q_LAMBDA", "0.01"))
+            if CastedLinear._qat_enabled and crownq_lambda > 0:
+                cq_loss = torch.zeros((), device=device)
+                for m in base_model.modules():
+                    if isinstance(m, CastedLinear) and m.weight.ndim == 2:
+                        w = m.weight.float()
+                        cr = float(m._clip_range)
+                        row_max = w.detach().abs().amax(dim=1)
+                        delta = row_max / cr  # quantization step size
+                        cq_loss = cq_loss + (w.pow(2) * delta.pow(2).unsqueeze(1)).mean()
+                loss = loss + crownq_lambda * cq_loss / 12.0
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(t.detach().float(), alpha=1.0 - ema_decay)
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        if args.swa_enabled and scale < 0.2 and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+        reached_cap = effective_train_ms is not None and approx_training_time_ms >= effective_train_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+    # Apply EMA weights directly (skip diagnostic evals to save ~5s of reserve)
+    log0("ema:applying EMA weights (skipping diagnostic evals)")
+    current_state = base_model.state_dict()
+    ema_sd = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+    base_model.load_state_dict(ema_sd, strict=True)
+    # GPTQ calibration on final model (within reserved training budget)
+    log0("gptq:calibrating with training data...")
+    t_gptq = time.perf_counter()
+    gptq_hessians = gptq_calibrate(base_model, args.train_files, device, n_samples=128, seq_len=args.train_seq_len)
+    log0(f"gptq:calibrated {len(gptq_hessians)} layers in {time.perf_counter()-t_gptq:.1f}s")
+    export_sd = base_model.state_dict()
+    if master_process:
+        torch.save(export_sd, "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    if args.prune_pct > 0:
+        for k, v in sd_cpu.items():
+            if v.ndim == 2 and v.numel() > 65536:
+                thresh = torch.quantile(v.abs().float(), args.prune_pct)
+                v[v.abs() < thresh] = 0.0
+        if master_process:
+            log0(f"pruning:{args.prune_pct*100:.1f}% magnitude pruning applied")
+    quant_result, quant_meta = mixed_quantize_int6_gptq(sd_cpu, {"mlp", "attn"}, gptq_hessians, num_layers=args.num_layers, int6_last_n=args.int6_last_n)
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zstandard.ZstdCompressor(level=22).compress(quant_raw) if _COMPRESSOR == "zstd" else zlib.compress(quant_raw, 9)
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = len(quant_blob)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+{_COMPRESSOR}: {quant_file_bytes} bytes")
+        log0(f"Total submission size int6+{_COMPRESSOR}: {quant_file_bytes + code_bytes} bytes")
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(zstandard.ZstdDecompressor().decompress(quant_blob_disk) if _COMPRESSOR == "zstd" else zlib.decompress(quant_blob_disk)),
+        map_location="cpu",
+    )
+    deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], sd_cpu)
+    eval_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim, xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims, ln_scale=args.ln_scale, dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+    ).to(device).bfloat16()
+    for m in eval_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(eval_model)
+    eval_model.load_state_dict(deq_state, strict=True)
+    sw_seq_len = int(os.environ.get("EVAL_SEQ_LEN", str(effective_eval_seq_len)))
+    if sw_seq_len != effective_eval_seq_len and rank == 0:
+        log0(f"Eval seq_len override: {effective_eval_seq_len} -> {sw_seq_len}")
+    if args.eval_stride > 0 and args.eval_stride < sw_seq_len and not os.environ.get("SKIP_SLIDING"):
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+    torch.cuda.synchronize()
+    t_ttt = time.perf_counter()
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", "4"))
+    ttt_lr = float(os.environ.get("TTT_LR", "0.0005"))
+    ttt_freeze = int(os.environ.get("TTT_FREEZE_BLOCKS", "1"))
+    ttt_chunk = int(os.environ.get("TTT_CHUNK_TOKENS", "32768"))
+    ttt_opt = os.environ.get("TTT_OPTIMIZER", "adamw")
+    log0(f"TTT: epochs={ttt_epochs} lr={ttt_lr} freeze_first={ttt_freeze} chunk={ttt_chunk} opt={ttt_opt}")
+    ttt_temp = args.ttt_temperature
+    log0(f"TTT temperature: {ttt_temp}")
+    ppm_alpha_val = float(os.environ.get("PPM_ALPHA", "0.85"))
+    bw_ttt = os.environ.get("BYTE_WEIGHTED_TTT", "1") == "1"
+    log0(f"PPM alpha: {ppm_alpha_val}, Byte-weighted TTT: {bw_ttt}")
+    ttt_val_loss, ttt_val_bpb = eval_val_sliding_ttt(
+        args, eval_model, rank, world_size, device,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        stride=args.eval_stride, ttt_epochs=ttt_epochs, ttt_lr=ttt_lr,
+        ttt_freeze_blocks=ttt_freeze, eval_seq_len=sw_seq_len,
+        ttt_chunk_tokens=ttt_chunk, ttt_optimizer=ttt_opt,
+        ttt_temp=ttt_temp,
+        ppm_alpha=float(os.environ.get("PPM_ALPHA", "0.85")),
+        byte_weighted_ttt=os.environ.get("BYTE_WEIGHTED_TTT", "1") == "1",
+        use_cache=os.environ.get("USE_CACHE", "1") == "1",
+        cache_alpha=float(os.environ.get("CACHE_ALPHA", "0.3")),
+        adaptive_lr=os.environ.get("ADAPTIVE_LR", "1") == "1",
+        adaptive_lr_max_mult=float(os.environ.get("ADAPTIVE_LR_MAX", "3.0")),
+        calibrate_temp=os.environ.get("CALIBRATE_TEMP", "1") == "1",
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_ttt val_loss:{ttt_val_loss:.4f} val_bpb:{ttt_val_bpb:.4f} "
+        f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_ttt):.0f}ms"
+    )
+    log0(f"final_int6_ttt_exact val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f}")
+    if distributed:
+        dist.destroy_process_group()
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-03-27_SGD_TTT_HedgeMixer_PerLayerLR_1.0450/train_seed1337.log
+++ b/records/track_10min_16mb/2026-03-27_SGD_TTT_HedgeMixer_PerLayerLR_1.0450/train_seed1337.log
@@ -1,0 +1,326 @@
+W0327 16:07:01.763000 3421924 torch/distributed/run.py:803] 
+W0327 16:07:01.763000 3421924 torch/distributed/run.py:803] *****************************************
+W0327 16:07:01.763000 3421924 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0327 16:07:01.763000 3421924 torch/distributed/run.py:803] *****************************************
+logs/5c271b91-ba6e-41fd-ac8b-f2bc3188d310.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+mixed_precision: 68 int5 layers, 0 int6 layers (last 0 blocks)
+model_params:33317980
+XSA:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] ws:8 gqa:8/8
+lr:embed=0.035 matrix=0.025 scalar=0.025 batch:786432 wall:600s seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9285 val_bpb:4.1034 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9305 train_time:147ms step_avg:147.26ms
+step:2/20000 train_loss:8.6412 train_time:241ms step_avg:120.72ms
+step:3/20000 train_loss:7.7277 train_time:338ms step_avg:112.58ms
+step:4/20000 train_loss:7.2812 train_time:433ms step_avg:108.34ms
+step:5/20000 train_loss:7.0676 train_time:529ms step_avg:105.79ms
+step:6/20000 train_loss:6.9649 train_time:625ms step_avg:104.14ms
+step:7/20000 train_loss:6.8520 train_time:720ms step_avg:102.92ms
+step:8/20000 train_loss:6.7087 train_time:816ms step_avg:102.02ms
+step:9/20000 train_loss:6.3652 train_time:912ms step_avg:101.35ms
+step:10/20000 train_loss:6.0324 train_time:1008ms step_avg:100.84ms
+step:500/20000 train_loss:2.3617 train_time:49037ms step_avg:98.07ms
+step:1000/20000 train_loss:2.2358 train_time:98186ms step_avg:98.19ms
+step:1500/20000 train_loss:2.1869 train_time:147396ms step_avg:98.26ms
+step:2000/20000 train_loss:2.0264 train_time:196655ms step_avg:98.33ms
+step:2500/20000 train_loss:2.1320 train_time:245953ms step_avg:98.38ms
+step:3000/20000 train_loss:2.1097 train_time:295306ms step_avg:98.44ms
+step:3500/20000 train_loss:2.1155 train_time:344642ms step_avg:98.47ms
+step:4000/20000 train_loss:1.9053 train_time:393949ms step_avg:98.49ms
+step:4000/20000 val_loss:1.9974 val_bpb:1.1830 train_time:393954ms step_avg:98.49ms
+late_qat:enabled step:4160 scale:0.4999
+step:4500/20000 train_loss:2.0525 train_time:444405ms step_avg:98.76ms
+step:5000/20000 train_loss:2.0255 train_time:495334ms step_avg:99.07ms
+swa:start step:5200
+step:5500/20000 train_loss:1.9353 train_time:546565ms step_avg:99.38ms
+step:5847/20000 val_loss:1.9037 val_bpb:1.1275 train_time:582082ms step_avg:99.55ms
+stopping_early: wallclock_cap train_time:582082ms step:5847/20000
+peak memory allocated: 26197 MiB reserved: 26810 MiB
+ema:applying EMA weights (skipping diagnostic evals)
+gptq:calibrating with training data...
+gptq:calibrated 68 layers in 1.9s
+Serialized model: 130432585 bytes
+Code size: 102023 bytes
+pruning:3.0% magnitude pruning applied
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+Serialized model int6+zstd: 15465515 bytes
+Total submission size int6+zstd: 15567538 bytes
+TTT: epochs=4 lr=0.002 freeze_first=1 chunk=32768 opt=sgd
+TTT temperature: 0.98
+PPM alpha: 0.85, Byte-weighted TTT: True
+  Logistic context mixer enabled: eta=0.1
+  Adaptive LR enabled: max_mult=3.0
+ttt:start chunks=1893 chunk_tokens=32768 windows=969088 stride=64 lr=0.002 epochs=4 opt=sgd freeze_first=1
+ttt:params unfrozen=2895884 frozen=30422096
+  ttt_lr_group: mult=3.0 params=1179648 lr=0.006000
+  ttt_lr_group: mult=0.5 params=917504 lr=0.001000
+  ttt_lr_group: mult=1.0 params=798732 lr=0.002000
+  Polyak averaging enabled: decay=0.998
+  Temperature calibration enabled: range=(0.85, 1.15) steps=7
+    ttt_train [1] seqs=16 start_train...
+    ttt_train [1] epoch=1/4 batches=2 ...
+      step done ep=1 bs=0 loss=2.3171
+    ttt_train [1] epoch=2/4 batches=2 ...
+      step done ep=2 bs=0 loss=2.2959
+    ttt_train [1] epoch=3/4 batches=2 ...
+      step done ep=3 bs=0 loss=2.2959
+    ttt_train [1] epoch=4/4 batches=2 ...
+      step done ep=4 bs=0 loss=2.2946
+    temp_cal [1] best_temp=1.0000 nll=2.073943
+  ttt_chunk [1/1893] bpb=1.160703 temp=1.0000 time=0.5s
+    ttt_train [2] seqs=16 start_train...
+    ttt_train [2] epoch=1/4 batches=2 ...
+      step done ep=1 bs=0 loss=2.7615
+    ttt_train [2] epoch=2/4 batches=2 ...
+      step done ep=2 bs=0 loss=2.7619
+    ttt_train [2] epoch=3/4 batches=2 ...
+      step done ep=3 bs=0 loss=2.7601
+    ttt_train [2] epoch=4/4 batches=2 ...
+      step done ep=4 bs=0 loss=2.7594
+    temp_cal [2] best_temp=1.0500 nll=2.030037
+  ttt_chunk [2/1893] bpb=1.236957 temp=1.0500 time=0.8s
+    ttt_train [3] seqs=16 start_train...
+    ttt_train [3] epoch=1/4 batches=2 ...
+      step done ep=1 bs=0 loss=1.8852
+    ttt_train [3] epoch=2/4 batches=2 ...
+      step done ep=2 bs=0 loss=1.8837
+    ttt_train [3] epoch=3/4 batches=2 ...
+      step done ep=3 bs=0 loss=1.8813
+    ttt_train [3] epoch=4/4 batches=2 ...
+      step done ep=4 bs=0 loss=1.8823
+    temp_cal [3] best_temp=1.0500 nll=1.702568
+  ttt_chunk [3/1893] bpb=1.184816 temp=1.0500 time=1.1s
+    temp_cal [4] best_temp=1.0500 nll=2.084971
+  ttt_chunk [4/1893] bpb=1.169450 temp=1.0500 time=1.4s
+    temp_cal [5] best_temp=1.0000 nll=1.915472
+  ttt_chunk [5/1893] bpb=1.152646 temp=1.0000 time=1.6s
+  ttt_chunk [11/1893] bpb=1.088046 temp=1.0000 time=3.3s
+  ttt_chunk [21/1893] bpb=1.054735 temp=1.0000 time=6.2s
+  ttt_chunk [31/1893] bpb=1.045614 temp=1.0000 time=9.0s
+  ttt_chunk [41/1893] bpb=1.028667 temp=1.0000 time=11.9s
+  ttt_chunk [51/1893] bpb=1.021144 temp=1.0000 time=14.7s
+  ttt_chunk [61/1893] bpb=1.024780 temp=1.0000 time=17.5s
+  ttt_chunk [71/1893] bpb=1.021082 temp=1.0500 time=20.4s
+  ttt_chunk [81/1893] bpb=1.018890 temp=1.0000 time=23.2s
+  ttt_chunk [91/1893] bpb=1.019004 temp=1.0000 time=26.1s
+  ttt_chunk [101/1893] bpb=1.021171 temp=1.0000 time=28.9s
+  ttt_chunk [111/1893] bpb=1.022967 temp=1.0000 time=31.8s
+  ttt_chunk [121/1893] bpb=1.016201 temp=1.0000 time=34.6s
+  ttt_chunk [131/1893] bpb=1.016059 temp=1.0000 time=37.4s
+  ttt_chunk [141/1893] bpb=1.020748 temp=1.0000 time=40.3s
+  ttt_chunk [151/1893] bpb=1.022108 temp=1.0000 time=43.1s
+  ttt_chunk [161/1893] bpb=1.021266 temp=1.0000 time=46.0s
+  ttt_chunk [171/1893] bpb=1.025171 temp=1.0000 time=48.8s
+  ttt_chunk [181/1893] bpb=1.027130 temp=1.0000 time=51.7s
+  ttt_chunk [191/1893] bpb=1.033650 temp=1.0000 time=54.5s
+  ttt_chunk [201/1893] bpb=1.032261 temp=1.0000 time=57.4s
+  ttt_chunk [211/1893] bpb=1.030254 temp=1.0000 time=60.2s
+  ttt_chunk [221/1893] bpb=1.031866 temp=1.0000 time=63.1s
+  ttt_chunk [231/1893] bpb=1.030589 temp=1.0000 time=65.9s
+  ttt_chunk [241/1893] bpb=1.031135 temp=1.0000 time=68.8s
+  ttt_chunk [251/1893] bpb=1.030539 temp=1.0000 time=71.7s
+  ttt_chunk [261/1893] bpb=1.028078 temp=1.0000 time=74.5s
+  ttt_chunk [271/1893] bpb=1.026967 temp=1.0000 time=77.4s
+  ttt_chunk [281/1893] bpb=1.028339 temp=1.0000 time=80.2s
+  ttt_chunk [291/1893] bpb=1.029934 temp=1.0000 time=83.1s
+  ttt_chunk [301/1893] bpb=1.030674 temp=1.0000 time=86.0s
+  ttt_chunk [311/1893] bpb=1.032634 temp=1.0000 time=88.8s
+  ttt_chunk [321/1893] bpb=1.034647 temp=1.0000 time=91.7s
+  ttt_chunk [331/1893] bpb=1.034638 temp=1.0000 time=94.6s
+  ttt_chunk [341/1893] bpb=1.033779 temp=1.0000 time=97.4s
+  ttt_chunk [351/1893] bpb=1.035868 temp=1.0000 time=100.3s
+  ttt_chunk [361/1893] bpb=1.036032 temp=1.0000 time=103.2s
+  ttt_chunk [371/1893] bpb=1.035457 temp=1.0000 time=106.1s
+  ttt_chunk [381/1893] bpb=1.035748 temp=1.0000 time=108.9s
+  ttt_chunk [391/1893] bpb=1.035617 temp=1.0000 time=111.8s
+  ttt_chunk [401/1893] bpb=1.033747 temp=1.0000 time=114.7s
+  ttt_chunk [411/1893] bpb=1.032620 temp=1.0000 time=117.5s
+  ttt_chunk [421/1893] bpb=1.031907 temp=1.0000 time=120.4s
+  ttt_chunk [431/1893] bpb=1.031967 temp=1.0000 time=123.3s
+  ttt_chunk [441/1893] bpb=1.032307 temp=1.0000 time=126.1s
+  ttt_chunk [451/1893] bpb=1.032775 temp=1.0000 time=129.0s
+  ttt_chunk [461/1893] bpb=1.031853 temp=1.0000 time=131.9s
+  ttt_chunk [471/1893] bpb=1.032591 temp=1.0000 time=134.7s
+  ttt_chunk [481/1893] bpb=1.032350 temp=1.0000 time=137.6s
+  ttt_chunk [491/1893] bpb=1.031401 temp=1.0000 time=140.5s
+  ttt_chunk [501/1893] bpb=1.030981 temp=1.0000 time=143.4s
+  ttt_chunk [511/1893] bpb=1.030366 temp=1.0000 time=146.2s
+  ttt_chunk [521/1893] bpb=1.028263 temp=1.0000 time=149.1s
+  ttt_chunk [531/1893] bpb=1.029501 temp=1.0000 time=152.0s
+  ttt_chunk [541/1893] bpb=1.029808 temp=1.0000 time=154.8s
+  ttt_chunk [551/1893] bpb=1.028951 temp=1.0000 time=157.7s
+  ttt_chunk [561/1893] bpb=1.029524 temp=1.0000 time=160.6s
+  ttt_chunk [571/1893] bpb=1.028696 temp=1.0000 time=163.4s
+  ttt_chunk [581/1893] bpb=1.027960 temp=1.0000 time=166.3s
+  ttt_chunk [591/1893] bpb=1.027519 temp=1.0000 time=169.2s
+  ttt_chunk [601/1893] bpb=1.027954 temp=1.0000 time=172.1s
+  ttt_chunk [611/1893] bpb=1.027983 temp=1.0000 time=174.9s
+  ttt_chunk [621/1893] bpb=1.027892 temp=1.0000 time=177.8s
+  ttt_chunk [631/1893] bpb=1.028650 temp=1.0000 time=180.7s
+  ttt_chunk [641/1893] bpb=1.028413 temp=1.0000 time=183.5s
+  ttt_chunk [651/1893] bpb=1.028567 temp=1.0000 time=186.4s
+  ttt_chunk [661/1893] bpb=1.028123 temp=1.0000 time=189.2s
+  ttt_chunk [671/1893] bpb=1.028471 temp=1.0000 time=192.0s
+  ttt_chunk [681/1893] bpb=1.029160 temp=1.0000 time=194.9s
+  ttt_chunk [691/1893] bpb=1.030121 temp=1.0000 time=197.7s
+  ttt_chunk [701/1893] bpb=1.029696 temp=1.0000 time=200.6s
+  ttt_chunk [711/1893] bpb=1.029794 temp=1.0000 time=203.4s
+  ttt_chunk [721/1893] bpb=1.029406 temp=1.0000 time=206.2s
+  ttt_chunk [731/1893] bpb=1.029454 temp=1.0000 time=209.1s
+  ttt_chunk [741/1893] bpb=1.029543 temp=1.0000 time=211.9s
+  ttt_chunk [751/1893] bpb=1.029394 temp=1.0000 time=214.8s
+  ttt_chunk [761/1893] bpb=1.029332 temp=1.0000 time=217.6s
+  ttt_chunk [771/1893] bpb=1.029116 temp=1.0000 time=220.5s
+  ttt_chunk [781/1893] bpb=1.029845 temp=1.0000 time=223.3s
+  ttt_chunk [791/1893] bpb=1.029413 temp=1.0000 time=226.1s
+  ttt_chunk [801/1893] bpb=1.029733 temp=1.0000 time=229.0s
+  ttt_chunk [811/1893] bpb=1.029584 temp=1.0000 time=231.8s
+  ttt_chunk [821/1893] bpb=1.029434 temp=1.0000 time=234.7s
+  ttt_chunk [831/1893] bpb=1.029294 temp=1.0000 time=237.6s
+  ttt_chunk [841/1893] bpb=1.028734 temp=1.0000 time=240.7s
+  ttt_chunk [851/1893] bpb=1.028603 temp=1.0000 time=243.8s
+  ttt_chunk [861/1893] bpb=1.028381 temp=1.0000 time=246.8s
+  ttt_chunk [871/1893] bpb=1.028728 temp=1.0000 time=249.7s
+  ttt_chunk [881/1893] bpb=1.028930 temp=1.0000 time=252.5s
+  ttt_chunk [891/1893] bpb=1.028583 temp=1.0000 time=255.4s
+  ttt_chunk [901/1893] bpb=1.028382 temp=1.0000 time=258.2s
+  ttt_chunk [911/1893] bpb=1.028523 temp=1.0000 time=261.1s
+  ttt_chunk [921/1893] bpb=1.028990 temp=1.0000 time=264.0s
+  ttt_chunk [931/1893] bpb=1.028971 temp=1.0000 time=266.9s
+  ttt_chunk [941/1893] bpb=1.028720 temp=1.0000 time=269.8s
+  ttt_chunk [951/1893] bpb=1.029157 temp=1.0000 time=272.6s
+  ttt_chunk [961/1893] bpb=1.029286 temp=1.0000 time=275.5s
+  ttt_chunk [971/1893] bpb=1.030115 temp=1.0000 time=278.4s
+  ttt_chunk [981/1893] bpb=1.030230 temp=1.0000 time=281.2s
+  ttt_chunk [991/1893] bpb=1.030278 temp=1.0000 time=284.1s
+  ttt_chunk [1001/1893] bpb=1.030286 temp=1.0000 time=287.0s
+  ttt_chunk [1011/1893] bpb=1.030162 temp=1.0000 time=289.9s
+  ttt_chunk [1021/1893] bpb=1.030475 temp=1.0000 time=292.7s
+  ttt_chunk [1031/1893] bpb=1.030960 temp=1.0000 time=295.6s
+  ttt_chunk [1041/1893] bpb=1.030718 temp=1.0000 time=298.5s
+  ttt_chunk [1051/1893] bpb=1.030509 temp=1.0000 time=301.3s
+  ttt_chunk [1061/1893] bpb=1.030616 temp=1.0000 time=304.2s
+  ttt_chunk [1071/1893] bpb=1.031212 temp=1.0000 time=307.1s
+  ttt_chunk [1081/1893] bpb=1.031477 temp=1.0000 time=310.0s
+  ttt_chunk [1091/1893] bpb=1.032202 temp=1.0000 time=312.8s
+  ttt_chunk [1101/1893] bpb=1.032292 temp=1.0000 time=315.7s
+  ttt_chunk [1111/1893] bpb=1.032177 temp=1.0000 time=318.5s
+  ttt_chunk [1121/1893] bpb=1.031979 temp=1.0000 time=321.4s
+  ttt_chunk [1131/1893] bpb=1.031986 temp=1.0000 time=324.2s
+  ttt_chunk [1141/1893] bpb=1.031799 temp=1.0000 time=327.1s
+  ttt_chunk [1151/1893] bpb=1.031836 temp=1.0000 time=329.9s
+  ttt_chunk [1161/1893] bpb=1.031592 temp=1.0000 time=332.7s
+  ttt_chunk [1171/1893] bpb=1.031928 temp=1.0000 time=335.6s
+  ttt_chunk [1181/1893] bpb=1.031339 temp=1.0000 time=338.4s
+  ttt_chunk [1191/1893] bpb=1.031244 temp=1.0000 time=341.3s
+  ttt_chunk [1201/1893] bpb=1.031637 temp=1.0000 time=344.1s
+  ttt_chunk [1211/1893] bpb=1.031274 temp=1.0000 time=347.0s
+  ttt_chunk [1221/1893] bpb=1.031093 temp=1.0000 time=349.8s
+  ttt_chunk [1231/1893] bpb=1.030993 temp=1.0000 time=352.6s
+  ttt_chunk [1241/1893] bpb=1.030723 temp=1.0000 time=355.5s
+  ttt_chunk [1251/1893] bpb=1.030287 temp=1.0000 time=358.3s
+  ttt_chunk [1261/1893] bpb=1.030323 temp=1.0000 time=361.2s
+  ttt_chunk [1271/1893] bpb=1.030090 temp=1.0000 time=364.0s
+  ttt_chunk [1281/1893] bpb=1.030041 temp=1.0000 time=366.8s
+  ttt_chunk [1291/1893] bpb=1.029930 temp=1.0000 time=369.7s
+  ttt_chunk [1301/1893] bpb=1.029458 temp=1.0000 time=372.5s
+  ttt_chunk [1311/1893] bpb=1.029258 temp=1.0000 time=375.3s
+  ttt_chunk [1321/1893] bpb=1.029077 temp=1.0000 time=378.2s
+  ttt_chunk [1331/1893] bpb=1.029155 temp=1.0000 time=381.0s
+  ttt_chunk [1341/1893] bpb=1.029144 temp=1.0000 time=383.9s
+  ttt_chunk [1351/1893] bpb=1.029134 temp=1.0000 time=386.7s
+  ttt_chunk [1361/1893] bpb=1.029326 temp=1.0000 time=389.5s
+  ttt_chunk [1371/1893] bpb=1.029283 temp=1.0000 time=392.4s
+  ttt_chunk [1381/1893] bpb=1.029371 temp=1.0000 time=395.2s
+  ttt_chunk [1391/1893] bpb=1.029107 temp=1.0000 time=398.1s
+  ttt_chunk [1401/1893] bpb=1.029224 temp=1.0000 time=400.9s
+  ttt_chunk [1411/1893] bpb=1.029423 temp=1.0000 time=403.7s
+  ttt_chunk [1421/1893] bpb=1.029802 temp=1.0000 time=406.6s
+  ttt_chunk [1431/1893] bpb=1.029593 temp=1.0000 time=409.4s
+  ttt_chunk [1441/1893] bpb=1.030158 temp=1.0000 time=412.2s
+  ttt_chunk [1451/1893] bpb=1.030599 temp=1.0000 time=415.1s
+  ttt_chunk [1461/1893] bpb=1.030307 temp=1.0000 time=417.9s
+  ttt_chunk [1471/1893] bpb=1.031447 temp=1.0000 time=420.8s
+  ttt_chunk [1481/1893] bpb=1.031128 temp=1.0000 time=423.6s
+  ttt_chunk [1491/1893] bpb=1.031063 temp=1.0000 time=426.4s
+  ttt_chunk [1501/1893] bpb=1.031098 temp=1.0000 time=429.3s
+  ttt_chunk [1511/1893] bpb=1.031168 temp=1.0000 time=432.1s
+  ttt_chunk [1521/1893] bpb=1.031340 temp=1.0000 time=434.9s
+  ttt_chunk [1531/1893] bpb=1.030941 temp=1.0000 time=437.8s
+  ttt_chunk [1541/1893] bpb=1.030936 temp=1.0000 time=440.6s
+  ttt_chunk [1551/1893] bpb=1.031402 temp=1.0000 time=443.4s
+  ttt_chunk [1561/1893] bpb=1.031533 temp=1.0000 time=446.3s
+  ttt_chunk [1571/1893] bpb=1.031551 temp=1.0000 time=449.1s
+  ttt_chunk [1581/1893] bpb=1.031796 temp=1.0000 time=451.9s
+  ttt_chunk [1591/1893] bpb=1.031847 temp=1.0000 time=454.7s
+  ttt_chunk [1601/1893] bpb=1.032147 temp=1.0000 time=457.5s
+  ttt_chunk [1611/1893] bpb=1.032187 temp=1.0000 time=460.4s
+  ttt_chunk [1621/1893] bpb=1.031911 temp=1.0000 time=463.2s
+  ttt_chunk [1631/1893] bpb=1.032320 temp=1.0000 time=466.0s
+  ttt_chunk [1641/1893] bpb=1.032461 temp=1.0000 time=468.9s
+  ttt_chunk [1651/1893] bpb=1.032515 temp=1.0000 time=471.7s
+  ttt_chunk [1661/1893] bpb=1.032528 temp=1.0000 time=474.5s
+  ttt_chunk [1671/1893] bpb=1.033088 temp=1.0000 time=477.4s
+  ttt_chunk [1681/1893] bpb=1.033373 temp=1.0000 time=480.2s
+  ttt_chunk [1691/1893] bpb=1.033364 temp=1.0000 time=483.0s
+  ttt_chunk [1701/1893] bpb=1.033699 temp=1.0000 time=485.9s
+  ttt_chunk [1711/1893] bpb=1.033879 temp=1.0000 time=488.7s
+  ttt_chunk [1721/1893] bpb=1.033981 temp=1.0000 time=491.6s
+  ttt_chunk [1731/1893] bpb=1.034013 temp=1.0000 time=494.4s
+  ttt_chunk [1741/1893] bpb=1.033998 temp=1.0000 time=497.3s
+  ttt_chunk [1751/1893] bpb=1.033956 temp=1.0000 time=500.1s
+  ttt_chunk [1761/1893] bpb=1.034241 temp=1.0000 time=502.9s
+  ttt_chunk [1771/1893] bpb=1.034307 temp=1.0000 time=505.8s
+  ttt_chunk [1781/1893] bpb=1.034500 temp=1.0000 time=508.6s
+  ttt_chunk [1791/1893] bpb=1.034241 temp=1.0000 time=511.5s
+  ttt_chunk [1801/1893] bpb=1.034290 temp=1.0000 time=514.3s
+  ttt_chunk [1811/1893] bpb=1.034361 temp=1.0000 time=517.1s
+  ttt_chunk [1821/1893] bpb=1.034601 temp=1.0000 time=520.0s
+  ttt_chunk [1831/1893] bpb=1.034190 temp=1.0000 time=522.8s
+  ttt_chunk [1841/1893] bpb=1.034313 temp=1.0000 time=525.7s
+  ttt_chunk [1851/1893] bpb=1.034242 temp=1.0000 time=528.6s
+  ttt_chunk [1861/1893] bpb=1.034050 temp=1.0000 time=531.4s
+  ttt_chunk [1871/1893] bpb=1.034184 temp=1.0000 time=534.3s
+  ttt_chunk [1881/1893] bpb=1.033904 temp=1.0000 time=537.2s
+  ttt_chunk [1891/1893] bpb=1.033846 temp=1.0000 time=540.0s
+  ttt_chunk [1893/1893] bpb=1.033911 temp=1.0000 time=540.4s
+ttt:done val_loss=1.741159 val_bpb=1.031215 elapsed=540.4s
+final_int6_ttt val_loss:1.7412 val_bpb:1.0312 stride:64 eval_time:541018ms
+final_int6_ttt_exact val_loss:1.74115851 val_bpb:1.03121488

--- a/records/track_10min_16mb/2026-03-27_SGD_TTT_HedgeMixer_PerLayerLR_1.0450/train_seed2025.log
+++ b/records/track_10min_16mb/2026-03-27_SGD_TTT_HedgeMixer_PerLayerLR_1.0450/train_seed2025.log
@@ -1,0 +1,326 @@
+W0327 16:48:40.976000 3425883 torch/distributed/run.py:803] 
+W0327 16:48:40.976000 3425883 torch/distributed/run.py:803] *****************************************
+W0327 16:48:40.976000 3425883 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0327 16:48:40.976000 3425883 torch/distributed/run.py:803] *****************************************
+logs/ba75e9e5-3015-4d4a-b7c9-c52b6f9eee5a.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+mixed_precision: 68 int5 layers, 0 int6 layers (last 0 blocks)
+model_params:33317980
+XSA:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] ws:8 gqa:8/8
+lr:embed=0.035 matrix=0.025 scalar=0.025 batch:786432 wall:600s seed:2025
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9290 val_bpb:4.1037 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9311 train_time:149ms step_avg:149.36ms
+step:2/20000 train_loss:8.6063 train_time:242ms step_avg:120.78ms
+step:3/20000 train_loss:7.7083 train_time:338ms step_avg:112.52ms
+step:4/20000 train_loss:7.2887 train_time:433ms step_avg:108.34ms
+step:5/20000 train_loss:7.0498 train_time:530ms step_avg:105.91ms
+step:6/20000 train_loss:6.8999 train_time:626ms step_avg:104.27ms
+step:7/20000 train_loss:6.8051 train_time:721ms step_avg:103.07ms
+step:8/20000 train_loss:6.7245 train_time:818ms step_avg:102.21ms
+step:9/20000 train_loss:6.3967 train_time:913ms step_avg:101.48ms
+step:10/20000 train_loss:6.0067 train_time:1010ms step_avg:100.98ms
+step:500/20000 train_loss:2.3608 train_time:49071ms step_avg:98.14ms
+step:1000/20000 train_loss:2.2380 train_time:98207ms step_avg:98.21ms
+step:1500/20000 train_loss:2.1893 train_time:147405ms step_avg:98.27ms
+step:2000/20000 train_loss:2.0303 train_time:196648ms step_avg:98.32ms
+step:2500/20000 train_loss:2.1311 train_time:245916ms step_avg:98.37ms
+step:3000/20000 train_loss:2.1134 train_time:295199ms step_avg:98.40ms
+step:3500/20000 train_loss:2.1181 train_time:344452ms step_avg:98.41ms
+step:4000/20000 train_loss:1.9097 train_time:393680ms step_avg:98.42ms
+step:4000/20000 val_loss:1.9981 val_bpb:1.1834 train_time:393685ms step_avg:98.42ms
+late_qat:enabled step:4164 scale:0.4999
+step:4500/20000 train_loss:2.0544 train_time:444084ms step_avg:98.69ms
+step:5000/20000 train_loss:2.0268 train_time:494933ms step_avg:98.99ms
+swa:start step:5200
+step:5500/20000 train_loss:1.9377 train_time:546070ms step_avg:99.29ms
+step:5851/20000 val_loss:1.9040 val_bpb:1.1276 train_time:582073ms step_avg:99.48ms
+stopping_early: wallclock_cap train_time:582073ms step:5851/20000
+peak memory allocated: 26197 MiB reserved: 26810 MiB
+ema:applying EMA weights (skipping diagnostic evals)
+gptq:calibrating with training data...
+gptq:calibrated 68 layers in 2.0s
+Serialized model: 130432585 bytes
+Code size: 102023 bytes
+pruning:3.0% magnitude pruning applied
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+Serialized model int6+zstd: 15050733 bytes
+Total submission size int6+zstd: 15152756 bytes
+TTT: epochs=4 lr=0.002 freeze_first=1 chunk=32768 opt=sgd
+TTT temperature: 0.98
+PPM alpha: 0.85, Byte-weighted TTT: True
+  Logistic context mixer enabled: eta=0.1
+  Adaptive LR enabled: max_mult=3.0
+ttt:start chunks=1893 chunk_tokens=32768 windows=969088 stride=64 lr=0.002 epochs=4 opt=sgd freeze_first=1
+ttt:params unfrozen=2895884 frozen=30422096
+  ttt_lr_group: mult=3.0 params=1179648 lr=0.006000
+  ttt_lr_group: mult=0.5 params=917504 lr=0.001000
+  ttt_lr_group: mult=1.0 params=798732 lr=0.002000
+  Polyak averaging enabled: decay=0.998
+  Temperature calibration enabled: range=(0.85, 1.15) steps=7
+    ttt_train [1] seqs=16 start_train...
+    ttt_train [1] epoch=1/4 batches=2 ...
+      step done ep=1 bs=0 loss=2.3144
+    ttt_train [1] epoch=2/4 batches=2 ...
+      step done ep=2 bs=0 loss=2.2928
+    ttt_train [1] epoch=3/4 batches=2 ...
+      step done ep=3 bs=0 loss=2.2925
+    ttt_train [1] epoch=4/4 batches=2 ...
+      step done ep=4 bs=0 loss=2.2916
+    temp_cal [1] best_temp=1.0000 nll=2.075736
+  ttt_chunk [1/1893] bpb=1.158851 temp=1.0000 time=0.5s
+    ttt_train [2] seqs=16 start_train...
+    ttt_train [2] epoch=1/4 batches=2 ...
+      step done ep=1 bs=0 loss=2.7658
+    ttt_train [2] epoch=2/4 batches=2 ...
+      step done ep=2 bs=0 loss=2.7648
+    ttt_train [2] epoch=3/4 batches=2 ...
+      step done ep=3 bs=0 loss=2.7638
+    ttt_train [2] epoch=4/4 batches=2 ...
+      step done ep=4 bs=0 loss=2.7635
+    temp_cal [2] best_temp=1.0000 nll=2.032876
+  ttt_chunk [2/1893] bpb=1.245595 temp=1.0000 time=0.8s
+    ttt_train [3] seqs=16 start_train...
+    ttt_train [3] epoch=1/4 batches=2 ...
+      step done ep=1 bs=0 loss=1.8964
+    ttt_train [3] epoch=2/4 batches=2 ...
+      step done ep=2 bs=0 loss=1.8955
+    ttt_train [3] epoch=3/4 batches=2 ...
+      step done ep=3 bs=0 loss=1.8948
+    ttt_train [3] epoch=4/4 batches=2 ...
+      step done ep=4 bs=0 loss=1.8944
+    temp_cal [3] best_temp=1.0000 nll=1.700298
+  ttt_chunk [3/1893] bpb=1.191674 temp=1.0000 time=1.1s
+    temp_cal [4] best_temp=1.0000 nll=2.090077
+  ttt_chunk [4/1893] bpb=1.176153 temp=1.0000 time=1.4s
+    temp_cal [5] best_temp=1.0000 nll=1.913113
+  ttt_chunk [5/1893] bpb=1.155989 temp=1.0000 time=1.7s
+  ttt_chunk [11/1893] bpb=1.096122 temp=1.0000 time=3.4s
+  ttt_chunk [21/1893] bpb=1.066370 temp=1.0000 time=6.2s
+  ttt_chunk [31/1893] bpb=1.060032 temp=1.0000 time=9.1s
+  ttt_chunk [41/1893] bpb=1.045718 temp=1.0000 time=12.0s
+  ttt_chunk [51/1893] bpb=1.039834 temp=1.0000 time=14.8s
+  ttt_chunk [61/1893] bpb=1.045369 temp=1.0000 time=17.7s
+  ttt_chunk [71/1893] bpb=1.043685 temp=1.0000 time=20.6s
+  ttt_chunk [81/1893] bpb=1.042860 temp=1.0000 time=23.5s
+  ttt_chunk [91/1893] bpb=1.044214 temp=1.0000 time=26.4s
+  ttt_chunk [101/1893] bpb=1.047730 temp=1.0000 time=29.2s
+  ttt_chunk [111/1893] bpb=1.050412 temp=1.0000 time=32.1s
+  ttt_chunk [121/1893] bpb=1.044339 temp=1.0000 time=35.0s
+  ttt_chunk [131/1893] bpb=1.045224 temp=1.0000 time=37.9s
+  ttt_chunk [141/1893] bpb=1.051189 temp=1.0000 time=40.7s
+  ttt_chunk [151/1893] bpb=1.053695 temp=1.0000 time=43.6s
+  ttt_chunk [161/1893] bpb=1.053472 temp=1.0000 time=46.5s
+  ttt_chunk [171/1893] bpb=1.058224 temp=1.0000 time=49.4s
+  ttt_chunk [181/1893] bpb=1.061176 temp=1.0000 time=52.2s
+  ttt_chunk [191/1893] bpb=1.068845 temp=1.0000 time=55.1s
+  ttt_chunk [201/1893] bpb=1.068214 temp=1.0000 time=58.0s
+  ttt_chunk [211/1893] bpb=1.066820 temp=1.0000 time=60.9s
+  ttt_chunk [221/1893] bpb=1.069111 temp=1.0000 time=63.8s
+  ttt_chunk [231/1893] bpb=1.068550 temp=1.0000 time=66.6s
+  ttt_chunk [241/1893] bpb=1.069554 temp=1.0000 time=69.5s
+  ttt_chunk [251/1893] bpb=1.069623 temp=1.0000 time=72.4s
+  ttt_chunk [261/1893] bpb=1.067674 temp=1.0000 time=75.2s
+  ttt_chunk [271/1893] bpb=1.067143 temp=1.0000 time=78.1s
+  ttt_chunk [281/1893] bpb=1.069093 temp=1.0000 time=81.0s
+  ttt_chunk [291/1893] bpb=1.071194 temp=1.0000 time=83.9s
+  ttt_chunk [301/1893] bpb=1.072428 temp=1.0000 time=86.7s
+  ttt_chunk [311/1893] bpb=1.074857 temp=1.0000 time=89.6s
+  ttt_chunk [321/1893] bpb=1.077304 temp=1.0000 time=92.5s
+  ttt_chunk [331/1893] bpb=1.077696 temp=1.0000 time=95.3s
+  ttt_chunk [341/1893] bpb=1.077168 temp=1.0000 time=98.2s
+  ttt_chunk [351/1893] bpb=1.079767 temp=1.0000 time=101.1s
+  ttt_chunk [361/1893] bpb=1.080223 temp=1.0000 time=104.0s
+  ttt_chunk [371/1893] bpb=1.080030 temp=1.0000 time=106.9s
+  ttt_chunk [381/1893] bpb=1.080568 temp=1.0000 time=109.7s
+  ttt_chunk [391/1893] bpb=1.080693 temp=1.0000 time=112.6s
+  ttt_chunk [401/1893] bpb=1.079010 temp=1.0000 time=115.5s
+  ttt_chunk [411/1893] bpb=1.078107 temp=1.0000 time=118.3s
+  ttt_chunk [421/1893] bpb=1.077565 temp=1.0000 time=121.2s
+  ttt_chunk [431/1893] bpb=1.077721 temp=1.0000 time=124.1s
+  ttt_chunk [441/1893] bpb=1.078322 temp=1.0000 time=127.0s
+  ttt_chunk [451/1893] bpb=1.078953 temp=1.0000 time=129.8s
+  ttt_chunk [461/1893] bpb=1.078143 temp=1.0000 time=132.7s
+  ttt_chunk [471/1893] bpb=1.079061 temp=1.0000 time=135.5s
+  ttt_chunk [481/1893] bpb=1.078952 temp=1.0000 time=138.4s
+  ttt_chunk [491/1893] bpb=1.078169 temp=1.0000 time=141.3s
+  ttt_chunk [501/1893] bpb=1.077891 temp=1.0000 time=144.1s
+  ttt_chunk [511/1893] bpb=1.077429 temp=1.0000 time=147.0s
+  ttt_chunk [521/1893] bpb=1.075320 temp=1.0000 time=149.9s
+  ttt_chunk [531/1893] bpb=1.076655 temp=1.0000 time=152.7s
+  ttt_chunk [541/1893] bpb=1.077124 temp=1.0000 time=155.6s
+  ttt_chunk [551/1893] bpb=1.076321 temp=1.0000 time=158.4s
+  ttt_chunk [561/1893] bpb=1.076965 temp=1.0000 time=161.3s
+  ttt_chunk [571/1893] bpb=1.076172 temp=1.0000 time=164.2s
+  ttt_chunk [581/1893] bpb=1.075478 temp=1.0000 time=167.0s
+  ttt_chunk [591/1893] bpb=1.075051 temp=1.0000 time=169.9s
+  ttt_chunk [601/1893] bpb=1.075588 temp=1.0000 time=172.8s
+  ttt_chunk [611/1893] bpb=1.075596 temp=1.0000 time=175.6s
+  ttt_chunk [621/1893] bpb=1.075533 temp=1.0000 time=178.5s
+  ttt_chunk [631/1893] bpb=1.076320 temp=1.0000 time=181.4s
+  ttt_chunk [641/1893] bpb=1.076098 temp=1.0000 time=184.2s
+  ttt_chunk [651/1893] bpb=1.076292 temp=1.0000 time=187.1s
+  ttt_chunk [661/1893] bpb=1.075808 temp=1.0000 time=190.0s
+  ttt_chunk [671/1893] bpb=1.076193 temp=1.0000 time=192.8s
+  ttt_chunk [681/1893] bpb=1.076842 temp=1.0000 time=195.7s
+  ttt_chunk [691/1893] bpb=1.077812 temp=1.0000 time=198.6s
+  ttt_chunk [701/1893] bpb=1.077355 temp=1.0000 time=201.5s
+  ttt_chunk [711/1893] bpb=1.077428 temp=1.0000 time=204.3s
+  ttt_chunk [721/1893] bpb=1.077057 temp=1.0000 time=207.2s
+  ttt_chunk [731/1893] bpb=1.077110 temp=1.0000 time=210.1s
+  ttt_chunk [741/1893] bpb=1.077203 temp=1.0000 time=213.0s
+  ttt_chunk [751/1893] bpb=1.077061 temp=1.0000 time=215.8s
+  ttt_chunk [761/1893] bpb=1.076968 temp=1.0000 time=218.7s
+  ttt_chunk [771/1893] bpb=1.076697 temp=1.0000 time=221.5s
+  ttt_chunk [781/1893] bpb=1.077419 temp=1.0000 time=224.4s
+  ttt_chunk [791/1893] bpb=1.076945 temp=1.0000 time=227.3s
+  ttt_chunk [801/1893] bpb=1.077240 temp=1.0000 time=230.2s
+  ttt_chunk [811/1893] bpb=1.077007 temp=1.0000 time=233.0s
+  ttt_chunk [821/1893] bpb=1.076801 temp=1.0000 time=235.9s
+  ttt_chunk [831/1893] bpb=1.076594 temp=1.0000 time=238.8s
+  ttt_chunk [841/1893] bpb=1.075930 temp=1.0000 time=241.7s
+  ttt_chunk [851/1893] bpb=1.075669 temp=1.0000 time=244.5s
+  ttt_chunk [861/1893] bpb=1.075329 temp=1.0000 time=247.4s
+  ttt_chunk [871/1893] bpb=1.075585 temp=1.0000 time=250.3s
+  ttt_chunk [881/1893] bpb=1.075704 temp=1.0000 time=253.2s
+  ttt_chunk [891/1893] bpb=1.075221 temp=1.0000 time=256.1s
+  ttt_chunk [901/1893] bpb=1.074875 temp=1.0000 time=259.0s
+  ttt_chunk [911/1893] bpb=1.074908 temp=1.0000 time=261.8s
+  ttt_chunk [921/1893] bpb=1.075265 temp=1.0000 time=264.7s
+  ttt_chunk [931/1893] bpb=1.075162 temp=1.0000 time=267.6s
+  ttt_chunk [941/1893] bpb=1.074785 temp=1.0000 time=270.5s
+  ttt_chunk [951/1893] bpb=1.075104 temp=1.0000 time=273.4s
+  ttt_chunk [961/1893] bpb=1.075112 temp=1.0000 time=276.2s
+  ttt_chunk [971/1893] bpb=1.075868 temp=1.0000 time=279.1s
+  ttt_chunk [981/1893] bpb=1.075875 temp=1.0000 time=282.0s
+  ttt_chunk [991/1893] bpb=1.075812 temp=1.0000 time=284.9s
+  ttt_chunk [1001/1893] bpb=1.075673 temp=1.0000 time=287.8s
+  ttt_chunk [1011/1893] bpb=1.075376 temp=1.0000 time=290.7s
+  ttt_chunk [1021/1893] bpb=1.075575 temp=1.0000 time=293.6s
+  ttt_chunk [1031/1893] bpb=1.075872 temp=1.0000 time=296.5s
+  ttt_chunk [1041/1893] bpb=1.075427 temp=1.0000 time=299.4s
+  ttt_chunk [1051/1893] bpb=1.075040 temp=1.0000 time=302.2s
+  ttt_chunk [1061/1893] bpb=1.074975 temp=1.0000 time=305.1s
+  ttt_chunk [1071/1893] bpb=1.075459 temp=1.0000 time=308.0s
+  ttt_chunk [1081/1893] bpb=1.075583 temp=1.0000 time=310.9s
+  ttt_chunk [1091/1893] bpb=1.076132 temp=1.0000 time=313.8s
+  ttt_chunk [1101/1893] bpb=1.076015 temp=1.0000 time=316.7s
+  ttt_chunk [1111/1893] bpb=1.075701 temp=1.0000 time=319.6s
+  ttt_chunk [1121/1893] bpb=1.075347 temp=1.0000 time=322.5s
+  ttt_chunk [1131/1893] bpb=1.075108 temp=1.0000 time=325.4s
+  ttt_chunk [1141/1893] bpb=1.074696 temp=1.0000 time=328.3s
+  ttt_chunk [1151/1893] bpb=1.074564 temp=1.0000 time=331.2s
+  ttt_chunk [1161/1893] bpb=1.074054 temp=1.0000 time=334.0s
+  ttt_chunk [1171/1893] bpb=1.074221 temp=1.0000 time=336.9s
+  ttt_chunk [1181/1893] bpb=1.073352 temp=1.0000 time=339.8s
+  ttt_chunk [1191/1893] bpb=1.073046 temp=1.0000 time=342.7s
+  ttt_chunk [1201/1893] bpb=1.073213 temp=1.0000 time=345.6s
+  ttt_chunk [1211/1893] bpb=1.072600 temp=1.0000 time=348.5s
+  ttt_chunk [1221/1893] bpb=1.072128 temp=1.0000 time=351.4s
+  ttt_chunk [1231/1893] bpb=1.071752 temp=1.0000 time=354.3s
+  ttt_chunk [1241/1893] bpb=1.071234 temp=1.0000 time=357.2s
+  ttt_chunk [1251/1893] bpb=1.070527 temp=1.0000 time=360.0s
+  ttt_chunk [1261/1893] bpb=1.070296 temp=1.0000 time=362.9s
+  ttt_chunk [1271/1893] bpb=1.069764 temp=1.0000 time=365.8s
+  ttt_chunk [1281/1893] bpb=1.069429 temp=1.0000 time=368.7s
+  ttt_chunk [1291/1893] bpb=1.069048 temp=1.0000 time=371.6s
+  ttt_chunk [1301/1893] bpb=1.068297 temp=1.0000 time=374.4s
+  ttt_chunk [1311/1893] bpb=1.067802 temp=1.0000 time=377.3s
+  ttt_chunk [1321/1893] bpb=1.067333 temp=1.0000 time=380.2s
+  ttt_chunk [1331/1893] bpb=1.067132 temp=1.0000 time=383.1s
+  ttt_chunk [1341/1893] bpb=1.066854 temp=1.0500 time=386.0s
+  ttt_chunk [1351/1893] bpb=1.066598 temp=1.0000 time=388.9s
+  ttt_chunk [1361/1893] bpb=1.066489 temp=1.0000 time=391.8s
+  ttt_chunk [1371/1893] bpb=1.066162 temp=1.0000 time=394.6s
+  ttt_chunk [1381/1893] bpb=1.065979 temp=1.0000 time=397.5s
+  ttt_chunk [1391/1893] bpb=1.065397 temp=1.0000 time=400.4s
+  ttt_chunk [1401/1893] bpb=1.065202 temp=1.0000 time=403.3s
+  ttt_chunk [1411/1893] bpb=1.065123 temp=1.0000 time=406.2s
+  ttt_chunk [1421/1893] bpb=1.065214 temp=1.0000 time=409.0s
+  ttt_chunk [1431/1893] bpb=1.064733 temp=1.0000 time=411.9s
+  ttt_chunk [1441/1893] bpb=1.065001 temp=1.0000 time=414.8s
+  ttt_chunk [1451/1893] bpb=1.065144 temp=1.0000 time=417.7s
+  ttt_chunk [1461/1893] bpb=1.064566 temp=1.0000 time=420.6s
+  ttt_chunk [1471/1893] bpb=1.065427 temp=1.0000 time=423.4s
+  ttt_chunk [1481/1893] bpb=1.064825 temp=1.0000 time=426.3s
+  ttt_chunk [1491/1893] bpb=1.064493 temp=1.0000 time=429.2s
+  ttt_chunk [1501/1893] bpb=1.064261 temp=1.0000 time=432.1s
+  ttt_chunk [1511/1893] bpb=1.064052 temp=1.0000 time=435.0s
+  ttt_chunk [1521/1893] bpb=1.063934 temp=1.0000 time=437.8s
+  ttt_chunk [1531/1893] bpb=1.063254 temp=1.0000 time=440.7s
+  ttt_chunk [1541/1893] bpb=1.062971 temp=1.0000 time=443.6s
+  ttt_chunk [1551/1893] bpb=1.063141 temp=1.0000 time=446.5s
+  ttt_chunk [1561/1893] bpb=1.062988 temp=1.0000 time=449.3s
+  ttt_chunk [1571/1893] bpb=1.062706 temp=1.0000 time=452.2s
+  ttt_chunk [1581/1893] bpb=1.062663 temp=1.0000 time=455.1s
+  ttt_chunk [1591/1893] bpb=1.062414 temp=1.0000 time=457.9s
+  ttt_chunk [1601/1893] bpb=1.062431 temp=1.0000 time=460.8s
+  ttt_chunk [1611/1893] bpb=1.062207 temp=1.0000 time=463.7s
+  ttt_chunk [1621/1893] bpb=1.061673 temp=1.0000 time=466.6s
+  ttt_chunk [1631/1893] bpb=1.061823 temp=1.0000 time=469.4s
+  ttt_chunk [1641/1893] bpb=1.061681 temp=1.0000 time=472.3s
+  ttt_chunk [1651/1893] bpb=1.061469 temp=1.0000 time=475.2s
+  ttt_chunk [1661/1893] bpb=1.061188 temp=1.0000 time=478.0s
+  ttt_chunk [1671/1893] bpb=1.061440 temp=1.0000 time=480.9s
+  ttt_chunk [1681/1893] bpb=1.061413 temp=1.0000 time=483.8s
+  ttt_chunk [1691/1893] bpb=1.061087 temp=1.0000 time=486.6s
+  ttt_chunk [1701/1893] bpb=1.061100 temp=1.0000 time=489.5s
+  ttt_chunk [1711/1893] bpb=1.060955 temp=1.0000 time=492.4s
+  ttt_chunk [1721/1893] bpb=1.060785 temp=1.0000 time=495.2s
+  ttt_chunk [1731/1893] bpb=1.060541 temp=1.0000 time=498.1s
+  ttt_chunk [1741/1893] bpb=1.060222 temp=1.0000 time=501.0s
+  ttt_chunk [1751/1893] bpb=1.059916 temp=1.0000 time=503.9s
+  ttt_chunk [1761/1893] bpb=1.059899 temp=1.0000 time=506.7s
+  ttt_chunk [1771/1893] bpb=1.059624 temp=1.0000 time=509.6s
+  ttt_chunk [1781/1893] bpb=1.059497 temp=1.0000 time=512.5s
+  ttt_chunk [1791/1893] bpb=1.058945 temp=1.0000 time=515.3s
+  ttt_chunk [1801/1893] bpb=1.058686 temp=1.0000 time=518.2s
+  ttt_chunk [1811/1893] bpb=1.058436 temp=1.0000 time=521.1s
+  ttt_chunk [1821/1893] bpb=1.058355 temp=1.0000 time=523.9s
+  ttt_chunk [1831/1893] bpb=1.057636 temp=1.0000 time=526.8s
+  ttt_chunk [1841/1893] bpb=1.057450 temp=1.0000 time=529.7s
+  ttt_chunk [1851/1893] bpb=1.057084 temp=1.0000 time=532.6s
+  ttt_chunk [1861/1893] bpb=1.056575 temp=1.0000 time=535.4s
+  ttt_chunk [1871/1893] bpb=1.056413 temp=1.0000 time=538.3s
+  ttt_chunk [1881/1893] bpb=1.055832 temp=1.0000 time=541.2s
+  ttt_chunk [1891/1893] bpb=1.055441 temp=1.0000 time=544.0s
+  ttt_chunk [1893/1893] bpb=1.055444 temp=1.0000 time=544.4s
+ttt:done val_loss=1.778742 val_bpb=1.053474 elapsed=544.4s
+final_int6_ttt val_loss:1.7787 val_bpb:1.0535 stride:64 eval_time:545007ms
+final_int6_ttt_exact val_loss:1.77874173 val_bpb:1.05347383

--- a/records/track_10min_16mb/2026-03-27_SGD_TTT_HedgeMixer_PerLayerLR_1.0450/train_seed42.log
+++ b/records/track_10min_16mb/2026-03-27_SGD_TTT_HedgeMixer_PerLayerLR_1.0450/train_seed42.log
@@ -1,0 +1,326 @@
+W0327 16:28:16.187000 3424374 torch/distributed/run.py:803] 
+W0327 16:28:16.187000 3424374 torch/distributed/run.py:803] *****************************************
+W0327 16:28:16.187000 3424374 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0327 16:28:16.187000 3424374 torch/distributed/run.py:803] *****************************************
+logs/fb62f4a8-ae46-4bf0-b7f9-8d7a76993402.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+mixed_precision: 68 int5 layers, 0 int6 layers (last 0 blocks)
+model_params:33317980
+XSA:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] ws:8 gqa:8/8
+lr:embed=0.035 matrix=0.025 scalar=0.025 batch:786432 wall:600s seed:42
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9301 val_bpb:4.1044 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9309 train_time:147ms step_avg:146.87ms
+step:2/20000 train_loss:8.7072 train_time:244ms step_avg:122.17ms
+step:3/20000 train_loss:7.7697 train_time:341ms step_avg:113.68ms
+step:4/20000 train_loss:7.2985 train_time:437ms step_avg:109.13ms
+step:5/20000 train_loss:7.0365 train_time:532ms step_avg:106.40ms
+step:6/20000 train_loss:6.9493 train_time:628ms step_avg:104.67ms
+step:7/20000 train_loss:6.8512 train_time:724ms step_avg:103.39ms
+step:8/20000 train_loss:6.7336 train_time:820ms step_avg:102.50ms
+step:9/20000 train_loss:6.3601 train_time:916ms step_avg:101.83ms
+step:10/20000 train_loss:6.0336 train_time:1012ms step_avg:101.23ms
+step:500/20000 train_loss:2.3597 train_time:49053ms step_avg:98.11ms
+step:1000/20000 train_loss:2.2431 train_time:98216ms step_avg:98.22ms
+step:1500/20000 train_loss:2.1857 train_time:147399ms step_avg:98.27ms
+step:2000/20000 train_loss:2.0307 train_time:196673ms step_avg:98.34ms
+step:2500/20000 train_loss:2.1352 train_time:245961ms step_avg:98.38ms
+step:3000/20000 train_loss:2.1159 train_time:295252ms step_avg:98.42ms
+step:3500/20000 train_loss:2.1207 train_time:344537ms step_avg:98.44ms
+step:4000/20000 train_loss:1.9077 train_time:393849ms step_avg:98.46ms
+step:4000/20000 val_loss:1.9985 val_bpb:1.1836 train_time:393855ms step_avg:98.46ms
+late_qat:enabled step:4162 scale:0.4998
+step:4500/20000 train_loss:2.0529 train_time:444322ms step_avg:98.74ms
+step:5000/20000 train_loss:2.0262 train_time:495264ms step_avg:99.05ms
+swa:start step:5200
+step:5500/20000 train_loss:1.9338 train_time:546486ms step_avg:99.36ms
+step:5847/20000 val_loss:1.9043 val_bpb:1.1278 train_time:582008ms step_avg:99.54ms
+stopping_early: wallclock_cap train_time:582008ms step:5847/20000
+peak memory allocated: 26197 MiB reserved: 26810 MiB
+ema:applying EMA weights (skipping diagnostic evals)
+gptq:calibrating with training data...
+gptq:calibrated 68 layers in 1.9s
+Serialized model: 130432585 bytes
+Code size: 102023 bytes
+pruning:3.0% magnitude pruning applied
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+gptq_quantize: 66 GPTQ layers, 0 naive layers
+mixed_precision: 33161216 int5 params, 0 int6 params
+Serialized model int6+zstd: 15570135 bytes
+Total submission size int6+zstd: 15672158 bytes
+TTT: epochs=4 lr=0.002 freeze_first=1 chunk=32768 opt=sgd
+TTT temperature: 0.98
+PPM alpha: 0.85, Byte-weighted TTT: True
+  Logistic context mixer enabled: eta=0.1
+  Adaptive LR enabled: max_mult=3.0
+ttt:start chunks=1893 chunk_tokens=32768 windows=969088 stride=64 lr=0.002 epochs=4 opt=sgd freeze_first=1
+ttt:params unfrozen=2895884 frozen=30422096
+  ttt_lr_group: mult=3.0 params=1179648 lr=0.006000
+  ttt_lr_group: mult=0.5 params=917504 lr=0.001000
+  ttt_lr_group: mult=1.0 params=798732 lr=0.002000
+  Polyak averaging enabled: decay=0.998
+  Temperature calibration enabled: range=(0.85, 1.15) steps=7
+    ttt_train [1] seqs=16 start_train...
+    ttt_train [1] epoch=1/4 batches=2 ...
+      step done ep=1 bs=0 loss=2.3166
+    ttt_train [1] epoch=2/4 batches=2 ...
+      step done ep=2 bs=0 loss=2.2939
+    ttt_train [1] epoch=3/4 batches=2 ...
+      step done ep=3 bs=0 loss=2.2932
+    ttt_train [1] epoch=4/4 batches=2 ...
+      step done ep=4 bs=0 loss=2.2931
+    temp_cal [1] best_temp=1.0000 nll=2.075466
+  ttt_chunk [1/1893] bpb=1.159408 temp=1.0000 time=0.5s
+    ttt_train [2] seqs=16 start_train...
+    ttt_train [2] epoch=1/4 batches=2 ...
+      step done ep=1 bs=0 loss=2.7662
+    ttt_train [2] epoch=2/4 batches=2 ...
+      step done ep=2 bs=0 loss=2.7654
+    ttt_train [2] epoch=3/4 batches=2 ...
+      step done ep=3 bs=0 loss=2.7637
+    ttt_train [2] epoch=4/4 batches=2 ...
+      step done ep=4 bs=0 loss=2.7629
+    temp_cal [2] best_temp=1.0000 nll=2.034016
+  ttt_chunk [2/1893] bpb=1.244065 temp=1.0000 time=0.8s
+    ttt_train [3] seqs=16 start_train...
+    ttt_train [3] epoch=1/4 batches=2 ...
+      step done ep=1 bs=0 loss=1.8865
+    ttt_train [3] epoch=2/4 batches=2 ...
+      step done ep=2 bs=0 loss=1.8880
+    ttt_train [3] epoch=3/4 batches=2 ...
+      step done ep=3 bs=0 loss=1.8872
+    ttt_train [3] epoch=4/4 batches=2 ...
+      step done ep=4 bs=0 loss=1.8862
+    temp_cal [3] best_temp=1.0000 nll=1.706483
+  ttt_chunk [3/1893] bpb=1.188893 temp=1.0000 time=1.1s
+    temp_cal [4] best_temp=1.0000 nll=2.093959
+  ttt_chunk [4/1893] bpb=1.173686 temp=1.0000 time=1.4s
+    temp_cal [5] best_temp=1.0000 nll=1.913507
+  ttt_chunk [5/1893] bpb=1.155006 temp=1.0000 time=1.7s
+  ttt_chunk [11/1893] bpb=1.097155 temp=1.0000 time=3.3s
+  ttt_chunk [21/1893] bpb=1.065802 temp=1.0000 time=6.1s
+  ttt_chunk [31/1893] bpb=1.058463 temp=1.0000 time=8.9s
+  ttt_chunk [41/1893] bpb=1.043249 temp=1.0000 time=11.8s
+  ttt_chunk [51/1893] bpb=1.036892 temp=1.0000 time=14.6s
+  ttt_chunk [61/1893] bpb=1.042558 temp=1.0000 time=17.4s
+  ttt_chunk [71/1893] bpb=1.040376 temp=1.0000 time=20.2s
+  ttt_chunk [81/1893] bpb=1.039338 temp=1.0000 time=23.0s
+  ttt_chunk [91/1893] bpb=1.040104 temp=1.0000 time=25.8s
+  ttt_chunk [101/1893] bpb=1.043473 temp=1.0500 time=28.6s
+  ttt_chunk [111/1893] bpb=1.046277 temp=1.0000 time=31.4s
+  ttt_chunk [121/1893] bpb=1.040281 temp=1.0000 time=34.2s
+  ttt_chunk [131/1893] bpb=1.040902 temp=1.0000 time=37.1s
+  ttt_chunk [141/1893] bpb=1.046687 temp=1.0000 time=39.9s
+  ttt_chunk [151/1893] bpb=1.049024 temp=1.0000 time=42.7s
+  ttt_chunk [161/1893] bpb=1.048763 temp=1.0000 time=45.5s
+  ttt_chunk [171/1893] bpb=1.053407 temp=0.9500 time=48.3s
+  ttt_chunk [181/1893] bpb=1.056086 temp=1.0000 time=51.1s
+  ttt_chunk [191/1893] bpb=1.063702 temp=1.0000 time=54.0s
+  ttt_chunk [201/1893] bpb=1.062917 temp=1.0000 time=56.8s
+  ttt_chunk [211/1893] bpb=1.061504 temp=1.0000 time=59.6s
+  ttt_chunk [221/1893] bpb=1.063760 temp=1.0000 time=62.4s
+  ttt_chunk [231/1893] bpb=1.063111 temp=1.0000 time=65.2s
+  ttt_chunk [241/1893] bpb=1.063987 temp=1.0000 time=68.0s
+  ttt_chunk [251/1893] bpb=1.063966 temp=1.0000 time=70.8s
+  ttt_chunk [261/1893] bpb=1.061888 temp=1.0000 time=73.6s
+  ttt_chunk [271/1893] bpb=1.061247 temp=1.0000 time=76.4s
+  ttt_chunk [281/1893] bpb=1.063161 temp=1.0000 time=79.3s
+  ttt_chunk [291/1893] bpb=1.065304 temp=1.0000 time=82.1s
+  ttt_chunk [301/1893] bpb=1.066503 temp=1.0000 time=84.9s
+  ttt_chunk [311/1893] bpb=1.068943 temp=1.0000 time=87.7s
+  ttt_chunk [321/1893] bpb=1.071432 temp=1.0000 time=90.5s
+  ttt_chunk [331/1893] bpb=1.071784 temp=1.0000 time=93.3s
+  ttt_chunk [341/1893] bpb=1.071372 temp=1.0000 time=96.2s
+  ttt_chunk [351/1893] bpb=1.073932 temp=1.0500 time=99.0s
+  ttt_chunk [361/1893] bpb=1.074434 temp=1.0000 time=101.8s
+  ttt_chunk [371/1893] bpb=1.074212 temp=1.0000 time=104.6s
+  ttt_chunk [381/1893] bpb=1.074843 temp=1.0000 time=107.4s
+  ttt_chunk [391/1893] bpb=1.074999 temp=1.0000 time=110.2s
+  ttt_chunk [401/1893] bpb=1.073354 temp=1.0000 time=113.1s
+  ttt_chunk [411/1893] bpb=1.072517 temp=1.0000 time=115.9s
+  ttt_chunk [421/1893] bpb=1.072016 temp=1.0000 time=118.7s
+  ttt_chunk [431/1893] bpb=1.072289 temp=1.0000 time=121.5s
+  ttt_chunk [441/1893] bpb=1.072991 temp=1.0000 time=124.3s
+  ttt_chunk [451/1893] bpb=1.073653 temp=1.0000 time=127.1s
+  ttt_chunk [461/1893] bpb=1.072890 temp=1.0000 time=129.9s
+  ttt_chunk [471/1893] bpb=1.073863 temp=1.0000 time=132.8s
+  ttt_chunk [481/1893] bpb=1.073803 temp=1.0000 time=135.6s
+  ttt_chunk [491/1893] bpb=1.073002 temp=1.0000 time=138.4s
+  ttt_chunk [501/1893] bpb=1.072745 temp=1.0000 time=141.2s
+  ttt_chunk [511/1893] bpb=1.072349 temp=1.0000 time=144.0s
+  ttt_chunk [521/1893] bpb=1.070347 temp=1.0000 time=146.8s
+  ttt_chunk [531/1893] bpb=1.071760 temp=1.0000 time=149.7s
+  ttt_chunk [541/1893] bpb=1.072241 temp=1.0000 time=152.5s
+  ttt_chunk [551/1893] bpb=1.071412 temp=1.0000 time=155.3s
+  ttt_chunk [561/1893] bpb=1.072095 temp=1.0000 time=158.1s
+  ttt_chunk [571/1893] bpb=1.071355 temp=1.0000 time=160.9s
+  ttt_chunk [581/1893] bpb=1.070727 temp=1.0000 time=163.8s
+  ttt_chunk [591/1893] bpb=1.070241 temp=1.0000 time=166.6s
+  ttt_chunk [601/1893] bpb=1.070782 temp=1.0000 time=169.4s
+  ttt_chunk [611/1893] bpb=1.070862 temp=1.0000 time=172.2s
+  ttt_chunk [621/1893] bpb=1.070817 temp=1.0000 time=175.0s
+  ttt_chunk [631/1893] bpb=1.071582 temp=1.0000 time=177.8s
+  ttt_chunk [641/1893] bpb=1.071370 temp=1.0000 time=180.6s
+  ttt_chunk [651/1893] bpb=1.071574 temp=1.0000 time=183.4s
+  ttt_chunk [661/1893] bpb=1.071107 temp=1.0000 time=186.3s
+  ttt_chunk [671/1893] bpb=1.071516 temp=1.0000 time=189.1s
+  ttt_chunk [681/1893] bpb=1.072191 temp=1.0000 time=191.9s
+  ttt_chunk [691/1893] bpb=1.073179 temp=1.0000 time=194.7s
+  ttt_chunk [701/1893] bpb=1.072706 temp=1.0000 time=197.5s
+  ttt_chunk [711/1893] bpb=1.072768 temp=1.0000 time=200.3s
+  ttt_chunk [721/1893] bpb=1.072417 temp=1.0000 time=203.1s
+  ttt_chunk [731/1893] bpb=1.072473 temp=1.0000 time=205.9s
+  ttt_chunk [741/1893] bpb=1.072612 temp=1.0000 time=208.8s
+  ttt_chunk [751/1893] bpb=1.072501 temp=1.0000 time=211.6s
+  ttt_chunk [761/1893] bpb=1.072403 temp=1.0000 time=214.4s
+  ttt_chunk [771/1893] bpb=1.072111 temp=1.0000 time=217.2s
+  ttt_chunk [781/1893] bpb=1.072828 temp=1.0000 time=220.0s
+  ttt_chunk [791/1893] bpb=1.072394 temp=1.0000 time=222.8s
+  ttt_chunk [801/1893] bpb=1.072674 temp=1.0000 time=225.7s
+  ttt_chunk [811/1893] bpb=1.072455 temp=1.0000 time=228.5s
+  ttt_chunk [821/1893] bpb=1.072234 temp=1.0000 time=231.3s
+  ttt_chunk [831/1893] bpb=1.071997 temp=1.0000 time=234.1s
+  ttt_chunk [841/1893] bpb=1.071314 temp=1.0000 time=236.9s
+  ttt_chunk [851/1893] bpb=1.071071 temp=1.0000 time=239.8s
+  ttt_chunk [861/1893] bpb=1.070744 temp=1.0000 time=242.6s
+  ttt_chunk [871/1893] bpb=1.070987 temp=1.0000 time=245.4s
+  ttt_chunk [881/1893] bpb=1.071135 temp=1.0000 time=248.2s
+  ttt_chunk [891/1893] bpb=1.070653 temp=1.0000 time=251.1s
+  ttt_chunk [901/1893] bpb=1.070360 temp=1.0000 time=253.9s
+  ttt_chunk [911/1893] bpb=1.070406 temp=1.0000 time=256.7s
+  ttt_chunk [921/1893] bpb=1.070804 temp=1.0000 time=259.5s
+  ttt_chunk [931/1893] bpb=1.070722 temp=1.0000 time=262.3s
+  ttt_chunk [941/1893] bpb=1.070364 temp=1.0000 time=265.2s
+  ttt_chunk [951/1893] bpb=1.070721 temp=1.0000 time=268.0s
+  ttt_chunk [961/1893] bpb=1.070764 temp=1.0000 time=270.8s
+  ttt_chunk [971/1893] bpb=1.071497 temp=1.0000 time=273.6s
+  ttt_chunk [981/1893] bpb=1.071507 temp=1.0000 time=276.4s
+  ttt_chunk [991/1893] bpb=1.071443 temp=1.0000 time=279.3s
+  ttt_chunk [1001/1893] bpb=1.071349 temp=1.0000 time=282.1s
+  ttt_chunk [1011/1893] bpb=1.071049 temp=1.0000 time=284.9s
+  ttt_chunk [1021/1893] bpb=1.071281 temp=1.0000 time=287.7s
+  ttt_chunk [1031/1893] bpb=1.071640 temp=1.0000 time=290.5s
+  ttt_chunk [1041/1893] bpb=1.071228 temp=1.0000 time=293.3s
+  ttt_chunk [1051/1893] bpb=1.070892 temp=1.0000 time=296.1s
+  ttt_chunk [1061/1893] bpb=1.070872 temp=1.0000 time=298.9s
+  ttt_chunk [1071/1893] bpb=1.071356 temp=1.0000 time=301.8s
+  ttt_chunk [1081/1893] bpb=1.071471 temp=1.0000 time=304.6s
+  ttt_chunk [1091/1893] bpb=1.072023 temp=1.0000 time=307.4s
+  ttt_chunk [1101/1893] bpb=1.071942 temp=1.0000 time=310.2s
+  ttt_chunk [1111/1893] bpb=1.071645 temp=1.0000 time=313.0s
+  ttt_chunk [1121/1893] bpb=1.071298 temp=1.0000 time=315.8s
+  ttt_chunk [1131/1893] bpb=1.071069 temp=1.0000 time=318.6s
+  ttt_chunk [1141/1893] bpb=1.070660 temp=1.0000 time=321.5s
+  ttt_chunk [1151/1893] bpb=1.070536 temp=1.0000 time=324.3s
+  ttt_chunk [1161/1893] bpb=1.070070 temp=1.0000 time=327.1s
+  ttt_chunk [1171/1893] bpb=1.070247 temp=1.0000 time=329.9s
+  ttt_chunk [1181/1893] bpb=1.069408 temp=1.0000 time=332.7s
+  ttt_chunk [1191/1893] bpb=1.069138 temp=1.0000 time=335.6s
+  ttt_chunk [1201/1893] bpb=1.069352 temp=1.0000 time=338.4s
+  ttt_chunk [1211/1893] bpb=1.068757 temp=1.0000 time=341.2s
+  ttt_chunk [1221/1893] bpb=1.068317 temp=1.0000 time=344.0s
+  ttt_chunk [1231/1893] bpb=1.067966 temp=1.0000 time=346.8s
+  ttt_chunk [1241/1893] bpb=1.067486 temp=1.0000 time=349.6s
+  ttt_chunk [1251/1893] bpb=1.066807 temp=1.0000 time=352.5s
+  ttt_chunk [1261/1893] bpb=1.066587 temp=1.0000 time=355.3s
+  ttt_chunk [1271/1893] bpb=1.066093 temp=1.0000 time=358.1s
+  ttt_chunk [1281/1893] bpb=1.065783 temp=1.0000 time=360.9s
+  ttt_chunk [1291/1893] bpb=1.065431 temp=1.0000 time=363.7s
+  ttt_chunk [1301/1893] bpb=1.064711 temp=1.0000 time=366.5s
+  ttt_chunk [1311/1893] bpb=1.064239 temp=1.0000 time=369.3s
+  ttt_chunk [1321/1893] bpb=1.063785 temp=1.0000 time=372.1s
+  ttt_chunk [1331/1893] bpb=1.063591 temp=1.0000 time=375.0s
+  ttt_chunk [1341/1893] bpb=1.063302 temp=1.0000 time=377.8s
+  ttt_chunk [1351/1893] bpb=1.063047 temp=1.0000 time=380.6s
+  ttt_chunk [1361/1893] bpb=1.062961 temp=1.0000 time=383.4s
+  ttt_chunk [1371/1893] bpb=1.062652 temp=1.0000 time=386.2s
+  ttt_chunk [1381/1893] bpb=1.062472 temp=1.0000 time=389.0s
+  ttt_chunk [1391/1893] bpb=1.061912 temp=1.0000 time=391.9s
+  ttt_chunk [1401/1893] bpb=1.061727 temp=1.0000 time=394.7s
+  ttt_chunk [1411/1893] bpb=1.061682 temp=1.0000 time=397.5s
+  ttt_chunk [1421/1893] bpb=1.061800 temp=1.0000 time=400.3s
+  ttt_chunk [1431/1893] bpb=1.061328 temp=1.0000 time=403.1s
+  ttt_chunk [1441/1893] bpb=1.061622 temp=1.0000 time=405.9s
+  ttt_chunk [1451/1893] bpb=1.061780 temp=1.0000 time=408.8s
+  ttt_chunk [1461/1893] bpb=1.061210 temp=1.0000 time=411.6s
+  ttt_chunk [1471/1893] bpb=1.062072 temp=1.0000 time=414.4s
+  ttt_chunk [1481/1893] bpb=1.061475 temp=1.0000 time=417.2s
+  ttt_chunk [1491/1893] bpb=1.061159 temp=1.0000 time=420.0s
+  ttt_chunk [1501/1893] bpb=1.060951 temp=1.0000 time=422.8s
+  ttt_chunk [1511/1893] bpb=1.060773 temp=1.0000 time=425.6s
+  ttt_chunk [1521/1893] bpb=1.060681 temp=1.0000 time=428.5s
+  ttt_chunk [1531/1893] bpb=1.060011 temp=1.0000 time=431.3s
+  ttt_chunk [1541/1893] bpb=1.059727 temp=1.0000 time=434.1s
+  ttt_chunk [1551/1893] bpb=1.059905 temp=1.0000 time=436.9s
+  ttt_chunk [1561/1893] bpb=1.059770 temp=1.0000 time=439.8s
+  ttt_chunk [1571/1893] bpb=1.059506 temp=1.0000 time=442.6s
+  ttt_chunk [1581/1893] bpb=1.059481 temp=1.0000 time=445.4s
+  ttt_chunk [1591/1893] bpb=1.059253 temp=1.0000 time=448.2s
+  ttt_chunk [1601/1893] bpb=1.059286 temp=1.0000 time=451.0s
+  ttt_chunk [1611/1893] bpb=1.059092 temp=1.0000 time=453.8s
+  ttt_chunk [1621/1893] bpb=1.058569 temp=1.0000 time=456.7s
+  ttt_chunk [1631/1893] bpb=1.058720 temp=1.0000 time=459.5s
+  ttt_chunk [1641/1893] bpb=1.058588 temp=1.0000 time=462.3s
+  ttt_chunk [1651/1893] bpb=1.058387 temp=1.0000 time=465.1s
+  ttt_chunk [1661/1893] bpb=1.058118 temp=1.0000 time=467.9s
+  ttt_chunk [1671/1893] bpb=1.058376 temp=1.0000 time=470.7s
+  ttt_chunk [1681/1893] bpb=1.058379 temp=1.0000 time=473.5s
+  ttt_chunk [1691/1893] bpb=1.058065 temp=1.0000 time=476.3s
+  ttt_chunk [1701/1893] bpb=1.058099 temp=1.0000 time=479.2s
+  ttt_chunk [1711/1893] bpb=1.057969 temp=1.0000 time=482.0s
+  ttt_chunk [1721/1893] bpb=1.057795 temp=1.0000 time=484.8s
+  ttt_chunk [1731/1893] bpb=1.057553 temp=1.0000 time=487.6s
+  ttt_chunk [1741/1893] bpb=1.057251 temp=1.0000 time=490.4s
+  ttt_chunk [1751/1893] bpb=1.056954 temp=1.0000 time=493.2s
+  ttt_chunk [1761/1893] bpb=1.056946 temp=1.0000 time=496.1s
+  ttt_chunk [1771/1893] bpb=1.056687 temp=1.0000 time=498.9s
+  ttt_chunk [1781/1893] bpb=1.056579 temp=1.0000 time=501.7s
+  ttt_chunk [1791/1893] bpb=1.056053 temp=1.0000 time=504.5s
+  ttt_chunk [1801/1893] bpb=1.055813 temp=1.0000 time=507.3s
+  ttt_chunk [1811/1893] bpb=1.055579 temp=1.0000 time=510.1s
+  ttt_chunk [1821/1893] bpb=1.055516 temp=1.0000 time=512.9s
+  ttt_chunk [1831/1893] bpb=1.054813 temp=1.0000 time=515.8s
+  ttt_chunk [1841/1893] bpb=1.054644 temp=1.0000 time=518.6s
+  ttt_chunk [1851/1893] bpb=1.054304 temp=1.0000 time=521.4s
+  ttt_chunk [1861/1893] bpb=1.053803 temp=1.0000 time=524.2s
+  ttt_chunk [1871/1893] bpb=1.053654 temp=1.0000 time=527.0s
+  ttt_chunk [1881/1893] bpb=1.053077 temp=1.0000 time=529.8s
+  ttt_chunk [1891/1893] bpb=1.052711 temp=1.0000 time=532.6s
+  ttt_chunk [1893/1893] bpb=1.052719 temp=1.0000 time=533.0s
+ttt:done val_loss=1.773337 val_bpb=1.050273 elapsed=533.0s
+final_int6_ttt val_loss:1.7733 val_bpb:1.0503 stride:64 eval_time:533623ms
+final_int6_ttt_exact val_loss:1.77333724 val_bpb:1.05027298


### PR DESCRIPTION
   ## Summary
 
 **val_bpb: 1.0450** (3-seed mean, std 0.012) | eval <545s | artifact <15.7MB

  Built on PR #720 by @agalimova. Improves on our earlier PR #953 (1.0722 → 1.0450).

  ### Key Change: SGD Optimizer for TTT

  Switched TTT from AdamW (lr=0.0005) to **SGD momentum=0.9** (lr=0.002). This single change accounts for -0.041 BPB. SGD provides more aggressive parameter updates that better exploit the short adaptation window.

  
  ### 3-Seed Results

  | Seed | TTT BPB | Eval Time | Artifact |
  |------|---------|-----------|----------|
  | 1337 | **1.0312** | 540s | 15.57MB |
  | 42 | **1.0503** | 533s | 15.67MB |
  | 2025 | **1.0535** | 544s | 15.15MB |
  | **Mean** | **1.0450** | | |

  ### Ablation

  | Config | BPB | Notes |
  |--------|-----|-------|
  | Full (SGD TTT + mixer) | **1.0312** | This submission |
  | AdamW TTT + mixer | 1.0726 | Previous PR #953 |
  | No mixer (AdamW TTT only) | 1.1559 | Mixer is essential |
  | No TTT (sliding only) | 1.1210 | Pure neural baseline |

  ### Run

  ```bash
  export NCCL_NET=Socket SKIP_SLIDING=1 TTT_OPTIMIZER=sgd TTT_LR=0.002
  SEED=1337 torchrun --nproc_per_node=8 train_gpt.py

  Compliance

  - 3 seeds, all train ≤600s, eval ≤600s, artifact ≤16MB
  - Score-first legal TTT + backward-looking HedgeMixer
  - No external data access during eval

  Test Plan

  - 3-seed verification (1337, 42, 2025)
  - Ablation: no-mixer, no-TTT baselines measured
  - All final_int6_ttt_exact metrics emitted