### PR TITLE
[WIP] Latent LM with TurboQuant 3-bit Quantization

### DIFF
--- a/records/track_10min_16mb/2026-03-28_LatentLM_TurboQuant_LeWM/README.md
+++ b/records/track_10min_16mb/2026-03-28_LatentLM_TurboQuant_LeWM/README.md
@@ -1,0 +1,105 @@
+# Latent Language Model with TurboQuant Compression
+
+**Status**: 🚧 Work in Progress - Approach Documentation
+
+## Summary
+
+Exploring an unexplored direction by combining three cutting-edge techniques:
+
+1. **LeWM-style Latent Prediction** (LeCun et al., March 2026)
+2. **TurboQuant 3-bit Quantization** (Google, ICLR 2026)
+3. **AutoResearch-style Automated Experimentation** (Karpathy, March 2026)
+
+## Core Insight
+
+Current top submissions use Int6 quantization:
+- 16MB ÷ 0.75 bytes/param ≈ **21M parameters**
+
+TurboQuant enables 3-bit with zero accuracy loss:
+- 16MB ÷ 0.375 bytes/param ≈ **42M parameters**
+
+**= 2× parameter budget for the same artifact size**
+
+## Architecture
+
+```
+Token → Encoder → Latent (64d) → Predictor → Decoder → Logits
+          ↑                          ↑           ↑
+       Shared                   Main params    Tied
+                              (TurboQuant 3-bit)
+```
+
+### Components
+
+| Component | Design | Params |
+|-----------|--------|--------|
+| Encoder | Token Embed (256d) → Linear → Latent (64d) | ~300K |
+| Predictor | Transformer 8-12 layers in latent space | ~30-40M |
+| Decoder | Tied with encoder projection | 0 |
+| **Total** | TurboQuant 3-bit compressed | **<16MB** |
+
+### Training Objective (from LeWM)
+
+```python
+Loss = CrossEntropy(predicted, target) + λ × SIGReg(latent)
+```
+
+Only 2 loss terms (vs. 6+ in typical JEPA methods):
+- **CrossEntropy**: Standard next-token prediction
+- **SIGReg**: Gaussian regularizer preventing latent collapse
+
+## Why This Approach
+
+### Unexplored on Leaderboard
+- No JEPA/latent-space submissions yet
+- No TurboQuant submissions yet
+- Combines techniques from March 2026 papers
+
+### Theoretical Advantages
+1. **Latent space prediction**: More parameter-efficient than token-space
+2. **TurboQuant**: Near-optimal distortion with theoretical guarantees
+3. **Tied weights**: Encoder/decoder sharing saves parameters
+
+## Implementation Plan
+
+### Phase 1: Infrastructure (Day 1-2)
+- [ ] Implement LatentLM base architecture
+- [ ] Integrate SIGReg loss
+- [ ] Validate training loop
+
+### Phase 2: TurboQuant (Day 3-4)
+- [ ] Implement PolarQuant
+- [ ] Implement QJL error correction
+- [ ] Verify 3-bit compression <16MB
+
+### Phase 3: AutoResearch Loop (Day 5-6)
+- [ ] Set up automated experiment pipeline
+- [ ] Run overnight architecture search
+
+### Phase 4: Optimization (Day 7-14)
+- [ ] Explore Mamba/SSM as predictor
+- [ ] Tune latent dimension
+- [ ] Add TTT (test-time training)
+- [ ] Final submission
+
+## Expected Results
+
+| Configuration | Params | Size | BPB (est.) |
+|---------------|--------|------|------------|
+| Baseline (Int6) | ~20M | ~15MB | ~1.12 |
+| Ours (TurboQuant) | ~40M | ~14MB | ~1.08-1.10? |
+
+## References
+
+- LeWorldModel: https://le-wm.github.io/
+- TurboQuant: https://research.google/blog/turboquant-redefining-ai-efficiency-with-extreme-compression/
+- AutoResearch: https://github.com/karpathy/autoresearch
+
+## Author
+
+- **GitHub**: Elarwei001
+- **Date**: 2026-03-28
+
+---
+
+*This is a work-in-progress submission. Implementation ongoing.*

--- a/records/track_10min_16mb/2026-03-28_LatentLM_TurboQuant_LeWM/submission.json
+++ b/records/track_10min_16mb/2026-03-28_LatentLM_TurboQuant_LeWM/submission.json
@@ -1,0 +1,23 @@
+{
+  "name": "Elar Wei",
+  "github": "Elarwei001",
+  "approach": "LatentLM + TurboQuant + LeWM-style training",
+  "status": "work_in_progress",
+  "val_bpb": null,
+  "target_bpb": "<1.10",
+  "artifact_size_mb": null,
+  "target_size_mb": "<16",
+  "date": "2026-03-28",
+  "techniques": [
+    "Latent space prediction (LeWM-inspired)",
+    "TurboQuant 3-bit quantization",
+    "SIGReg regularization",
+    "Tied encoder/decoder",
+    "AutoResearch-style automated search"
+  ],
+  "novelty": [
+    "First JEPA/latent-space approach on leaderboard",
+    "First TurboQuant application to Parameter Golf",
+    "2x parameter budget via 3-bit vs Int6"
+  ]
+}

--- a/records/track_10min_16mb/2026-03-28_LatentLM_TurboQuant_LeWM/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-28_LatentLM_TurboQuant_LeWM/train_gpt.py
@@ -1,0 +1,296 @@
+"""
+Latent Language Model with TurboQuant Compression
+==================================================
+
+Work in Progress - Architecture Skeleton
+
+Combining:
+- LeWM-style latent space prediction
+- TurboQuant 3-bit quantization
+- SIGReg regularization
+
+Author: Elarwei001
+Date: 2026-03-28
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import math
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+class Config:
+    # Model
+    vocab_size: int = 1024
+    embed_dim: int = 256
+    latent_dim: int = 64
+    n_layers: int = 8
+    n_heads: int = 8
+    
+    # Training
+    batch_size: int = 64
+    seq_length: int = 1024
+    learning_rate: float = 1e-3
+    sigreg_weight: float = 0.1
+    
+    # Quantization
+    quant_bits: int = 3  # TurboQuant target
+
+# =============================================================================
+# SIGReg Loss (from LeWM/LeJEPA)
+# =============================================================================
+
+def sigreg_loss(z: torch.Tensor) -> torch.Tensor:
+    """
+    Gaussian regularizer to prevent latent collapse.
+    Forces latent space to follow N(0,1) distribution.
+    
+    Args:
+        z: [batch, seq_len, latent_dim]
+    
+    Returns:
+        Scalar loss
+    """
+    z_flat = z.reshape(-1, z.size(-1))  # [B*L, D]
+    
+    # Mean should be close to 0
+    mean_loss = (z_flat.mean(dim=0) ** 2).mean()
+    
+    # Std should be close to 1
+    std_loss = ((z_flat.std(dim=0) - 1) ** 2).mean()
+    
+    return mean_loss + std_loss
+
+# =============================================================================
+# Encoder (Token -> Latent)
+# =============================================================================
+
+class Encoder(nn.Module):
+    """
+    Encodes tokens to compact latent representations.
+    """
+    def __init__(self, config: Config):
+        super().__init__()
+        self.embed = nn.Embedding(config.vocab_size, config.embed_dim)
+        self.proj = nn.Linear(config.embed_dim, config.latent_dim)
+    
+    def forward(self, token_ids: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            token_ids: [batch, seq_len]
+        Returns:
+            latent: [batch, seq_len, latent_dim]
+        """
+        x = self.embed(token_ids)
+        z = self.proj(x)
+        return z
+
+# =============================================================================
+# Predictor (Latent -> Latent)
+# =============================================================================
+
+class LatentAttention(nn.Module):
+    """
+    Causal self-attention in latent space.
+    """
+    def __init__(self, config: Config):
+        super().__init__()
+        self.n_heads = config.n_heads
+        self.head_dim = config.latent_dim // config.n_heads
+        
+        self.qkv = nn.Linear(config.latent_dim, 3 * config.latent_dim)
+        self.proj = nn.Linear(config.latent_dim, config.latent_dim)
+    
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        B, L, D = z.shape
+        
+        qkv = self.qkv(z).reshape(B, L, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # [3, B, H, L, d]
+        
+        # Causal attention
+        attn = (q @ k.transpose(-2, -1)) / math.sqrt(self.head_dim)
+        mask = torch.triu(torch.ones(L, L, device=z.device), diagonal=1).bool()
+        attn.masked_fill_(mask, float('-inf'))
+        attn = F.softmax(attn, dim=-1)
+        
+        out = (attn @ v).transpose(1, 2).reshape(B, L, D)
+        return self.proj(out)
+
+
+class LatentBlock(nn.Module):
+    """
+    Transformer block operating in latent space.
+    """
+    def __init__(self, config: Config):
+        super().__init__()
+        self.ln1 = nn.LayerNorm(config.latent_dim)
+        self.attn = LatentAttention(config)
+        self.ln2 = nn.LayerNorm(config.latent_dim)
+        self.mlp = nn.Sequential(
+            nn.Linear(config.latent_dim, config.latent_dim * 4),
+            nn.GELU(),
+            nn.Linear(config.latent_dim * 4, config.latent_dim),
+        )
+    
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        z = z + self.attn(self.ln1(z))
+        z = z + self.mlp(self.ln2(z))
+        return z
+
+
+class Predictor(nn.Module):
+    """
+    Predicts next latent from current latent sequence.
+    """
+    def __init__(self, config: Config):
+        super().__init__()
+        self.blocks = nn.ModuleList([
+            LatentBlock(config) for _ in range(config.n_layers)
+        ])
+    
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        for block in self.blocks:
+            z = block(z)
+        return z
+
+# =============================================================================
+# Decoder (Latent -> Logits)
+# =============================================================================
+
+class Decoder(nn.Module):
+    """
+    Decodes latent to token logits.
+    Can optionally tie weights with encoder.
+    """
+    def __init__(self, config: Config, encoder: Encoder = None):
+        super().__init__()
+        self.tied = encoder is not None
+        
+        if self.tied:
+            # Tied weights: use encoder's embedding transposed
+            self.encoder = encoder
+            self.proj_inv = nn.Linear(config.latent_dim, config.embed_dim)
+        else:
+            self.proj = nn.Linear(config.latent_dim, config.vocab_size)
+    
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            z: [batch, seq_len, latent_dim]
+        Returns:
+            logits: [batch, seq_len, vocab_size]
+        """
+        if self.tied:
+            x = self.proj_inv(z)
+            logits = x @ self.encoder.embed.weight.T
+        else:
+            logits = self.proj(z)
+        return logits
+
+# =============================================================================
+# Full Model
+# =============================================================================
+
+class LatentLM(nn.Module):
+    """
+    Latent Language Model combining encoder, predictor, and decoder.
+    """
+    def __init__(self, config: Config):
+        super().__init__()
+        self.config = config
+        
+        self.encoder = Encoder(config)
+        self.predictor = Predictor(config)
+        self.decoder = Decoder(config, encoder=self.encoder)  # Tied weights
+    
+    def forward(self, token_ids: torch.Tensor) -> torch.Tensor:
+        z = self.encoder(token_ids)
+        z_pred = self.predictor(z)
+        logits = self.decoder(z_pred)
+        return logits
+    
+    def compute_loss(self, token_ids: torch.Tensor) -> dict:
+        """
+        Compute loss with SIGReg regularization.
+        
+        Returns:
+            dict with 'loss', 'ce_loss', 'sigreg_loss'
+        """
+        z = self.encoder(token_ids)
+        z_pred = self.predictor(z[:, :-1])
+        logits = self.decoder(z_pred)
+        
+        # Cross-entropy loss
+        targets = token_ids[:, 1:]
+        ce_loss = F.cross_entropy(
+            logits.reshape(-1, self.config.vocab_size),
+            targets.reshape(-1)
+        )
+        
+        # SIGReg loss
+        sig_loss = sigreg_loss(z)
+        
+        # Total loss
+        total_loss = ce_loss + self.config.sigreg_weight * sig_loss
+        
+        return {
+            'loss': total_loss,
+            'ce_loss': ce_loss,
+            'sigreg_loss': sig_loss,
+        }
+    
+    def count_parameters(self) -> int:
+        return sum(p.numel() for p in self.parameters())
+
+# =============================================================================
+# TurboQuant (Placeholder - To Be Implemented)
+# =============================================================================
+
+class TurboQuant:
+    """
+    TurboQuant quantization module.
+    
+    TODO: Implement PolarQuant + QJL
+    - PolarQuant: Random rotation -> polar coordinates
+    - QJL: 1-bit error correction
+    """
+    
+    @staticmethod
+    def quantize(model: nn.Module, bits: int = 3) -> nn.Module:
+        """Quantize model weights to target bits."""
+        # TODO: Implement
+        raise NotImplementedError("TurboQuant implementation in progress")
+    
+    @staticmethod
+    def save_compressed(model: nn.Module, path: str) -> int:
+        """Save compressed model and return size in bytes."""
+        # TODO: Implement
+        raise NotImplementedError("TurboQuant save in progress")
+
+# =============================================================================
+# Main (Training Loop Skeleton)
+# =============================================================================
+
+def main():
+    config = Config()
+    
+    # Initialize model
+    model = LatentLM(config)
+    print(f"Model parameters: {model.count_parameters():,}")
+    
+    # Estimate size
+    param_bytes = model.count_parameters() * 2  # FP16
+    quant_bytes = model.count_parameters() * (config.quant_bits / 8)
+    print(f"FP16 size: {param_bytes / 1e6:.2f} MB")
+    print(f"Estimated {config.quant_bits}-bit size: {quant_bytes / 1e6:.2f} MB")
+    
+    # TODO: Load data, train, quantize, evaluate
+    print("\n⚠️  Training loop not yet implemented")
+    print("This is an architecture skeleton for the Parameter Golf challenge.")
+    print("Full implementation in progress...")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Exploring an **unexplored direction** by combining three cutting-edge techniques:

1. **LeWM-style Latent Prediction** (LeCun et al., March 2026)
2. **TurboQuant 3-bit Quantization** (Google, ICLR 2026)  
3. **AutoResearch-style Automation** (Karpathy, March 2026)

## Core Insight

| Quantization | Params in 16MB |
|--------------|----------------|
| Int6 (current SOTA) | ~21M |
| **TurboQuant 3-bit** | **~42M** |

= **2× parameter budget** for the same artifact size

## Architecture

```
Token → Encoder → Latent (64d) → Predictor → Decoder → Logits
```

- **Encoder**: Token embed → Linear projection to latent
- **Predictor**: Transformer in latent space (main compute)
- **Decoder**: Tied with encoder (0 extra params)
- **Loss**: CrossEntropy + SIGReg (only 2 terms)

## Status

🚧 **Work in Progress**

- [x] Architecture design
- [x] Code skeleton
- [ ] Full implementation
- [ ] TurboQuant integration
- [ ] Training & evaluation
- [ ] Final submission

## Why This Approach

- No JEPA/latent-space submissions on leaderboard yet
- No TurboQuant submissions yet
- Combines 3 techniques from March 2026

## Author

- GitHub: @Elarwei001
- Date: 2026-03-28