### PR TITLE
Record: 11L Muon TTT + Entropy-Adaptive Epochs (8×H100) — val_bpb 1.1179 (3-seed mean)

### DIFF
--- a/records/track_10min_16mb/2026-03-28_MuonTTT_EntropyAdaptive_11L_8xH100/README.md
+++ b/records/track_10min_16mb/2026-03-28_MuonTTT_EntropyAdaptive_11L_8xH100/README.md
@@ -1,0 +1,136 @@
+# 11L Muon TTT + Entropy-Adaptive Epochs
+
+**val_bpb: 1.1179** (3-seed mean, std 0.0002) | **~15.9 MB** | 8xH100 SXM
+
+## Results (8xH100 80GB SXM, PyTorch 2.9.1+cu128)
+
+| Seed | step_avg | steps | Pre-TTT bpb | Post-TTT bpb | TTT gain | TTT time | Artifact |
+|------|----------|-------|-------------|-------------|----------|----------|----------|
+| 1337 | 83.5ms | 7,189 | 1.1214 | **1.11765** | -0.0037 | 477s | 15,944,410 |
+| 42   | 83.5ms | 7,177 | 1.1217 | **1.11813** | -0.0035 | 485s | 15,873,826 |
+| 2025 | 83.5ms | 7,175 | 1.1217 | **1.11790** | -0.0038 | 479s | 15,879,042 |
+| **Mean** | **83.5ms** | **~7,180** | **~1.1216** | **1.1179 (std 0.0002)** | **-0.0037** | **~480s** | |
+
+## Key Innovation 1: Muon as TTT Optimizer
+
+Every prior TTT submission uses SGD in the test-time training loop. This submission replaces SGD with Newton-Schulz orthogonalized gradient updates -- the same Muon principle that dominates the training leaderboard, now applied to test-time adaptation.
+
+### Why this works
+
+Muon constrains each matrix update to the space of orthogonal transformations, normalizing the gradient direction. For TTT this means:
+- No gradient blowup: updates only rotate weight matrices, cannot inflate them
+- Better gradient signal: Newton-Schulz whitens the gradient, removing scale correlation between rows that SGD accumulates
+- Faster per-epoch convergence: each TTT epoch moves farther in the useful direction
+
+The result: +0.0037 TTT gain per seed vs SOTA's +0.0025 (SGD, same 3 epochs), with total TTT time remaining under 600s.
+
+### Implementation
+
+Replaces optimizer.step() in the TTT loop:
+
+    with torch.no_grad():
+        for p in ttt_params:
+            if p.grad is None:
+                continue
+            g = p.grad.detach().float()
+            if g.ndim >= 2:
+                g = zeropower_via_newtonschulz5(g, steps=3)
+            p.data.add_(g.to(p.dtype), alpha=-cos_lr)
+
+zeropower_via_newtonschulz5 is already present in every train_gpt.py. 3 NS steps balance orthogonalization quality vs eval wall-clock (5 steps exceeded the 600s eval budget; 3 steps complete in ~480s).
+
+## Key Innovation 2: Entropy-Adaptive TTT Epochs
+
+All prior TTT submissions use a fixed epoch count per chunk. This submission dynamically assigns 2, 3, or 4 TTT epochs per chunk based on the model's measured uncertainty on that content.
+
+After SCORE phase, the per-chunk NLL is globally synchronized across all DDP ranks (critical: per-rank NLL gives different epoch counts per rank -> different number of dist.all_reduce calls per chunk -> NCCL collective mismatch -> watchdog timeout at 600s). The global NLL gates epoch selection:
+
+    cls_t = torch.tensor(chunk_loss_sum, device=device, dtype=torch.float64)
+    ctc_t = torch.tensor(chunk_token_count, device=device, dtype=torch.float64)
+    if world_size > 1:
+        dist.all_reduce(cls_t, op=dist.ReduceOp.SUM)
+        dist.all_reduce(ctc_t, op=dist.ReduceOp.SUM)
+    chunk_nll = (cls_t / ctc_t).item()
+
+    if chunk_nll > 2.1:    # hard content (code, math): 4 epochs
+        effective_epochs = 4
+    elif chunk_nll < 1.75: # easy content (prose): 2 epochs
+        effective_epochs = 2
+    else:
+        effective_epochs = 3
+
+This concentrates adaptation budget where it helps most. Average epochs ~3.0; total TTT time unchanged vs fixed-3-epoch baseline.
+
+## Legal TTT Protocol
+
+Score-first TTT following PR #461 framework:
+
+1. Val tokens split into 1,893 non-overlapping 32K-token chunks
+2. For each chunk:
+   - SCORE: Sliding window eval under torch.inference_mode() -- no gradients, no weight mutation
+   - TRAIN: Muon-style update on already-scored chunk. Entropy-adaptive 2/3/4 epochs, cosine LR decay, grad clip 1.0
+3. Last chunk scored but never trained on
+4. Chunk N scored by model adapted only on chunks 0..N-1
+
+### TTT Hyperparameters
+
+| Parameter | Value |
+|-----------|-------|
+| Chunk size | 32,768 tokens |
+| Optimizer | Muon-style (Newton-Schulz NS=3 + LR step) |
+| Learning rate | 0.002 (cosine decay across chunks) |
+| Epochs per chunk | 2/3/4 entropy-adaptive (H_HIGH=2.1, H_LOW=1.75 nats) |
+| Frozen blocks | None (all blocks adapt) |
+| Gradient clip | 1.0 |
+
+## Training Architecture
+
+Full SOTA stack from PR #399 and PR #414:
+
+| Component | Setting |
+|-----------|---------|
+| Layers | 11 (512d, 8H, 4KV) |
+| MLP | 3x with LeakyReLU(0.5)^2 |
+| BigramHash | 1536 |
+| XSA | Last 4 layers |
+| RoPE | Partial (16/64 dims) |
+| LN Scale | 1/sqrt(layer+1) |
+| VE128 | Layers 9-10 |
+| Weight avg | EMA(0.997) + Tight SWA(every 50) |
+| Quantization | GPTQ-lite int6 + lzma (preset=7) |
+| Optimizer | Parameter Banking + Parallel Muon |
+
+## Run Command
+
+    NUM_LAYERS=11 BIGRAM_VOCAB_SIZE=1536 XSA_LAST_N=4
+    EMA_ENABLED=1 EMA_DECAY=0.997 SWA_ENABLED=1 SWA_EVERY=50
+    ROPE_DIMS=16 LN_SCALE=1 LATE_QAT=1 LATE_QAT_THRESHOLD=0.15
+    VE_ENABLED=1 VE_DIM=128 VE_LAYERS=9,10
+    TTT_ENABLED=1 TTT_LR=0.002 TTT_EPOCHS=3 TTT_CHUNK_TOKENS=32768
+    TTT_FREEZE_BLOCKS=0 TTT_MOMENTUM=0.9 TTT_BATCH_SEQS=32 TTT_GRAD_CLIP=1.0
+    TTT_MUON=1 TTT_NS_STEPS=3 TTT_ENTROPY_ADAPT=1
+    TTT_ENTROPY_HIGH=2.1 TTT_ENTROPY_LOW=1.75
+    MUON_WD=0.04 ADAM_WD=0.04
+    MATRIX_LR=0.025 SCALAR_LR=0.025 TIED_EMBED_LR=0.035
+    MUON_MOMENTUM=0.99 MUON_MOMENTUM_WARMUP_START=0.92
+    MUON_MOMENTUM_WARMUP_STEPS=1500 WARMDOWN_ITERS=3500
+    ITERATIONS=9000 MAX_WALLCLOCK_SECONDS=599 EVAL_STRIDE=64
+    SEED=1337
+    torchrun --standalone --nproc_per_node=8 train_gpt.py
+
+## Timing Budget
+
+| Phase | Time |
+|-------|------|
+| Training | ~600s (<=10 min) |
+| Standard eval (int6 roundtrip + sliding window) | ~82s |
+| Legal TTT (score-first + adaptation) | ~480s |
+| Total eval | ~562s (< 10 min) |
+
+## Credits
+
+- LeakyReLU^2 activation: PR #493 by @parinzee, PR #518 by @sofiabod
+- Optimizer (Parameter Banking + Parallel Muon): PR #399 by @abaybektursun
+- TTT recipe (score-first framework): PR #461 by @Christopher-Lee-McClendon
+- Base architecture: PR #414 by @signalrush
+- SOTA base adapted from: @abaybektursun (val_bpb 1.1194)

--- a/records/track_10min_16mb/2026-03-28_MuonTTT_EntropyAdaptive_11L_8xH100/submission.json
+++ b/records/track_10min_16mb/2026-03-28_MuonTTT_EntropyAdaptive_11L_8xH100/submission.json
@@ -1,0 +1,9 @@
+{
+  "name": "Record: 11L Muon TTT + Entropy-Adaptive Epochs",
+  "val_bpb": 1.1179,
+  "bytes_total": 15944410,
+  "blurb": "Two novel TTT innovations on SOTA base (PR #399 + PR #414 + PR #461 stack): (1) Muon-style Newton-Schulz orthogonalized gradient updates replace SGD in the TTT loop (NS=3 steps per matrix parameter per epoch) -- more stable and effective test-time adaptation; (2) Entropy-adaptive epoch selection -- per-chunk NLL (globally synced across DDP ranks) gates between 2/3/4 TTT epochs, concentrating adaptation budget on harder content. 3-seed mean: 1.1179 (std 0.0002). All artifacts under 16MB, all eval under 10 min.",
+  "author": "Aamod Bhatt",
+  "github_id": "aamodbhatt",
+  "date": "2026-03-28"
+}

--- a/records/track_10min_16mb/2026-03-28_MuonTTT_EntropyAdaptive_11L_8xH100/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-28_MuonTTT_EntropyAdaptive_11L_8xH100/train_gpt.py
@@ -1,0 +1,1954 @@
+from __future__ import annotations
+import copy
+import glob
+import io
+import lzma
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from flash_attn_interface import flash_attn_func as flash_attn_3_func
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3500))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 3.0))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.035))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.025))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.025))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    mtp_num_heads = int(os.environ.get("MTP_NUM_HEADS", 0))
+    mtp_loss_weight = float(os.environ.get("MTP_LOSS_WEIGHT", 0.2))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    lawa_enabled = bool(int(os.environ.get("LAWA_ENABLED", "0")))
+    lawa_k = int(os.environ.get("LAWA_K", 10))
+    lawa_freq = int(os.environ.get("LAWA_FREQ", 100))
+    muon_wd = float(os.environ.get("MUON_WD", 0.04))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.04))
+    qat_enabled = bool(int(os.environ.get("QAT_ENABLED", "0")))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 2048))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 4))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    dtg_enabled = bool(int(os.environ.get("DTG_ENABLED", "0")))
+    late_qat_threshold = float(os.environ.get("LATE_QAT_THRESHOLD", 0.15))
+    ve_enabled = bool(int(os.environ.get("VE_ENABLED", "1")))
+    ve_dim = int(os.environ.get("VE_DIM", 128))
+    ve_layers = os.environ.get("VE_LAYERS", "9,10")
+    gated_attention = bool(int(os.environ.get("GATED_ATTENTION", "0")))
+    value_residual = bool(int(os.environ.get("VALUE_RESIDUAL", "0")))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.002))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 3))
+    ttt_chunk_tokens = int(os.environ.get("TTT_CHUNK_TOKENS", 32768))
+    ttt_freeze_blocks = int(os.environ.get("TTT_FREEZE_BLOCKS", 2))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+    ttt_batch_seqs = int(os.environ.get("TTT_BATCH_SEQS", 32))
+    ttt_grad_clip = float(os.environ.get("TTT_GRAD_CLIP", 1.0))
+    ttt_muon = bool(int(os.environ.get("TTT_MUON", "1")))          # use Muon-style NS update for TTT
+    ttt_ns_steps = int(os.environ.get("TTT_NS_STEPS", "3"))               # Newton-Schulz steps for TTT Muon
+    ttt_entropy_adapt = bool(int(os.environ.get("TTT_ENTROPY_ADAPT", "1")))  # entropy-adaptive epochs
+    ttt_entropy_high = float(os.environ.get("TTT_ENTROPY_HIGH", "2.1"))  # nats – hard chunk threshold
+    ttt_entropy_low = float(os.environ.get("TTT_ENTROPY_LOW", "1.75"))   # nats – easy chunk threshold
+
+# --- Batched Newton-Schulz orthogonalization ---
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 5, eps: float = 1e-7) -> Tensor:
+    """Batched Newton-Schulz orthogonalization. G: (B,M,N) or (M,N)."""
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+# --- Parallel Muon optimizer ---
+
+class Muon(torch.optim.Optimizer):
+    """Parallel Muon: post-backward reduce-scatter -> local NS5 -> all-gather.
+
+    No DDP for bank params. After backward, this optimizer:
+    1. Launches async reduce-scatter for all banks (biggest first)
+    2. Returns control so Adam can step on small params while RS is in-flight
+    3. Waits for each RS, runs local NS5 on the shard, launches async all-gather
+    4. Each all-gather overlaps with next bank's NS5
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append({
+                    'p': p,
+                    'B': B,
+                    'padded_grad': torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'shard': torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'shard_mom': torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'full_update': torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'scale': max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                })
+        # Sort by size descending -- launch biggest reduce-scatters first
+        self._bank_meta.sort(key=lambda m: -m['p'].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        """Phase 1: launch async reduce-scatter for all banks. Call right after backward."""
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m['p']
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m['padded_grad']
+            pg[:m['B']].copy_(p.grad.bfloat16())
+            if pg.shape[0] > m['B']:
+                pg[m['B']:].zero_()
+            fut = dist.reduce_scatter_tensor(m['shard'], pg, op=dist.ReduceOp.AVG, async_op=True)
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        """Phase 3: wait for RS, local NS5, all-gather. Call AFTER Adam steps."""
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        if not self._built:
+            self._build()
+
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+
+            prev_ag_handle = None
+            prev_m = None
+
+            sharded = self._distributed and hasattr(self, '_rs_futures')
+
+            for i, m in enumerate(self._bank_meta):
+                p = m['p']
+                if p.grad is None:
+                    continue
+
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m['p']
+                    upd = prev_m['full_update'][:prev_m['B']]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m['scale'])
+
+                if sharded and self._rs_futures[i] is not None:
+                    self._rs_futures[i].wait()
+                    g = m['shard']
+                    buf = m['shard_mom']
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m['full_update'], update, async_op=True)
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update.to(dtype=p.dtype), alpha=-lr * m['scale'])
+
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m['p']
+                upd = prev_m['full_update'][:prev_m['B']]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m['scale'])
+
+            if hasattr(self, '_rs_futures'):
+                del self._rs_futures
+
+        return loss
+
+# --- Tokenizer evaluation helpers ---
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    seq_len = eval_seq_len or args.train_seq_len
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# --- Quantization helpers ---
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,dtg_gate,ve_layer_scales,ve_shared.scale,attn_gate,vr_lambda",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+# --- Data loading ---
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# --- Transformer modules ---
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                scale = (row_max / 31.0).clamp_min(1.0 / 31.0)
+                w_q = (torch.clamp(torch.round(w32 / scale[:, None]), -32, 31) * scale[:, None]).to(x.dtype)
+            w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024, rope_dims: int = 0):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / (base ** (torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (rd / (rd - 2)))
+                inv_freq = 1.0 / (new_base ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd))
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int = 0) -> Tensor:
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        # No CastedLinear -- weights come from banks
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rope_dims = 0  # set by GPT.__init__ for partial RoPE
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False  # set by GPT.__init__ for deep layers only
+        # Gated attention and value residual (non-banked small params)
+        self.gated_attention = gated_attention
+        if gated_attention:
+            self.attn_gate = nn.Linear(dim, num_heads, bias=True)
+            nn.init.zeros_(self.attn_gate.weight)
+            nn.init.constant_(self.attn_gate.bias, 4.0)
+        self.value_residual = value_residual
+        if value_residual:
+            self.vr_lambda = nn.Parameter(torch.tensor([0.5, 0.5], dtype=torch.float32))
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        """Efficient XSA: subtract self-value projection via GQA-aware reshape (no repeat_interleave).
+        y: [B, T, H, D], v: [B, T, Hkv, D]. H must be divisible by Hkv."""
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)        # [B, T, Hkv, group, D]
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)    # [B, T, Hkv, 1, D] -- broadcast ready
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+    def forward(self, x: Tensor, q_w: Tensor, k_w: Tensor, v_w: Tensor, out_w: Tensor, v_embed: Tensor | None = None, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        bsz, seqlen, dim = x.shape
+        q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype))
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        raw_v = v if self.value_residual else None
+        if self.value_residual and v0 is not None:
+            lam = self.vr_lambda.to(dtype=v.dtype)
+            v = lam[0] * v0 + lam[1] * v
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        if self.gated_attention:
+            # gate shape: (bsz, seqlen, num_heads) -> (bsz, seqlen, num_heads, 1) for B,T,H,D layout
+            gate = torch.sigmoid(self.attn_gate(x)).unsqueeze(-1)
+            y = y * gate
+        y = y.reshape(bsz, seqlen, dim)
+        return F.linear(y, out_w.to(x.dtype)), raw_v
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class ValueEmbedding(nn.Module):
+    """Reinject token identity into attention values at specific layers.
+    Each table maps vocab tokens to a low-dim embedding, projected to model_dim."""
+    def __init__(self, vocab_size: int, ve_dim: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, ve_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(ve_dim, model_dim, bias=False) if ve_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(token_ids)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        # No CastedLinear -- weights come from banks
+    def forward(self, x: Tensor, up_w: Tensor, down_w: Tensor) -> Tensor:
+        x = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5)
+        return F.linear(x.square(), down_w.to(x.dtype))
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        layer_idx: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+                                        gated_attention=gated_attention, value_residual=value_residual)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+        if dtg:
+            self.dtg_gate = nn.Linear(dim, 1, bias=True)
+            nn.init.zeros_(self.dtg_gate.weight)
+            nn.init.constant_(self.dtg_gate.bias, 2.0)
+        else:
+            self.dtg_gate = None
+    def forward(self, x: Tensor, x0: Tensor, q_w: Tensor, k_w: Tensor, v_w: Tensor, out_w: Tensor, up_w: Tensor, down_w: Tensor, v_embed: Tensor | None = None, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out, raw_v = self.attn(self.attn_norm(x_in) * self.ln_scale_factor, q_w, k_w, v_w, out_w, v_embed=v_embed, v0=v0)
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        if self.dtg_gate is not None:
+            gate = torch.sigmoid(self.dtg_gate(x_in.detach()))
+            x_out = x_in + gate * (x_out - x_in)
+        return x_out, raw_v
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        mtp_num_heads: int = 0,
+        mtp_loss_weight: float = 0.1,
+        bigram_vocab_size: int = 0,
+        bigram_dim: int = 128,
+        xsa_last_n: int = 0,
+        rope_dims: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        ve_enabled: bool = False,
+        ve_dim: int = 128,
+        ve_layers: str = "9,10",
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self._ve_target_dim = num_kv_heads * (model_dim // num_heads)  # kv_dim for value projection
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.value_residual = value_residual
+        self.mtp_num_heads = mtp_num_heads
+        self.mtp_loss_weight = mtp_loss_weight
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.smear = SmearGate(model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        # Parameter banks: contiguous 3D tensors for batched optimizer
+        head_dim = model_dim // num_heads
+        kv_dim = num_kv_heads * head_dim
+        mlp_dim = int(mlp_mult * model_dim)
+        self.num_layers = num_layers
+        self.qo_bank = nn.Parameter(torch.empty(2 * num_layers, model_dim, model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * num_layers, kv_dim, model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(num_layers, mlp_dim, model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(num_layers, model_dim, mlp_dim))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                    layer_idx=i,
+                    ln_scale=ln_scale,
+                    dtg=dtg,
+                    gated_attention=gated_attention,
+                    value_residual=value_residual,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        if rope_dims > 0:
+            head_dim = model_dim // num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = rope_dims
+                block.attn.rotary = Rotary(head_dim, base=rope_base, train_seq_len=1024, rope_dims=rope_dims)
+        self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+        kv_dim_ve = self._ve_target_dim
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim_ve)
+            self.ve_layer_scales = nn.ParameterList(
+                [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices]
+            )
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.value_embeds = nn.ModuleList()  # keep empty for compat
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.mtp_heads = nn.ModuleList(
+            [CastedLinear(model_dim, vocab_size, bias=False) for _ in range(mtp_num_heads)]
+        )
+        for head in self.mtp_heads:
+            head._zero_init = True
+        if xsa_last_n > 0:
+            for i in range(max(0, num_layers - xsa_last_n), num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self._init_weights()
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        # Init banks: orthogonal, with proj layers scaled down and out/down zero-init
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)        # Q
+            nn.init.zeros_(self.qo_bank.data[n + i])                    # Out (zero init)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)        # K
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)    # V
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)    # MLP up
+            nn.init.zeros_(self.mlp_down_bank.data[i])                  # MLP down (zero init)
+            # Scale proj layers (out_proj and mlp_down are "proj" layers)
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        # Init remaining nn.Linear modules (bigram proj, mtp heads, lm_head)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+    def _get_ve(self, layer_idx: int, input_ids: Tensor, ve_cache: dict | None = None) -> Tensor | None:
+        """Get value embedding for a specific layer using shared table + per-layer scale."""
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if ve_cache is not None and 've' not in ve_cache:
+            ve_cache['ve'] = self.ve_shared(input_ids)
+        ve_base = ve_cache['ve'] if ve_cache is not None else self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_base * self.ve_layer_scales[ve_idx].to(dtype=ve_base.dtype)
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x, raw_v = self.blocks[i](x, x0,
+                self.qo_bank[i], self.kv_bank[i], self.kv_bank[n + i],
+                self.qo_bank[n + i], self.mlp_up_bank[i], self.mlp_down_bank[i],
+                v_embed=ve, v0=v0)
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x, _ = self.blocks[bi](x, x0,
+                self.qo_bank[bi], self.kv_bank[bi], self.kv_bank[n + bi],
+                self.qo_bank[n + bi], self.mlp_up_bank[bi], self.mlp_down_bank[bi],
+                v_embed=ve, v0=v0)
+        x = self.final_norm(x)
+        x_flat = x.reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x_flat, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x_flat)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        main_loss = F.cross_entropy(logits.float(), targets, reduction="mean")
+        if self.training and self.mtp_num_heads > 0 and self.mtp_loss_weight > 0.0:
+            _, seqlen, dim = x.shape
+            mtp_loss_sum = x.new_zeros(())
+            mtp_loss_count = 0
+            for k, mtp_head in enumerate(self.mtp_heads):
+                valid_t = seqlen - (k + 1)
+                if valid_t <= 0:
+                    continue
+                mtp_hidden = x[:, :valid_t, :].reshape(-1, dim)
+                mtp_targets = target_ids[:, k + 1 :].reshape(-1)
+                mtp_logits_proj = mtp_head(mtp_hidden)
+                mtp_logits = self.logit_softcap * torch.tanh(mtp_logits_proj / self.logit_softcap)
+                mtp_loss_sum = mtp_loss_sum + F.cross_entropy(mtp_logits.float(), mtp_targets, reduction="mean")
+                mtp_loss_count += 1
+            if mtp_loss_count > 0:
+                main_loss = main_loss + self.mtp_loss_weight * (mtp_loss_sum / mtp_loss_count)
+        return main_loss
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Return logits (bsz, seq_len, vocab) without computing loss."""
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x, raw_v = self.blocks[i](x, x0,
+                self.qo_bank[i], self.kv_bank[i], self.kv_bank[n + i],
+                self.qo_bank[n + i], self.mlp_up_bank[i], self.mlp_down_bank[i],
+                v_embed=ve, v0=v0)
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x, _ = self.blocks[bi](x, x0,
+                self.qo_bank[bi], self.kv_bank[bi], self.kv_bank[n + bi],
+                self.qo_bank[n + bi], self.mlp_up_bank[bi], self.mlp_down_bank[bi],
+                v_embed=ve, v0=v0)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+# --- Sliding window evaluation ---
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context."""
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= 1]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    base_model.eval()
+    compiled_logits = torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = compiled_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+def eval_val_sliding_ttt(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    stride: int, batch_seqs: int = 32, log0=print,
+) -> tuple[float, float]:
+    """Legal score-first TTT (PR #461 recipe): score each chunk with sliding windows,
+    then train on it. Every token scored BEFORE any update that could use it."""
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = args.ttt_chunk_tokens
+
+    # Pre-compute all window starts
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+
+    # Assign each window to a chunk based on the first token it scores
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    chunk_windows: list[list[int]] = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        end = min(ws + seq_len, total_tokens)
+        wlen = end - ws
+        s = 0 if ws == 0 else max(wlen - stride, 0)
+        scored_start = ws + s
+        ci = min(scored_start // ttt_chunk, num_chunks - 1)
+        chunk_windows[ci].append(ws)
+
+    log0(f"ttt_sliding:start chunks={num_chunks} chunk_tokens={ttt_chunk} "
+         f"total_windows={len(window_starts)} stride={stride} "
+         f"ttt_lr={args.ttt_lr} ttt_epochs={args.ttt_epochs} "
+         f"freeze_blocks={args.ttt_freeze_blocks}")
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Freeze first N blocks
+    frozen_block_ids = set(range(min(args.ttt_freeze_blocks, len(base_model.blocks))))
+    ttt_params = []
+    for name, p in base_model.named_parameters():
+        freeze = False
+        for bi in frozen_block_ids:
+            if f"blocks.{bi}." in name:
+                freeze = True
+                break
+        if freeze:
+            p.requires_grad_(False)
+        else:
+            p.requires_grad_(True)
+            ttt_params.append(p)
+
+    log0(f"ttt_sliding:params unfrozen={sum(p.numel() for p in ttt_params)} "
+         f"frozen={sum(p.numel() for p in base_model.parameters() if not p.requires_grad)}")
+
+    # Muon TTT: no external optimizer; we apply Newton-Schulz orthogonalized updates
+    # For non-matrix params (1-D) we use plain LR-scaled gradient updates (like AdamW scalar track)
+    use_muon_ttt = args.ttt_muon
+    if not use_muon_ttt:
+        optimizer = torch.optim.SGD(ttt_params, lr=args.ttt_lr, momentum=args.ttt_momentum)
+    else:
+        optimizer = None  # manual update below
+    t0 = time.perf_counter()
+
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows:
+            continue
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+
+        # Track per-chunk NLL for entropy-adaptive epoch selection
+        chunk_loss_sum = 0.0
+        chunk_token_count = 0
+        # --- Phase 1: SCORE this chunk's windows (inference_mode) ---
+        my_s = (len(windows) * rank) // world_size
+        my_e = (len(windows) * (rank + 1)) // world_size
+        my_windows = windows[my_s:my_e]
+
+        base_model.eval()
+        with torch.inference_mode():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi:bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens: list[int] = []
+                for i, ws in enumerate(batch_ws):
+                    end = min(ws + seq_len, total_tokens)
+                    wlen = end - ws
+                    wlens.append(wlen)
+                    chunk_tok = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                    x_batch[i, :wlen] = chunk_tok[:-1]
+                    y_batch[i, :wlen] = chunk_tok[1:]
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model.forward_logits(x_batch)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y_batch.reshape(-1), reduction="none",
+                ).reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]
+                    s = 0 if ws == 0 else max(wlen - stride, 0)
+                    scored_nll = nll[i, s:wlen].to(torch.float64)
+                    loss_sum += scored_nll.sum()
+                    token_count += float(wlen - s)
+                    chunk_loss_sum += scored_nll.sum().item()
+                    chunk_token_count += float(wlen - s)
+                    tgt, prev = y_batch[i, s:wlen], x_batch[i, s:wlen]
+                    tb = base_bytes_lut[tgt].to(torch.float64)
+                    tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                    byte_count += tb.sum()
+
+        # --- Phase 2: TRAIN on this chunk (already scored = legal) ---
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and args.ttt_epochs > 0:
+            base_model.train()
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if chunk_seqs > 0:
+                cos_lr = args.ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                if not use_muon_ttt:
+                    for pg in optimizer.param_groups:
+                        pg['lr'] = cos_lr
+                my_seq_s = (chunk_seqs * rank) // world_size
+                my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+                my_chunk_seqs = my_seq_e - my_seq_s
+                # --- Entropy-adaptive epoch count (synchronized across ranks) ---
+                # Sync chunk NLL across all ranks so every rank uses the same effective_epochs
+                chunk_nll = float('inf')
+                if args.ttt_entropy_adapt:
+                    cls_t = torch.tensor(chunk_loss_sum, device=device, dtype=torch.float64)
+                    ctc_t = torch.tensor(chunk_token_count, device=device, dtype=torch.float64)
+                    if world_size > 1:
+                        dist.all_reduce(cls_t, op=dist.ReduceOp.SUM)
+                        dist.all_reduce(ctc_t, op=dist.ReduceOp.SUM)
+                    if ctc_t.item() > 0:
+                        chunk_nll = (cls_t / ctc_t).item()
+                effective_epochs = args.ttt_epochs
+                if args.ttt_entropy_adapt:
+                    if chunk_nll > args.ttt_entropy_high:
+                        effective_epochs = args.ttt_epochs + 1   # hard chunk → extra epoch
+                    elif chunk_nll < args.ttt_entropy_low:
+                        effective_epochs = max(args.ttt_epochs - 1, 1)  # easy chunk → save time
+                # Wall-clock guard: if we're past 85% of soft eval cap, cap at baseline epochs
+                elapsed_now = time.perf_counter() - t0
+                eval_soft_cap = float(os.environ.get("EVAL_TIME_SOFT_CAP_SECONDS", "570"))
+                if elapsed_now > eval_soft_cap * 0.85:
+                    effective_epochs = min(effective_epochs, args.ttt_epochs)
+
+                for _ep in range(effective_epochs):
+                    for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                        be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                        actual_bs = my_seq_s + bs
+                        start_tok = chunk_start + actual_bs * seq_len
+                        end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                        if end_tok > val_tokens.numel():
+                            continue
+                        local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                        x = local[:-1].reshape(-1, seq_len)
+                        y = local[1:].reshape(-1, seq_len)
+                        if not use_muon_ttt:
+                            optimizer.zero_grad(set_to_none=True)
+                        else:
+                            for p in ttt_params:
+                                p.grad = None
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            loss = base_model(x, y)
+                        loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        torch.nn.utils.clip_grad_norm_(ttt_params, args.ttt_grad_clip)
+                        if not use_muon_ttt:
+                            optimizer.step()
+                        else:
+                            # Muon-style update: Newton-Schulz orthogonalization for matrix params,
+                            # plain LR-scaled gradient for vector params (norms, biases, scalars).
+                            with torch.no_grad():
+                                for p in ttt_params:
+                                    if p.grad is None:
+                                        continue
+                                    g = p.grad.detach().float()
+                                    if g.ndim >= 2:
+                                        g = zeropower_via_newtonschulz5(g, steps=args.ttt_ns_steps)
+                                    p.data.add_(g.to(p.dtype), alpha=-cos_lr)
+
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            log0(f"  ttt_chunk [{ci+1}/{num_chunks}] bpb={rbpb:.6f} time={elapsed:.1f}s")
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+    log0(f"ttt_sliding:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+         f"elapsed={time.perf_counter() - t0:.1f}s")
+    return val_loss, val_bpb
+
+
+# --- GPTQ-lite int6 quantization ---
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+def quantize_int6_per_row(t: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        best_q, best_s, best_err = None, None, float('inf')
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            if pct < 1.0:
+                row_clip = torch.quantile(t32.abs(), pct, dim=1)
+            else:
+                row_clip = t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+            recon = q.float() * s.float()[:, None]
+            err = (t32 - recon).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_s, best_err = q, s, err
+        return best_q, best_s
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+
+def _unbank_state_dict(sd: dict[str, Tensor], num_layers: int) -> dict[str, Tensor]:
+    """Convert 3D bank tensors into individual 2D tensors with standard names."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    for name, tensor in sd.items():
+        if name == "qo_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_q.weight"] = tensor[i]
+                out[f"blocks.{i}.attn.proj.weight"] = tensor[n + i]
+        elif name == "kv_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_k.weight"] = tensor[i]
+                out[f"blocks.{i}.attn.c_v.weight"] = tensor[n + i]
+        elif name == "mlp_up_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.fc.weight"] = tensor[i]
+        elif name == "mlp_down_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.proj.weight"] = tensor[i]
+        else:
+            out[name] = tensor
+    return out
+
+def _rebank_state_dict(sd: dict[str, Tensor], num_layers: int, template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    """Convert individual 2D tensors back into 3D bank tensors."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    # Reconstruct banks from individual weight keys
+    qo_slices = [None] * (2 * n)
+    kv_slices = [None] * (2 * n)
+    up_slices = [None] * n
+    down_slices = [None] * n
+    consumed = set()
+    for i in range(n):
+        qk = f"blocks.{i}.attn.c_q.weight"
+        if qk in sd:
+            qo_slices[i] = sd[qk]
+            consumed.add(qk)
+        ok = f"blocks.{i}.attn.proj.weight"
+        if ok in sd:
+            qo_slices[n + i] = sd[ok]
+            consumed.add(ok)
+        kk = f"blocks.{i}.attn.c_k.weight"
+        if kk in sd:
+            kv_slices[i] = sd[kk]
+            consumed.add(kk)
+        vk = f"blocks.{i}.attn.c_v.weight"
+        if vk in sd:
+            kv_slices[n + i] = sd[vk]
+            consumed.add(vk)
+        fk = f"blocks.{i}.mlp.fc.weight"
+        if fk in sd:
+            up_slices[i] = sd[fk]
+            consumed.add(fk)
+        dk = f"blocks.{i}.mlp.proj.weight"
+        if dk in sd:
+            down_slices[i] = sd[dk]
+            consumed.add(dk)
+    out["qo_bank"] = torch.stack(qo_slices).to(dtype=template_sd["qo_bank"].dtype)
+    out["kv_bank"] = torch.stack(kv_slices).to(dtype=template_sd["kv_bank"].dtype)
+    out["mlp_up_bank"] = torch.stack(up_slices).to(dtype=template_sd["mlp_up_bank"].dtype)
+    out["mlp_down_bank"] = torch.stack(down_slices).to(dtype=template_sd["mlp_down_bank"].dtype)
+    for name, tensor in sd.items():
+        if name not in consumed:
+            out[name] = tensor
+    return out
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    num_layers_total = max(
+        (int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")),
+        default=0,
+    ) + 1
+    late_k_layers = set(range(num_layers_total - 2, num_layers_total))
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+# --- Training ---
+
+def main() -> None:
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    # zeropower_via_newtonschulz5 runs eagerly with bmm -- do NOT compile
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    effective_eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+    CastedLinear._qat_enabled = args.qat_enabled
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=args.mtp_num_heads,
+        mtp_loss_weight=args.mtp_loss_weight,
+        bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims,
+        ln_scale=args.ln_scale,
+        dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled,
+        ve_dim=args.ve_dim,
+        ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention,
+        value_residual=args.value_residual,
+    ).to(device).bfloat16()
+    # Banks stay FP32 (like CastedLinear weights), cast to BF16 in forward
+    base_model.qo_bank.data = base_model.qo_bank.data.float()
+    base_model.kv_bank.data = base_model.kv_bank.data.float()
+    base_model.mlp_up_bank.data = base_model.mlp_up_bank.data.float()
+    base_model.mlp_down_bank.data = base_model.mlp_down_bank.data.float()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    # No DDP -- Parallel Muon handles bank grad communication via reduce-scatter,
+    # and non-bank grads are manually all-reduced before Adam steps.
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model = compiled_model
+
+    # Optimizer split:
+    # - 4 parameter banks -> Muon (batched Newton-Schulz)
+    # - token embedding -> Adam
+    # - scalars/control tensors -> Adam
+    # - bigram proj, mtp heads, VE proj -> Adam (small matrix params not worth banking)
+    matrix_params = [
+        base_model.qo_bank, base_model.kv_bank,
+        base_model.mlp_up_bank, base_model.mlp_down_bank,
+    ]
+    block_named_params = list(base_model.blocks.named_parameters())
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_params.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None:
+            scalar_params.append(base_model.bigram.proj.weight)
+    if base_model.ve_shared is not None:
+        tok_params.append({"params": [base_model.ve_shared.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.ve_shared.proj is not None:
+            scalar_params.append(base_model.ve_shared.proj.weight)
+        scalar_params.append(base_model.ve_shared.scale)
+        for s in base_model.ve_layer_scales:
+            scalar_params.append(s)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    # Non-bank params that need manual all-reduce (replicated across GPUs)
+    replicated_params = list(optimizer_tok.param_groups[0]["params"])
+    for pg in optimizer_tok.param_groups[1:]:
+        replicated_params.extend(pg["params"])
+    replicated_params.extend(scalar_params)
+
+    optimizer_head = None
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        replicated_params.append(base_model.lm_head.weight)
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if optimizer_head is not None:
+        optimizers.append(optimizer_head)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    mtp_params = sum(p.numel() for p in base_model.mtp_heads.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"mtp_num_heads:{args.mtp_num_heads} mtp_loss_weight:{args.mtp_loss_weight} mtp_params:{mtp_params}")
+    xsa_layers = [i for i, b in enumerate(base_model.blocks) if b.attn.use_xsa]
+    log0(f"XSA:last_{args.xsa_last_n} active_layers:{xsa_layers}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            # All-reduce all grads for warmup (simple, not optimized)
+            if distributed:
+                for p in base_model.parameters():
+                    if p.grad is not None:
+                        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    from collections import deque
+    lawa_queue: deque[dict[str, Tensor]] = deque(maxlen=args.lawa_k)
+    ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    ema_decay = 0.997
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        if args.late_qat_threshold > 0 and scale < args.late_qat_threshold and not CastedLinear._qat_enabled:
+            CastedLinear._qat_enabled = True
+            log0(f"late_qat:enabled step:{step} scale:{scale:.4f}")
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        # === 3-phase overlapped optimizer step ===
+        # Phase 1: Launch async reduce-scatter for banks (biggest first)
+        optimizer_muon.launch_reduce_scatters()
+        # Phase 2: All-reduce non-bank grads + step Adam (while bank RS is in-flight)
+        if distributed:
+            for p in replicated_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+        optimizer_tok.step()
+        optimizer_scalar.step()
+        if optimizer_head is not None:
+            optimizer_head.step()
+        # Phase 3: Wait for RS, local NS5, all-gather (banks processed last)
+        optimizer_muon.step()
+        zero_grad_all()
+        # EMA update
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(t.detach().float(), alpha=1.0 - ema_decay)
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        if args.swa_enabled and scale < 0.2 and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+        if args.lawa_enabled and step % args.lawa_freq == 0:
+            lawa_queue.append({name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()})
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+    # Apply weight averaging
+    if args.lawa_enabled and len(lawa_queue) > 1:
+        log0(f"lawa:applying LAWA averaging k={len(lawa_queue)}")
+        current_state = base_model.state_dict()
+        avg_state = {name: torch.zeros(t.shape, dtype=torch.float32, device='cpu') for name, t in current_state.items()}
+        for snap in lawa_queue:
+            for name in avg_state:
+                avg_state[name] += snap[name].float()
+        for name in avg_state:
+            avg_state[name] /= len(lawa_queue)
+            avg_state[name] = avg_state[name].to(dtype=current_state[name].dtype)
+        base_model.load_state_dict(avg_state, strict=True)
+    else:
+        log0("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+        base_model.load_state_dict(avg_state, strict=True)
+    torch.cuda.synchronize()
+    t_diag = time.perf_counter()
+    diag_val_loss, diag_val_bpb = eval_val(
+        args, compiled_model, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"DIAGNOSTIC post_ema val_loss:{diag_val_loss:.4f} val_bpb:{diag_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_diag):.0f}ms"
+    )
+    full_state_dict = base_model.state_dict()
+    export_sd = {k: v for k, v in full_state_dict.items() if "mtp_heads" not in k}
+    excluded_mtp = sum(int(t.numel()) for k, t in full_state_dict.items() if "mtp_heads" in k)
+    if excluded_mtp > 0:
+        log0(f"export_excluding_mtp_params:{excluded_mtp}")
+    if master_process:
+        torch.save(export_sd, "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+    # Unbank 3D tensors into individual 2D tensors for quantization
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    unbanked_sd = _unbank_state_dict(sd_cpu, args.num_layers)
+    quant_result, quant_meta = mixed_quantize_int6(unbanked_sd, {"mlp", "attn"})
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = lzma.compress(quant_raw, preset=7)
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = len(quant_blob)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+lzma: {quant_file_bytes} bytes")
+        log0(f"Total submission size int6+lzma: {quant_file_bytes + code_bytes} bytes")
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(lzma.decompress(quant_blob_disk)),
+        map_location="cpu",
+    )
+    deq_unbanked = dequantize_mixed_int6(quant_state["w"], quant_state["m"], unbanked_sd)
+    # Re-bank the dequantized tensors
+    deq_state = _rebank_state_dict(deq_unbanked, args.num_layers, sd_cpu)
+    eval_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=0, mtp_loss_weight=0.0,
+        bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims, ln_scale=args.ln_scale, dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention, value_residual=args.value_residual,
+    ).to(device).bfloat16()
+    eval_model.qo_bank.data = eval_model.qo_bank.data.float()
+    eval_model.kv_bank.data = eval_model.kv_bank.data.float()
+    eval_model.mlp_up_bank.data = eval_model.mlp_up_bank.data.float()
+    eval_model.mlp_down_bank.data = eval_model.mlp_down_bank.data.float()
+    for m in eval_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(eval_model)
+    eval_model.load_state_dict(deq_state, strict=True)
+    compiled_eval = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args, compiled_eval, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        eval_seq_len=effective_eval_seq_len,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+    sw_seq_len = effective_eval_seq_len
+    if args.eval_stride > 0 and args.eval_stride < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+        log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+    if args.eval_stride != 64 and 64 < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide64 = time.perf_counter()
+        sw64_val_loss, sw64_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=64,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window_s64 val_loss:{sw64_val_loss:.4f} val_bpb:{sw64_val_bpb:.4f} "
+            f"stride:64 eval_time:{1000.0 * (time.perf_counter() - t_slide64):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_s64_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+        log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+    # Legal score-first TTT (PR #461 recipe)
+    if args.ttt_enabled:
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_loss, ttt_bpb = eval_val_sliding_ttt(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, log0=log0,
+        )
+        torch.cuda.synchronize()
+        log0(f"legal_ttt val_loss:{ttt_loss:.4f} val_bpb:{ttt_bpb:.4f} "
+             f"eval_time:{1000.0 * (time.perf_counter() - t_ttt):.0f}ms")
+        log0(f"legal_ttt_exact val_loss:{ttt_loss:.8f} val_bpb:{ttt_bpb:.8f}")
+    if distributed:
+        dist.destroy_process_group()
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-03-28_MuonTTT_EntropyAdaptive_11L_8xH100/train_seed1337.log
+++ b/records/track_10min_16mb/2026-03-28_MuonTTT_EntropyAdaptive_11L_8xH100/train_seed1337.log
@@ -1,0 +1,275 @@
+W0327 23:47:52.820000 59557 torch/distributed/run.py:803] 
+W0327 23:47:52.820000 59557 torch/distributed/run.py:803] *****************************************
+W0327 23:47:52.820000 59557 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0327 23:47:52.820000 59557 torch/distributed/run.py:803] *****************************************
+logs/run1b_muon_ttt_ns3_seed1337.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26928220
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_4 active_layers:[7, 8, 9, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:9000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/9000 val_loss:6.9304 val_bpb:4.1046 train_time:0ms step_avg:0.01ms
+step:1/9000 train_loss:6.9322 train_time:132ms step_avg:131.72ms
+step:2/9000 train_loss:8.6545 train_time:159ms step_avg:79.37ms
+step:3/9000 train_loss:7.6926 train_time:239ms step_avg:79.61ms
+step:4/9000 train_loss:7.2518 train_time:320ms step_avg:79.90ms
+step:5/9000 train_loss:7.1705 train_time:401ms step_avg:80.10ms
+step:6/9000 train_loss:7.1160 train_time:481ms step_avg:80.20ms
+step:7/9000 train_loss:7.0271 train_time:565ms step_avg:80.77ms
+step:8/9000 train_loss:6.9597 train_time:648ms step_avg:81.02ms
+step:9/9000 train_loss:6.5744 train_time:730ms step_avg:81.12ms
+step:10/9000 train_loss:6.2001 train_time:814ms step_avg:81.36ms
+step:500/9000 train_loss:2.3935 train_time:41426ms step_avg:82.85ms
+step:1000/9000 train_loss:2.2635 train_time:83144ms step_avg:83.14ms
+step:1500/9000 train_loss:2.2073 train_time:125004ms step_avg:83.34ms
+step:2000/9000 train_loss:2.0563 train_time:166782ms step_avg:83.39ms
+step:2500/9000 train_loss:2.1574 train_time:208519ms step_avg:83.41ms
+step:3000/9000 train_loss:2.1500 train_time:250231ms step_avg:83.41ms
+step:3500/9000 train_loss:2.1676 train_time:291931ms step_avg:83.41ms
+step:4000/9000 train_loss:1.9646 train_time:333604ms step_avg:83.40ms
+step:4000/9000 val_loss:2.0567 val_bpb:1.2181 train_time:333654ms step_avg:83.41ms
+step:4500/9000 train_loss:2.1166 train_time:375269ms step_avg:83.39ms
+step:5000/9000 train_loss:2.0992 train_time:416920ms step_avg:83.38ms
+step:5500/9000 train_loss:2.0144 train_time:458562ms step_avg:83.37ms
+step:6000/9000 train_loss:1.9350 train_time:500192ms step_avg:83.37ms
+swa:start step:6500
+step:6500/9000 train_loss:2.0830 train_time:541808ms step_avg:83.36ms
+late_qat:enabled step:6670 scale:0.1498
+step:7000/9000 train_loss:1.7905 train_time:584063ms step_avg:83.44ms
+step:7189/9000 val_loss:1.9209 val_bpb:1.1376 train_time:600068ms step_avg:83.47ms
+stopping_early: wallclock_cap train_time:600068ms step:7189/9000
+peak memory allocated: 21471 MiB reserved: 22002 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9191 val_bpb:1.1366 eval_time:1973ms
+Serialized model: 106027446 bytes
+Code size: 93038 bytes
+Serialized model int6+lzma: 15851372 bytes
+Total submission size int6+lzma: 15944410 bytes
+final_int6_roundtrip val_loss:1.9331 val_bpb:1.1449 eval_time:6284ms
+final_int6_roundtrip_exact val_loss:1.93305924 val_bpb:1.14486657
+final_int6_sliding_window val_loss:1.8934 val_bpb:1.1214 stride:64 eval_time:74154ms
+final_int6_sliding_window_exact val_loss:1.89337811 val_bpb:1.12136814
+final_int8_zlib_roundtrip_exact val_loss:1.89337811 val_bpb:1.12136814
+ttt_sliding:start chunks=1893 chunk_tokens=32768 total_windows=969088 stride=64 ttt_lr=0.002 ttt_epochs=3 freeze_blocks=0
+ttt_sliding:params unfrozen=26928220 frozen=0
+  ttt_chunk [1/1893] bpb=1.159361 time=0.5s
+  ttt_chunk [11/1893] bpb=1.146201 time=2.9s
+  ttt_chunk [21/1893] bpb=1.131428 time=5.4s
+  ttt_chunk [31/1893] bpb=1.128968 time=8.0s
+  ttt_chunk [41/1893] bpb=1.114804 time=10.5s
+  ttt_chunk [51/1893] bpb=1.109042 time=13.0s
+  ttt_chunk [61/1893] bpb=1.115817 time=15.6s
+  ttt_chunk [71/1893] bpb=1.114274 time=18.1s
+  ttt_chunk [81/1893] bpb=1.113383 time=20.5s
+  ttt_chunk [91/1893] bpb=1.114187 time=23.0s
+  ttt_chunk [101/1893] bpb=1.117811 time=25.5s
+  ttt_chunk [111/1893] bpb=1.120252 time=28.0s
+  ttt_chunk [121/1893] bpb=1.113678 time=30.4s
+  ttt_chunk [131/1893] bpb=1.113996 time=32.9s
+  ttt_chunk [141/1893] bpb=1.119631 time=35.4s
+  ttt_chunk [151/1893] bpb=1.121440 time=37.9s
+  ttt_chunk [161/1893] bpb=1.120931 time=40.5s
+  ttt_chunk [171/1893] bpb=1.125218 time=43.0s
+  ttt_chunk [181/1893] bpb=1.127498 time=45.5s
+  ttt_chunk [191/1893] bpb=1.134713 time=48.0s
+  ttt_chunk [201/1893] bpb=1.133455 time=50.6s
+  ttt_chunk [211/1893] bpb=1.131281 time=53.1s
+  ttt_chunk [221/1893] bpb=1.132771 time=55.6s
+  ttt_chunk [231/1893] bpb=1.131464 time=58.1s
+  ttt_chunk [241/1893] bpb=1.131787 time=60.7s
+  ttt_chunk [251/1893] bpb=1.131297 time=63.2s
+  ttt_chunk [261/1893] bpb=1.128443 time=65.6s
+  ttt_chunk [271/1893] bpb=1.127250 time=68.1s
+  ttt_chunk [281/1893] bpb=1.128627 time=70.7s
+  ttt_chunk [291/1893] bpb=1.130481 time=73.2s
+  ttt_chunk [301/1893] bpb=1.131184 time=75.7s
+  ttt_chunk [311/1893] bpb=1.133302 time=78.2s
+  ttt_chunk [321/1893] bpb=1.135227 time=80.8s
+  ttt_chunk [331/1893] bpb=1.135063 time=83.3s
+  ttt_chunk [341/1893] bpb=1.134023 time=85.8s
+  ttt_chunk [351/1893] bpb=1.136300 time=88.4s
+  ttt_chunk [361/1893] bpb=1.136477 time=90.8s
+  ttt_chunk [371/1893] bpb=1.135770 time=93.3s
+  ttt_chunk [381/1893] bpb=1.136014 time=95.9s
+  ttt_chunk [391/1893] bpb=1.135899 time=98.5s
+  ttt_chunk [401/1893] bpb=1.133868 time=101.0s
+  ttt_chunk [411/1893] bpb=1.132670 time=103.5s
+  ttt_chunk [421/1893] bpb=1.131713 time=106.0s
+  ttt_chunk [431/1893] bpb=1.131589 time=108.6s
+  ttt_chunk [441/1893] bpb=1.131957 time=111.2s
+  ttt_chunk [451/1893] bpb=1.132313 time=113.7s
+  ttt_chunk [461/1893] bpb=1.131246 time=116.3s
+  ttt_chunk [471/1893] bpb=1.131909 time=118.9s
+  ttt_chunk [481/1893] bpb=1.131550 time=121.4s
+  ttt_chunk [491/1893] bpb=1.130408 time=123.9s
+  ttt_chunk [501/1893] bpb=1.129927 time=126.4s
+  ttt_chunk [511/1893] bpb=1.129274 time=129.0s
+  ttt_chunk [521/1893] bpb=1.126928 time=131.5s
+  ttt_chunk [531/1893] bpb=1.128112 time=134.2s
+  ttt_chunk [541/1893] bpb=1.128485 time=136.7s
+  ttt_chunk [551/1893] bpb=1.127460 time=139.2s
+  ttt_chunk [561/1893] bpb=1.127993 time=141.8s
+  ttt_chunk [571/1893] bpb=1.126972 time=144.3s
+  ttt_chunk [581/1893] bpb=1.126175 time=146.7s
+  ttt_chunk [591/1893] bpb=1.125528 time=149.2s
+  ttt_chunk [601/1893] bpb=1.126022 time=151.7s
+  ttt_chunk [611/1893] bpb=1.125971 time=154.2s
+  ttt_chunk [621/1893] bpb=1.125789 time=156.8s
+  ttt_chunk [631/1893] bpb=1.126474 time=159.3s
+  ttt_chunk [641/1893] bpb=1.126179 time=161.7s
+  ttt_chunk [651/1893] bpb=1.126297 time=164.2s
+  ttt_chunk [661/1893] bpb=1.125733 time=166.6s
+  ttt_chunk [671/1893] bpb=1.126078 time=169.1s
+  ttt_chunk [681/1893] bpb=1.126827 time=171.6s
+  ttt_chunk [691/1893] bpb=1.127830 time=174.2s
+  ttt_chunk [701/1893] bpb=1.127278 time=176.7s
+  ttt_chunk [711/1893] bpb=1.127234 time=179.3s
+  ttt_chunk [721/1893] bpb=1.126901 time=181.7s
+  ttt_chunk [731/1893] bpb=1.126944 time=184.3s
+  ttt_chunk [741/1893] bpb=1.127065 time=186.9s
+  ttt_chunk [751/1893] bpb=1.126893 time=189.4s
+  ttt_chunk [761/1893] bpb=1.126812 time=192.0s
+  ttt_chunk [771/1893] bpb=1.126504 time=194.6s
+  ttt_chunk [781/1893] bpb=1.127252 time=197.1s
+  ttt_chunk [791/1893] bpb=1.126853 time=199.7s
+  ttt_chunk [801/1893] bpb=1.127143 time=202.2s
+  ttt_chunk [811/1893] bpb=1.126883 time=204.8s
+  ttt_chunk [821/1893] bpb=1.126688 time=207.4s
+  ttt_chunk [831/1893] bpb=1.126484 time=209.9s
+  ttt_chunk [841/1893] bpb=1.125830 time=212.4s
+  ttt_chunk [851/1893] bpb=1.125559 time=214.9s
+  ttt_chunk [861/1893] bpb=1.125279 time=217.4s
+  ttt_chunk [871/1893] bpb=1.125553 time=220.0s
+  ttt_chunk [881/1893] bpb=1.125716 time=222.3s
+  ttt_chunk [891/1893] bpb=1.125269 time=224.7s
+  ttt_chunk [901/1893] bpb=1.124994 time=227.1s
+  ttt_chunk [911/1893] bpb=1.125112 time=229.6s
+  ttt_chunk [921/1893] bpb=1.125599 time=232.2s
+  ttt_chunk [931/1893] bpb=1.125550 time=234.7s
+  ttt_chunk [941/1893] bpb=1.125243 time=237.2s
+  ttt_chunk [951/1893] bpb=1.125621 time=239.7s
+  ttt_chunk [961/1893] bpb=1.125706 time=242.3s
+  ttt_chunk [971/1893] bpb=1.126561 time=244.9s
+  ttt_chunk [981/1893] bpb=1.126623 time=247.4s
+  ttt_chunk [991/1893] bpb=1.126653 time=250.0s
+  ttt_chunk [1001/1893] bpb=1.126605 time=252.6s
+  ttt_chunk [1011/1893] bpb=1.126404 time=255.2s
+  ttt_chunk [1021/1893] bpb=1.126738 time=257.7s
+  ttt_chunk [1031/1893] bpb=1.127177 time=260.3s
+  ttt_chunk [1041/1893] bpb=1.126844 time=262.9s
+  ttt_chunk [1051/1893] bpb=1.126600 time=265.4s
+  ttt_chunk [1061/1893] bpb=1.126634 time=268.0s
+  ttt_chunk [1071/1893] bpb=1.127241 time=270.5s
+  ttt_chunk [1081/1893] bpb=1.127504 time=273.0s
+  ttt_chunk [1091/1893] bpb=1.128216 time=275.6s
+  ttt_chunk [1101/1893] bpb=1.128229 time=278.2s
+  ttt_chunk [1111/1893] bpb=1.128077 time=280.7s
+  ttt_chunk [1121/1893] bpb=1.127884 time=283.2s
+  ttt_chunk [1131/1893] bpb=1.127768 time=285.6s
+  ttt_chunk [1141/1893] bpb=1.127473 time=288.1s
+  ttt_chunk [1151/1893] bpb=1.127471 time=290.6s
+  ttt_chunk [1161/1893] bpb=1.127077 time=293.2s
+  ttt_chunk [1171/1893] bpb=1.127404 time=295.7s
+  ttt_chunk [1181/1893] bpb=1.126651 time=298.2s
+  ttt_chunk [1191/1893] bpb=1.126516 time=300.7s
+  ttt_chunk [1201/1893] bpb=1.126927 time=303.3s
+  ttt_chunk [1211/1893] bpb=1.126439 time=305.7s
+  ttt_chunk [1221/1893] bpb=1.126135 time=308.3s
+  ttt_chunk [1231/1893] bpb=1.125853 time=310.8s
+  ttt_chunk [1241/1893] bpb=1.125502 time=313.3s
+  ttt_chunk [1251/1893] bpb=1.124889 time=315.6s
+  ttt_chunk [1261/1893] bpb=1.124865 time=318.1s
+  ttt_chunk [1271/1893] bpb=1.124492 time=320.6s
+  ttt_chunk [1281/1893] bpb=1.124279 time=323.1s
+  ttt_chunk [1291/1893] bpb=1.124047 time=325.6s
+  ttt_chunk [1301/1893] bpb=1.123447 time=328.2s
+  ttt_chunk [1311/1893] bpb=1.123041 time=330.6s
+  ttt_chunk [1321/1893] bpb=1.122713 time=333.1s
+  ttt_chunk [1331/1893] bpb=1.122643 time=335.7s
+  ttt_chunk [1341/1893] bpb=1.122511 time=338.2s
+  ttt_chunk [1351/1893] bpb=1.122444 time=340.7s
+  ttt_chunk [1361/1893] bpb=1.122503 time=343.3s
+  ttt_chunk [1371/1893] bpb=1.122372 time=345.8s
+  ttt_chunk [1381/1893] bpb=1.122364 time=348.3s
+  ttt_chunk [1391/1893] bpb=1.121966 time=350.7s
+  ttt_chunk [1401/1893] bpb=1.121917 time=353.2s
+  ttt_chunk [1411/1893] bpb=1.122037 time=355.8s
+  ttt_chunk [1421/1893] bpb=1.122287 time=358.2s
+  ttt_chunk [1431/1893] bpb=1.121974 time=360.7s
+  ttt_chunk [1441/1893] bpb=1.122479 time=363.4s
+  ttt_chunk [1451/1893] bpb=1.122817 time=365.8s
+  ttt_chunk [1461/1893] bpb=1.122370 time=368.3s
+  ttt_chunk [1471/1893] bpb=1.123396 time=370.9s
+  ttt_chunk [1481/1893] bpb=1.122929 time=373.4s
+  ttt_chunk [1491/1893] bpb=1.122764 time=375.9s
+  ttt_chunk [1501/1893] bpb=1.122665 time=378.4s
+  ttt_chunk [1511/1893] bpb=1.122663 time=380.9s
+  ttt_chunk [1521/1893] bpb=1.122690 time=383.4s
+  ttt_chunk [1531/1893] bpb=1.122164 time=386.0s
+  ttt_chunk [1541/1893] bpb=1.122022 time=388.5s
+  ttt_chunk [1551/1893] bpb=1.122325 time=391.0s
+  ttt_chunk [1561/1893] bpb=1.122322 time=393.6s
+  ttt_chunk [1571/1893] bpb=1.122156 time=396.1s
+  ttt_chunk [1581/1893] bpb=1.122251 time=398.6s
+  ttt_chunk [1591/1893] bpb=1.122103 time=401.2s
+  ttt_chunk [1601/1893] bpb=1.122263 time=403.7s
+  ttt_chunk [1611/1893] bpb=1.122190 time=406.3s
+  ttt_chunk [1621/1893] bpb=1.121789 time=408.6s
+  ttt_chunk [1631/1893] bpb=1.122095 time=411.2s
+  ttt_chunk [1641/1893] bpb=1.122104 time=413.7s
+  ttt_chunk [1651/1893] bpb=1.122062 time=416.2s
+  ttt_chunk [1661/1893] bpb=1.121936 time=418.8s
+  ttt_chunk [1671/1893] bpb=1.122392 time=421.3s
+  ttt_chunk [1681/1893] bpb=1.122541 time=423.9s
+  ttt_chunk [1691/1893] bpb=1.122379 time=426.4s
+  ttt_chunk [1701/1893] bpb=1.122539 time=429.0s
+  ttt_chunk [1711/1893] bpb=1.122538 time=431.6s
+  ttt_chunk [1721/1893] bpb=1.122549 time=434.0s
+  ttt_chunk [1731/1893] bpb=1.122438 time=436.6s
+  ttt_chunk [1741/1893] bpb=1.122231 time=439.1s
+  ttt_chunk [1751/1893] bpb=1.122050 time=441.7s
+  ttt_chunk [1761/1893] bpb=1.122201 time=444.2s
+  ttt_chunk [1771/1893] bpb=1.122112 time=446.7s
+  ttt_chunk [1781/1893] bpb=1.122127 time=449.3s
+  ttt_chunk [1791/1893] bpb=1.121717 time=451.7s
+  ttt_chunk [1801/1893] bpb=1.121588 time=454.2s
+  ttt_chunk [1811/1893] bpb=1.121473 time=456.8s
+  ttt_chunk [1821/1893] bpb=1.121540 time=459.4s
+  ttt_chunk [1831/1893] bpb=1.120933 time=461.9s
+  ttt_chunk [1841/1893] bpb=1.120892 time=464.4s
+  ttt_chunk [1851/1893] bpb=1.120680 time=466.9s
+  ttt_chunk [1861/1893] bpb=1.120309 time=469.4s
+  ttt_chunk [1871/1893] bpb=1.120302 time=472.0s
+  ttt_chunk [1881/1893] bpb=1.119857 time=474.4s
+  ttt_chunk [1891/1893] bpb=1.119623 time=477.0s
+  ttt_chunk [1893/1893] bpb=1.119667 time=477.3s
+ttt_sliding:done val_loss=1.887101 val_bpb=1.117650 elapsed=477.3s
+legal_ttt val_loss:1.8871 val_bpb:1.1177 eval_time:477854ms
+legal_ttt_exact val_loss:1.88710072 val_bpb:1.11765030

--- a/records/track_10min_16mb/2026-03-28_MuonTTT_EntropyAdaptive_11L_8xH100/train_seed2025.log
+++ b/records/track_10min_16mb/2026-03-28_MuonTTT_EntropyAdaptive_11L_8xH100/train_seed2025.log
@@ -1,0 +1,275 @@
+W0328 01:35:38.316000 93345 torch/distributed/run.py:803] 
+W0328 01:35:38.316000 93345 torch/distributed/run.py:803] *****************************************
+W0328 01:35:38.316000 93345 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0328 01:35:38.316000 93345 torch/distributed/run.py:803] *****************************************
+logs/51ad2124-736f-4927-8d11-83429489d7ce.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26928220
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_4 active_layers:[7, 8, 9, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:9000 warmup_steps:20 max_wallclock_seconds:599.000
+seed:2025
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/9000 val_loss:6.9302 val_bpb:4.1045 train_time:0ms step_avg:0.02ms
+step:1/9000 train_loss:6.9311 train_time:132ms step_avg:131.62ms
+step:2/9000 train_loss:8.6818 train_time:160ms step_avg:79.78ms
+step:3/9000 train_loss:7.7058 train_time:240ms step_avg:80.14ms
+step:4/9000 train_loss:7.2716 train_time:321ms step_avg:80.29ms
+step:5/9000 train_loss:7.1779 train_time:404ms step_avg:80.78ms
+step:6/9000 train_loss:7.0950 train_time:491ms step_avg:81.91ms
+step:7/9000 train_loss:7.0228 train_time:572ms step_avg:81.69ms
+step:8/9000 train_loss:6.9406 train_time:653ms step_avg:81.64ms
+step:9/9000 train_loss:6.6071 train_time:734ms step_avg:81.52ms
+step:10/9000 train_loss:6.2037 train_time:815ms step_avg:81.49ms
+step:500/9000 train_loss:2.3991 train_time:41443ms step_avg:82.89ms
+step:1000/9000 train_loss:2.2642 train_time:83160ms step_avg:83.16ms
+step:1500/9000 train_loss:2.2121 train_time:124925ms step_avg:83.28ms
+step:2000/9000 train_loss:2.0516 train_time:166699ms step_avg:83.35ms
+step:2500/9000 train_loss:2.1578 train_time:208449ms step_avg:83.38ms
+step:3000/9000 train_loss:2.1498 train_time:250264ms step_avg:83.42ms
+step:3500/9000 train_loss:2.1680 train_time:291976ms step_avg:83.42ms
+step:4000/9000 train_loss:1.9631 train_time:333663ms step_avg:83.42ms
+step:4000/9000 val_loss:2.0570 val_bpb:1.2183 train_time:333712ms step_avg:83.43ms
+step:4500/9000 train_loss:2.1176 train_time:375327ms step_avg:83.41ms
+step:5000/9000 train_loss:2.0992 train_time:416989ms step_avg:83.40ms
+step:5500/9000 train_loss:2.0111 train_time:458636ms step_avg:83.39ms
+step:6000/9000 train_loss:1.9384 train_time:500279ms step_avg:83.38ms
+swa:start step:6500
+step:6500/9000 train_loss:2.0815 train_time:541933ms step_avg:83.37ms
+late_qat:enabled step:6656 scale:0.1498
+step:7000/9000 train_loss:1.7874 train_time:584240ms step_avg:83.46ms
+step:7175/9000 val_loss:1.9210 val_bpb:1.1377 train_time:599068ms step_avg:83.49ms
+stopping_early: wallclock_cap train_time:599068ms step:7175/9000
+peak memory allocated: 21471 MiB reserved: 22002 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9193 val_bpb:1.1367 eval_time:1977ms
+Serialized model: 106027446 bytes
+Code size: 93038 bytes
+Serialized model int6+lzma: 15786004 bytes
+Total submission size int6+lzma: 15879042 bytes
+final_int6_roundtrip val_loss:1.9333 val_bpb:1.1450 eval_time:6327ms
+final_int6_roundtrip_exact val_loss:1.93333252 val_bpb:1.14502842
+final_int6_sliding_window val_loss:1.8939 val_bpb:1.1217 stride:64 eval_time:74606ms
+final_int6_sliding_window_exact val_loss:1.89387417 val_bpb:1.12166193
+final_int8_zlib_roundtrip_exact val_loss:1.89387417 val_bpb:1.12166193
+ttt_sliding:start chunks=1893 chunk_tokens=32768 total_windows=969088 stride=64 ttt_lr=0.002 ttt_epochs=3 freeze_blocks=0
+ttt_sliding:params unfrozen=26928220 frozen=0
+  ttt_chunk [1/1893] bpb=1.157213 time=0.5s
+  ttt_chunk [11/1893] bpb=1.146150 time=3.0s
+  ttt_chunk [21/1893] bpb=1.131983 time=5.5s
+  ttt_chunk [31/1893] bpb=1.129800 time=8.0s
+  ttt_chunk [41/1893] bpb=1.115753 time=10.6s
+  ttt_chunk [51/1893] bpb=1.109750 time=13.0s
+  ttt_chunk [61/1893] bpb=1.115753 time=15.6s
+  ttt_chunk [71/1893] bpb=1.114495 time=18.1s
+  ttt_chunk [81/1893] bpb=1.113640 time=20.6s
+  ttt_chunk [91/1893] bpb=1.114745 time=23.0s
+  ttt_chunk [101/1893] bpb=1.118217 time=25.6s
+  ttt_chunk [111/1893] bpb=1.120613 time=28.1s
+  ttt_chunk [121/1893] bpb=1.113957 time=30.5s
+  ttt_chunk [131/1893] bpb=1.114078 time=33.0s
+  ttt_chunk [141/1893] bpb=1.119665 time=35.6s
+  ttt_chunk [151/1893] bpb=1.121456 time=38.1s
+  ttt_chunk [161/1893] bpb=1.120832 time=40.6s
+  ttt_chunk [171/1893] bpb=1.125423 time=43.2s
+  ttt_chunk [181/1893] bpb=1.127674 time=45.7s
+  ttt_chunk [191/1893] bpb=1.135139 time=48.2s
+  ttt_chunk [201/1893] bpb=1.133873 time=50.8s
+  ttt_chunk [211/1893] bpb=1.131733 time=53.3s
+  ttt_chunk [221/1893] bpb=1.133254 time=55.8s
+  ttt_chunk [231/1893] bpb=1.131978 time=58.3s
+  ttt_chunk [241/1893] bpb=1.132435 time=60.9s
+  ttt_chunk [251/1893] bpb=1.131925 time=63.4s
+  ttt_chunk [261/1893] bpb=1.129055 time=65.8s
+  ttt_chunk [271/1893] bpb=1.127913 time=68.3s
+  ttt_chunk [281/1893] bpb=1.129263 time=70.8s
+  ttt_chunk [291/1893] bpb=1.131080 time=73.3s
+  ttt_chunk [301/1893] bpb=1.131819 time=75.9s
+  ttt_chunk [311/1893] bpb=1.133852 time=78.4s
+  ttt_chunk [321/1893] bpb=1.135848 time=80.9s
+  ttt_chunk [331/1893] bpb=1.135752 time=83.4s
+  ttt_chunk [341/1893] bpb=1.134782 time=86.0s
+  ttt_chunk [351/1893] bpb=1.137073 time=88.5s
+  ttt_chunk [361/1893] bpb=1.137237 time=91.0s
+  ttt_chunk [371/1893] bpb=1.136629 time=93.5s
+  ttt_chunk [381/1893] bpb=1.136776 time=96.1s
+  ttt_chunk [391/1893] bpb=1.136570 time=98.7s
+  ttt_chunk [401/1893] bpb=1.134505 time=101.2s
+  ttt_chunk [411/1893] bpb=1.133340 time=103.7s
+  ttt_chunk [421/1893] bpb=1.132381 time=106.2s
+  ttt_chunk [431/1893] bpb=1.132265 time=108.8s
+  ttt_chunk [441/1893] bpb=1.132715 time=111.4s
+  ttt_chunk [451/1893] bpb=1.133043 time=113.9s
+  ttt_chunk [461/1893] bpb=1.131903 time=116.5s
+  ttt_chunk [471/1893] bpb=1.132493 time=119.1s
+  ttt_chunk [481/1893] bpb=1.132134 time=121.6s
+  ttt_chunk [491/1893] bpb=1.131040 time=124.2s
+  ttt_chunk [501/1893] bpb=1.130580 time=126.8s
+  ttt_chunk [511/1893] bpb=1.129868 time=129.3s
+  ttt_chunk [521/1893] bpb=1.127426 time=131.9s
+  ttt_chunk [531/1893] bpb=1.128584 time=134.6s
+  ttt_chunk [541/1893] bpb=1.128870 time=137.1s
+  ttt_chunk [551/1893] bpb=1.127882 time=139.7s
+  ttt_chunk [561/1893] bpb=1.128434 time=142.3s
+  ttt_chunk [571/1893] bpb=1.127393 time=144.8s
+  ttt_chunk [581/1893] bpb=1.126593 time=147.2s
+  ttt_chunk [591/1893] bpb=1.125926 time=149.7s
+  ttt_chunk [601/1893] bpb=1.126401 time=152.2s
+  ttt_chunk [611/1893] bpb=1.126301 time=154.7s
+  ttt_chunk [621/1893] bpb=1.126164 time=157.3s
+  ttt_chunk [631/1893] bpb=1.126878 time=159.8s
+  ttt_chunk [641/1893] bpb=1.126621 time=162.3s
+  ttt_chunk [651/1893] bpb=1.126749 time=164.8s
+  ttt_chunk [661/1893] bpb=1.126248 time=167.2s
+  ttt_chunk [671/1893] bpb=1.126593 time=169.7s
+  ttt_chunk [681/1893] bpb=1.127317 time=172.2s
+  ttt_chunk [691/1893] bpb=1.128289 time=174.8s
+  ttt_chunk [701/1893] bpb=1.127720 time=177.3s
+  ttt_chunk [711/1893] bpb=1.127718 time=179.8s
+  ttt_chunk [721/1893] bpb=1.127401 time=182.3s
+  ttt_chunk [731/1893] bpb=1.127458 time=184.8s
+  ttt_chunk [741/1893] bpb=1.127582 time=187.3s
+  ttt_chunk [751/1893] bpb=1.127447 time=189.8s
+  ttt_chunk [761/1893] bpb=1.127362 time=192.4s
+  ttt_chunk [771/1893] bpb=1.127045 time=195.0s
+  ttt_chunk [781/1893] bpb=1.127768 time=197.5s
+  ttt_chunk [791/1893] bpb=1.127357 time=200.0s
+  ttt_chunk [801/1893] bpb=1.127659 time=202.6s
+  ttt_chunk [811/1893] bpb=1.127398 time=205.1s
+  ttt_chunk [821/1893] bpb=1.127153 time=207.7s
+  ttt_chunk [831/1893] bpb=1.126984 time=210.2s
+  ttt_chunk [841/1893] bpb=1.126338 time=212.7s
+  ttt_chunk [851/1893] bpb=1.126043 time=215.2s
+  ttt_chunk [861/1893] bpb=1.125803 time=217.7s
+  ttt_chunk [871/1893] bpb=1.126077 time=220.3s
+  ttt_chunk [881/1893] bpb=1.126249 time=222.6s
+  ttt_chunk [891/1893] bpb=1.125808 time=225.0s
+  ttt_chunk [901/1893] bpb=1.125530 time=227.5s
+  ttt_chunk [911/1893] bpb=1.125640 time=230.0s
+  ttt_chunk [921/1893] bpb=1.126086 time=232.5s
+  ttt_chunk [931/1893] bpb=1.126042 time=235.1s
+  ttt_chunk [941/1893] bpb=1.125707 time=237.6s
+  ttt_chunk [951/1893] bpb=1.126083 time=240.1s
+  ttt_chunk [961/1893] bpb=1.126157 time=242.7s
+  ttt_chunk [971/1893] bpb=1.127000 time=245.3s
+  ttt_chunk [981/1893] bpb=1.127070 time=247.8s
+  ttt_chunk [991/1893] bpb=1.127091 time=250.4s
+  ttt_chunk [1001/1893] bpb=1.127044 time=252.9s
+  ttt_chunk [1011/1893] bpb=1.126815 time=255.5s
+  ttt_chunk [1021/1893] bpb=1.127150 time=258.1s
+  ttt_chunk [1031/1893] bpb=1.127600 time=260.7s
+  ttt_chunk [1041/1893] bpb=1.127254 time=263.3s
+  ttt_chunk [1051/1893] bpb=1.127004 time=265.8s
+  ttt_chunk [1061/1893] bpb=1.127072 time=268.4s
+  ttt_chunk [1071/1893] bpb=1.127706 time=270.9s
+  ttt_chunk [1081/1893] bpb=1.127954 time=273.5s
+  ttt_chunk [1091/1893] bpb=1.128696 time=276.1s
+  ttt_chunk [1101/1893] bpb=1.128701 time=278.6s
+  ttt_chunk [1111/1893] bpb=1.128574 time=281.1s
+  ttt_chunk [1121/1893] bpb=1.128361 time=283.7s
+  ttt_chunk [1131/1893] bpb=1.128230 time=286.1s
+  ttt_chunk [1141/1893] bpb=1.127928 time=288.6s
+  ttt_chunk [1151/1893] bpb=1.127948 time=291.2s
+  ttt_chunk [1161/1893] bpb=1.127576 time=293.7s
+  ttt_chunk [1171/1893] bpb=1.127908 time=296.2s
+  ttt_chunk [1181/1893] bpb=1.127175 time=298.7s
+  ttt_chunk [1191/1893] bpb=1.127049 time=301.3s
+  ttt_chunk [1201/1893] bpb=1.127446 time=303.9s
+  ttt_chunk [1211/1893] bpb=1.126968 time=306.3s
+  ttt_chunk [1221/1893] bpb=1.126658 time=308.8s
+  ttt_chunk [1231/1893] bpb=1.126389 time=311.4s
+  ttt_chunk [1241/1893] bpb=1.126011 time=313.9s
+  ttt_chunk [1251/1893] bpb=1.125410 time=316.3s
+  ttt_chunk [1261/1893] bpb=1.125383 time=318.8s
+  ttt_chunk [1271/1893] bpb=1.124974 time=321.3s
+  ttt_chunk [1281/1893] bpb=1.124793 time=323.9s
+  ttt_chunk [1291/1893] bpb=1.124558 time=326.4s
+  ttt_chunk [1301/1893] bpb=1.123981 time=329.0s
+  ttt_chunk [1311/1893] bpb=1.123591 time=331.5s
+  ttt_chunk [1321/1893] bpb=1.123236 time=334.0s
+  ttt_chunk [1331/1893] bpb=1.123155 time=336.5s
+  ttt_chunk [1341/1893] bpb=1.123018 time=339.1s
+  ttt_chunk [1351/1893] bpb=1.122951 time=341.6s
+  ttt_chunk [1361/1893] bpb=1.122989 time=344.1s
+  ttt_chunk [1371/1893] bpb=1.122853 time=346.7s
+  ttt_chunk [1381/1893] bpb=1.122825 time=349.2s
+  ttt_chunk [1391/1893] bpb=1.122414 time=351.7s
+  ttt_chunk [1401/1893] bpb=1.122356 time=354.2s
+  ttt_chunk [1411/1893] bpb=1.122453 time=356.7s
+  ttt_chunk [1421/1893] bpb=1.122688 time=359.2s
+  ttt_chunk [1431/1893] bpb=1.122386 time=361.7s
+  ttt_chunk [1441/1893] bpb=1.122874 time=364.4s
+  ttt_chunk [1451/1893] bpb=1.123198 time=366.9s
+  ttt_chunk [1461/1893] bpb=1.122727 time=369.4s
+  ttt_chunk [1471/1893] bpb=1.123774 time=372.0s
+  ttt_chunk [1481/1893] bpb=1.123313 time=374.6s
+  ttt_chunk [1491/1893] bpb=1.123123 time=377.1s
+  ttt_chunk [1501/1893] bpb=1.123038 time=379.6s
+  ttt_chunk [1511/1893] bpb=1.123030 time=382.1s
+  ttt_chunk [1521/1893] bpb=1.123039 time=384.7s
+  ttt_chunk [1531/1893] bpb=1.122531 time=387.2s
+  ttt_chunk [1541/1893] bpb=1.122379 time=389.7s
+  ttt_chunk [1551/1893] bpb=1.122681 time=392.3s
+  ttt_chunk [1561/1893] bpb=1.122675 time=394.8s
+  ttt_chunk [1571/1893] bpb=1.122502 time=397.4s
+  ttt_chunk [1581/1893] bpb=1.122613 time=399.9s
+  ttt_chunk [1591/1893] bpb=1.122467 time=402.5s
+  ttt_chunk [1601/1893] bpb=1.122628 time=405.0s
+  ttt_chunk [1611/1893] bpb=1.122552 time=407.6s
+  ttt_chunk [1621/1893] bpb=1.122132 time=410.0s
+  ttt_chunk [1631/1893] bpb=1.122421 time=412.5s
+  ttt_chunk [1641/1893] bpb=1.122421 time=415.0s
+  ttt_chunk [1651/1893] bpb=1.122362 time=417.6s
+  ttt_chunk [1661/1893] bpb=1.122235 time=420.1s
+  ttt_chunk [1671/1893] bpb=1.122698 time=422.7s
+  ttt_chunk [1681/1893] bpb=1.122854 time=425.2s
+  ttt_chunk [1691/1893] bpb=1.122683 time=427.8s
+  ttt_chunk [1701/1893] bpb=1.122819 time=430.4s
+  ttt_chunk [1711/1893] bpb=1.122802 time=432.9s
+  ttt_chunk [1721/1893] bpb=1.122804 time=435.3s
+  ttt_chunk [1731/1893] bpb=1.122671 time=437.9s
+  ttt_chunk [1741/1893] bpb=1.122453 time=440.5s
+  ttt_chunk [1751/1893] bpb=1.122274 time=443.0s
+  ttt_chunk [1761/1893] bpb=1.122422 time=445.6s
+  ttt_chunk [1771/1893] bpb=1.122321 time=448.1s
+  ttt_chunk [1781/1893] bpb=1.122341 time=450.7s
+  ttt_chunk [1791/1893] bpb=1.121937 time=453.1s
+  ttt_chunk [1801/1893] bpb=1.121812 time=455.7s
+  ttt_chunk [1811/1893] bpb=1.121711 time=458.2s
+  ttt_chunk [1821/1893] bpb=1.121754 time=460.8s
+  ttt_chunk [1831/1893] bpb=1.121146 time=463.4s
+  ttt_chunk [1841/1893] bpb=1.121066 time=465.9s
+  ttt_chunk [1851/1893] bpb=1.120842 time=468.3s
+  ttt_chunk [1861/1893] bpb=1.120475 time=470.9s
+  ttt_chunk [1871/1893] bpb=1.120468 time=473.4s
+  ttt_chunk [1881/1893] bpb=1.120013 time=475.8s
+  ttt_chunk [1891/1893] bpb=1.119775 time=478.4s
+  ttt_chunk [1893/1893] bpb=1.119819 time=478.7s
+ttt_sliding:done val_loss=1.887521 val_bpb=1.117899 elapsed=478.7s
+legal_ttt val_loss:1.8875 val_bpb:1.1179 eval_time:479224ms
+legal_ttt_exact val_loss:1.88752121 val_bpb:1.11789934

--- a/records/track_10min_16mb/2026-03-28_MuonTTT_EntropyAdaptive_11L_8xH100/train_seed42.log
+++ b/records/track_10min_16mb/2026-03-28_MuonTTT_EntropyAdaptive_11L_8xH100/train_seed42.log
@@ -1,0 +1,275 @@
+W0328 01:58:00.242000 94313 torch/distributed/run.py:803] 
+W0328 01:58:00.242000 94313 torch/distributed/run.py:803] *****************************************
+W0328 01:58:00.242000 94313 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0328 01:58:00.242000 94313 torch/distributed/run.py:803] *****************************************
+logs/58a783cd-c3a9-42ba-8a34-26ee87798f69.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26928220
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_4 active_layers:[7, 8, 9, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:9000 warmup_steps:20 max_wallclock_seconds:599.000
+seed:42
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/9000 val_loss:6.9293 val_bpb:4.1039 train_time:0ms step_avg:0.01ms
+step:1/9000 train_loss:6.9308 train_time:131ms step_avg:130.99ms
+step:2/9000 train_loss:8.6422 train_time:160ms step_avg:79.92ms
+step:3/9000 train_loss:7.6901 train_time:240ms step_avg:80.04ms
+step:4/9000 train_loss:7.2782 train_time:322ms step_avg:80.54ms
+step:5/9000 train_loss:7.2222 train_time:403ms step_avg:80.58ms
+step:6/9000 train_loss:7.1409 train_time:485ms step_avg:80.86ms
+step:7/9000 train_loss:7.0923 train_time:568ms step_avg:81.07ms
+step:8/9000 train_loss:7.0291 train_time:650ms step_avg:81.28ms
+step:9/9000 train_loss:6.6343 train_time:731ms step_avg:81.26ms
+step:10/9000 train_loss:6.2569 train_time:815ms step_avg:81.48ms
+step:500/9000 train_loss:2.3952 train_time:41422ms step_avg:82.84ms
+step:1000/9000 train_loss:2.2574 train_time:83206ms step_avg:83.21ms
+step:1500/9000 train_loss:2.2105 train_time:124956ms step_avg:83.30ms
+step:2000/9000 train_loss:2.0560 train_time:166685ms step_avg:83.34ms
+step:2500/9000 train_loss:2.1603 train_time:208428ms step_avg:83.37ms
+step:3000/9000 train_loss:2.1494 train_time:250139ms step_avg:83.38ms
+step:3500/9000 train_loss:2.1733 train_time:291834ms step_avg:83.38ms
+step:4000/9000 train_loss:1.9682 train_time:333534ms step_avg:83.38ms
+step:4000/9000 val_loss:2.0572 val_bpb:1.2184 train_time:333585ms step_avg:83.40ms
+step:4500/9000 train_loss:2.1198 train_time:375205ms step_avg:83.38ms
+step:5000/9000 train_loss:2.1010 train_time:416849ms step_avg:83.37ms
+step:5500/9000 train_loss:2.0140 train_time:458486ms step_avg:83.36ms
+step:6000/9000 train_loss:1.9381 train_time:500134ms step_avg:83.36ms
+swa:start step:6500
+step:6500/9000 train_loss:2.0817 train_time:541764ms step_avg:83.35ms
+late_qat:enabled step:6658 scale:0.1500
+step:7000/9000 train_loss:1.7891 train_time:584037ms step_avg:83.43ms
+step:7177/9000 val_loss:1.9217 val_bpb:1.1381 train_time:599058ms step_avg:83.47ms
+stopping_early: wallclock_cap train_time:599058ms step:7177/9000
+peak memory allocated: 21471 MiB reserved: 22002 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9199 val_bpb:1.1371 eval_time:1977ms
+Serialized model: 106027446 bytes
+Code size: 93038 bytes
+Serialized model int6+lzma: 15780788 bytes
+Total submission size int6+lzma: 15873826 bytes
+final_int6_roundtrip val_loss:1.9337 val_bpb:1.1452 eval_time:6271ms
+final_int6_roundtrip_exact val_loss:1.93365776 val_bpb:1.14522104
+final_int6_sliding_window val_loss:1.8939 val_bpb:1.1217 stride:64 eval_time:74583ms
+final_int6_sliding_window_exact val_loss:1.89387243 val_bpb:1.12166090
+final_int8_zlib_roundtrip_exact val_loss:1.89387243 val_bpb:1.12166090
+ttt_sliding:start chunks=1893 chunk_tokens=32768 total_windows=969088 stride=64 ttt_lr=0.002 ttt_epochs=3 freeze_blocks=0
+ttt_sliding:params unfrozen=26928220 frozen=0
+  ttt_chunk [1/1893] bpb=1.163564 time=0.5s
+  ttt_chunk [11/1893] bpb=1.147559 time=3.0s
+  ttt_chunk [21/1893] bpb=1.131890 time=5.5s
+  ttt_chunk [31/1893] bpb=1.129424 time=8.2s
+  ttt_chunk [41/1893] bpb=1.115715 time=10.7s
+  ttt_chunk [51/1893] bpb=1.110300 time=13.2s
+  ttt_chunk [61/1893] bpb=1.116705 time=15.8s
+  ttt_chunk [71/1893] bpb=1.115147 time=18.4s
+  ttt_chunk [81/1893] bpb=1.114224 time=20.8s
+  ttt_chunk [91/1893] bpb=1.115324 time=23.3s
+  ttt_chunk [101/1893] bpb=1.118834 time=25.9s
+  ttt_chunk [111/1893] bpb=1.121161 time=28.4s
+  ttt_chunk [121/1893] bpb=1.114292 time=30.9s
+  ttt_chunk [131/1893] bpb=1.114635 time=33.4s
+  ttt_chunk [141/1893] bpb=1.120073 time=36.0s
+  ttt_chunk [151/1893] bpb=1.121918 time=38.6s
+  ttt_chunk [161/1893] bpb=1.121185 time=41.2s
+  ttt_chunk [171/1893] bpb=1.125485 time=43.8s
+  ttt_chunk [181/1893] bpb=1.127617 time=46.3s
+  ttt_chunk [191/1893] bpb=1.134961 time=48.9s
+  ttt_chunk [201/1893] bpb=1.133663 time=51.5s
+  ttt_chunk [211/1893] bpb=1.131524 time=54.1s
+  ttt_chunk [221/1893] bpb=1.132942 time=56.6s
+  ttt_chunk [231/1893] bpb=1.131655 time=59.1s
+  ttt_chunk [241/1893] bpb=1.132049 time=61.7s
+  ttt_chunk [251/1893] bpb=1.131664 time=64.3s
+  ttt_chunk [261/1893] bpb=1.128766 time=66.8s
+  ttt_chunk [271/1893] bpb=1.127561 time=69.2s
+  ttt_chunk [281/1893] bpb=1.128924 time=71.8s
+  ttt_chunk [291/1893] bpb=1.130687 time=74.4s
+  ttt_chunk [301/1893] bpb=1.131425 time=76.9s
+  ttt_chunk [311/1893] bpb=1.133488 time=79.5s
+  ttt_chunk [321/1893] bpb=1.135443 time=82.0s
+  ttt_chunk [331/1893] bpb=1.135227 time=84.6s
+  ttt_chunk [341/1893] bpb=1.134219 time=87.2s
+  ttt_chunk [351/1893] bpb=1.136494 time=89.7s
+  ttt_chunk [361/1893] bpb=1.136633 time=92.2s
+  ttt_chunk [371/1893] bpb=1.135976 time=94.8s
+  ttt_chunk [381/1893] bpb=1.136160 time=97.4s
+  ttt_chunk [391/1893] bpb=1.135987 time=100.0s
+  ttt_chunk [401/1893] bpb=1.133966 time=102.6s
+  ttt_chunk [411/1893] bpb=1.132784 time=105.1s
+  ttt_chunk [421/1893] bpb=1.131921 time=107.6s
+  ttt_chunk [431/1893] bpb=1.131814 time=110.3s
+  ttt_chunk [441/1893] bpb=1.132189 time=112.9s
+  ttt_chunk [451/1893] bpb=1.132478 time=115.5s
+  ttt_chunk [461/1893] bpb=1.131385 time=118.1s
+  ttt_chunk [471/1893] bpb=1.132036 time=120.7s
+  ttt_chunk [481/1893] bpb=1.131638 time=123.3s
+  ttt_chunk [491/1893] bpb=1.130494 time=125.8s
+  ttt_chunk [501/1893] bpb=1.130040 time=128.4s
+  ttt_chunk [511/1893] bpb=1.129401 time=131.0s
+  ttt_chunk [521/1893] bpb=1.126977 time=133.6s
+  ttt_chunk [531/1893] bpb=1.128169 time=136.2s
+  ttt_chunk [541/1893] bpb=1.128509 time=138.8s
+  ttt_chunk [551/1893] bpb=1.127494 time=141.4s
+  ttt_chunk [561/1893] bpb=1.128034 time=144.0s
+  ttt_chunk [571/1893] bpb=1.127037 time=146.5s
+  ttt_chunk [581/1893] bpb=1.126260 time=149.0s
+  ttt_chunk [591/1893] bpb=1.125674 time=151.5s
+  ttt_chunk [601/1893] bpb=1.126156 time=154.1s
+  ttt_chunk [611/1893] bpb=1.126091 time=156.6s
+  ttt_chunk [621/1893] bpb=1.125943 time=159.2s
+  ttt_chunk [631/1893] bpb=1.126689 time=161.7s
+  ttt_chunk [641/1893] bpb=1.126468 time=164.2s
+  ttt_chunk [651/1893] bpb=1.126543 time=166.8s
+  ttt_chunk [661/1893] bpb=1.126027 time=169.3s
+  ttt_chunk [671/1893] bpb=1.126396 time=171.8s
+  ttt_chunk [681/1893] bpb=1.127132 time=174.4s
+  ttt_chunk [691/1893] bpb=1.128127 time=177.0s
+  ttt_chunk [701/1893] bpb=1.127586 time=179.5s
+  ttt_chunk [711/1893] bpb=1.127590 time=182.0s
+  ttt_chunk [721/1893] bpb=1.127208 time=184.5s
+  ttt_chunk [731/1893] bpb=1.127258 time=187.1s
+  ttt_chunk [741/1893] bpb=1.127373 time=189.6s
+  ttt_chunk [751/1893] bpb=1.127246 time=192.1s
+  ttt_chunk [761/1893] bpb=1.127144 time=194.7s
+  ttt_chunk [771/1893] bpb=1.126834 time=197.3s
+  ttt_chunk [781/1893] bpb=1.127591 time=199.9s
+  ttt_chunk [791/1893] bpb=1.127190 time=202.4s
+  ttt_chunk [801/1893] bpb=1.127493 time=205.0s
+  ttt_chunk [811/1893] bpb=1.127250 time=207.6s
+  ttt_chunk [821/1893] bpb=1.127009 time=210.2s
+  ttt_chunk [831/1893] bpb=1.126855 time=212.7s
+  ttt_chunk [841/1893] bpb=1.126217 time=215.3s
+  ttt_chunk [851/1893] bpb=1.125976 time=217.8s
+  ttt_chunk [861/1893] bpb=1.125732 time=220.3s
+  ttt_chunk [871/1893] bpb=1.126004 time=222.9s
+  ttt_chunk [881/1893] bpb=1.126166 time=225.3s
+  ttt_chunk [891/1893] bpb=1.125728 time=227.8s
+  ttt_chunk [901/1893] bpb=1.125443 time=230.2s
+  ttt_chunk [911/1893] bpb=1.125556 time=232.8s
+  ttt_chunk [921/1893] bpb=1.126022 time=235.3s
+  ttt_chunk [931/1893] bpb=1.125947 time=237.9s
+  ttt_chunk [941/1893] bpb=1.125640 time=240.5s
+  ttt_chunk [951/1893] bpb=1.126033 time=243.1s
+  ttt_chunk [961/1893] bpb=1.126097 time=245.7s
+  ttt_chunk [971/1893] bpb=1.126940 time=248.3s
+  ttt_chunk [981/1893] bpb=1.127032 time=250.8s
+  ttt_chunk [991/1893] bpb=1.127043 time=253.4s
+  ttt_chunk [1001/1893] bpb=1.126998 time=256.0s
+  ttt_chunk [1011/1893] bpb=1.126757 time=258.6s
+  ttt_chunk [1021/1893] bpb=1.127099 time=261.2s
+  ttt_chunk [1031/1893] bpb=1.127547 time=263.8s
+  ttt_chunk [1041/1893] bpb=1.127210 time=266.5s
+  ttt_chunk [1051/1893] bpb=1.126970 time=269.1s
+  ttt_chunk [1061/1893] bpb=1.127002 time=271.7s
+  ttt_chunk [1071/1893] bpb=1.127603 time=274.2s
+  ttt_chunk [1081/1893] bpb=1.127870 time=276.9s
+  ttt_chunk [1091/1893] bpb=1.128612 time=279.5s
+  ttt_chunk [1101/1893] bpb=1.128638 time=282.0s
+  ttt_chunk [1111/1893] bpb=1.128492 time=284.6s
+  ttt_chunk [1121/1893] bpb=1.128274 time=287.2s
+  ttt_chunk [1131/1893] bpb=1.128135 time=289.7s
+  ttt_chunk [1141/1893] bpb=1.127824 time=292.2s
+  ttt_chunk [1151/1893] bpb=1.127844 time=294.7s
+  ttt_chunk [1161/1893] bpb=1.127462 time=297.3s
+  ttt_chunk [1171/1893] bpb=1.127792 time=299.9s
+  ttt_chunk [1181/1893] bpb=1.127049 time=302.4s
+  ttt_chunk [1191/1893] bpb=1.126913 time=305.0s
+  ttt_chunk [1201/1893] bpb=1.127341 time=307.7s
+  ttt_chunk [1211/1893] bpb=1.126863 time=310.1s
+  ttt_chunk [1221/1893] bpb=1.126566 time=312.7s
+  ttt_chunk [1231/1893] bpb=1.126281 time=315.3s
+  ttt_chunk [1241/1893] bpb=1.125930 time=317.8s
+  ttt_chunk [1251/1893] bpb=1.125346 time=320.2s
+  ttt_chunk [1261/1893] bpb=1.125316 time=322.7s
+  ttt_chunk [1271/1893] bpb=1.124934 time=325.3s
+  ttt_chunk [1281/1893] bpb=1.124727 time=327.9s
+  ttt_chunk [1291/1893] bpb=1.124482 time=330.4s
+  ttt_chunk [1301/1893] bpb=1.123879 time=333.0s
+  ttt_chunk [1311/1893] bpb=1.123487 time=335.6s
+  ttt_chunk [1321/1893] bpb=1.123164 time=338.1s
+  ttt_chunk [1331/1893] bpb=1.123096 time=340.7s
+  ttt_chunk [1341/1893] bpb=1.122974 time=343.3s
+  ttt_chunk [1351/1893] bpb=1.122892 time=345.8s
+  ttt_chunk [1361/1893] bpb=1.122945 time=348.4s
+  ttt_chunk [1371/1893] bpb=1.122809 time=351.0s
+  ttt_chunk [1381/1893] bpb=1.122795 time=353.5s
+  ttt_chunk [1391/1893] bpb=1.122398 time=356.0s
+  ttt_chunk [1401/1893] bpb=1.122363 time=358.6s
+  ttt_chunk [1411/1893] bpb=1.122473 time=361.2s
+  ttt_chunk [1421/1893] bpb=1.122727 time=363.7s
+  ttt_chunk [1431/1893] bpb=1.122430 time=366.2s
+  ttt_chunk [1441/1893] bpb=1.122915 time=368.9s
+  ttt_chunk [1451/1893] bpb=1.123241 time=371.4s
+  ttt_chunk [1461/1893] bpb=1.122774 time=373.9s
+  ttt_chunk [1471/1893] bpb=1.123808 time=376.6s
+  ttt_chunk [1481/1893] bpb=1.123323 time=379.1s
+  ttt_chunk [1491/1893] bpb=1.123138 time=381.7s
+  ttt_chunk [1501/1893] bpb=1.123050 time=384.2s
+  ttt_chunk [1511/1893] bpb=1.123062 time=386.7s
+  ttt_chunk [1521/1893] bpb=1.123073 time=389.3s
+  ttt_chunk [1531/1893] bpb=1.122546 time=391.9s
+  ttt_chunk [1541/1893] bpb=1.122399 time=394.4s
+  ttt_chunk [1551/1893] bpb=1.122711 time=397.0s
+  ttt_chunk [1561/1893] bpb=1.122693 time=399.6s
+  ttt_chunk [1571/1893] bpb=1.122531 time=402.1s
+  ttt_chunk [1581/1893] bpb=1.122647 time=404.7s
+  ttt_chunk [1591/1893] bpb=1.122489 time=407.3s
+  ttt_chunk [1601/1893] bpb=1.122653 time=409.9s
+  ttt_chunk [1611/1893] bpb=1.122597 time=412.5s
+  ttt_chunk [1621/1893] bpb=1.122183 time=415.0s
+  ttt_chunk [1631/1893] bpb=1.122483 time=417.6s
+  ttt_chunk [1641/1893] bpb=1.122491 time=420.1s
+  ttt_chunk [1651/1893] bpb=1.122440 time=422.7s
+  ttt_chunk [1661/1893] bpb=1.122317 time=425.2s
+  ttt_chunk [1671/1893] bpb=1.122789 time=427.8s
+  ttt_chunk [1681/1893] bpb=1.122929 time=430.4s
+  ttt_chunk [1691/1893] bpb=1.122772 time=433.0s
+  ttt_chunk [1701/1893] bpb=1.122922 time=435.6s
+  ttt_chunk [1711/1893] bpb=1.122925 time=438.2s
+  ttt_chunk [1721/1893] bpb=1.122935 time=440.7s
+  ttt_chunk [1731/1893] bpb=1.122811 time=443.3s
+  ttt_chunk [1741/1893] bpb=1.122612 time=445.9s
+  ttt_chunk [1751/1893] bpb=1.122456 time=448.5s
+  ttt_chunk [1761/1893] bpb=1.122599 time=451.1s
+  ttt_chunk [1771/1893] bpb=1.122505 time=453.6s
+  ttt_chunk [1781/1893] bpb=1.122531 time=456.2s
+  ttt_chunk [1791/1893] bpb=1.122132 time=458.7s
+  ttt_chunk [1801/1893] bpb=1.122003 time=461.3s
+  ttt_chunk [1811/1893] bpb=1.121897 time=463.9s
+  ttt_chunk [1821/1893] bpb=1.121947 time=466.5s
+  ttt_chunk [1831/1893] bpb=1.121349 time=469.1s
+  ttt_chunk [1841/1893] bpb=1.121263 time=471.7s
+  ttt_chunk [1851/1893] bpb=1.121051 time=474.2s
+  ttt_chunk [1861/1893] bpb=1.120685 time=476.8s
+  ttt_chunk [1871/1893] bpb=1.120658 time=479.4s
+  ttt_chunk [1881/1893] bpb=1.120215 time=481.8s
+  ttt_chunk [1891/1893] bpb=1.119984 time=484.4s
+  ttt_chunk [1893/1893] bpb=1.120030 time=484.7s
+ttt_sliding:done val_loss=1.887909 val_bpb=1.118129 elapsed=484.7s
+legal_ttt val_loss:1.8879 val_bpb:1.1181 eval_time:485267ms
+legal_ttt_exact val_loss:1.88790947 val_bpb:1.11812929


### PR DESCRIPTION
## Summary

Two novel TTT innovations on the SOTA base stack (PR #399 + PR #414 + PR #461): Muon-style Newton-Schulz orthogonalized updates replace SGD in the TTT loop, and entropy-adaptive epoch selection concentrates adaptation budget on harder content. Beats current SOTA (1.1194) with a 3-seed mean of 1.1179.

## Run Results (3 seeds)

| Seed | `legal_ttt_exact val_bpb` | `legal_ttt_exact val_loss` | pre-quant `val_bpb` | train time | eval time (TTT) | artifact size |
|------|--------------------------|---------------------------|---------------------|------------|-----------------|---------------|
| 1337 | `1.11765030` | `1.88710072` | `1.1366` | `599.1s` | `477.9s` | `15,944,410 bytes` |
| 42   | `1.11812929` | `1.88790947` | `1.1371` | `599.1s` | `485.3s` | `15,873,826 bytes` |
| 2025 | `1.11789934` | `1.88752121` | `1.1367` | `599.1s` | `479.2s` | `15,879,042 bytes` |
| **mean** | **`1.11789`** | | | | | |

## Method Notes

- `NUM_LAYERS=11`, `BIGRAM_VOCAB_SIZE=1536`, `XSA_LAST_N=4`
- `TTT_ENABLED=1`, score-first path
- `TTT_MUON=1` — Newton-Schulz orthogonalized updates in TTT loop (NS steps=3)
- `TTT_ENTROPY_ADAPT=1` — entropy-adaptive 2/3/4 epochs per chunk (H_HIGH=2.1, H_LOW=1.75)
- `TTT_LR=0.002`, `TTT_EPOCHS=3`, `TTT_CHUNK_TOKENS=32768`
- `NGRAM_EVAL_ENABLED=0`
- `NGRAM_TWO_PASS_ENABLED=0`
- `NGRAM_FULL_RESCORE=0`
- `EMA_ENABLED=1`, `SWA_ENABLED=1`, `LATE_QAT=1`, `VE_ENABLED=1`
- `WARMDOWN_ITERS=3500`, `MAX_WALLCLOCK_SECONDS=599`

## Submission Checklist

- [x] One folder under `records/track_10min_16mb/`
- [x] Included `README.md`, `submission.json`, `train_gpt.py`, and train logs (3 seeds)
- [x] Training <= 600s
- [x] Eval <= 600s
- [x] Artifact <= 16,000,000 bytes
- [x] No tokenizer/dataset modifications
- [x] Score-first TTT (SCORE under inference_mode before TRAIN on same chunk)
- [x] No n-gram, no two-pass, no external data lookup