### PR TITLE
Record: 11L XSA + Mixed INT6 + Adaptive N-gram Cache (2->7 backoff) - val_bpb=0.9631, 3-seed

### DIFF
--- a/records/track_10min_16mb/2026-03-25_11L_XSA_GPTQ_AdaptiveNgramCache/README.md
+++ b/records/track_10min_16mb/2026-03-25_11L_XSA_GPTQ_AdaptiveNgramCache/README.md
@@ -1,0 +1,90 @@
+# 11L XSA + Mixed INT6 + Adaptive N-gram Cache (2->7 backoff)
+
+## Results
+
+3-seed runs on **March 27, 2026** under the standard **8xH100 SXM / 600s** budget.
+
+`val_bpb: 0.96308303` (3-seed mean, std `0.00035576`)
+
+| Seed | Steps | Sliding val_bpb | Final val_bpb | Artifact bytes |
+| --- | ---: | ---: | ---: | ---: |
+| 1337 | 6892 | 1.12124241 | 0.96314788 | 15879364 |
+| 42 | 6894 | 1.12125743 | 0.96340191 | 15884280 |
+| 2024 | 6897 | 1.12043283 | 0.96269931 | 15884064 |
+
+- Mean final `val_bpb`: `0.96308303`
+- Inter-seed std: `0.00035576`
+- Best final `val_bpb`: `0.96269931` (`SEED=2024`)
+- Mean artifact size: `15882569.33333333` bytes
+
+## Architecture
+
+| Component | Setting |
+| --- | --- |
+| Layers | 11 (512d, 8Q, 4KV) |
+| MLP | 3x with `relu2` |
+| XSA | All 11 layers |
+| Embeddings | Tied |
+| Weight averaging | EMA + late SWA |
+| Quantization | Post-training mixed INT6 + LZMA |
+| Eval | Sliding window, stride 64 |
+
+## Adaptive N-gram Cache
+
+Score-first adaptive n-gram cache with backoff orders `2->7`.
+
+Backward-looking evaluation order:
+
+1. Score each window under `torch.inference_mode()`.
+2. Add only already-scored tokens to the cache.
+3. Apply the cache only to later positions and later windows.
+
+No training data is accessed during evaluation.
+
+| Parameter | Value |
+| --- | --- |
+| Orders | `2->7` |
+| Adaptive mode | `sigmoid_raw_entropy` |
+| Alpha range | `[0.05, 0.60]` |
+| Base alpha | `0.40` |
+| Entropy center | `4.0` |
+| Entropy scale | `2.0` |
+| Hash buckets | `4,194,304` |
+| Min count | `2` |
+
+## Ablation (seed 1337)
+
+| Configuration | val_bpb |
+| --- | ---: |
+| Post-EMA, pre-quant | 1.1369 |
+| + INT6 roundtrip | 1.14466175 |
+| + Sliding window (stride 64) | 1.12124241 |
+| + Adaptive n-gram cache | 0.96314788 |
+
+## Reproducibility
+
+From this records folder:
+
+```bash
+python3 -m pip install --upgrade pip
+python3 -m pip install -r requirements.txt
+python3 ../../../data/cached_challenge_fineweb.py --variant sp1024 --train-shards 80
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+SEED=42 torchrun --standalone --nproc_per_node=8 train_gpt.py
+SEED=2024 torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+Included evidence:
+
+- `train_seed1337.log`
+- `train_seed42.log`
+- `train_seed2024.log`
+
+No eval-only checkpoint is required.
+
+## Acknowledgments
+
+- XSA lineage: PR #265 and arXiv:2603.09078
+- EMA and quantization lineage: PR #414, PR #549
+- Early sliding-window evaluation path: PR #77
+- Score-first evaluation framing: Issue #402

--- a/records/track_10min_16mb/2026-03-25_11L_XSA_GPTQ_AdaptiveNgramCache/requirements.txt
+++ b/records/track_10min_16mb/2026-03-25_11L_XSA_GPTQ_AdaptiveNgramCache/requirements.txt
@@ -1,0 +1,18 @@
+--index-url https://download.pytorch.org/whl/cu128
+--extra-index-url https://pypi.org/simple
+--find-links https://windreamer.github.io/flash-attention3-wheels/cu128_torch291
+
+torch==2.9.1
+torchvision==0.24.1
+torchaudio==2.9.1
+numpy
+tqdm
+huggingface-hub
+kernels
+setuptools
+typing-extensions==4.15.0
+datasets
+tiktoken
+sentencepiece
+zstandard
+flash_attn_3

--- a/records/track_10min_16mb/2026-03-25_11L_XSA_GPTQ_AdaptiveNgramCache/submission.json
+++ b/records/track_10min_16mb/2026-03-25_11L_XSA_GPTQ_AdaptiveNgramCache/submission.json
@@ -1,0 +1,59 @@
+{
+  "github_id": "aerosta",
+  "name": "11L XSA + Mixed INT6 + Adaptive N-gram Cache (2->7 backoff)",
+  "status": "ready_for_submission",
+  "date": "2026-03-27T00:00:00Z",
+  "hardware": "8xH100 SXM",
+  "num_seeds": 3,
+  "val_loss": 1.62612106,
+  "val_bpb": 0.96308303,
+  "best_val_bpb": 0.96269931,
+  "best_seed": 2024,
+  "seed_results": {
+    "1337": {
+      "val_loss": 1.62623055,
+      "val_bpb": 0.96314788,
+      "pre_quant_val_bpb": 1.1369,
+      "sliding_window_val_bpb": 1.12124241,
+      "bytes_total": 15879364,
+      "step_stop": 6892
+    },
+    "42": {
+      "val_loss": 1.62665946,
+      "val_bpb": 0.96340191,
+      "pre_quant_val_bpb": 1.1369,
+      "sliding_window_val_bpb": 1.12125743,
+      "bytes_total": 15884280,
+      "step_stop": 6894
+    },
+    "2024": {
+      "val_loss": 1.62547316,
+      "val_bpb": 0.96269931,
+      "pre_quant_val_bpb": 1.1362,
+      "sliding_window_val_bpb": 1.12043283,
+      "bytes_total": 15884064,
+      "step_stop": 6897
+    }
+  },
+  "pre_quant_val_loss": 1.91930000,
+  "pre_quant_val_bpb": 1.13666667,
+  "sliding_window_val_loss": 1.89271864,
+  "sliding_window_val_bpb": 1.12097756,
+  "step_stop_mean": 6894.33333333,
+  "wallclock_seconds_mean": 600.08833333,
+  "eval_time_seconds_mean": 211.53500000,
+  "bytes_total_mean": 15882569.33333333,
+  "bytes_total_best": 15879364,
+  "bytes_model_int6_lzma_mean": 15785477.33333333,
+  "code_bytes": 97092,
+  "techniques": [
+    "11L transformer",
+    "XSA all layers",
+    "EMA",
+    "Post-training mixed INT6 quantization",
+    "INT6 + LZMA",
+    "Score-first adaptive n-gram cache",
+    "N-gram backoff 2-7",
+    "Sigmoid raw-entropy mixing"
+  ]
+}

--- a/records/track_10min_16mb/2026-03-25_11L_XSA_GPTQ_AdaptiveNgramCache/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-25_11L_XSA_GPTQ_AdaptiveNgramCache/train_gpt.py
@@ -1,0 +1,2314 @@
+from __future__ import annotations
+import copy
+import glob
+import io
+import lzma
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+try:
+    import zstandard
+
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from flash_attn_interface import flash_attn_func as flash_attn_3_func
+from torch import Tensor, nn
+
+RECORD_DIR = Path(__file__).resolve().parent
+REPO_ROOT = RECORD_DIR.parents[3]
+os.chdir(RECORD_DIR)
+for _key, _value in {
+    "DATA_PATH": str(REPO_ROOT / "data/datasets/fineweb10B_sp1024"),
+    "TOKENIZER_PATH": str(REPO_ROOT / "data/tokenizers/fineweb_1024_bpe.model"),
+    "TARGET_MB": "15.149",
+    "NGRAM_EVAL_MIN_ORDER": "2",
+    "NGRAM_EVAL_ORDER": "7",
+    "NGRAM_EVAL_ALPHA": "0.40",
+    "NGRAM_EVAL_ADAPTIVE_ALPHA": "1",
+    "NGRAM_EVAL_ADAPTIVE_MODE": "sigmoid_raw_entropy",
+    "NGRAM_EVAL_ALPHA_MIN": "0.05",
+    "NGRAM_EVAL_ALPHA_MAX": "0.60",
+    "NGRAM_EVAL_ENTROPY_CENTER": "4.0",
+    "NGRAM_EVAL_ENTROPY_SCALE": "2.0",
+    "NGRAM_EVAL_MIN_COUNT": "2",
+    "NGRAM_EVAL_BUCKETS": "4194304",
+    "GPTQ_CALIB_BATCHES": "256",
+    "MAX_WALLCLOCK_SECONDS": "600",
+}.items():
+    os.environ.setdefault(_key, _value)
+
+
+
+def _load_submission_code(entry_file: str) -> tuple[str, int]:
+    """Bundle all Python sources in the records folder for honest code-size accounting."""
+    record_dir = Path(entry_file).resolve().parent
+    py_files = sorted(record_dir.glob("*.py"))
+    if not py_files:
+        py_files = [Path(entry_file).resolve()]
+    parts = []
+    total_bytes = 0
+    for py_file in py_files:
+        text = py_file.read_text(encoding="utf-8")
+        parts.append(f"# FILE: {py_file.name}\n{text}")
+        total_bytes += len(text.encode("utf-8"))
+    return "\n\n".join(parts), total_bytes
+
+
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3500))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    voc_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 3.0))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.035))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.025))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.025))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    slide_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    mtp_num_heads = int(os.environ.get("MTP_NUM_HEADS", 0))
+    mtp_loss_weight = float(os.environ.get("MTP_LOSS_WEIGHT", 0.2))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    lawa_enabled = bool(int(os.environ.get("LAWA_ENABLED", "0")))
+    lawa_k = int(os.environ.get("LAWA_K", 10))
+    lawa_freq = int(os.environ.get("LAWA_FREQ", 100))
+    muon_wd = float(os.environ.get("MUON_WD", 0.04))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.04))
+    qat_enabled = bool(int(os.environ.get("QAT_ENABLED", "0")))
+    bigram_slots = int(os.environ.get("BIGRAM_VOCAB_SIZE", 2048))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    dtg_enabled = bool(int(os.environ.get("DTG_ENABLED", "0")))
+    late_qat_threshold = float(os.environ.get("LATE_QAT_THRESHOLD", 0.15))
+    ve_enabled = bool(int(os.environ.get("VE_ENABLED", "1")))
+    ve_dim = int(os.environ.get("VE_DIM", 128))
+    ve_layers = os.environ.get("VE_LAYERS", "9,10")
+    gated_attention = bool(int(os.environ.get("GATED_ATTENTION", "0")))
+    value_residual = bool(int(os.environ.get("VALUE_RESIDUAL", "0")))
+    ngram_eval_order = int(os.environ.get("NGRAM_EVAL_ORDER", 7))
+    ngram_eval_min_order = int(os.environ.get("NGRAM_EVAL_MIN_ORDER", 2))
+    ngram_eval_alpha = float(os.environ.get("NGRAM_EVAL_ALPHA", 0.40))
+    ngram_eval_adaptive_alpha = bool(int(os.environ.get("NGRAM_EVAL_ADAPTIVE_ALPHA", "1")))
+    ngram_eval_adaptive_mode = os.environ.get("NGRAM_EVAL_ADAPTIVE_MODE", "sigmoid_raw_entropy")
+    ngram_eval_alpha_min = float(os.environ.get("NGRAM_EVAL_ALPHA_MIN", 0.05))
+    ngram_eval_alpha_max = float(os.environ.get("NGRAM_EVAL_ALPHA_MAX", 0.60))
+    ngram_eval_entropy_center = float(os.environ.get("NGRAM_EVAL_ENTROPY_CENTER", 4.0))
+    ngram_eval_entropy_scale = float(os.environ.get("NGRAM_EVAL_ENTROPY_SCALE", 2.0))
+    ngram_eval_min_count = int(os.environ.get("NGRAM_EVAL_MIN_COUNT", 2))
+    ngram_eval_buckets = int(os.environ.get("NGRAM_EVAL_BUCKETS", 4_194_304))
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 5, eps: float = 1e-7) -> Tensor:
+    """Batched Newton-Schulz orthogonalization for one matrix or a small batch."""
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+
+class Muon(torch.optim.Optimizer):
+    """Bank-aware Muon step with overlapped comms.
+
+    After backward we:
+    1. kick off reduce-scatter for large banked tensors
+    2. let Adam update the replicated small tensors while comms are in flight
+    3. run local NS5 on each shard
+    4. all-gather the updates back into full bank tensors
+    """
+
+    def __init__(
+        self,
+        params,
+        lr: float,
+        momentum: float,
+        backend_steps: int,
+        nesterov: bool = True,
+        weight_decay: float = 0.0,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+            ),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append(
+                    {
+                        "p": p,
+                        "B": B,
+                        "padded_grad": torch.zeros(
+                            padded_B, *tail, device=dev, dtype=torch.bfloat16
+                        ),
+                        "shard": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                        "shard_mom": torch.zeros(
+                            shard_B, *tail, device=dev, dtype=torch.bfloat16
+                        ),
+                        "full_update": torch.zeros(
+                            padded_B, *tail, device=dev, dtype=torch.bfloat16
+                        ),
+                        "scale": max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                    }
+                )
+        self._bank_meta.sort(key=lambda m: -m["p"].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        """Start async reduce-scatter for every bank immediately after backward."""
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m["p"]
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m["padded_grad"]
+            pg[: m["B"]].copy_(p.grad.bfloat16())
+            if pg.shape[0] > m["B"]:
+                pg[m["B"] :].zero_()
+            fut = dist.reduce_scatter_tensor(m["shard"], pg, op=dist.ReduceOp.AVG, async_op=True)
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        """Finish the banked optimizer step after the small Adam steps complete."""
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        if not self._built:
+            self._build()
+
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+
+            prev_ag_handle = None
+            prev_m = None
+
+            sharded = self._distributed and hasattr(self, "_rs_futures")
+
+            for i, m in enumerate(self._bank_meta):
+                p = m["p"]
+                if p.grad is None:
+                    continue
+
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m["p"]
+                    upd = prev_m["full_update"][: prev_m["B"]]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+
+                if sharded and self._rs_futures[i] is not None:
+                    self._rs_futures[i].wait()
+                    g = m["shard"]
+                    buf = m["shard_mom"]
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m["full_update"], update, async_op=True
+                    )
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update.to(dtype=p.dtype), alpha=-lr * m["scale"])
+
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m["p"]
+                upd = prev_m["full_update"][: prev_m["B"]]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+
+            if hasattr(self, "_rs_futures"):
+                del self._rs_futures
+
+        return loss
+
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, voc_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, voc_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    seq_len = eval_seq_len or args.train_seq_len
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (
+                has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]
+            ).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,dtg_gate,ve_layer_scales,ve_shared.scale,attn_gate,vr_lambda",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        (
+            "param_count",
+            "num_tensors",
+            "num_float_tensors",
+            "num_nonfloat_tensors",
+            "baseline_tensor_bytes",
+            "int8_payload_bytes",
+        ),
+        0,
+    )
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(
+                dtype=dtype
+            ).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(
+        self, global_tokens: int, seq_len: int, grad_accum_steps: int
+    ) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                scale = (row_max / 31.0).clamp_min(1.0 / 31.0)
+                w_q = (
+                    torch.clamp(torch.round(w32 / scale[:, None]), -32, 31) * scale[:, None]
+                ).to(x.dtype)
+            w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (
+                param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+            ) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        base: float = 10000.0,
+        train_seq_len: int = 1024,
+        rope_dims: int = 0,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / (
+            base ** (torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims)
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (rd / (rd - 2)))
+                inv_freq = 1.0 / (
+                    new_base ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd)
+                )
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        cos = self._cos_cached
+        sin = self._sin_cached
+        if torch.is_grad_enabled():
+            if hasattr(cos, "is_inference") and cos.is_inference():
+                cos = cos.clone()
+            if hasattr(sin, "is_inference") and sin.is_inference():
+                sin = sin.clone()
+        return cos.to(dtype=dtype), sin.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int = 0) -> Tensor:
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False
+        self.gated_attention = gated_attention
+        if gated_attention:
+            self.attn_gate = nn.Linear(dim, num_heads, bias=True)
+            nn.init.zeros_(self.attn_gate.weight)
+            nn.init.constant_(self.attn_gate.bias, 4.0)
+        self.value_residual = value_residual
+        if value_residual:
+            self.vrl_alpha = nn.Parameter(torch.zeros(1, dtype=torch.float32))
+
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        """Efficient XSA: subtract self-value projection via GQA-aware reshape (no repeat_interleave).
+        y: [B, T, H, D], v: [B, T, Hkv, D]. H must be divisible by Hkv."""
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(
+        self,
+        x: Tensor,
+        q_w: Tensor,
+        k_w: Tensor,
+        v_w: Tensor,
+        out_w: Tensor,
+        v_embed: Tensor | None = None,
+        v0: Tensor | None = None,
+    ) -> tuple[Tensor, Tensor | None]:
+        bsz, seqlen, dim = x.shape
+        q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype))
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        raw_v = v if self.value_residual else None
+        if self.value_residual and v0 is not None:
+            alpha = torch.sigmoid(self.vrl_alpha.to(dtype=v.dtype))
+            v = v + alpha * v0
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        if self.gated_attention:
+            gate = torch.sigmoid(self.attn_gate(x)).unsqueeze(-1)
+            y = y * gate
+        y = y.reshape(bsz, seqlen, dim)
+        return F.linear(y, out_w.to(x.dtype)), raw_v
+
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(
+        self,
+        hash_slots: int,
+        bigram_dim: int,
+        model_dim: int,
+        trigram: bool = False,
+    ):
+        super().__init__()
+        self.hash_slots = hash_slots
+        self._trigram = trigram
+        self.embed = nn.Embedding(hash_slots, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.hash_slots - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+
+    def trigram_hash(self, tokens: Tensor) -> Tensor:
+        """Map (t-2, t-1, t) triples into the same table without adding parameters."""
+        t = tokens.to(torch.int32)
+        mod = self.hash_slots - 1
+        out = torch.empty_like(t)
+        out[..., :2] = mod
+        out[..., 2:] = (36313 * t[..., 2:] ^ 27191 * t[..., 1:-1] ^ 51497 * t[..., :-2]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self._trigram:
+            h = h + self.embed(self.trigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+class ValueEmbedding(nn.Module):
+    """Feed token identity back into attention values on selected layers."""
+
+    def __init__(self, voc_size: int, ve_dim: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(voc_size, ve_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(ve_dim, model_dim, bias=False) if ve_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(token_ids)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+
+    def forward(self, x: Tensor, up_w: Tensor, down_w: Tensor) -> Tensor:
+        x = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5)
+        return F.linear(x.square(), down_w.to(x.dtype))
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        layer_idx: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim,
+            num_heads,
+            num_kv_heads,
+            rope_base,
+            qk_gain_init,
+            gated_attention=gated_attention,
+            value_residual=value_residual,
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+        if dtg:
+            self.dtg_gate = nn.Linear(dim, 1, bias=True)
+            nn.init.zeros_(self.dtg_gate.weight)
+            nn.init.constant_(self.dtg_gate.bias, 2.0)
+        else:
+            self.dtg_gate = None
+
+    def forward(
+        self,
+        x: Tensor,
+        x0: Tensor,
+        q_w: Tensor,
+        k_w: Tensor,
+        v_w: Tensor,
+        out_w: Tensor,
+        up_w: Tensor,
+        down_w: Tensor,
+        v_embed: Tensor | None = None,
+        v0: Tensor | None = None,
+    ) -> tuple[Tensor, Tensor | None]:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out, raw_v = self.attn(
+            self.attn_norm(x_in) * self.ln_scale_factor,
+            q_w,
+            k_w,
+            v_w,
+            out_w,
+            v_embed=v_embed,
+            v0=v0,
+        )
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(
+            self.mlp_norm(x_out) * self.ln_scale_factor,
+            up_w,
+            down_w,
+        )
+        if self.dtg_gate is not None:
+            gate = torch.sigmoid(self.dtg_gate(x_in.detach()))
+            x_out = x_in + gate * (x_out - x_in)
+        return x_out, raw_v
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        voc_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        mtp_num_heads: int = 0,
+        mtp_loss_weight: float = 0.1,
+        bigram_slots: int = 0,
+        bigram_dim: int = 128,
+        xsa_last_n: int = 0,
+        rope_dims: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        ve_enabled: bool = False,
+        ve_dim: int = 128,
+        ve_layers: str = "9,10",
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self._ve_target_dim = num_kv_heads * (model_dim // num_heads)
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.value_residual = value_residual
+        self.mtp_num_heads = mtp_num_heads
+        self.mtp_loss_weight = mtp_loss_weight
+        self.tok_emb = nn.Embedding(voc_size, model_dim)
+        self.bigram = (
+            BigramHashEmbedding(
+                bigram_slots,
+                bigram_dim,
+                model_dim,
+                trigram=bool(int(os.environ.get("TRIGRAM", "0"))),
+            )
+            if bigram_slots > 0
+            else None
+        )
+        self.smear = SmearGate(model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        head_dim = model_dim // num_heads
+        kv_dim = num_kv_heads * head_dim
+        mlp_dim = int(mlp_mult * model_dim)
+        self.num_layers = num_layers
+        self.qo_bank = nn.Parameter(torch.empty(2 * num_layers, model_dim, model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * num_layers, kv_dim, model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(num_layers, mlp_dim, model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(num_layers, model_dim, mlp_dim))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                    layer_idx=i,
+                    ln_scale=ln_scale,
+                    dtg=dtg,
+                    gated_attention=gated_attention,
+                    value_residual=value_residual,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        if rope_dims > 0:
+            head_dim = model_dim // num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = rope_dims
+                block.attn.rotary = Rotary(
+                    head_dim, base=rope_base, train_seq_len=1024, rope_dims=rope_dims
+                )
+        self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+        kv_dim_ve = self._ve_target_dim
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(voc_size, ve_dim, kv_dim_ve)
+            self.ve_layer_scales = nn.ParameterList(
+                [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices]
+            )
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.value_embeds = nn.ModuleList()
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, voc_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.mtp_heads = nn.ModuleList(
+            [CastedLinear(model_dim, voc_size, bias=False) for _ in range(mtp_num_heads)]
+        )
+        for head in self.mtp_heads:
+            head._zero_init = True
+        if xsa_last_n > 0:
+            for i in range(max(0, num_layers - xsa_last_n), num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.qo_bank.data[n + i])
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.mlp_down_bank.data[i])
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _get_ve(
+        self, layer_idx: int, input_ids: Tensor, ve_cache: dict | None = None
+    ) -> Tensor | None:
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if ve_cache is not None and "ve" not in ve_cache:
+            ve_cache["ve"] = self.ve_shared(input_ids)
+        ve_base = ve_cache["ve"] if ve_cache is not None else self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_base * self.ve_layer_scales[ve_idx].to(dtype=ve_base.dtype)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x, raw_v = self.blocks[i](
+                x,
+                x0,
+                self.qo_bank[i],
+                self.kv_bank[i],
+                self.kv_bank[n + i],
+                self.qo_bank[n + i],
+                self.mlp_up_bank[i],
+                self.mlp_down_bank[i],
+                v_embed=ve,
+                v0=v0,
+            )
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x, _ = self.blocks[bi](
+                x,
+                x0,
+                self.qo_bank[bi],
+                self.kv_bank[bi],
+                self.kv_bank[n + bi],
+                self.qo_bank[n + bi],
+                self.mlp_up_bank[bi],
+                self.mlp_down_bank[bi],
+                v_embed=ve,
+                v0=v0,
+            )
+        x = self.final_norm(x)
+        x_flat = x.reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x_flat, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x_flat)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        main_loss = F.cross_entropy(logits.float(), targets, reduction="mean")
+        if self.training and self.mtp_num_heads > 0 and self.mtp_loss_weight > 0.0:
+            _, seqlen, dim = x.shape
+            mtp_loss_sum = x.new_zeros(())
+            mtp_loss_count = 0
+            for k, mtp_head in enumerate(self.mtp_heads):
+                valid_t = seqlen - (k + 1)
+                if valid_t <= 0:
+                    continue
+                mtp_hidden = x[:, :valid_t, :].reshape(-1, dim)
+                mtp_targets = target_ids[:, k + 1 :].reshape(-1)
+                mtp_logits_proj = mtp_head(mtp_hidden)
+                mtp_logits = self.logit_softcap * torch.tanh(mtp_logits_proj / self.logit_softcap)
+                mtp_loss_sum = mtp_loss_sum + F.cross_entropy(
+                    mtp_logits.float(), mtp_targets, reduction="mean"
+                )
+                mtp_loss_count += 1
+            if mtp_loss_count > 0:
+                main_loss = main_loss + self.mtp_loss_weight * (mtp_loss_sum / mtp_loss_count)
+        return main_loss
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Return raw next-token logits without forming the loss."""
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x, raw_v = self.blocks[i](
+                x,
+                x0,
+                self.qo_bank[i],
+                self.kv_bank[i],
+                self.kv_bank[n + i],
+                self.qo_bank[n + i],
+                self.mlp_up_bank[i],
+                self.mlp_down_bank[i],
+                v_embed=ve,
+                v0=v0,
+            )
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x, _ = self.blocks[bi](
+                x,
+                x0,
+                self.qo_bank[bi],
+                self.kv_bank[bi],
+                self.kv_bank[n + bi],
+                self.qo_bank[n + bi],
+                self.mlp_up_bank[bi],
+                self.mlp_down_bank[bi],
+                v_embed=ve,
+                v0=v0,
+            )
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    """Sliding-window evaluation where each token gets the deepest legal context."""
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [
+        ws for ws in range(0, total_tokens, stride) if min(ws + seq_len, total_tokens) - ws >= 1
+    ]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    base_model.eval()
+    compiled_logits = torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi : bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws : end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = compiled_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+def eval_val_sliding_hashed_ngram(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    order: int,
+    min_order: int,
+    alpha: float,
+    adaptive_alpha: bool,
+    adaptive_mode: str,
+    alpha_min: float,
+    alpha_max: float,
+    entropy_center: float,
+    entropy_scale: float,
+    min_count: int,
+    buckets: int,
+    batch_seqs: int = 32,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    """Score-first hashed n-gram interpolation with optional lower-order backoff."""
+    if order < 2:
+        raise ValueError(f"NGRAM_EVAL_ORDER must be >=2, got {order}")
+    if min_order < 2 or min_order > order:
+        raise ValueError(f"NGRAM_EVAL_MIN_ORDER must satisfy 2 <= min_order <= order, got {min_order}, {order}")
+    if not (0.0 <= alpha <= 1.0):
+        raise ValueError(f"NGRAM_EVAL_ALPHA must be in [0, 1], got {alpha}")
+    if adaptive_mode not in {"linear", "sigmoid_raw_entropy"}:
+        raise ValueError(
+            f"NGRAM_EVAL_ADAPTIVE_MODE must be one of linear,sigmoid_raw_entropy, got {adaptive_mode}"
+        )
+    if not (0.0 <= alpha_min <= alpha_max <= 1.0):
+        raise ValueError(
+            f"NGRAM_EVAL_ALPHA_MIN/MAX must satisfy 0 <= min <= max <= 1, got {alpha_min}, {alpha_max}"
+        )
+    if entropy_scale <= 0:
+        raise ValueError(f"NGRAM_EVAL_ENTROPY_SCALE must be > 0, got {entropy_scale}")
+    if min_count < 1:
+        raise ValueError(f"NGRAM_EVAL_MIN_COUNT must be >=1, got {min_count}")
+    if buckets < 1024 or (buckets & (buckets - 1)) != 0:
+        raise ValueError(f"NGRAM_EVAL_BUCKETS must be a power of two >=1024, got {buckets}")
+
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    all_window_starts = [
+        ws for ws in range(0, total_tokens, stride) if min(ws + seq_len, total_tokens) - ws >= 1
+    ]
+    my_s = (len(all_window_starts) * rank) // world_size
+    my_e = (len(all_window_starts) * (rank + 1)) // world_size
+    window_starts = all_window_starts[my_s:my_e]
+
+    val_np = val_tokens.cpu().numpy()
+    orders = list(range(min_order, order + 1))
+    ctx_tables = [np.zeros((buckets,), dtype=np.uint32) for _ in orders]
+    full_tables = [np.zeros((buckets,), dtype=np.uint32) for _ in orders]
+    mask = np.uint64(buckets - 1)
+    primes = np.array(
+        [
+            np.uint64(36313),
+            np.uint64(27191),
+            np.uint64(51647),
+            np.uint64(81929),
+            np.uint64(131071),
+            np.uint64(196613),
+            np.uint64(262147),
+        ],
+        dtype=np.uint64,
+    )
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    base_model.eval()
+    compiled_logits = torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+
+    with torch.inference_mode():
+        for bi in range(0, len(window_starts), batch_seqs):
+            batch_ws = window_starts[bi : bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws : end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = compiled_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                seg_len = wlen - s
+                if seg_len <= 0:
+                    continue
+
+                seg_nll = nll[i, s:wlen].to(torch.float64).cpu().numpy()
+                seg_p = np.exp(-seg_nll)
+                alpha_eff = None
+                if adaptive_alpha:
+                    seg_logits = logits[i, s:wlen].float()
+                    seg_log_probs = F.log_softmax(seg_logits, dim=-1)
+                    seg_entropy = -(seg_log_probs.exp() * seg_log_probs).sum(dim=-1).cpu().numpy()
+                    if adaptive_mode == "linear":
+                        entropy_norm = np.clip(seg_entropy / math.log(seg_logits.size(-1)), 0.0, 1.0)
+                        alpha_eff = alpha_min + (alpha_max - alpha_min) * entropy_norm
+                    else:
+                        entropy_gate = 1.0 / (1.0 + np.exp(-entropy_scale * (seg_entropy - entropy_center)))
+                        alpha_eff = alpha_min + (alpha_max - alpha_min) * entropy_gate
+                global_pos = np.arange(ws + s + 1, ws + wlen + 1, dtype=np.int64)
+                valid = global_pos >= (min_order - 1)
+                if valid.any():
+                    valid_idx = np.nonzero(valid)[0]
+                    pos = global_pos[valid_idx]
+                    tgt_np = val_np[pos].astype(np.uint64)
+                    ctx_keys_per_order: list[np.ndarray] = []
+                    full_keys_per_order: list[np.ndarray] = []
+                    ctx_counts_per_order: list[np.ndarray] = []
+                    full_counts_per_order: list[np.ndarray] = []
+                    for oi, ngram_order in enumerate(orders):
+                        ctx_hash = np.zeros((len(pos),), dtype=np.uint64)
+                        ctx_width = ngram_order - 1
+                        for k in range(ctx_width):
+                            tok = val_np[pos - (ctx_width - k)].astype(np.uint64)
+                            ctx_hash ^= tok * primes[k % len(primes)]
+                        ctx_key = (ctx_hash & mask).astype(np.int64)
+                        full_key = ((ctx_hash ^ (tgt_np * primes[ctx_width % len(primes)])) & mask).astype(np.int64)
+                        ctx_keys_per_order.append(ctx_key)
+                        full_keys_per_order.append(full_key)
+                        ctx_counts_per_order.append(ctx_tables[oi][ctx_key].astype(np.float64))
+                        full_counts_per_order.append(full_tables[oi][full_key].astype(np.float64))
+
+                    can_mix = np.zeros((len(pos),), dtype=bool)
+                    p_ng = np.zeros((len(pos),), dtype=np.float64)
+                    for oi in range(len(orders) - 1, -1, -1):
+                        ctx_counts = ctx_counts_per_order[oi]
+                        full_counts = full_counts_per_order[oi]
+                        use = (~can_mix) & (ctx_counts >= float(min_count))
+                        if use.any():
+                            p_est = full_counts[use] / np.maximum(ctx_counts[use], 1.0)
+                            p_ng[use] = np.clip(p_est, 0.0, 1.0)
+                            can_mix[use] = True
+                    if can_mix.any():
+                        if adaptive_alpha:
+                            local_alpha = alpha_eff[valid_idx]
+                        else:
+                            local_alpha = np.full((len(valid_idx),), alpha, dtype=np.float64)
+                        mixed = (1.0 - local_alpha) * seg_p[valid_idx] + local_alpha * p_ng
+                        seg_p[valid_idx[can_mix]] = mixed[can_mix]
+                    seg_nll = -np.log(np.clip(seg_p, 1e-12, 1.0))
+                    for oi in range(len(orders)):
+                        np.add.at(ctx_tables[oi], ctx_keys_per_order[oi], 1)
+                        np.add.at(full_tables[oi], full_keys_per_order[oi], 1)
+
+                loss_sum += float(seg_nll.sum())
+                token_count += float(seg_len)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    base_model.train()
+    return val_loss, val_bpb
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+
+
+def quantize_int6_per_row(t: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        best_q, best_s, best_err = None, None, float("inf")
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            if pct < 1.0:
+                row_clip = torch.quantile(t32.abs(), pct, dim=1)
+            else:
+                row_clip = t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+            recon = q.float() * s.float()[:, None]
+            err = (t32 - recon).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_s, best_err = q, s, err
+        return best_q, best_s
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+
+def _unbank_state_dict(sd: dict[str, Tensor], num_layers: int) -> dict[str, Tensor]:
+    """Convert 3D bank tensors into individual 2D tensors with standard names."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    for name, tensor in sd.items():
+        if name == "qo_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_q.weight"] = tensor[i]
+                out[f"blocks.{i}.attn.proj.weight"] = tensor[n + i]
+        elif name == "kv_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_k.weight"] = tensor[i]
+                out[f"blocks.{i}.attn.c_v.weight"] = tensor[n + i]
+        elif name == "mlp_up_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.fc.weight"] = tensor[i]
+        elif name == "mlp_down_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.proj.weight"] = tensor[i]
+        else:
+            out[name] = tensor
+    return out
+
+
+def _rebank_state_dict(
+    sd: dict[str, Tensor], num_layers: int, template_sd: dict[str, Tensor]
+) -> dict[str, Tensor]:
+    """Convert individual 2D tensors back into 3D bank tensors."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    qo_slices = [None] * (2 * n)
+    kv_slices = [None] * (2 * n)
+    up_slices = [None] * n
+    down_slices = [None] * n
+    consumed = set()
+    for i in range(n):
+        qk = f"blocks.{i}.attn.c_q.weight"
+        if qk in sd:
+            qo_slices[i] = sd[qk]
+            consumed.add(qk)
+        ok = f"blocks.{i}.attn.proj.weight"
+        if ok in sd:
+            qo_slices[n + i] = sd[ok]
+            consumed.add(ok)
+        kk = f"blocks.{i}.attn.c_k.weight"
+        if kk in sd:
+            kv_slices[i] = sd[kk]
+            consumed.add(kk)
+        vk = f"blocks.{i}.attn.c_v.weight"
+        if vk in sd:
+            kv_slices[n + i] = sd[vk]
+            consumed.add(vk)
+        fk = f"blocks.{i}.mlp.fc.weight"
+        if fk in sd:
+            up_slices[i] = sd[fk]
+            consumed.add(fk)
+        dk = f"blocks.{i}.mlp.proj.weight"
+        if dk in sd:
+            down_slices[i] = sd[dk]
+            consumed.add(dk)
+    out["qo_bank"] = torch.stack(qo_slices).to(dtype=template_sd["qo_bank"].dtype)
+    out["kv_bank"] = torch.stack(kv_slices).to(dtype=template_sd["kv_bank"].dtype)
+    out["mlp_up_bank"] = torch.stack(up_slices).to(dtype=template_sd["mlp_up_bank"].dtype)
+    out["mlp_down_bank"] = torch.stack(down_slices).to(dtype=template_sd["mlp_down_bank"].dtype)
+    for name, tensor in sd.items():
+        if name not in consumed:
+            out[name] = tensor
+    return out
+
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    num_layers_total = max((int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")), default=0) + 1
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            cr = 31
+            q, s = quantize_int6_per_row(t, clip_range=cr)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+
+
+def dequantize_mixed_int6(
+    result: dict[str, Tensor], meta: dict[str, object], template_sd: dict[str, Tensor]
+) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+def main() -> None:
+    code, code_bytes = _load_submission_code(__file__)
+    args = Hyperparameters()
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.voc_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.voc_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    effective_eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.voc_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+    CastedLinear._qat_enabled = args.qat_enabled
+    base_model = GPT(
+        voc_size=args.voc_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=args.mtp_num_heads,
+        mtp_loss_weight=args.mtp_loss_weight,
+        bigram_slots=args.bigram_slots,
+        bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims,
+        ln_scale=args.ln_scale,
+        dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled,
+        ve_dim=args.ve_dim,
+        ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention,
+        value_residual=args.value_residual,
+    ).to(device).bfloat16()
+    base_model.qo_bank.data = base_model.qo_bank.data.float()
+    base_model.kv_bank.data = base_model.kv_bank.data.float()
+    base_model.mlp_up_bank.data = base_model.mlp_up_bank.data.float()
+    base_model.mlp_down_bank.data = base_model.mlp_down_bank.data.float()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model = compiled_model
+
+    matrix_params = [
+        base_model.qo_bank,
+        base_model.kv_bank,
+        base_model.mlp_up_bank,
+        base_model.mlp_down_bank,
+    ]
+    block_named_params = list(base_model.blocks.named_parameters())
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_params.append(
+            {"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr}
+        )
+        if base_model.bigram.proj is not None:
+            scalar_params.append(base_model.bigram.proj.weight)
+    if base_model.ve_shared is not None:
+        tok_params.append(
+            {"params": [base_model.ve_shared.embed.weight], "lr": token_lr, "base_lr": token_lr}
+        )
+        if base_model.ve_shared.proj is not None:
+            scalar_params.append(base_model.ve_shared.proj.weight)
+        scalar_params.append(base_model.ve_shared.scale)
+        for s in base_model.ve_layer_scales:
+            scalar_params.append(s)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    replicated_params = list(optimizer_tok.param_groups[0]["params"])
+    for pg in optimizer_tok.param_groups[1:]:
+        replicated_params.extend(pg["params"])
+    replicated_params.extend(scalar_params)
+
+    optimizer_head = None
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        replicated_params.append(base_model.lm_head.weight)
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if optimizer_head is not None:
+        optimizers.append(optimizer_head)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    mtp_params = sum(p.numel() for p in base_model.mtp_heads.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"mtp_num_heads:{args.mtp_num_heads} mtp_loss_weight:{args.mtp_loss_weight} mtp_params:{mtp_params}")
+    xsa_layers = [i for i, b in enumerate(base_model.blocks) if b.attn.use_xsa]
+    log0(f"XSA:last_{args.xsa_last_n} active_layers:{xsa_layers}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    if args.ngram_eval_order >= 2:
+        log0(
+            f"ngram_eval:min_order={args.ngram_eval_min_order} order={args.ngram_eval_order} "
+            f"alpha={args.ngram_eval_alpha} adaptive_alpha={int(args.ngram_eval_adaptive_alpha)} "
+            f"adaptive_mode={args.ngram_eval_adaptive_mode} "
+            f"alpha_min={args.ngram_eval_alpha_min} alpha_max={args.ngram_eval_alpha_max} "
+            f"entropy_center={args.ngram_eval_entropy_center} entropy_scale={args.ngram_eval_entropy_scale} "
+            f"min_count={args.ngram_eval_min_count} buckets={args.ngram_eval_buckets}"
+        )
+    log0(f"seed:{args.seed}")
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return (
+                max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0)
+                if warmdown_start <= step < args.iterations
+                else 1.0
+            )
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            if distributed:
+                for p in base_model.parameters():
+                    if p.grad is not None:
+                        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    from collections import deque
+
+    lawa_queue: deque[dict[str, Tensor]] = deque(maxlen=args.lawa_k)
+    ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    ema_decay = 0.997
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        if args.late_qat_threshold > 0 and scale < args.late_qat_threshold and not CastedLinear._qat_enabled:
+            CastedLinear._qat_enabled = True
+            log0(f"late_qat:enabled step:{step} scale:{scale:.4f}")
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        optimizer_muon.launch_reduce_scatters()
+        if distributed:
+            for p in replicated_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+        optimizer_tok.step()
+        optimizer_scalar.step()
+        if optimizer_head is not None:
+            optimizer_head.step()
+        optimizer_muon.step()
+        zero_grad_all()
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(t.detach().float(), alpha=1.0 - ema_decay)
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        if args.swa_enabled and scale < 0.2 and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+        if args.lawa_enabled and step % args.lawa_freq == 0:
+            lawa_queue.append({name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()})
+        should_log_train = args.train_log_every > 0 and (
+            step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+    if args.lawa_enabled and len(lawa_queue) > 1:
+        log0(f"lawa:applying LAWA averaging k={len(lawa_queue)}")
+        current_state = base_model.state_dict()
+        avg_state = {
+            name: torch.zeros(t.shape, dtype=torch.float32, device="cpu")
+            for name, t in current_state.items()
+        }
+        for snap in lawa_queue:
+            for name in avg_state:
+                avg_state[name] += snap[name].float()
+        for name in avg_state:
+            avg_state[name] /= len(lawa_queue)
+            avg_state[name] = avg_state[name].to(dtype=current_state[name].dtype)
+        base_model.load_state_dict(avg_state, strict=True)
+    else:
+        log0("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+        base_model.load_state_dict(avg_state, strict=True)
+    torch.cuda.synchronize()
+    t_diag = time.perf_counter()
+    diag_val_loss, diag_val_bpb = eval_val(
+        args,
+        compiled_model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"DIAGNOSTIC post_ema val_loss:{diag_val_loss:.4f} val_bpb:{diag_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_diag):.0f}ms"
+    )
+    full_state_dict = base_model.state_dict()
+    export_sd = {k: v for k, v in full_state_dict.items() if "mtp_heads" not in k}
+    excluded_mtp = sum(int(t.numel()) for k, t in full_state_dict.items() if "mtp_heads" in k)
+    if excluded_mtp > 0:
+        log0(f"export_excluding_mtp_params:{excluded_mtp}")
+    if master_process:
+        torch.save(export_sd, "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    unbanked_sd = _unbank_state_dict(sd_cpu, args.num_layers)
+    log0("gptq:using post-training mixed int6 quantization without train-data calibration")
+    quant_result, quant_meta = mixed_quantize_int6(unbanked_sd, {"mlp", "attn"})
+    target_mb = float(os.environ.get("TARGET_MB", "15.149"))
+    code_bytes_est = code_bytes
+    ones_info = []
+    for name, info in quant_meta.items():
+        if not (isinstance(info, dict) and info.get("type") == "int6"):
+            continue
+        qk, sk = name + ".q", name + ".scale"
+        if qk not in quant_result or sk not in quant_result:
+            continue
+        q, s = quant_result[qk], quant_result[sk]
+        if s.ndim > 0:
+            ones_mask = q.abs() == 1
+            if ones_mask.any():
+                row_idx = torch.arange(q.shape[0]).unsqueeze(1).expand_as(q)[ones_mask]
+                flat_idx = torch.arange(q.numel()).reshape(q.shape)[ones_mask]
+                errors = s.float()[row_idx].pow(2)
+                for fi, err in zip(flat_idx.tolist(), errors.tolist()):
+                    ones_info.append((qk, fi, err))
+    if ones_info:
+        ones_info.sort(key=lambda x: x[2])
+
+        def _try_prune(n):
+            tmp = {k: v.clone() for k, v in quant_result.items()}
+            for i in range(min(n, len(ones_info))):
+                tmp[ones_info[i][0]].view(-1)[ones_info[i][1]] = 0
+            buf = io.BytesIO()
+            torch.save({"w": tmp, "m": quant_meta}, buf)
+            return len(lzma.compress(buf.getvalue(), preset=6)) + code_bytes_est, tmp
+
+        no_sz, _ = _try_prune(0)
+        target_bytes = int(target_mb * 1024 * 1024)
+        log0(
+            f"selective_prune: {len(ones_info)} ±1 candidates, "
+            f"unpruned={no_sz / (1024 * 1024):.2f}MB target={target_mb}MB"
+        )
+        if no_sz <= target_bytes:
+            log0("selective_prune: already fits, no pruning needed")
+        else:
+            full_sz, _ = _try_prune(len(ones_info))
+            log0(f"selective_prune: full ±1 prune={full_sz / (1024 * 1024):.2f}MB")
+            if full_sz > target_bytes:
+                log0("selective_prune: even full prune not enough, applying all")
+                _, quant_result = _try_prune(len(ones_info))
+            else:
+                lo, hi = 0, len(ones_info)
+                while lo < hi:
+                    mid = (lo + hi) // 2
+                    sz, _ = _try_prune(mid)
+                    if sz <= target_bytes:
+                        hi = mid
+                    else:
+                        lo = mid + 1
+                log0(
+                    f"selective_prune: pruning {lo}/{len(ones_info)} ±1 values "
+                    f"({100 * lo / len(ones_info):.1f}%) to fit {target_mb}MB"
+                )
+                _, quant_result = _try_prune(lo)
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = lzma.compress(quant_raw, preset=6)
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = len(quant_blob)
+        log0(f"Serialized model int6+lzma: {quant_file_bytes} bytes")
+        log0(f"Total submission size int6+lzma: {quant_file_bytes + code_bytes} bytes")
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(lzma.decompress(quant_blob_disk)), map_location="cpu")
+    deq_unbanked = dequantize_mixed_int6(quant_state["w"], quant_state["m"], unbanked_sd)
+    deq_state = _rebank_state_dict(deq_unbanked, args.num_layers, sd_cpu)
+    eval_model = GPT(
+        voc_size=args.voc_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=0,
+        mtp_loss_weight=0.0,
+        bigram_slots=args.bigram_slots,
+        bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims,
+        ln_scale=args.ln_scale,
+        dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled,
+        ve_dim=args.ve_dim,
+        ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention,
+        value_residual=args.value_residual,
+    ).to(device).bfloat16()
+    eval_model.qo_bank.data = eval_model.qo_bank.data.float()
+    eval_model.kv_bank.data = eval_model.kv_bank.data.float()
+    eval_model.mlp_up_bank.data = eval_model.mlp_up_bank.data.float()
+    eval_model.mlp_down_bank.data = eval_model.mlp_down_bank.data.float()
+    for m in eval_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(eval_model)
+    eval_model.load_state_dict(deq_state, strict=True)
+    compiled_eval = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        compiled_eval,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+        eval_seq_len=effective_eval_seq_len,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+    sw_seq_len = effective_eval_seq_len
+    if args.slide_stride > 0 and args.slide_stride < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args,
+            eval_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            stride=args.slide_stride,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"stride:{args.slide_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+        log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+    if args.slide_stride != 64 and 64 < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide64 = time.perf_counter()
+        sw64_val_loss, sw64_val_bpb = eval_val_sliding(
+            args,
+            eval_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            stride=64,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window_s64 val_loss:{sw64_val_loss:.4f} val_bpb:{sw64_val_bpb:.4f} "
+            f"stride:64 eval_time:{1000.0 * (time.perf_counter() - t_slide64):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_s64_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+        log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+    if args.ngram_eval_order >= 2:
+        if distributed:
+            dist.barrier()
+        torch.cuda.synchronize()
+        t_ng = time.perf_counter()
+        ng_loss, ng_bpb = eval_val_sliding_hashed_ngram(
+            args,
+            eval_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            stride=args.slide_stride,
+            order=args.ngram_eval_order,
+            min_order=args.ngram_eval_min_order,
+            alpha=args.ngram_eval_alpha,
+            adaptive_alpha=args.ngram_eval_adaptive_alpha,
+            adaptive_mode=args.ngram_eval_adaptive_mode,
+            alpha_min=args.ngram_eval_alpha_min,
+            alpha_max=args.ngram_eval_alpha_max,
+            entropy_center=args.ngram_eval_entropy_center,
+            entropy_scale=args.ngram_eval_entropy_scale,
+            min_count=args.ngram_eval_min_count,
+            buckets=args.ngram_eval_buckets,
+            eval_seq_len=sw_seq_len,
+        )
+        ngram_label = f"ngram{args.ngram_eval_order}"
+        if args.ngram_eval_min_order < args.ngram_eval_order:
+            ngram_label = f"ngram_backoff{args.ngram_eval_min_order}to{args.ngram_eval_order}"
+        if args.ngram_eval_adaptive_alpha:
+            ngram_label += "_adapt"
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window_{ngram_label} val_loss:{ng_loss:.4f} val_bpb:{ng_bpb:.4f} "
+            f"eval_time:{1000.0 * (time.perf_counter() - t_ng):.0f}ms"
+        )
+        log0(
+            f"final_int6_sliding_window_{ngram_label}_exact "
+            f"val_loss:{ng_loss:.8f} val_bpb:{ng_bpb:.8f}"
+        )
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-03-25_11L_XSA_GPTQ_AdaptiveNgramCache/train_seed1337.log
+++ b/records/track_10min_16mb/2026-03-25_11L_XSA_GPTQ_AdaptiveNgramCache/train_seed1337.log
@@ -1,0 +1,85 @@
+W0327 21:40:36.989000 5593 torch/distributed/run.py:803] 
+W0327 21:40:36.989000 5593 torch/distributed/run.py:803] *****************************************
+W0327 21:40:36.989000 5593 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0327 21:40:36.989000 5593 torch/distributed/run.py:803] *****************************************
+logs/e4823f4b-77d9-475b-9523-83b9ff0aaf06.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/workspace/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=/workspace/parameter-golf/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26993756
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_11 active_layers:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+ngram_eval:min_order=2 order=7 alpha=0.4 adaptive_alpha=1 adaptive_mode=sigmoid_raw_entropy alpha_min=0.05 alpha_max=0.6 entropy_center=4.0 entropy_scale=2.0 min_count=2 buckets=4194304
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9309 val_bpb:4.1049 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9317 train_time:131ms step_avg:131.07ms
+step:2/20000 train_loss:8.6729 train_time:171ms step_avg:85.62ms
+step:3/20000 train_loss:7.5836 train_time:258ms step_avg:85.83ms
+step:4/20000 train_loss:7.3017 train_time:344ms step_avg:86.10ms
+step:5/20000 train_loss:7.2500 train_time:432ms step_avg:86.45ms
+step:6/20000 train_loss:7.1165 train_time:522ms step_avg:87.01ms
+step:7/20000 train_loss:6.9428 train_time:609ms step_avg:87.00ms
+step:8/20000 train_loss:6.8207 train_time:699ms step_avg:87.39ms
+step:9/20000 train_loss:6.4418 train_time:787ms step_avg:87.40ms
+step:10/20000 train_loss:6.0547 train_time:873ms step_avg:87.32ms
+step:500/20000 train_loss:2.3767 train_time:42967ms step_avg:85.93ms
+step:1000/20000 train_loss:2.2546 train_time:86176ms step_avg:86.18ms
+step:1500/20000 train_loss:2.2044 train_time:129461ms step_avg:86.31ms
+step:2000/20000 train_loss:2.0494 train_time:172858ms step_avg:86.43ms
+step:2500/20000 train_loss:2.1550 train_time:216319ms step_avg:86.53ms
+step:3000/20000 train_loss:2.1452 train_time:259756ms step_avg:86.59ms
+step:3500/20000 train_loss:2.1649 train_time:303193ms step_avg:86.63ms
+step:4000/20000 train_loss:1.9553 train_time:346640ms step_avg:86.66ms
+step:4000/20000 val_loss:2.0471 val_bpb:1.2124 train_time:346698ms step_avg:86.67ms
+step:4500/20000 train_loss:2.1052 train_time:390211ms step_avg:86.71ms
+step:5000/20000 train_loss:2.0902 train_time:433754ms step_avg:86.75ms
+step:5500/20000 train_loss:2.0013 train_time:477462ms step_avg:86.81ms
+step:6000/20000 train_loss:1.9255 train_time:521194ms step_avg:86.87ms
+swa:start step:6250
+late_qat:enabled step:6376 scale:0.1500
+step:6500/20000 train_loss:2.0659 train_time:565337ms step_avg:86.97ms
+step:6892/20000 val_loss:1.9213 val_bpb:1.1379 train_time:600063ms step_avg:87.07ms
+stopping_early: wallclock_cap train_time:600063ms step:6892/20000
+peak memory allocated: 22860 MiB reserved: 23042 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9197 val_bpb:1.1369 eval_time:2067ms
+Serialized model: 106158518 bytes
+Code size: 97092 bytes
+gptq:using post-training mixed int6 quantization without train-data calibration
+selective_prune: 4095296 ±1 candidates, unpruned=15.19MB target=15.149MB
+selective_prune: full ±1 prune=14.16MB
+selective_prune: pruning 322196/4095296 ±1 values (7.9%) to fit 15.149MB
+Serialized model int6+lzma: 15782272 bytes
+Total submission size int6+lzma: 15879364 bytes
+final_int6_roundtrip val_loss:1.9327 val_bpb:1.1447 eval_time:20201ms
+final_int6_roundtrip_exact val_loss:1.93271342 val_bpb:1.14466175
+final_int6_sliding_window val_loss:1.8932 val_bpb:1.1212 stride:64 eval_time:98406ms
+final_int6_sliding_window_exact val_loss:1.89316583 val_bpb:1.12124241
+final_int8_zlib_roundtrip_exact val_loss:1.89316583 val_bpb:1.12124241
+final_int6_sliding_window_ngram_backoff2to7_adapt val_loss:1.6262 val_bpb:0.9631 eval_time:115549ms
+final_int6_sliding_window_ngram_backoff2to7_adapt_exact val_loss:1.62623055 val_bpb:0.96314788

--- a/records/track_10min_16mb/2026-03-25_11L_XSA_GPTQ_AdaptiveNgramCache/train_seed2024.log
+++ b/records/track_10min_16mb/2026-03-25_11L_XSA_GPTQ_AdaptiveNgramCache/train_seed2024.log
@@ -1,0 +1,85 @@
+W0327 22:36:29.364000 117930 torch/distributed/run.py:803] 
+W0327 22:36:29.364000 117930 torch/distributed/run.py:803] *****************************************
+W0327 22:36:29.364000 117930 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0327 22:36:29.364000 117930 torch/distributed/run.py:803] *****************************************
+logs/477b93f0-8696-44db-9d3c-393037375b18.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/workspace/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=/workspace/parameter-golf/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26993756
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_11 active_layers:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+ngram_eval:min_order=2 order=7 alpha=0.4 adaptive_alpha=1 adaptive_mode=sigmoid_raw_entropy alpha_min=0.05 alpha_max=0.6 entropy_center=4.0 entropy_scale=2.0 min_count=2 buckets=4194304
+seed:2024
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9327 val_bpb:4.1059 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9341 train_time:125ms step_avg:124.67ms
+step:2/20000 train_loss:8.7651 train_time:159ms step_avg:79.30ms
+step:3/20000 train_loss:7.6342 train_time:246ms step_avg:82.12ms
+step:4/20000 train_loss:7.2425 train_time:335ms step_avg:83.84ms
+step:5/20000 train_loss:7.1528 train_time:425ms step_avg:85.08ms
+step:6/20000 train_loss:7.0518 train_time:515ms step_avg:85.89ms
+step:7/20000 train_loss:6.9351 train_time:603ms step_avg:86.21ms
+step:8/20000 train_loss:6.8311 train_time:691ms step_avg:86.38ms
+step:9/20000 train_loss:6.4909 train_time:776ms step_avg:86.27ms
+step:10/20000 train_loss:6.0609 train_time:863ms step_avg:86.34ms
+step:500/20000 train_loss:2.3842 train_time:43005ms step_avg:86.01ms
+step:1000/20000 train_loss:2.2518 train_time:86201ms step_avg:86.20ms
+step:1500/20000 train_loss:2.2002 train_time:129516ms step_avg:86.34ms
+step:2000/20000 train_loss:2.0471 train_time:173089ms step_avg:86.54ms
+step:2500/20000 train_loss:2.1521 train_time:216501ms step_avg:86.60ms
+step:3000/20000 train_loss:2.1466 train_time:260084ms step_avg:86.69ms
+step:3500/20000 train_loss:2.1628 train_time:303775ms step_avg:86.79ms
+step:4000/20000 train_loss:1.9553 train_time:347258ms step_avg:86.81ms
+step:4000/20000 val_loss:2.0459 val_bpb:1.2117 train_time:347344ms step_avg:86.84ms
+step:4500/20000 train_loss:2.1067 train_time:390786ms step_avg:86.84ms
+step:5000/20000 train_loss:2.0857 train_time:434298ms step_avg:86.86ms
+step:5500/20000 train_loss:2.0018 train_time:477773ms step_avg:86.87ms
+step:6000/20000 train_loss:1.9249 train_time:521263ms step_avg:86.88ms
+swa:start step:6250
+late_qat:enabled step:6379 scale:0.1498
+step:6500/20000 train_loss:2.0652 train_time:565043ms step_avg:86.93ms
+step:6897/20000 val_loss:1.9202 val_bpb:1.1372 train_time:600100ms step_avg:87.01ms
+stopping_early: wallclock_cap train_time:600100ms step:6897/20000
+peak memory allocated: 22850 MiB reserved: 23004 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9185 val_bpb:1.1362 eval_time:2073ms
+Serialized model: 106158518 bytes
+Code size: 97092 bytes
+gptq:using post-training mixed int6 quantization without train-data calibration
+selective_prune: 4074681 ±1 candidates, unpruned=15.18MB target=15.149MB
+selective_prune: full ±1 prune=14.14MB
+selective_prune: pruning 253671/4074681 ±1 values (6.2%) to fit 15.149MB
+Serialized model int6+lzma: 15786972 bytes
+Total submission size int6+lzma: 15884064 bytes
+final_int6_roundtrip val_loss:1.9315 val_bpb:1.1439 eval_time:6041ms
+final_int6_roundtrip_exact val_loss:1.93151038 val_bpb:1.14394924
+final_int6_sliding_window val_loss:1.8918 val_bpb:1.1204 stride:64 eval_time:76086ms
+final_int6_sliding_window_exact val_loss:1.89179890 val_bpb:1.12043283
+final_int8_zlib_roundtrip_exact val_loss:1.89179890 val_bpb:1.12043283
+final_int6_sliding_window_ngram_backoff2to7_adapt val_loss:1.6255 val_bpb:0.9627 eval_time:114447ms
+final_int6_sliding_window_ngram_backoff2to7_adapt_exact val_loss:1.62547316 val_bpb:0.96269931

--- a/records/track_10min_16mb/2026-03-25_11L_XSA_GPTQ_AdaptiveNgramCache/train_seed42.log
+++ b/records/track_10min_16mb/2026-03-25_11L_XSA_GPTQ_AdaptiveNgramCache/train_seed42.log
@@ -1,0 +1,85 @@
+W0327 22:12:38.748000 90663 torch/distributed/run.py:803] 
+W0327 22:12:38.748000 90663 torch/distributed/run.py:803] *****************************************
+W0327 22:12:38.748000 90663 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0327 22:12:38.748000 90663 torch/distributed/run.py:803] *****************************************
+logs/901a85a3-82ec-4485-9870-aba71babe27a.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/workspace/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=/workspace/parameter-golf/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26993756
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_11 active_layers:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+ngram_eval:min_order=2 order=7 alpha=0.4 adaptive_alpha=1 adaptive_mode=sigmoid_raw_entropy alpha_min=0.05 alpha_max=0.6 entropy_center=4.0 entropy_scale=2.0 min_count=2 buckets=4194304
+seed:42
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9297 val_bpb:4.1042 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9319 train_time:148ms step_avg:148.37ms
+step:2/20000 train_loss:8.6433 train_time:183ms step_avg:91.26ms
+step:3/20000 train_loss:7.6217 train_time:270ms step_avg:90.07ms
+step:4/20000 train_loss:7.3289 train_time:358ms step_avg:89.47ms
+step:5/20000 train_loss:7.2467 train_time:446ms step_avg:89.24ms
+step:6/20000 train_loss:7.0561 train_time:535ms step_avg:89.24ms
+step:7/20000 train_loss:6.9057 train_time:626ms step_avg:89.36ms
+step:8/20000 train_loss:6.8574 train_time:713ms step_avg:89.12ms
+step:9/20000 train_loss:6.5243 train_time:805ms step_avg:89.42ms
+step:10/20000 train_loss:6.0725 train_time:893ms step_avg:89.32ms
+step:500/20000 train_loss:2.4054 train_time:43083ms step_avg:86.17ms
+step:1000/20000 train_loss:2.2682 train_time:86309ms step_avg:86.31ms
+step:1500/20000 train_loss:2.2054 train_time:129594ms step_avg:86.40ms
+step:2000/20000 train_loss:2.0507 train_time:173008ms step_avg:86.50ms
+step:2500/20000 train_loss:2.1520 train_time:216656ms step_avg:86.66ms
+step:3000/20000 train_loss:2.1464 train_time:260273ms step_avg:86.76ms
+step:3500/20000 train_loss:2.1663 train_time:303758ms step_avg:86.79ms
+step:4000/20000 train_loss:1.9535 train_time:347256ms step_avg:86.81ms
+step:4000/20000 val_loss:2.0467 val_bpb:1.2122 train_time:347337ms step_avg:86.83ms
+step:4500/20000 train_loss:2.1044 train_time:390791ms step_avg:86.84ms
+step:5000/20000 train_loss:2.0884 train_time:434360ms step_avg:86.87ms
+step:5500/20000 train_loss:2.0040 train_time:477883ms step_avg:86.89ms
+step:6000/20000 train_loss:1.9245 train_time:521383ms step_avg:86.90ms
+swa:start step:6250
+late_qat:enabled step:6376 scale:0.1499
+step:6500/20000 train_loss:2.0635 train_time:565248ms step_avg:86.96ms
+step:6894/20000 val_loss:1.9214 val_bpb:1.1380 train_time:600102ms step_avg:87.05ms
+stopping_early: wallclock_cap train_time:600102ms step:6894/20000
+peak memory allocated: 22850 MiB reserved: 23004 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9197 val_bpb:1.1369 eval_time:2075ms
+Serialized model: 106158518 bytes
+Code size: 97092 bytes
+gptq:using post-training mixed int6 quantization without train-data calibration
+selective_prune: 4072981 ±1 candidates, unpruned=15.19MB target=15.149MB
+selective_prune: full ±1 prune=14.16MB
+selective_prune: pruning 304263/4072981 ±1 values (7.5%) to fit 15.149MB
+Serialized model int6+lzma: 15787188 bytes
+Total submission size int6+lzma: 15884280 bytes
+final_int6_roundtrip val_loss:1.9329 val_bpb:1.1448 eval_time:5945ms
+final_int6_roundtrip_exact val_loss:1.93290736 val_bpb:1.14477662
+final_int6_sliding_window val_loss:1.8932 val_bpb:1.1213 stride:64 eval_time:76210ms
+final_int6_sliding_window_exact val_loss:1.89319120 val_bpb:1.12125743
+final_int8_zlib_roundtrip_exact val_loss:1.89319120 val_bpb:1.12125743
+final_int6_sliding_window_ngram_backoff2to7_adapt val_loss:1.6267 val_bpb:0.9634 eval_time:115505ms
+final_int6_sliding_window_ngram_backoff2to7_adapt_exact val_loss:1.62665946 val_bpb:0.96340191


### PR DESCRIPTION
## 11L XSA + Mixed INT6 + Adaptive N-gram Cache (2->7 backoff)

`val_bpb: 0.96308303` (3-seed mean, std `0.00035576`) | `15,882,569` bytes mean | `8xH100 SXM, 600s`

## Results (8xH100 SXM, 600s)

| Seed | Steps | Sliding val_bpb | Final val_bpb | Artifact bytes |
|------|------:|----------------:|--------------:|---------------:|
| 1337 | 6,892 | 1.12124241 | 0.96314788 | 15,879,364 |
| 42 | 6,894 | 1.12125743 | 0.96340191 | 15,884,280 |
| 2024 | 6,897 | 1.12043283 | 0.96269931 | 15,884,064 |

Mean `val_bpb`: `0.96308303`. Inter-seed std: `0.00035576`.

## Architecture

| Component | Setting |
|-----------|---------|
| Layers | 11 (512d, 8Q, 4KV) |
| MLP | 3x with `relu2` |
| XSA | All 11 layers |
| Embeddings | Tied |
| Weight averaging | EMA + late SWA |
| Quantization | Post-training mixed INT6 + LZMA |
| Eval | Sliding window, stride 64 |

## Adaptive N-gram Cache

Score-first adaptive n-gram cache with backoff orders `2->7`.

Backward-looking evaluation order:
1. Score each window under `torch.inference_mode()`.
2. Add only already-scored tokens to the cache.
3. Apply the cache only to later positions and later windows.

No training data is accessed during evaluation.

| Parameter | Value |
|-----------|-------|
| Orders | `2->7` |
| Adaptive mode | `sigmoid_raw_entropy` |
| Alpha range | `[0.05, 0.60]` |
| Hash buckets | `4,194,304` |
| Min count | `2` |

## Ablation (seed 1337)

| Configuration | val_bpb |
|--------------|--------:|
| Post-EMA, pre-quant | 1.1369 |
| + INT6 quantization | 1.14466175 |
| + Sliding window (stride 64) | 1.12124241 |
| + Adaptive n-gram cache | 0.96314788 |

## Reproducibility

From the records folder:
```bash
torchrun --standalone --nproc_per_node=8 train_gpt.py
SEED=42 torchrun --standalone --nproc_per_node=8 train_gpt.py
SEED=2024 torchrun --standalone --nproc_per_node=8 train_gpt.py
```

## Credits

- XSA: PR #265 and arXiv:2603.09078
- EMA and quantization lineage: PR #414, PR #549
- Early sliding-window evaluation path: PR #77
- Score-first evaluation framing: Issue #402