### PR TITLE
Non-Record: Extended Compute Scaling Analysis: 1.0853 BPB at 50K steps (11.5 hours) on 4×A100MIG

### DIFF
--- a/records/track_non_record_16mb/2026-03-28_ExtendedCompute_50K_11hours_4xA100MIG_ScalingAnalysis/README.md
+++ b/records/track_non_record_16mb/2026-03-28_ExtendedCompute_50K_11hours_4xA100MIG_ScalingAnalysis/README.md
@@ -1,0 +1,218 @@
+# Extended Compute Scaling Analysis (20K–50K Steps)
+
+**val_bpb: 1.0853** (50K steps, seed 1337) | **~14.35 MB** | 4×A100 MIG (Unlimited Compute Track)
+
+## Summary
+
+This submission is a **non-record submission**. It studies how the current record-track SOTA ([PR #549](https://github.com/openai/parameter-golf/pull/549) by @abaybektursun) scales under extended compute, removing the 10-minute wall-clock constraint. The same architecture and code are trained for 20K–50K steps (5.5-11.5 hours training) on 4×A100 MIG instances (approximately 10× slower per step than 8×H100 SXM).
+
+Key findings:
+- **50K steps achieves 1.0853 BPB post-TTT**, a -0.034 improvement over the record-track SOTA (1.1194)
+- **Artifact size balloons mid-training** (peaking at 17.2MB around step 10K–15K) but **recovers to 14.35MB** after warmdown completes — warmdown smooths weight entropy and restores compressibility
+- **Diminishing returns** set in beyond ~30K steps, with the BPB curve flattening significantly
+- **TTT gains scale with base model quality**: TTT provides -0.014 BPB on the 50K model vs -0.0025 on the 7K SOTA
+
+## Results
+
+### Best run: 50K steps and 11.5 hours (4×A100 MIG, seed 1337)
+
+| Phase | val_loss | val_bpb | Artifact |
+|-------|----------|---------|----------|
+| Pre-TTT (EMA) | 1.8469 | 1.0939 | 14,348,646 |
+| Int6 roundtrip | 1.8963 | 1.1231 | 14,348,646 |
+| Sliding window (s=64) | 1.8566 | 1.0996 | 14,348,646 |
+| **Legal TTT** | **1.8325** | **1.0853** | **14,348,646** |
+
+### 20K steps and 5.5 hours (4×A100 MIG, 2-seed comparison)
+
+| Seed | step_avg | steps | Pre-TTT bpb | **Post-TTT bpb** | TTT gain | Artifact |
+|------|----------|-------|-------------|-----------------|----------|----------|
+| 1337 | 828.7ms | 20,000 | 1.1018 | **1.0957** | -0.0061 | 15,077,933 |
+| 42 | 828.8ms | 20,000 | 1.1020 | **1.0962** | -0.0058 | 15,137,145 |
+| **Mean** | **828.8ms** | **20,000** | **1.1019** | **1.0960 (std 0.0004)** | **-0.0060** | **15,107,539**|
+
+### Comparison with record-track SOTA
+
+| Config | Steps | Hardware | Pre-TTT bpb | Post-TTT bpb | Delta vs SOTA |
+|--------|-------|----------|-------------|--------------|---------------|
+| SOTA (PR #549) | ~7,185 | 8×H100 SXM | 1.1218 | 1.1194 | — |
+| This work (20K) | 20,000, 5.5 hours | 4×A100 MIG | 1.1019 | 1.0960 | **-0.0234** |
+| This work (50K) | 50,000, 11.5 hours | 4×A100 MIG | 1.0939 | **1.0853** | **-0.0341** |
+
+## Scaling Analysis: BPB & Artifact Size vs Training Steps
+
+Data from the 50K run with validation every 2,500 steps. Artifact size is computed as int6+LZMA compressed model + code bytes.
+
+| Steps | Pre-TTT val_bpb | artifact_bytes | Under 16MB? |
+|------:|--------:|---------------:|:-----------:|
+| 0 | 4.1046 | 4,577,902 | Yes |
+| 2,500 | 1.2554 | 13,062,362 | Yes |
+| 5,000 | 1.2290 | 14,137,046 | Yes |
+| 7,500 | 1.2201 | 15,465,582 | Yes |
+| 10,000 | 1.2022 | 17,185,494 | **No** |
+| 12,500 | 1.1987 | 17,195,458 | **No** |
+| 15,000 | 1.1936 | 17,238,818 | **No** |
+| 17,500 | 1.1918 | 17,178,826 | **No** |
+| 20,000 | 1.1905 | 17,182,262 | **No** |
+| 22,500 | 1.1900 | 17,168,362 | **No** |
+| 25,000 | 1.1898 | 17,167,526 | **No** |
+| 27,500 | 1.1877 | 17,158,910 | **No** |
+| 30,000 | 1.1861 | 17,148,538 | **No** |
+| 32,500 | 1.1804 | 17,016,594 | **No** |
+| 35,000 | 1.1740 | 16,753,850 | **No** |
+| 37,500 | 1.1669 | 16,422,374 | **No** |
+| 40,000 | 1.1582 | 16,034,950 | **No** |
+| 42,500 | 1.1487 | 15,698,694 | Yes |
+| 45,000 | 1.1340 | 15,144,098 | Yes |
+| 47,500 | 1.1167 | 14,726,650 | Yes |
+| 50,000 | 1.0942 | 14,330,478 | Yes |
+
+**Note:** Intermediate checkpoints do not benefit from warmdown. The final model (step 50K) has full warmdown applied, resulting in 14.35MB — well under the 16MB limit. The artifact size peaks mid-training when weights are high-entropy, then drops as warmdown smooths them.
+
+### BPB vs Steps (ASCII plot)
+
+Power-law decay with three distinct phases: rapid early learning, mid-training plateau, warmdown-driven final drop.
+
+```
+BPB
+4.10 |*
+     |
+     |
+     |
+2.50 |
+     |
+1.26 | *
+1.23 |  *
+1.22 |   *
+1.20 |    *
+1.19 |     * * * * *
+1.18 |             * *
+1.17 |               *
+1.16 |                *
+1.15 |                 *
+1.13 |                  *
+1.12 |                   *
+1.09 |                    *
+     +----+----+----+----+----+-> steps (K)
+     0   10   20   30   40   50
+
+     |<early >|<--- plateau --->|<warmdown>|
+      (rapid)                    (sharp drop)
+```
+
+The plateau between steps 20K–30K shows diminishing returns from additional gradient updates alone. The sharp drop after step 30K is driven by warmdown reducing the learning rate toward zero, smoothing weights and simultaneously improving both BPB and compressibility.
+
+### Artifact Size vs Steps (ASCII plot)
+
+Non-monotonic: grows rapidly to a peak at ~15K steps, plateaus above 16MB, then shrinks back below budget during warmdown.
+
+```
+MB
+17.2 |         * * * * * * * * * * * *
+16.8 |                               *
+16.4 |                                *
+16.0 |------------------------------------*--------  16MB limit
+15.7 |                                    *
+15.1 |                                     *
+14.7 |     *                                *
+14.1 |  *                                    *
+13.1 | *
+ 4.6 |*
+     +----+----+----+----+----+-> steps (K)
+     0   10   20   30   40   50
+
+     |<-fits->|<--- OVER 16MB ------>|<fits->|
+```
+
+Intermediate checkpoints between steps ~10K–42K exceed the 16MB budget and cannot be submitted as-is. Only the final model (with warmdown complete) fits. This means **early stopping is not viable** for this architecture without a separate warmdown phase.
+
+### Observations
+
+1. **BPB vs steps follows a power-law decay** with diminishing returns. The biggest gains are in the first 7,500 steps. Beyond 25K–30K steps, warmdown begins and BPB drops sharply again.
+2. **Artifact size is non-monotonic**: it grows rapidly from 4.6MB (init) to 17.2MB (step 10K–15K peak), plateaus during mid-training, then shrinks back to 14.3MB during warmdown. This means intermediate checkpoints without warmdown may exceed 16MB even if the final model fits.
+3. **TTT gain scales with compute**: at 7K steps (SOTA), TTT provides -0.0025 BPB. At 20K steps, -0.006 BPB. At 50K steps, -0.014 BPB. The better-trained base model benefits more from test-time adaptation.
+
+## Architecture
+
+Identical to [PR #549](https://github.com/openai/parameter-golf/pull/549) (LeakyReLU² + Legal TTT + Parallel Muon):
+
+| Component | Setting |
+|-----------|---------|
+| Layers | 11 (512d, 8H, 4KV) |
+| MLP | 3× with LeakyReLU(0.5)² |
+| BigramHash | 1536 |
+| XSA | Last 4 layers |
+| RoPE | Partial (16/64 dims) |
+| LN Scale | 1/√(layer+1) |
+| VE128 | Layers 9-10 |
+| Weight avg | EMA(0.997) + Tight SWA(every 50) |
+| Quantization | GPTQ-lite int6 + lzma |
+| Optimizer | Parameter Banking + Parallel Muon |
+
+### Hyperparameter scaling for extended training
+
+LR schedule parameters scaled proportionally to maintain the same warmup/warmdown ratios:
+
+| Parameter | SOTA (9K steps) | 20K steps | 50K steps |
+|-----------|----------------|-----------|-----------|
+| ITERATIONS | 9,000 | 20,000 | 50,000 |
+| WARMDOWN_ITERS | 3,500 (38.9%) | 7,800 (39.0%) | 19,500 (39.0%) |
+| MUON_MOMENTUM_WARMUP_STEPS | 1,500 (16.7%) | 3,340 (16.7%) | 8,350 (16.7%) |
+| MAX_WALLCLOCK_SECONDS | 600 | 0 (unlimited) | 0 (unlimited) |
+
+## Run Commands
+
+### 20K steps
+```bash
+RUN_ID=run_recordsota_nonrecord_seed1337 \
+NUM_LAYERS=11 BIGRAM_VOCAB_SIZE=1536 XSA_LAST_N=4 \
+EMA_ENABLED=1 EMA_DECAY=0.997 SWA_ENABLED=1 SWA_EVERY=50 \
+ROPE_DIMS=16 LN_SCALE=1 LATE_QAT=1 LATE_QAT_THRESHOLD=0.15 \
+VE_ENABLED=1 VE_DIM=128 VE_LAYERS=9,10 \
+TTT_ENABLED=1 TTT_LR=0.002 TTT_EPOCHS=3 TTT_CHUNK_TOKENS=32768 \
+TTT_FREEZE_BLOCKS=0 TTT_MOMENTUM=0.9 TTT_BATCH_SEQS=32 TTT_GRAD_CLIP=1.0 \
+MUON_WD=0.04 ADAM_WD=0.04 \
+MATRIX_LR=0.025 SCALAR_LR=0.025 TIED_EMBED_LR=0.035 \
+MUON_MOMENTUM=0.99 MUON_MOMENTUM_WARMUP_START=0.92 \
+MUON_MOMENTUM_WARMUP_STEPS=3340 WARMDOWN_ITERS=7800 \
+ITERATIONS=20000 MAX_WALLCLOCK_SECONDS=0 EVAL_STRIDE=64 \
+SEED=1337 \
+CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train_gpt.py
+```
+
+### 50K steps
+```bash
+RUN_ID=scaling_50k_seed1337 \
+NUM_LAYERS=11 BIGRAM_VOCAB_SIZE=1536 XSA_LAST_N=4 \
+EMA_ENABLED=1 EMA_DECAY=0.997 SWA_ENABLED=1 SWA_EVERY=50 \
+ROPE_DIMS=16 LN_SCALE=1 LATE_QAT=1 LATE_QAT_THRESHOLD=0.15 \
+VE_ENABLED=1 VE_DIM=128 VE_LAYERS=9,10 \
+TTT_ENABLED=1 TTT_LR=0.002 TTT_EPOCHS=3 TTT_CHUNK_TOKENS=32768 \
+TTT_FREEZE_BLOCKS=0 TTT_MOMENTUM=0.9 TTT_BATCH_SEQS=32 TTT_GRAD_CLIP=1.0 \
+MUON_WD=0.04 ADAM_WD=0.04 \
+MATRIX_LR=0.025 SCALAR_LR=0.025 TIED_EMBED_LR=0.035 \
+MUON_MOMENTUM=0.99 MUON_MOMENTUM_WARMUP_START=0.92 \
+MUON_MOMENTUM_WARMUP_STEPS=8350 WARMDOWN_ITERS=19500 \
+ITERATIONS=50000 MAX_WALLCLOCK_SECONDS=0 EVAL_STRIDE=64 \
+VAL_LOSS_EVERY=2500 \
+SEED=1337 \
+CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --standalone --nproc_per_node=4 train_gpt.py
+```
+
+## Hardware
+
+- 4×NVIDIA A100 MIG instances
+- 829ms/step (vs 83ms/step on 8×H100 SXM — exactly 10× slower)
+- grad_accum_steps=2 (to match 8-GPU effective batch size of 786,432 tokens)
+- 20K run: ~4.6h training + ~34min TTT eval
+- 50K run: ~11.5h training + ~34min TTT eval
+
+## Credits
+
+This submission uses the full architecture and code from the record-track SOTA with no ML changes — only extended compute and proportionally scaled LR schedules.
+
+- **Base submission [PR #549](https://github.com/openai/parameter-golf/pull/549)**: @abaybektursun — LeakyReLU² + Legal TTT + Parallel Muon
+- **LeakyReLU² activation**: [PR #493](https://github.com/openai/parameter-golf/pull/493) by @parinzee, [PR #518](https://github.com/openai/parameter-golf/pull/518) by @sofiabod
+- **Optimizer (Parameter Banking + Parallel Muon)**: [PR #399](https://github.com/openai/parameter-golf/pull/399) by @abaybektursun
+- **TTT recipe**: [PR #461](https://github.com/openai/parameter-golf/pull/461) by @Christopher-Lee-McClendon
+- **Base model**: [PR #414](https://github.com/openai/parameter-golf/pull/414) by @signalrush

--- a/records/track_non_record_16mb/2026-03-28_ExtendedCompute_50K_11hours_4xA100MIG_ScalingAnalysis/run_scaling_50k.sh
+++ b/records/track_non_record_16mb/2026-03-28_ExtendedCompute_50K_11hours_4xA100MIG_ScalingAnalysis/run_scaling_50k.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+cd /projects/jundhu-v2/jundhu_projects/parameter_golf
+
+# 50K scaling run — intermediate val_bpb logged every 4K steps for scaling curve
+# Warmdown and momentum warmup scaled proportionally (~39% and ~16.7%)
+# 50K * 0.39 = 19500, 50K * 0.167 = 8350
+
+echo "=========================================="
+echo "Scaling run: 50K steps, seed=1337"
+echo "Started at: $(date)"
+echo "=========================================="
+
+env \
+    RUN_ID=scaling_50k_seed1337 \
+    NUM_LAYERS=11 BIGRAM_VOCAB_SIZE=1536 XSA_LAST_N=4 \
+    EMA_ENABLED=1 EMA_DECAY=0.997 SWA_ENABLED=1 SWA_EVERY=50 \
+    ROPE_DIMS=16 LN_SCALE=1 LATE_QAT=1 LATE_QAT_THRESHOLD=0.15 \
+    VE_ENABLED=1 VE_DIM=128 VE_LAYERS=9,10 \
+    TTT_ENABLED=1 TTT_LR=0.002 TTT_EPOCHS=3 TTT_CHUNK_TOKENS=32768 \
+    TTT_FREEZE_BLOCKS=0 TTT_MOMENTUM=0.9 TTT_BATCH_SEQS=32 TTT_GRAD_CLIP=1.0 \
+    MUON_WD=0.04 ADAM_WD=0.04 \
+    MATRIX_LR=0.025 SCALAR_LR=0.025 TIED_EMBED_LR=0.035 \
+    MUON_MOMENTUM=0.99 MUON_MOMENTUM_WARMUP_START=0.92 \
+    MUON_MOMENTUM_WARMUP_STEPS=8350 WARMDOWN_ITERS=19500 \
+    ITERATIONS=50000 MAX_WALLCLOCK_SECONDS=0 EVAL_STRIDE=64 \
+    VAL_LOSS_EVERY=2500 \
+    SEED=1337 \
+    CUDA_VISIBLE_DEVICES=0,1,2,3 \
+    torchrun --standalone --nproc_per_node=4 train_gpt.py \
+    2>&1 | tee logs/scaling_50k_seed1337.txt
+
+echo "=========================================="
+echo "50K run finished at: $(date)"
+echo "=========================================="

--- a/records/track_non_record_16mb/2026-03-28_ExtendedCompute_50K_11hours_4xA100MIG_ScalingAnalysis/submission.json
+++ b/records/track_non_record_16mb/2026-03-28_ExtendedCompute_50K_11hours_4xA100MIG_ScalingAnalysis/submission.json
@@ -1,0 +1,9 @@
+{
+  "name": "Extended Compute Scaling Analysis (20K–50K steps)",
+  "val_bpb": 1.0853,
+  "bytes_total": 14348646,
+  "blurb": "Scaling analysis of the PR #549 SOTA stack (LeakyReLU² + TTT + Parallel Muon) under extended compute on 4×A100 MIG. 50K steps (~11.5 hours training) achieves 1.0853 BPB post-TTT with 14.35MB artifact. Includes compute scaling curve (artifact size and BPB vs steps) showing warmdown-driven compression recovery and diminishing returns beyond ~30K steps.",
+  "author": "Jundong Hu",
+  "github_id": "OnlyJundong",
+  "date": "2026-03-28"
+}

--- a/records/track_non_record_16mb/2026-03-28_ExtendedCompute_50K_11hours_4xA100MIG_ScalingAnalysis/train_gpt.py
+++ b/records/track_non_record_16mb/2026-03-28_ExtendedCompute_50K_11hours_4xA100MIG_ScalingAnalysis/train_gpt.py
@@ -1,0 +1,1938 @@
+from __future__ import annotations
+import copy
+import glob
+import io
+import lzma
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+# Fix for MIG/multi-GPU: ensure each process only sees its assigned GPU
+# Must be set before importing torch
+if "LOCAL_RANK" in os.environ and "CUDA_VISIBLE_DEVICES" in os.environ:
+    visible_devices = os.environ["CUDA_VISIBLE_DEVICES"].split(",")
+    local_rank = int(os.environ["LOCAL_RANK"])
+    if local_rank < len(visible_devices):
+        os.environ["CUDA_VISIBLE_DEVICES"] = visible_devices[local_rank]
+
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+try:
+    from flash_attn_interface import flash_attn_func as flash_attn_3_func
+    _HAS_FA3 = True
+except ImportError:
+    _HAS_FA3 = False
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3500))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 3.0))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.035))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.025))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.025))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    mtp_num_heads = int(os.environ.get("MTP_NUM_HEADS", 0))
+    mtp_loss_weight = float(os.environ.get("MTP_LOSS_WEIGHT", 0.2))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    lawa_enabled = bool(int(os.environ.get("LAWA_ENABLED", "0")))
+    lawa_k = int(os.environ.get("LAWA_K", 10))
+    lawa_freq = int(os.environ.get("LAWA_FREQ", 100))
+    muon_wd = float(os.environ.get("MUON_WD", 0.04))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.04))
+    qat_enabled = bool(int(os.environ.get("QAT_ENABLED", "0")))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 2048))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 4))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    dtg_enabled = bool(int(os.environ.get("DTG_ENABLED", "0")))
+    late_qat_threshold = float(os.environ.get("LATE_QAT_THRESHOLD", 0.15))
+    ve_enabled = bool(int(os.environ.get("VE_ENABLED", "1")))
+    ve_dim = int(os.environ.get("VE_DIM", 128))
+    ve_layers = os.environ.get("VE_LAYERS", "9,10")
+    gated_attention = bool(int(os.environ.get("GATED_ATTENTION", "0")))
+    value_residual = bool(int(os.environ.get("VALUE_RESIDUAL", "0")))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.002))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 3))
+    ttt_chunk_tokens = int(os.environ.get("TTT_CHUNK_TOKENS", 32768))
+    ttt_freeze_blocks = int(os.environ.get("TTT_FREEZE_BLOCKS", 2))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+    ttt_batch_seqs = int(os.environ.get("TTT_BATCH_SEQS", 32))
+    ttt_grad_clip = float(os.environ.get("TTT_GRAD_CLIP", 1.0))
+
+# --- Batched Newton-Schulz orthogonalization ---
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 5, eps: float = 1e-7) -> Tensor:
+    """Batched Newton-Schulz orthogonalization. G: (B,M,N) or (M,N)."""
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+# --- Parallel Muon optimizer ---
+
+class Muon(torch.optim.Optimizer):
+    """Parallel Muon: post-backward reduce-scatter -> local NS5 -> all-gather.
+
+    No DDP for bank params. After backward, this optimizer:
+    1. Launches async reduce-scatter for all banks (biggest first)
+    2. Returns control so Adam can step on small params while RS is in-flight
+    3. Waits for each RS, runs local NS5 on the shard, launches async all-gather
+    4. Each all-gather overlaps with next bank's NS5
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append({
+                    'p': p,
+                    'B': B,
+                    'padded_grad': torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'shard': torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'shard_mom': torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'full_update': torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'scale': max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                })
+        # Sort by size descending -- launch biggest reduce-scatters first
+        self._bank_meta.sort(key=lambda m: -m['p'].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        """Phase 1: launch async reduce-scatter for all banks. Call right after backward."""
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m['p']
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m['padded_grad']
+            pg[:m['B']].copy_(p.grad.bfloat16())
+            if pg.shape[0] > m['B']:
+                pg[m['B']:].zero_()
+            fut = dist.reduce_scatter_tensor(m['shard'], pg, op=dist.ReduceOp.AVG, async_op=True)
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        """Phase 3: wait for RS, local NS5, all-gather. Call AFTER Adam steps."""
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        if not self._built:
+            self._build()
+
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+
+            prev_ag_handle = None
+            prev_m = None
+
+            sharded = self._distributed and hasattr(self, '_rs_futures')
+
+            for i, m in enumerate(self._bank_meta):
+                p = m['p']
+                if p.grad is None:
+                    continue
+
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m['p']
+                    upd = prev_m['full_update'][:prev_m['B']]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m['scale'])
+
+                if sharded and self._rs_futures[i] is not None:
+                    self._rs_futures[i].wait()
+                    g = m['shard']
+                    buf = m['shard_mom']
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m['full_update'], update, async_op=True)
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update.to(dtype=p.dtype), alpha=-lr * m['scale'])
+
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m['p']
+                upd = prev_m['full_update'][:prev_m['B']]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m['scale'])
+
+            if hasattr(self, '_rs_futures'):
+                del self._rs_futures
+
+        return loss
+
+# --- Tokenizer evaluation helpers ---
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    seq_len = eval_seq_len or args.train_seq_len
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# --- Quantization helpers ---
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,dtg_gate,ve_layer_scales,ve_shared.scale,attn_gate,vr_lambda",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+# --- Data loading ---
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# --- Transformer modules ---
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                scale = (row_max / 31.0).clamp_min(1.0 / 31.0)
+                w_q = (torch.clamp(torch.round(w32 / scale[:, None]), -32, 31) * scale[:, None]).to(x.dtype)
+            w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024, rope_dims: int = 0):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / (base ** (torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (rd / (rd - 2)))
+                inv_freq = 1.0 / (new_base ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd))
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int = 0) -> Tensor:
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        # No CastedLinear -- weights come from banks
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rope_dims = 0  # set by GPT.__init__ for partial RoPE
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False  # set by GPT.__init__ for deep layers only
+        # Gated attention and value residual (non-banked small params)
+        self.gated_attention = gated_attention
+        if gated_attention:
+            self.attn_gate = nn.Linear(dim, num_heads, bias=True)
+            nn.init.zeros_(self.attn_gate.weight)
+            nn.init.constant_(self.attn_gate.bias, 4.0)
+        self.value_residual = value_residual
+        if value_residual:
+            self.vr_lambda = nn.Parameter(torch.tensor([0.5, 0.5], dtype=torch.float32))
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        """Efficient XSA: subtract self-value projection via GQA-aware reshape (no repeat_interleave).
+        y: [B, T, H, D], v: [B, T, Hkv, D]. H must be divisible by Hkv."""
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)        # [B, T, Hkv, group, D]
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)    # [B, T, Hkv, 1, D] -- broadcast ready
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+    def forward(self, x: Tensor, q_w: Tensor, k_w: Tensor, v_w: Tensor, out_w: Tensor, v_embed: Tensor | None = None, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        bsz, seqlen, dim = x.shape
+        q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype))
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        raw_v = v if self.value_residual else None
+        if self.value_residual and v0 is not None:
+            lam = self.vr_lambda.to(dtype=v.dtype)
+            v = lam[0] * v0 + lam[1] * v
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if _HAS_FA3:
+            y = flash_attn_3_func(q, k, v, causal=True)
+        else:
+            # SDPA expects (B, H, T, D), FA3 uses (B, T, H, D)
+            y = F.scaled_dot_product_attention(
+                q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
+                is_causal=True,
+                enable_gqa=(self.num_kv_heads != self.num_heads),
+            ).transpose(1, 2)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        if self.gated_attention:
+            # gate shape: (bsz, seqlen, num_heads) -> (bsz, seqlen, num_heads, 1) for B,T,H,D layout
+            gate = torch.sigmoid(self.attn_gate(x)).unsqueeze(-1)
+            y = y * gate
+        y = y.reshape(bsz, seqlen, dim)
+        return F.linear(y, out_w.to(x.dtype)), raw_v
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class ValueEmbedding(nn.Module):
+    """Reinject token identity into attention values at specific layers.
+    Each table maps vocab tokens to a low-dim embedding, projected to model_dim."""
+    def __init__(self, vocab_size: int, ve_dim: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, ve_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(ve_dim, model_dim, bias=False) if ve_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(token_ids)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        # No CastedLinear -- weights come from banks
+    def forward(self, x: Tensor, up_w: Tensor, down_w: Tensor) -> Tensor:
+        x = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5)
+        return F.linear(x.square(), down_w.to(x.dtype))
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        layer_idx: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+                                        gated_attention=gated_attention, value_residual=value_residual)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+        if dtg:
+            self.dtg_gate = nn.Linear(dim, 1, bias=True)
+            nn.init.zeros_(self.dtg_gate.weight)
+            nn.init.constant_(self.dtg_gate.bias, 2.0)
+        else:
+            self.dtg_gate = None
+    def forward(self, x: Tensor, x0: Tensor, q_w: Tensor, k_w: Tensor, v_w: Tensor, out_w: Tensor, up_w: Tensor, down_w: Tensor, v_embed: Tensor | None = None, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out, raw_v = self.attn(self.attn_norm(x_in) * self.ln_scale_factor, q_w, k_w, v_w, out_w, v_embed=v_embed, v0=v0)
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        if self.dtg_gate is not None:
+            gate = torch.sigmoid(self.dtg_gate(x_in.detach()))
+            x_out = x_in + gate * (x_out - x_in)
+        return x_out, raw_v
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        mtp_num_heads: int = 0,
+        mtp_loss_weight: float = 0.1,
+        bigram_vocab_size: int = 0,
+        bigram_dim: int = 128,
+        xsa_last_n: int = 0,
+        rope_dims: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        ve_enabled: bool = False,
+        ve_dim: int = 128,
+        ve_layers: str = "9,10",
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self._ve_target_dim = num_kv_heads * (model_dim // num_heads)  # kv_dim for value projection
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.value_residual = value_residual
+        self.mtp_num_heads = mtp_num_heads
+        self.mtp_loss_weight = mtp_loss_weight
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.smear = SmearGate(model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        # Parameter banks: contiguous 3D tensors for batched optimizer
+        head_dim = model_dim // num_heads
+        kv_dim = num_kv_heads * head_dim
+        mlp_dim = int(mlp_mult * model_dim)
+        self.num_layers = num_layers
+        self.qo_bank = nn.Parameter(torch.empty(2 * num_layers, model_dim, model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * num_layers, kv_dim, model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(num_layers, mlp_dim, model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(num_layers, model_dim, mlp_dim))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                    layer_idx=i,
+                    ln_scale=ln_scale,
+                    dtg=dtg,
+                    gated_attention=gated_attention,
+                    value_residual=value_residual,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        if rope_dims > 0:
+            head_dim = model_dim // num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = rope_dims
+                block.attn.rotary = Rotary(head_dim, base=rope_base, train_seq_len=1024, rope_dims=rope_dims)
+        self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+        kv_dim_ve = self._ve_target_dim
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim_ve)
+            self.ve_layer_scales = nn.ParameterList(
+                [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices]
+            )
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.value_embeds = nn.ModuleList()  # keep empty for compat
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.mtp_heads = nn.ModuleList(
+            [CastedLinear(model_dim, vocab_size, bias=False) for _ in range(mtp_num_heads)]
+        )
+        for head in self.mtp_heads:
+            head._zero_init = True
+        if xsa_last_n > 0:
+            for i in range(max(0, num_layers - xsa_last_n), num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self._init_weights()
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        # Init banks: orthogonal, with proj layers scaled down and out/down zero-init
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)        # Q
+            nn.init.zeros_(self.qo_bank.data[n + i])                    # Out (zero init)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)        # K
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)    # V
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)    # MLP up
+            nn.init.zeros_(self.mlp_down_bank.data[i])                  # MLP down (zero init)
+            # Scale proj layers (out_proj and mlp_down are "proj" layers)
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        # Init remaining nn.Linear modules (bigram proj, mtp heads, lm_head)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+    def _get_ve(self, layer_idx: int, input_ids: Tensor, ve_cache: dict | None = None) -> Tensor | None:
+        """Get value embedding for a specific layer using shared table + per-layer scale."""
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if ve_cache is not None and 've' not in ve_cache:
+            ve_cache['ve'] = self.ve_shared(input_ids)
+        ve_base = ve_cache['ve'] if ve_cache is not None else self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_base * self.ve_layer_scales[ve_idx].to(dtype=ve_base.dtype)
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x, raw_v = self.blocks[i](x, x0,
+                self.qo_bank[i], self.kv_bank[i], self.kv_bank[n + i],
+                self.qo_bank[n + i], self.mlp_up_bank[i], self.mlp_down_bank[i],
+                v_embed=ve, v0=v0)
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x, _ = self.blocks[bi](x, x0,
+                self.qo_bank[bi], self.kv_bank[bi], self.kv_bank[n + bi],
+                self.qo_bank[n + bi], self.mlp_up_bank[bi], self.mlp_down_bank[bi],
+                v_embed=ve, v0=v0)
+        x = self.final_norm(x)
+        x_flat = x.reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x_flat, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x_flat)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        main_loss = F.cross_entropy(logits.float(), targets, reduction="mean")
+        if self.training and self.mtp_num_heads > 0 and self.mtp_loss_weight > 0.0:
+            _, seqlen, dim = x.shape
+            mtp_loss_sum = x.new_zeros(())
+            mtp_loss_count = 0
+            for k, mtp_head in enumerate(self.mtp_heads):
+                valid_t = seqlen - (k + 1)
+                if valid_t <= 0:
+                    continue
+                mtp_hidden = x[:, :valid_t, :].reshape(-1, dim)
+                mtp_targets = target_ids[:, k + 1 :].reshape(-1)
+                mtp_logits_proj = mtp_head(mtp_hidden)
+                mtp_logits = self.logit_softcap * torch.tanh(mtp_logits_proj / self.logit_softcap)
+                mtp_loss_sum = mtp_loss_sum + F.cross_entropy(mtp_logits.float(), mtp_targets, reduction="mean")
+                mtp_loss_count += 1
+            if mtp_loss_count > 0:
+                main_loss = main_loss + self.mtp_loss_weight * (mtp_loss_sum / mtp_loss_count)
+        return main_loss
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Return logits (bsz, seq_len, vocab) without computing loss."""
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x, raw_v = self.blocks[i](x, x0,
+                self.qo_bank[i], self.kv_bank[i], self.kv_bank[n + i],
+                self.qo_bank[n + i], self.mlp_up_bank[i], self.mlp_down_bank[i],
+                v_embed=ve, v0=v0)
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x, _ = self.blocks[bi](x, x0,
+                self.qo_bank[bi], self.kv_bank[bi], self.kv_bank[n + bi],
+                self.qo_bank[n + bi], self.mlp_up_bank[bi], self.mlp_down_bank[bi],
+                v_embed=ve, v0=v0)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+# --- Sliding window evaluation ---
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context."""
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= 1]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    base_model.eval()
+    compiled_logits = torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = compiled_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+def eval_val_sliding_ttt(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    stride: int, batch_seqs: int = 32, log0=print,
+) -> tuple[float, float]:
+    """Legal score-first TTT (PR #461 recipe): score each chunk with sliding windows,
+    then train on it. Every token scored BEFORE any update that could use it."""
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = args.ttt_chunk_tokens
+
+    # Pre-compute all window starts
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+
+    # Assign each window to a chunk based on the first token it scores
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    chunk_windows: list[list[int]] = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        end = min(ws + seq_len, total_tokens)
+        wlen = end - ws
+        s = 0 if ws == 0 else max(wlen - stride, 0)
+        scored_start = ws + s
+        ci = min(scored_start // ttt_chunk, num_chunks - 1)
+        chunk_windows[ci].append(ws)
+
+    log0(f"ttt_sliding:start chunks={num_chunks} chunk_tokens={ttt_chunk} "
+         f"total_windows={len(window_starts)} stride={stride} "
+         f"ttt_lr={args.ttt_lr} ttt_epochs={args.ttt_epochs} "
+         f"freeze_blocks={args.ttt_freeze_blocks}")
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Freeze first N blocks
+    frozen_block_ids = set(range(min(args.ttt_freeze_blocks, len(base_model.blocks))))
+    ttt_params = []
+    for name, p in base_model.named_parameters():
+        freeze = False
+        for bi in frozen_block_ids:
+            if f"blocks.{bi}." in name:
+                freeze = True
+                break
+        if freeze:
+            p.requires_grad_(False)
+        else:
+            p.requires_grad_(True)
+            ttt_params.append(p)
+
+    log0(f"ttt_sliding:params unfrozen={sum(p.numel() for p in ttt_params)} "
+         f"frozen={sum(p.numel() for p in base_model.parameters() if not p.requires_grad)}")
+
+    optimizer = torch.optim.SGD(ttt_params, lr=args.ttt_lr, momentum=args.ttt_momentum)
+    t0 = time.perf_counter()
+
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows:
+            continue
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+
+        # --- Phase 1: SCORE this chunk's windows (inference_mode) ---
+        my_s = (len(windows) * rank) // world_size
+        my_e = (len(windows) * (rank + 1)) // world_size
+        my_windows = windows[my_s:my_e]
+
+        base_model.eval()
+        with torch.inference_mode():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi:bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens: list[int] = []
+                for i, ws in enumerate(batch_ws):
+                    end = min(ws + seq_len, total_tokens)
+                    wlen = end - ws
+                    wlens.append(wlen)
+                    chunk_tok = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                    x_batch[i, :wlen] = chunk_tok[:-1]
+                    y_batch[i, :wlen] = chunk_tok[1:]
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model.forward_logits(x_batch)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y_batch.reshape(-1), reduction="none",
+                ).reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]
+                    s = 0 if ws == 0 else max(wlen - stride, 0)
+                    scored_nll = nll[i, s:wlen].to(torch.float64)
+                    loss_sum += scored_nll.sum()
+                    token_count += float(wlen - s)
+                    tgt, prev = y_batch[i, s:wlen], x_batch[i, s:wlen]
+                    tb = base_bytes_lut[tgt].to(torch.float64)
+                    tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                    byte_count += tb.sum()
+
+        # --- Phase 2: TRAIN on this chunk (already scored = legal) ---
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and args.ttt_epochs > 0:
+            base_model.train()
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if chunk_seqs > 0:
+                cos_lr = args.ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                for pg in optimizer.param_groups:
+                    pg['lr'] = cos_lr
+                my_seq_s = (chunk_seqs * rank) // world_size
+                my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+                my_chunk_seqs = my_seq_e - my_seq_s
+                for _ep in range(args.ttt_epochs):
+                    for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                        be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                        actual_bs = my_seq_s + bs
+                        start_tok = chunk_start + actual_bs * seq_len
+                        end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                        if end_tok > val_tokens.numel():
+                            continue
+                        local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                        x = local[:-1].reshape(-1, seq_len)
+                        y = local[1:].reshape(-1, seq_len)
+                        optimizer.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            loss = base_model(x, y)
+                        loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        torch.nn.utils.clip_grad_norm_(ttt_params, args.ttt_grad_clip)
+                        optimizer.step()
+
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            log0(f"  ttt_chunk [{ci+1}/{num_chunks}] bpb={rbpb:.6f} time={elapsed:.1f}s")
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+    log0(f"ttt_sliding:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+         f"elapsed={time.perf_counter() - t0:.1f}s")
+    return val_loss, val_bpb
+
+
+# --- GPTQ-lite int6 quantization ---
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+def quantize_int6_per_row(t: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        best_q, best_s, best_err = None, None, float('inf')
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            if pct < 1.0:
+                row_clip = torch.quantile(t32.abs(), pct, dim=1)
+            else:
+                row_clip = t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+            recon = q.float() * s.float()[:, None]
+            err = (t32 - recon).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_s, best_err = q, s, err
+        return best_q, best_s
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+
+def _unbank_state_dict(sd: dict[str, Tensor], num_layers: int) -> dict[str, Tensor]:
+    """Convert 3D bank tensors into individual 2D tensors with standard names."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    for name, tensor in sd.items():
+        if name == "qo_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_q.weight"] = tensor[i]
+                out[f"blocks.{i}.attn.proj.weight"] = tensor[n + i]
+        elif name == "kv_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_k.weight"] = tensor[i]
+                out[f"blocks.{i}.attn.c_v.weight"] = tensor[n + i]
+        elif name == "mlp_up_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.fc.weight"] = tensor[i]
+        elif name == "mlp_down_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.proj.weight"] = tensor[i]
+        else:
+            out[name] = tensor
+    return out
+
+def _rebank_state_dict(sd: dict[str, Tensor], num_layers: int, template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    """Convert individual 2D tensors back into 3D bank tensors."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    # Reconstruct banks from individual weight keys
+    qo_slices = [None] * (2 * n)
+    kv_slices = [None] * (2 * n)
+    up_slices = [None] * n
+    down_slices = [None] * n
+    consumed = set()
+    for i in range(n):
+        qk = f"blocks.{i}.attn.c_q.weight"
+        if qk in sd:
+            qo_slices[i] = sd[qk]
+            consumed.add(qk)
+        ok = f"blocks.{i}.attn.proj.weight"
+        if ok in sd:
+            qo_slices[n + i] = sd[ok]
+            consumed.add(ok)
+        kk = f"blocks.{i}.attn.c_k.weight"
+        if kk in sd:
+            kv_slices[i] = sd[kk]
+            consumed.add(kk)
+        vk = f"blocks.{i}.attn.c_v.weight"
+        if vk in sd:
+            kv_slices[n + i] = sd[vk]
+            consumed.add(vk)
+        fk = f"blocks.{i}.mlp.fc.weight"
+        if fk in sd:
+            up_slices[i] = sd[fk]
+            consumed.add(fk)
+        dk = f"blocks.{i}.mlp.proj.weight"
+        if dk in sd:
+            down_slices[i] = sd[dk]
+            consumed.add(dk)
+    out["qo_bank"] = torch.stack(qo_slices).to(dtype=template_sd["qo_bank"].dtype)
+    out["kv_bank"] = torch.stack(kv_slices).to(dtype=template_sd["kv_bank"].dtype)
+    out["mlp_up_bank"] = torch.stack(up_slices).to(dtype=template_sd["mlp_up_bank"].dtype)
+    out["mlp_down_bank"] = torch.stack(down_slices).to(dtype=template_sd["mlp_down_bank"].dtype)
+    for name, tensor in sd.items():
+        if name not in consumed:
+            out[name] = tensor
+    return out
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    num_layers_total = max(
+        (int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")),
+        default=0,
+    ) + 1
+    late_k_layers = set(range(num_layers_total - 2, num_layers_total))
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+# --- Training ---
+
+def main() -> None:
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    # zeropower_via_newtonschulz5 runs eagerly with bmm -- do NOT compile
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    # With MIG fix above, each process only sees its assigned GPU as device 0
+    device = torch.device("cuda", 0)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    effective_eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+    CastedLinear._qat_enabled = args.qat_enabled
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=args.mtp_num_heads,
+        mtp_loss_weight=args.mtp_loss_weight,
+        bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims,
+        ln_scale=args.ln_scale,
+        dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled,
+        ve_dim=args.ve_dim,
+        ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention,
+        value_residual=args.value_residual,
+    ).to(device).bfloat16()
+    # Banks stay FP32 (like CastedLinear weights), cast to BF16 in forward
+    base_model.qo_bank.data = base_model.qo_bank.data.float()
+    base_model.kv_bank.data = base_model.kv_bank.data.float()
+    base_model.mlp_up_bank.data = base_model.mlp_up_bank.data.float()
+    base_model.mlp_down_bank.data = base_model.mlp_down_bank.data.float()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    # No DDP -- Parallel Muon handles bank grad communication via reduce-scatter,
+    # and non-bank grads are manually all-reduced before Adam steps.
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model = compiled_model
+
+    # Optimizer split:
+    # - 4 parameter banks -> Muon (batched Newton-Schulz)
+    # - token embedding -> Adam
+    # - scalars/control tensors -> Adam
+    # - bigram proj, mtp heads, VE proj -> Adam (small matrix params not worth banking)
+    matrix_params = [
+        base_model.qo_bank, base_model.kv_bank,
+        base_model.mlp_up_bank, base_model.mlp_down_bank,
+    ]
+    block_named_params = list(base_model.blocks.named_parameters())
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_params.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None:
+            scalar_params.append(base_model.bigram.proj.weight)
+    if base_model.ve_shared is not None:
+        tok_params.append({"params": [base_model.ve_shared.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.ve_shared.proj is not None:
+            scalar_params.append(base_model.ve_shared.proj.weight)
+        scalar_params.append(base_model.ve_shared.scale)
+        for s in base_model.ve_layer_scales:
+            scalar_params.append(s)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    # Non-bank params that need manual all-reduce (replicated across GPUs)
+    replicated_params = list(optimizer_tok.param_groups[0]["params"])
+    for pg in optimizer_tok.param_groups[1:]:
+        replicated_params.extend(pg["params"])
+    replicated_params.extend(scalar_params)
+
+    optimizer_head = None
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        replicated_params.append(base_model.lm_head.weight)
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if optimizer_head is not None:
+        optimizers.append(optimizer_head)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    mtp_params = sum(p.numel() for p in base_model.mtp_heads.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"mtp_num_heads:{args.mtp_num_heads} mtp_loss_weight:{args.mtp_loss_weight} mtp_params:{mtp_params}")
+    xsa_layers = [i for i, b in enumerate(base_model.blocks) if b.attn.use_xsa]
+    log0(f"XSA:last_{args.xsa_last_n} active_layers:{xsa_layers}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            # All-reduce all grads for warmup (simple, not optimized)
+            if distributed:
+                for p in base_model.parameters():
+                    if p.grad is not None:
+                        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    from collections import deque
+    lawa_queue: deque[dict[str, Tensor]] = deque(maxlen=args.lawa_k)
+    ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    ema_decay = 0.997
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            # Estimate artifact size (int6+lzma) at each validation step
+            try:
+                sd_snap = {k: v.detach().cpu() for k, v in base_model.state_dict().items()
+                           if "mtp_heads" not in k}
+                unbanked_snap = _unbank_state_dict(sd_snap, args.num_layers)
+                q_snap, m_snap = mixed_quantize_int6(unbanked_snap, {"mlp", "attn"})
+                snap_buf = io.BytesIO()
+                torch.save({"w": q_snap, "m": m_snap}, snap_buf)
+                snap_compressed = len(lzma.compress(snap_buf.getvalue(), preset=6))
+                snap_code_bytes = len(code.encode("utf-8"))
+                snap_total = snap_compressed + snap_code_bytes
+                log0(
+                    f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                    f"artifact_bytes:{snap_total} model_int6_lzma:{snap_compressed} "
+                    f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+                )
+            except Exception as e:
+                log0(
+                    f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                    f"artifact_size:error({e}) "
+                    f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+                )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        if args.late_qat_threshold > 0 and scale < args.late_qat_threshold and not CastedLinear._qat_enabled:
+            CastedLinear._qat_enabled = True
+            log0(f"late_qat:enabled step:{step} scale:{scale:.4f}")
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        # === 3-phase overlapped optimizer step ===
+        # Phase 1: Launch async reduce-scatter for banks (biggest first)
+        optimizer_muon.launch_reduce_scatters()
+        # Phase 2: All-reduce non-bank grads + step Adam (while bank RS is in-flight)
+        if distributed:
+            for p in replicated_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+        optimizer_tok.step()
+        optimizer_scalar.step()
+        if optimizer_head is not None:
+            optimizer_head.step()
+        # Phase 3: Wait for RS, local NS5, all-gather (banks processed last)
+        optimizer_muon.step()
+        zero_grad_all()
+        # EMA update
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(t.detach().float(), alpha=1.0 - ema_decay)
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        if args.swa_enabled and scale < 0.2 and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+        if args.lawa_enabled and step % args.lawa_freq == 0:
+            lawa_queue.append({name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()})
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+    # Apply weight averaging
+    if args.lawa_enabled and len(lawa_queue) > 1:
+        log0(f"lawa:applying LAWA averaging k={len(lawa_queue)}")
+        current_state = base_model.state_dict()
+        avg_state = {name: torch.zeros(t.shape, dtype=torch.float32, device='cpu') for name, t in current_state.items()}
+        for snap in lawa_queue:
+            for name in avg_state:
+                avg_state[name] += snap[name].float()
+        for name in avg_state:
+            avg_state[name] /= len(lawa_queue)
+            avg_state[name] = avg_state[name].to(dtype=current_state[name].dtype)
+        base_model.load_state_dict(avg_state, strict=True)
+    else:
+        log0("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+        base_model.load_state_dict(avg_state, strict=True)
+    torch.cuda.synchronize()
+    t_diag = time.perf_counter()
+    diag_val_loss, diag_val_bpb = eval_val(
+        args, compiled_model, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"DIAGNOSTIC post_ema val_loss:{diag_val_loss:.4f} val_bpb:{diag_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_diag):.0f}ms"
+    )
+    full_state_dict = base_model.state_dict()
+    export_sd = {k: v for k, v in full_state_dict.items() if "mtp_heads" not in k}
+    excluded_mtp = sum(int(t.numel()) for k, t in full_state_dict.items() if "mtp_heads" in k)
+    if excluded_mtp > 0:
+        log0(f"export_excluding_mtp_params:{excluded_mtp}")
+    if master_process:
+        torch.save(export_sd, "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+    # Unbank 3D tensors into individual 2D tensors for quantization
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    unbanked_sd = _unbank_state_dict(sd_cpu, args.num_layers)
+    quant_result, quant_meta = mixed_quantize_int6(unbanked_sd, {"mlp", "attn"})
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = lzma.compress(quant_raw, preset=6)
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = len(quant_blob)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+lzma: {quant_file_bytes} bytes")
+        log0(f"Total submission size int6+lzma: {quant_file_bytes + code_bytes} bytes")
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(lzma.decompress(quant_blob_disk)),
+        map_location="cpu",
+    )
+    deq_unbanked = dequantize_mixed_int6(quant_state["w"], quant_state["m"], unbanked_sd)
+    # Re-bank the dequantized tensors
+    deq_state = _rebank_state_dict(deq_unbanked, args.num_layers, sd_cpu)
+    eval_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=0, mtp_loss_weight=0.0,
+        bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims, ln_scale=args.ln_scale, dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention, value_residual=args.value_residual,
+    ).to(device).bfloat16()
+    eval_model.qo_bank.data = eval_model.qo_bank.data.float()
+    eval_model.kv_bank.data = eval_model.kv_bank.data.float()
+    eval_model.mlp_up_bank.data = eval_model.mlp_up_bank.data.float()
+    eval_model.mlp_down_bank.data = eval_model.mlp_down_bank.data.float()
+    for m in eval_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(eval_model)
+    eval_model.load_state_dict(deq_state, strict=True)
+    compiled_eval = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args, compiled_eval, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        eval_seq_len=effective_eval_seq_len,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+    sw_seq_len = effective_eval_seq_len
+    if args.eval_stride > 0 and args.eval_stride < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+        log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+    if args.eval_stride != 64 and 64 < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide64 = time.perf_counter()
+        sw64_val_loss, sw64_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=64,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window_s64 val_loss:{sw64_val_loss:.4f} val_bpb:{sw64_val_bpb:.4f} "
+            f"stride:64 eval_time:{1000.0 * (time.perf_counter() - t_slide64):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_s64_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+        log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+    # Legal score-first TTT (PR #461 recipe)
+    if args.ttt_enabled:
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_loss, ttt_bpb = eval_val_sliding_ttt(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, log0=log0,
+        )
+        torch.cuda.synchronize()
+        log0(f"legal_ttt val_loss:{ttt_loss:.4f} val_bpb:{ttt_bpb:.4f} "
+             f"eval_time:{1000.0 * (time.perf_counter() - t_ttt):.0f}ms")
+        log0(f"legal_ttt_exact val_loss:{ttt_loss:.8f} val_bpb:{ttt_bpb:.8f}")
+    if distributed:
+        dist.destroy_process_group()
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-03-28_ExtendedCompute_50K_11hours_4xA100MIG_ScalingAnalysis/train_step20k_seed1337.txt
+++ b/records/track_non_record_16mb/2026-03-28_ExtendedCompute_50K_11hours_4xA100MIG_ScalingAnalysis/train_step20k_seed1337.txt
@@ -1,0 +1,2241 @@
+logs/run_recordsota_nonrecord_seed1337.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26928220
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_4 active_layers:[7, 8, 9, 10]
+world_size:4 grad_accum_steps:2
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:0.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9304 val_bpb:4.1046 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9317 train_time:850ms step_avg:849.64ms
+step:2/20000 train_loss:8.6832 train_time:1394ms step_avg:696.84ms
+step:3/20000 train_loss:7.6849 train_time:2245ms step_avg:748.41ms
+step:4/20000 train_loss:7.1825 train_time:3097ms step_avg:774.24ms
+step:5/20000 train_loss:7.1342 train_time:3949ms step_avg:789.77ms
+step:6/20000 train_loss:7.1129 train_time:4801ms step_avg:800.14ms
+step:7/20000 train_loss:7.1092 train_time:5653ms step_avg:807.50ms
+step:8/20000 train_loss:6.9540 train_time:6505ms step_avg:813.11ms
+step:9/20000 train_loss:6.6136 train_time:7357ms step_avg:817.44ms
+step:10/20000 train_loss:6.2387 train_time:8218ms step_avg:821.76ms
+step:500/20000 train_loss:2.3635 train_time:414424ms step_avg:828.85ms
+step:1000/20000 train_loss:2.2672 train_time:828685ms step_avg:828.68ms
+step:1500/20000 train_loss:2.1838 train_time:1243209ms step_avg:828.81ms
+step:2000/20000 train_loss:2.0379 train_time:1657693ms step_avg:828.85ms
+step:2500/20000 train_loss:2.1580 train_time:2071960ms step_avg:828.78ms
+step:3000/20000 train_loss:2.1211 train_time:2486377ms step_avg:828.79ms
+step:3500/20000 train_loss:2.1881 train_time:2900521ms step_avg:828.72ms
+step:4000/20000 train_loss:2.1446 train_time:3314659ms step_avg:828.66ms
+step:4000/20000 val_loss:2.0755 val_bpb:1.2292 train_time:3315001ms step_avg:828.75ms
+step:4500/20000 train_loss:2.1098 train_time:3728932ms step_avg:828.65ms
+step:5000/20000 train_loss:2.0727 train_time:4143237ms step_avg:828.65ms
+step:5500/20000 train_loss:2.1133 train_time:4557500ms step_avg:828.64ms
+step:6000/20000 train_loss:2.0121 train_time:4971750ms step_avg:828.63ms
+step:6500/20000 train_loss:2.2772 train_time:5385925ms step_avg:828.60ms
+step:7000/20000 train_loss:1.9077 train_time:5800366ms step_avg:828.62ms
+step:7500/20000 train_loss:2.0332 train_time:6214436ms step_avg:828.59ms
+step:8000/20000 train_loss:1.9856 train_time:6628761ms step_avg:828.60ms
+step:8000/20000 val_loss:2.0333 val_bpb:1.2043 train_time:6629111ms step_avg:828.64ms
+step:8500/20000 train_loss:1.9662 train_time:7043229ms step_avg:828.62ms
+step:9000/20000 train_loss:2.0891 train_time:7457441ms step_avg:828.60ms
+step:9500/20000 train_loss:2.2474 train_time:7872123ms step_avg:828.64ms
+step:10000/20000 train_loss:2.0618 train_time:8286352ms step_avg:828.64ms
+step:10500/20000 train_loss:2.0948 train_time:8700592ms step_avg:828.63ms
+step:11000/20000 train_loss:1.9865 train_time:9115076ms step_avg:828.64ms
+step:11500/20000 train_loss:1.9466 train_time:9529240ms step_avg:828.63ms
+step:12000/20000 train_loss:1.9609 train_time:9943485ms step_avg:828.62ms
+step:12000/20000 val_loss:2.0241 val_bpb:1.1988 train_time:9943828ms step_avg:828.65ms
+step:12500/20000 train_loss:1.9691 train_time:10357780ms step_avg:828.62ms
+step:13000/20000 train_loss:1.9781 train_time:10772024ms step_avg:828.62ms
+step:13500/20000 train_loss:2.0928 train_time:11186188ms step_avg:828.61ms
+step:14000/20000 train_loss:1.8907 train_time:11600289ms step_avg:828.59ms
+step:14500/20000 train_loss:2.0651 train_time:12014544ms step_avg:828.59ms
+step:15000/20000 train_loss:2.0078 train_time:12428690ms step_avg:828.58ms
+step:15500/20000 train_loss:1.9744 train_time:12842898ms step_avg:828.57ms
+step:16000/20000 train_loss:2.0443 train_time:13257276ms step_avg:828.58ms
+step:16000/20000 val_loss:1.9697 val_bpb:1.1666 train_time:13257627ms step_avg:828.60ms
+step:16500/20000 train_loss:2.0235 train_time:13671525ms step_avg:828.58ms
+step:17000/20000 train_loss:2.0201 train_time:14085842ms step_avg:828.58ms
+step:17500/20000 train_loss:1.9946 train_time:14500144ms step_avg:828.58ms
+step:18000/20000 train_loss:1.8680 train_time:14914297ms step_avg:828.57ms
+swa:start step:18450
+step:18500/20000 train_loss:1.8339 train_time:15328815ms step_avg:828.58ms
+late_qat:enabled step:18831 scale:0.1499
+step:19000/20000 train_loss:1.8034 train_time:15744113ms step_avg:828.64ms
+step:19500/20000 train_loss:1.9822 train_time:16159354ms step_avg:828.68ms
+step:20000/20000 train_loss:1.8749 train_time:16574509ms step_avg:828.73ms
+step:20000/20000 val_loss:1.8748 val_bpb:1.1104 train_time:16574910ms step_avg:828.75ms
+peak memory allocated: 22092 MiB reserved: 22340 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.8738 val_bpb:1.1098 eval_time:19704ms
+Serialized model: 106027446 bytes
+Code size: 90361 bytes
+Serialized model int6+lzma: 14987572 bytes
+Total submission size int6+lzma: 15077933 bytes
+final_int6_roundtrip val_loss:1.8998 val_bpb:1.1252 eval_time:24388ms
+final_int6_roundtrip_exact val_loss:1.89979453 val_bpb:1.12516533
+final_int6_sliding_window val_loss:1.8604 val_bpb:1.1018 stride:64 eval_time:664624ms
+final_int6_sliding_window_exact val_loss:1.86041005 val_bpb:1.10184254
+final_int8_zlib_roundtrip_exact val_loss:1.86041005 val_bpb:1.10184254
+ttt_sliding:start chunks=1893 chunk_tokens=32768 total_windows=969088 stride=64 ttt_lr=0.002 ttt_epochs=3 freeze_blocks=0
+ttt_sliding:params unfrozen=26928220 frozen=0
+  ttt_chunk [1/1893] bpb=1.148962 time=1.1s
+  ttt_chunk [11/1893] bpb=1.106649 time=11.9s
+  ttt_chunk [21/1893] bpb=1.109183 time=22.7s
+  ttt_chunk [31/1893] bpb=1.112465 time=33.4s
+  ttt_chunk [41/1893] bpb=1.101158 time=44.2s
+  ttt_chunk [51/1893] bpb=1.097352 time=55.0s
+  ttt_chunk [61/1893] bpb=1.102163 time=65.7s
+  ttt_chunk [71/1893] bpb=1.099272 time=76.5s
+  ttt_chunk [81/1893] bpb=1.099287 time=87.3s
+  ttt_chunk [91/1893] bpb=1.097889 time=98.1s
+  ttt_chunk [101/1893] bpb=1.100512 time=108.9s
+  ttt_chunk [111/1893] bpb=1.101752 time=119.7s
+  ttt_chunk [121/1893] bpb=1.098599 time=130.4s
+  ttt_chunk [131/1893] bpb=1.098481 time=141.2s
+  ttt_chunk [141/1893] bpb=1.098188 time=152.0s
+  ttt_chunk [151/1893] bpb=1.101303 time=162.8s
+  ttt_chunk [161/1893] bpb=1.102934 time=173.6s
+  ttt_chunk [171/1893] bpb=1.103556 time=184.3s
+  ttt_chunk [181/1893] bpb=1.103556 time=195.1s
+  ttt_chunk [191/1893] bpb=1.106780 time=205.9s
+  ttt_chunk [201/1893] bpb=1.107089 time=216.7s
+  ttt_chunk [211/1893] bpb=1.104621 time=227.4s
+  ttt_chunk [221/1893] bpb=1.106682 time=238.2s
+  ttt_chunk [231/1893] bpb=1.106153 time=249.0s
+  ttt_chunk [241/1893] bpb=1.105951 time=259.8s
+  ttt_chunk [251/1893] bpb=1.104500 time=270.5s
+  ttt_chunk [261/1893] bpb=1.102854 time=281.3s
+  ttt_chunk [271/1893] bpb=1.101507 time=292.1s
+  ttt_chunk [281/1893] bpb=1.103788 time=302.9s
+  ttt_chunk [291/1893] bpb=1.104513 time=313.6s
+  ttt_chunk [301/1893] bpb=1.105062 time=324.4s
+  ttt_chunk [311/1893] bpb=1.106585 time=335.2s
+  ttt_chunk [321/1893] bpb=1.108036 time=346.0s
+  ttt_chunk [331/1893] bpb=1.107902 time=356.7s
+  ttt_chunk [341/1893] bpb=1.108209 time=367.5s
+  ttt_chunk [351/1893] bpb=1.109486 time=378.3s
+  ttt_chunk [361/1893] bpb=1.110674 time=389.1s
+  ttt_chunk [371/1893] bpb=1.110192 time=399.9s
+  ttt_chunk [381/1893] bpb=1.110144 time=410.6s
+  ttt_chunk [391/1893] bpb=1.109733 time=421.4s
+  ttt_chunk [401/1893] bpb=1.108356 time=432.2s
+  ttt_chunk [411/1893] bpb=1.107227 time=442.9s
+  ttt_chunk [421/1893] bpb=1.106719 time=453.7s
+  ttt_chunk [431/1893] bpb=1.107374 time=464.5s
+  ttt_chunk [441/1893] bpb=1.107195 time=475.3s
+  ttt_chunk [451/1893] bpb=1.106903 time=486.1s
+  ttt_chunk [461/1893] bpb=1.106178 time=496.8s
+  ttt_chunk [471/1893] bpb=1.105772 time=507.6s
+  ttt_chunk [481/1893] bpb=1.105518 time=518.4s
+  ttt_chunk [491/1893] bpb=1.105211 time=529.2s
+  ttt_chunk [501/1893] bpb=1.104631 time=539.9s
+  ttt_chunk [511/1893] bpb=1.104022 time=550.7s
+  ttt_chunk [521/1893] bpb=1.102977 time=561.5s
+  ttt_chunk [531/1893] bpb=1.103083 time=572.2s
+  ttt_chunk [541/1893] bpb=1.103047 time=583.0s
+  ttt_chunk [551/1893] bpb=1.101880 time=593.8s
+  ttt_chunk [561/1893] bpb=1.102420 time=604.6s
+  ttt_chunk [571/1893] bpb=1.101740 time=615.3s
+  ttt_chunk [581/1893] bpb=1.101206 time=626.1s
+  ttt_chunk [591/1893] bpb=1.100569 time=636.9s
+  ttt_chunk [601/1893] bpb=1.101233 time=647.7s
+  ttt_chunk [611/1893] bpb=1.100826 time=658.5s
+  ttt_chunk [621/1893] bpb=1.100733 time=669.2s
+  ttt_chunk [631/1893] bpb=1.101122 time=680.0s
+  ttt_chunk [641/1893] bpb=1.100907 time=690.8s
+  ttt_chunk [651/1893] bpb=1.100916 time=701.6s
+  ttt_chunk [661/1893] bpb=1.100822 time=712.3s
+  ttt_chunk [671/1893] bpb=1.100437 time=723.1s
+  ttt_chunk [681/1893] bpb=1.100704 time=733.9s
+  ttt_chunk [691/1893] bpb=1.101402 time=744.7s
+  ttt_chunk [701/1893] bpb=1.100649 time=755.4s
+  ttt_chunk [711/1893] bpb=1.101214 time=766.2s
+  ttt_chunk [721/1893] bpb=1.100855 time=777.0s
+  ttt_chunk [731/1893] bpb=1.101286 time=787.8s
+  ttt_chunk [741/1893] bpb=1.101246 time=798.6s
+  ttt_chunk [751/1893] bpb=1.100906 time=809.3s
+  ttt_chunk [761/1893] bpb=1.100754 time=820.1s
+  ttt_chunk [771/1893] bpb=1.100535 time=830.9s
+  ttt_chunk [781/1893] bpb=1.101052 time=841.6s
+  ttt_chunk [791/1893] bpb=1.100729 time=852.4s
+  ttt_chunk [801/1893] bpb=1.100817 time=863.2s
+  ttt_chunk [811/1893] bpb=1.100349 time=874.0s
+  ttt_chunk [821/1893] bpb=1.100161 time=884.7s
+  ttt_chunk [831/1893] bpb=1.099731 time=895.5s
+  ttt_chunk [841/1893] bpb=1.099163 time=906.3s
+  ttt_chunk [851/1893] bpb=1.099062 time=917.1s
+  ttt_chunk [861/1893] bpb=1.099192 time=927.9s
+  ttt_chunk [871/1893] bpb=1.099234 time=938.6s
+  ttt_chunk [881/1893] bpb=1.099269 time=949.4s
+  ttt_chunk [891/1893] bpb=1.099098 time=960.2s
+  ttt_chunk [901/1893] bpb=1.099091 time=971.0s
+  ttt_chunk [911/1893] bpb=1.099081 time=981.7s
+  ttt_chunk [921/1893] bpb=1.099457 time=992.5s
+  ttt_chunk [931/1893] bpb=1.099302 time=1003.3s
+  ttt_chunk [941/1893] bpb=1.099197 time=1014.1s
+  ttt_chunk [951/1893] bpb=1.099211 time=1024.8s
+  ttt_chunk [961/1893] bpb=1.098954 time=1035.6s
+  ttt_chunk [971/1893] bpb=1.099679 time=1046.4s
+  ttt_chunk [981/1893] bpb=1.099805 time=1057.1s
+  ttt_chunk [991/1893] bpb=1.099714 time=1067.9s
+  ttt_chunk [1001/1893] bpb=1.099874 time=1078.7s
+  ttt_chunk [1011/1893] bpb=1.100135 time=1089.5s
+  ttt_chunk [1021/1893] bpb=1.100290 time=1100.2s
+  ttt_chunk [1031/1893] bpb=1.100826 time=1111.0s
+  ttt_chunk [1041/1893] bpb=1.100503 time=1121.8s
+  ttt_chunk [1051/1893] bpb=1.100230 time=1132.6s
+  ttt_chunk [1061/1893] bpb=1.100500 time=1143.3s
+  ttt_chunk [1071/1893] bpb=1.100973 time=1154.1s
+  ttt_chunk [1081/1893] bpb=1.100979 time=1164.9s
+  ttt_chunk [1091/1893] bpb=1.101374 time=1175.7s
+  ttt_chunk [1101/1893] bpb=1.101517 time=1186.4s
+  ttt_chunk [1111/1893] bpb=1.101291 time=1197.2s
+  ttt_chunk [1121/1893] bpb=1.101240 time=1208.0s
+  ttt_chunk [1131/1893] bpb=1.101147 time=1218.8s
+  ttt_chunk [1141/1893] bpb=1.101001 time=1229.5s
+  ttt_chunk [1151/1893] bpb=1.101048 time=1240.3s
+  ttt_chunk [1161/1893] bpb=1.100357 time=1251.1s
+  ttt_chunk [1171/1893] bpb=1.100923 time=1261.9s
+  ttt_chunk [1181/1893] bpb=1.100425 time=1272.6s
+  ttt_chunk [1191/1893] bpb=1.100132 time=1283.4s
+  ttt_chunk [1201/1893] bpb=1.100718 time=1294.2s
+  ttt_chunk [1211/1893] bpb=1.100113 time=1304.9s
+  ttt_chunk [1221/1893] bpb=1.099789 time=1315.7s
+  ttt_chunk [1231/1893] bpb=1.099716 time=1326.5s
+  ttt_chunk [1241/1893] bpb=1.099538 time=1337.3s
+  ttt_chunk [1251/1893] bpb=1.099298 time=1348.0s
+  ttt_chunk [1261/1893] bpb=1.099230 time=1358.8s
+  ttt_chunk [1271/1893] bpb=1.099030 time=1369.6s
+  ttt_chunk [1281/1893] bpb=1.098825 time=1380.4s
+  ttt_chunk [1291/1893] bpb=1.098638 time=1391.1s
+  ttt_chunk [1301/1893] bpb=1.098263 time=1401.9s
+  ttt_chunk [1311/1893] bpb=1.097961 time=1412.7s
+  ttt_chunk [1321/1893] bpb=1.097795 time=1423.4s
+  ttt_chunk [1331/1893] bpb=1.097718 time=1434.2s
+  ttt_chunk [1341/1893] bpb=1.097600 time=1445.0s
+  ttt_chunk [1351/1893] bpb=1.097546 time=1455.8s
+  ttt_chunk [1361/1893] bpb=1.097752 time=1466.5s
+  ttt_chunk [1371/1893] bpb=1.097602 time=1477.3s
+  ttt_chunk [1381/1893] bpb=1.097542 time=1488.1s
+  ttt_chunk [1391/1893] bpb=1.097027 time=1498.8s
+  ttt_chunk [1401/1893] bpb=1.097052 time=1509.6s
+  ttt_chunk [1411/1893] bpb=1.097076 time=1520.4s
+  ttt_chunk [1421/1893] bpb=1.097336 time=1531.2s
+  ttt_chunk [1431/1893] bpb=1.097182 time=1541.9s
+  ttt_chunk [1441/1893] bpb=1.097860 time=1552.7s
+  ttt_chunk [1451/1893] bpb=1.097967 time=1563.5s
+  ttt_chunk [1461/1893] bpb=1.097711 time=1574.2s
+  ttt_chunk [1471/1893] bpb=1.098624 time=1585.0s
+  ttt_chunk [1481/1893] bpb=1.098435 time=1595.8s
+  ttt_chunk [1491/1893] bpb=1.098445 time=1606.5s
+  ttt_chunk [1501/1893] bpb=1.098608 time=1617.3s
+  ttt_chunk [1511/1893] bpb=1.098687 time=1628.1s
+  ttt_chunk [1521/1893] bpb=1.098715 time=1638.9s
+  ttt_chunk [1531/1893] bpb=1.098533 time=1649.6s
+  ttt_chunk [1541/1893] bpb=1.098501 time=1660.4s
+  ttt_chunk [1551/1893] bpb=1.098854 time=1671.2s
+  ttt_chunk [1561/1893] bpb=1.098993 time=1681.9s
+  ttt_chunk [1571/1893] bpb=1.099120 time=1692.7s
+  ttt_chunk [1581/1893] bpb=1.099236 time=1703.5s
+  ttt_chunk [1591/1893] bpb=1.099189 time=1714.3s
+  ttt_chunk [1601/1893] bpb=1.099373 time=1725.0s
+  ttt_chunk [1611/1893] bpb=1.099446 time=1735.8s
+  ttt_chunk [1621/1893] bpb=1.099315 time=1746.6s
+  ttt_chunk [1631/1893] bpb=1.099486 time=1757.4s
+  ttt_chunk [1641/1893] bpb=1.099365 time=1768.1s
+  ttt_chunk [1651/1893] bpb=1.099269 time=1778.9s
+  ttt_chunk [1661/1893] bpb=1.099155 time=1789.7s
+  ttt_chunk [1671/1893] bpb=1.099519 time=1800.4s
+  ttt_chunk [1681/1893] bpb=1.099767 time=1811.2s
+  ttt_chunk [1691/1893] bpb=1.099741 time=1822.0s
+  ttt_chunk [1701/1893] bpb=1.099731 time=1832.8s
+  ttt_chunk [1711/1893] bpb=1.099572 time=1843.5s
+  ttt_chunk [1721/1893] bpb=1.099426 time=1854.3s
+  ttt_chunk [1731/1893] bpb=1.099378 time=1865.1s
+  ttt_chunk [1741/1893] bpb=1.099166 time=1875.8s
+  ttt_chunk [1751/1893] bpb=1.099024 time=1886.6s
+  ttt_chunk [1761/1893] bpb=1.099109 time=1897.4s
+  ttt_chunk [1771/1893] bpb=1.099028 time=1908.2s
+  ttt_chunk [1781/1893] bpb=1.098987 time=1918.9s
+  ttt_chunk [1791/1893] bpb=1.098601 time=1929.7s
+  ttt_chunk [1801/1893] bpb=1.098603 time=1940.5s
+  ttt_chunk [1811/1893] bpb=1.098432 time=1951.3s
+  ttt_chunk [1821/1893] bpb=1.098469 time=1962.0s
+  ttt_chunk [1831/1893] bpb=1.098074 time=1972.8s
+  ttt_chunk [1841/1893] bpb=1.098044 time=1983.6s
+  ttt_chunk [1851/1893] bpb=1.097814 time=1994.3s
+  ttt_chunk [1861/1893] bpb=1.097345 time=2005.1s
+  ttt_chunk [1871/1893] bpb=1.097193 time=2015.9s
+  ttt_chunk [1881/1893] bpb=1.096820 time=2026.7s
+  ttt_chunk [1891/1893] bpb=1.096650 time=2037.4s
+  ttt_chunk [1893/1893] bpb=1.096669 time=2039.2s
+ttt_sliding:done val_loss=1.850081 val_bpb=1.095725 elapsed=2039.2s
+legal_ttt val_loss:1.8501 val_bpb:1.0957 eval_time:2039891ms
+legal_ttt_exact val_loss:1.85008136 val_bpb:1.09572529
+tch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# --- Quantization helpers ---
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,dtg_gate,ve_layer_scales,ve_shared.scale,attn_gate,vr_lambda",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+# --- Data loading ---
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# --- Transformer modules ---
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                scale = (row_max / 31.0).clamp_min(1.0 / 31.0)
+                w_q = (torch.clamp(torch.round(w32 / scale[:, None]), -32, 31) * scale[:, None]).to(x.dtype)
+            w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024, rope_dims: int = 0):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / (base ** (torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (rd / (rd - 2)))
+                inv_freq = 1.0 / (new_base ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd))
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int = 0) -> Tensor:
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        # No CastedLinear -- weights come from banks
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rope_dims = 0  # set by GPT.__init__ for partial RoPE
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False  # set by GPT.__init__ for deep layers only
+        # Gated attention and value residual (non-banked small params)
+        self.gated_attention = gated_attention
+        if gated_attention:
+            self.attn_gate = nn.Linear(dim, num_heads, bias=True)
+            nn.init.zeros_(self.attn_gate.weight)
+            nn.init.constant_(self.attn_gate.bias, 4.0)
+        self.value_residual = value_residual
+        if value_residual:
+            self.vr_lambda = nn.Parameter(torch.tensor([0.5, 0.5], dtype=torch.float32))
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        """Efficient XSA: subtract self-value projection via GQA-aware reshape (no repeat_interleave).
+        y: [B, T, H, D], v: [B, T, Hkv, D]. H must be divisible by Hkv."""
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)        # [B, T, Hkv, group, D]
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)    # [B, T, Hkv, 1, D] -- broadcast ready
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+    def forward(self, x: Tensor, q_w: Tensor, k_w: Tensor, v_w: Tensor, out_w: Tensor, v_embed: Tensor | None = None, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        bsz, seqlen, dim = x.shape
+        q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype))
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        raw_v = v if self.value_residual else None
+        if self.value_residual and v0 is not None:
+            lam = self.vr_lambda.to(dtype=v.dtype)
+            v = lam[0] * v0 + lam[1] * v
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if _HAS_FA3:
+            y = flash_attn_3_func(q, k, v, causal=True)
+        else:
+            # SDPA expects (B, H, T, D), FA3 uses (B, T, H, D)
+            y = F.scaled_dot_product_attention(
+                q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
+                is_causal=True,
+                enable_gqa=(self.num_kv_heads != self.num_heads),
+            ).transpose(1, 2)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        if self.gated_attention:
+            # gate shape: (bsz, seqlen, num_heads) -> (bsz, seqlen, num_heads, 1) for B,T,H,D layout
+            gate = torch.sigmoid(self.attn_gate(x)).unsqueeze(-1)
+            y = y * gate
+        y = y.reshape(bsz, seqlen, dim)
+        return F.linear(y, out_w.to(x.dtype)), raw_v
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class ValueEmbedding(nn.Module):
+    """Reinject token identity into attention values at specific layers.
+    Each table maps vocab tokens to a low-dim embedding, projected to model_dim."""
+    def __init__(self, vocab_size: int, ve_dim: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, ve_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(ve_dim, model_dim, bias=False) if ve_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(token_ids)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        # No CastedLinear -- weights come from banks
+    def forward(self, x: Tensor, up_w: Tensor, down_w: Tensor) -> Tensor:
+        x = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5)
+        return F.linear(x.square(), down_w.to(x.dtype))
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        layer_idx: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+                                        gated_attention=gated_attention, value_residual=value_residual)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+        if dtg:
+            self.dtg_gate = nn.Linear(dim, 1, bias=True)
+            nn.init.zeros_(self.dtg_gate.weight)
+            nn.init.constant_(self.dtg_gate.bias, 2.0)
+        else:
+            self.dtg_gate = None
+    def forward(self, x: Tensor, x0: Tensor, q_w: Tensor, k_w: Tensor, v_w: Tensor, out_w: Tensor, up_w: Tensor, down_w: Tensor, v_embed: Tensor | None = None, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out, raw_v = self.attn(self.attn_norm(x_in) * self.ln_scale_factor, q_w, k_w, v_w, out_w, v_embed=v_embed, v0=v0)
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        if self.dtg_gate is not None:
+            gate = torch.sigmoid(self.dtg_gate(x_in.detach()))
+            x_out = x_in + gate * (x_out - x_in)
+        return x_out, raw_v
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        mtp_num_heads: int = 0,
+        mtp_loss_weight: float = 0.1,
+        bigram_vocab_size: int = 0,
+        bigram_dim: int = 128,
+        xsa_last_n: int = 0,
+        rope_dims: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        ve_enabled: bool = False,
+        ve_dim: int = 128,
+        ve_layers: str = "9,10",
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self._ve_target_dim = num_kv_heads * (model_dim // num_heads)  # kv_dim for value projection
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.value_residual = value_residual
+        self.mtp_num_heads = mtp_num_heads
+        self.mtp_loss_weight = mtp_loss_weight
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.smear = SmearGate(model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        # Parameter banks: contiguous 3D tensors for batched optimizer
+        head_dim = model_dim // num_heads
+        kv_dim = num_kv_heads * head_dim
+        mlp_dim = int(mlp_mult * model_dim)
+        self.num_layers = num_layers
+        self.qo_bank = nn.Parameter(torch.empty(2 * num_layers, model_dim, model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * num_layers, kv_dim, model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(num_layers, mlp_dim, model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(num_layers, model_dim, mlp_dim))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                    layer_idx=i,
+                    ln_scale=ln_scale,
+                    dtg=dtg,
+                    gated_attention=gated_attention,
+                    value_residual=value_residual,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        if rope_dims > 0:
+            head_dim = model_dim // num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = rope_dims
+                block.attn.rotary = Rotary(head_dim, base=rope_base, train_seq_len=1024, rope_dims=rope_dims)
+        self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+        kv_dim_ve = self._ve_target_dim
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim_ve)
+            self.ve_layer_scales = nn.ParameterList(
+                [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices]
+            )
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.value_embeds = nn.ModuleList()  # keep empty for compat
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.mtp_heads = nn.ModuleList(
+            [CastedLinear(model_dim, vocab_size, bias=False) for _ in range(mtp_num_heads)]
+        )
+        for head in self.mtp_heads:
+            head._zero_init = True
+        if xsa_last_n > 0:
+            for i in range(max(0, num_layers - xsa_last_n), num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self._init_weights()
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        # Init banks: orthogonal, with proj layers scaled down and out/down zero-init
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)        # Q
+            nn.init.zeros_(self.qo_bank.data[n + i])                    # Out (zero init)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)        # K
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)    # V
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)    # MLP up
+            nn.init.zeros_(self.mlp_down_bank.data[i])                  # MLP down (zero init)
+            # Scale proj layers (out_proj and mlp_down are "proj" layers)
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        # Init remaining nn.Linear modules (bigram proj, mtp heads, lm_head)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+    def _get_ve(self, layer_idx: int, input_ids: Tensor, ve_cache: dict | None = None) -> Tensor | None:
+        """Get value embedding for a specific layer using shared table + per-layer scale."""
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if ve_cache is not None and 've' not in ve_cache:
+            ve_cache['ve'] = self.ve_shared(input_ids)
+        ve_base = ve_cache['ve'] if ve_cache is not None else self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_base * self.ve_layer_scales[ve_idx].to(dtype=ve_base.dtype)
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x, raw_v = self.blocks[i](x, x0,
+                self.qo_bank[i], self.kv_bank[i], self.kv_bank[n + i],
+                self.qo_bank[n + i], self.mlp_up_bank[i], self.mlp_down_bank[i],
+                v_embed=ve, v0=v0)
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x, _ = self.blocks[bi](x, x0,
+                self.qo_bank[bi], self.kv_bank[bi], self.kv_bank[n + bi],
+                self.qo_bank[n + bi], self.mlp_up_bank[bi], self.mlp_down_bank[bi],
+                v_embed=ve, v0=v0)
+        x = self.final_norm(x)
+        x_flat = x.reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x_flat, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x_flat)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        main_loss = F.cross_entropy(logits.float(), targets, reduction="mean")
+        if self.training and self.mtp_num_heads > 0 and self.mtp_loss_weight > 0.0:
+            _, seqlen, dim = x.shape
+            mtp_loss_sum = x.new_zeros(())
+            mtp_loss_count = 0
+            for k, mtp_head in enumerate(self.mtp_heads):
+                valid_t = seqlen - (k + 1)
+                if valid_t <= 0:
+                    continue
+                mtp_hidden = x[:, :valid_t, :].reshape(-1, dim)
+                mtp_targets = target_ids[:, k + 1 :].reshape(-1)
+                mtp_logits_proj = mtp_head(mtp_hidden)
+                mtp_logits = self.logit_softcap * torch.tanh(mtp_logits_proj / self.logit_softcap)
+                mtp_loss_sum = mtp_loss_sum + F.cross_entropy(mtp_logits.float(), mtp_targets, reduction="mean")
+                mtp_loss_count += 1
+            if mtp_loss_count > 0:
+                main_loss = main_loss + self.mtp_loss_weight * (mtp_loss_sum / mtp_loss_count)
+        return main_loss
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Return logits (bsz, seq_len, vocab) without computing loss."""
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x, raw_v = self.blocks[i](x, x0,
+                self.qo_bank[i], self.kv_bank[i], self.kv_bank[n + i],
+                self.qo_bank[n + i], self.mlp_up_bank[i], self.mlp_down_bank[i],
+                v_embed=ve, v0=v0)
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x, _ = self.blocks[bi](x, x0,
+                self.qo_bank[bi], self.kv_bank[bi], self.kv_bank[n + bi],
+                self.qo_bank[n + bi], self.mlp_up_bank[bi], self.mlp_down_bank[bi],
+                v_embed=ve, v0=v0)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+# --- Sliding window evaluation ---
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context."""
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= 1]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    base_model.eval()
+    compiled_logits = torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = compiled_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+def eval_val_sliding_ttt(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    stride: int, batch_seqs: int = 32, log0=print,
+) -> tuple[float, float]:
+    """Legal score-first TTT (PR #461 recipe): score each chunk with sliding windows,
+    then train on it. Every token scored BEFORE any update that could use it."""
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = args.ttt_chunk_tokens
+
+    # Pre-compute all window starts
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+
+    # Assign each window to a chunk based on the first token it scores
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    chunk_windows: list[list[int]] = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        end = min(ws + seq_len, total_tokens)
+        wlen = end - ws
+        s = 0 if ws == 0 else max(wlen - stride, 0)
+        scored_start = ws + s
+        ci = min(scored_start // ttt_chunk, num_chunks - 1)
+        chunk_windows[ci].append(ws)
+
+    log0(f"ttt_sliding:start chunks={num_chunks} chunk_tokens={ttt_chunk} "
+         f"total_windows={len(window_starts)} stride={stride} "
+         f"ttt_lr={args.ttt_lr} ttt_epochs={args.ttt_epochs} "
+         f"freeze_blocks={args.ttt_freeze_blocks}")
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Freeze first N blocks
+    frozen_block_ids = set(range(min(args.ttt_freeze_blocks, len(base_model.blocks))))
+    ttt_params = []
+    for name, p in base_model.named_parameters():
+        freeze = False
+        for bi in frozen_block_ids:
+            if f"blocks.{bi}." in name:
+                freeze = True
+                break
+        if freeze:
+            p.requires_grad_(False)
+        else:
+            p.requires_grad_(True)
+            ttt_params.append(p)
+
+    log0(f"ttt_sliding:params unfrozen={sum(p.numel() for p in ttt_params)} "
+         f"frozen={sum(p.numel() for p in base_model.parameters() if not p.requires_grad)}")
+
+    optimizer = torch.optim.SGD(ttt_params, lr=args.ttt_lr, momentum=args.ttt_momentum)
+    t0 = time.perf_counter()
+
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows:
+            continue
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+
+        # --- Phase 1: SCORE this chunk's windows (inference_mode) ---
+        my_s = (len(windows) * rank) // world_size
+        my_e = (len(windows) * (rank + 1)) // world_size
+        my_windows = windows[my_s:my_e]
+
+        base_model.eval()
+        with torch.inference_mode():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi:bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens: list[int] = []
+                for i, ws in enumerate(batch_ws):
+                    end = min(ws + seq_len, total_tokens)
+                    wlen = end - ws
+                    wlens.append(wlen)
+                    chunk_tok = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                    x_batch[i, :wlen] = chunk_tok[:-1]
+                    y_batch[i, :wlen] = chunk_tok[1:]
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model.forward_logits(x_batch)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y_batch.reshape(-1), reduction="none",
+                ).reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]
+                    s = 0 if ws == 0 else max(wlen - stride, 0)
+                    scored_nll = nll[i, s:wlen].to(torch.float64)
+                    loss_sum += scored_nll.sum()
+                    token_count += float(wlen - s)
+                    tgt, prev = y_batch[i, s:wlen], x_batch[i, s:wlen]
+                    tb = base_bytes_lut[tgt].to(torch.float64)
+                    tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                    byte_count += tb.sum()
+
+        # --- Phase 2: TRAIN on this chunk (already scored = legal) ---
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and args.ttt_epochs > 0:
+            base_model.train()
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if chunk_seqs > 0:
+                cos_lr = args.ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                for pg in optimizer.param_groups:
+                    pg['lr'] = cos_lr
+                my_seq_s = (chunk_seqs * rank) // world_size
+                my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+                my_chunk_seqs = my_seq_e - my_seq_s
+                for _ep in range(args.ttt_epochs):
+                    for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                        be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                        actual_bs = my_seq_s + bs
+                        start_tok = chunk_start + actual_bs * seq_len
+                        end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                        if end_tok > val_tokens.numel():
+                            continue
+                        local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                        x = local[:-1].reshape(-1, seq_len)
+                        y = local[1:].reshape(-1, seq_len)
+                        optimizer.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            loss = base_model(x, y)
+                        loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        torch.nn.utils.clip_grad_norm_(ttt_params, args.ttt_grad_clip)
+                        optimizer.step()
+
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            log0(f"  ttt_chunk [{ci+1}/{num_chunks}] bpb={rbpb:.6f} time={elapsed:.1f}s")
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+    log0(f"ttt_sliding:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+         f"elapsed={time.perf_counter() - t0:.1f}s")
+    return val_loss, val_bpb
+
+
+# --- GPTQ-lite int6 quantization ---
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+def quantize_int6_per_row(t: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        best_q, best_s, best_err = None, None, float('inf')
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            if pct < 1.0:
+                row_clip = torch.quantile(t32.abs(), pct, dim=1)
+            else:
+                row_clip = t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+            recon = q.float() * s.float()[:, None]
+            err = (t32 - recon).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_s, best_err = q, s, err
+        return best_q, best_s
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+
+def _unbank_state_dict(sd: dict[str, Tensor], num_layers: int) -> dict[str, Tensor]:
+    """Convert 3D bank tensors into individual 2D tensors with standard names."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    for name, tensor in sd.items():
+        if name == "qo_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_q.weight"] = tensor[i]
+                out[f"blocks.{i}.attn.proj.weight"] = tensor[n + i]
+        elif name == "kv_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_k.weight"] = tensor[i]
+                out[f"blocks.{i}.attn.c_v.weight"] = tensor[n + i]
+        elif name == "mlp_up_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.fc.weight"] = tensor[i]
+        elif name == "mlp_down_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.proj.weight"] = tensor[i]
+        else:
+            out[name] = tensor
+    return out
+
+def _rebank_state_dict(sd: dict[str, Tensor], num_layers: int, template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    """Convert individual 2D tensors back into 3D bank tensors."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    # Reconstruct banks from individual weight keys
+    qo_slices = [None] * (2 * n)
+    kv_slices = [None] * (2 * n)
+    up_slices = [None] * n
+    down_slices = [None] * n
+    consumed = set()
+    for i in range(n):
+        qk = f"blocks.{i}.attn.c_q.weight"
+        if qk in sd:
+            qo_slices[i] = sd[qk]
+            consumed.add(qk)
+        ok = f"blocks.{i}.attn.proj.weight"
+        if ok in sd:
+            qo_slices[n + i] = sd[ok]
+            consumed.add(ok)
+        kk = f"blocks.{i}.attn.c_k.weight"
+        if kk in sd:
+            kv_slices[i] = sd[kk]
+            consumed.add(kk)
+        vk = f"blocks.{i}.attn.c_v.weight"
+        if vk in sd:
+            kv_slices[n + i] = sd[vk]
+            consumed.add(vk)
+        fk = f"blocks.{i}.mlp.fc.weight"
+        if fk in sd:
+            up_slices[i] = sd[fk]
+            consumed.add(fk)
+        dk = f"blocks.{i}.mlp.proj.weight"
+        if dk in sd:
+            down_slices[i] = sd[dk]
+            consumed.add(dk)
+    out["qo_bank"] = torch.stack(qo_slices).to(dtype=template_sd["qo_bank"].dtype)
+    out["kv_bank"] = torch.stack(kv_slices).to(dtype=template_sd["kv_bank"].dtype)
+    out["mlp_up_bank"] = torch.stack(up_slices).to(dtype=template_sd["mlp_up_bank"].dtype)
+    out["mlp_down_bank"] = torch.stack(down_slices).to(dtype=template_sd["mlp_down_bank"].dtype)
+    for name, tensor in sd.items():
+        if name not in consumed:
+            out[name] = tensor
+    return out
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    num_layers_total = max(
+        (int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")),
+        default=0,
+    ) + 1
+    late_k_layers = set(range(num_layers_total - 2, num_layers_total))
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+# --- Training ---
+
+def main() -> None:
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    # zeropower_via_newtonschulz5 runs eagerly with bmm -- do NOT compile
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    # With MIG fix above, each process only sees its assigned GPU as device 0
+    device = torch.device("cuda", 0)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    effective_eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+    CastedLinear._qat_enabled = args.qat_enabled
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=args.mtp_num_heads,
+        mtp_loss_weight=args.mtp_loss_weight,
+        bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims,
+        ln_scale=args.ln_scale,
+        dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled,
+        ve_dim=args.ve_dim,
+        ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention,
+        value_residual=args.value_residual,
+    ).to(device).bfloat16()
+    # Banks stay FP32 (like CastedLinear weights), cast to BF16 in forward
+    base_model.qo_bank.data = base_model.qo_bank.data.float()
+    base_model.kv_bank.data = base_model.kv_bank.data.float()
+    base_model.mlp_up_bank.data = base_model.mlp_up_bank.data.float()
+    base_model.mlp_down_bank.data = base_model.mlp_down_bank.data.float()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    # No DDP -- Parallel Muon handles bank grad communication via reduce-scatter,
+    # and non-bank grads are manually all-reduced before Adam steps.
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model = compiled_model
+
+    # Optimizer split:
+    # - 4 parameter banks -> Muon (batched Newton-Schulz)
+    # - token embedding -> Adam
+    # - scalars/control tensors -> Adam
+    # - bigram proj, mtp heads, VE proj -> Adam (small matrix params not worth banking)
+    matrix_params = [
+        base_model.qo_bank, base_model.kv_bank,
+        base_model.mlp_up_bank, base_model.mlp_down_bank,
+    ]
+    block_named_params = list(base_model.blocks.named_parameters())
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_params.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None:
+            scalar_params.append(base_model.bigram.proj.weight)
+    if base_model.ve_shared is not None:
+        tok_params.append({"params": [base_model.ve_shared.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.ve_shared.proj is not None:
+            scalar_params.append(base_model.ve_shared.proj.weight)
+        scalar_params.append(base_model.ve_shared.scale)
+        for s in base_model.ve_layer_scales:
+            scalar_params.append(s)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    # Non-bank params that need manual all-reduce (replicated across GPUs)
+    replicated_params = list(optimizer_tok.param_groups[0]["params"])
+    for pg in optimizer_tok.param_groups[1:]:
+        replicated_params.extend(pg["params"])
+    replicated_params.extend(scalar_params)
+
+    optimizer_head = None
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        replicated_params.append(base_model.lm_head.weight)
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if optimizer_head is not None:
+        optimizers.append(optimizer_head)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    mtp_params = sum(p.numel() for p in base_model.mtp_heads.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"mtp_num_heads:{args.mtp_num_heads} mtp_loss_weight:{args.mtp_loss_weight} mtp_params:{mtp_params}")
+    xsa_layers = [i for i, b in enumerate(base_model.blocks) if b.attn.use_xsa]
+    log0(f"XSA:last_{args.xsa_last_n} active_layers:{xsa_layers}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            # All-reduce all grads for warmup (simple, not optimized)
+            if distributed:
+                for p in base_model.parameters():
+                    if p.grad is not None:
+                        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    from collections import deque
+    lawa_queue: deque[dict[str, Tensor]] = deque(maxlen=args.lawa_k)
+    ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    ema_decay = 0.997
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        if args.late_qat_threshold > 0 and scale < args.late_qat_threshold and not CastedLinear._qat_enabled:
+            CastedLinear._qat_enabled = True
+            log0(f"late_qat:enabled step:{step} scale:{scale:.4f}")
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        # === 3-phase overlapped optimizer step ===
+        # Phase 1: Launch async reduce-scatter for banks (biggest first)
+        optimizer_muon.launch_reduce_scatters()
+        # Phase 2: All-reduce non-bank grads + step Adam (while bank RS is in-flight)
+        if distributed:
+            for p in replicated_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+        optimizer_tok.step()
+        optimizer_scalar.step()
+        if optimizer_head is not None:
+            optimizer_head.step()
+        # Phase 3: Wait for RS, local NS5, all-gather (banks processed last)
+        optimizer_muon.step()
+        zero_grad_all()
+        # EMA update
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(t.detach().float(), alpha=1.0 - ema_decay)
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        if args.swa_enabled and scale < 0.2 and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+        if args.lawa_enabled and step % args.lawa_freq == 0:
+            lawa_queue.append({name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()})
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+    # Apply weight averaging
+    if args.lawa_enabled and len(lawa_queue) > 1:
+        log0(f"lawa:applying LAWA averaging k={len(lawa_queue)}")
+        current_state = base_model.state_dict()
+        avg_state = {name: torch.zeros(t.shape, dtype=torch.float32, device='cpu') for name, t in current_state.items()}
+        for snap in lawa_queue:
+            for name in avg_state:
+                avg_state[name] += snap[name].float()
+        for name in avg_state:
+            avg_state[name] /= len(lawa_queue)
+            avg_state[name] = avg_state[name].to(dtype=current_state[name].dtype)
+        base_model.load_state_dict(avg_state, strict=True)
+    else:
+        log0("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+        base_model.load_state_dict(avg_state, strict=True)
+    torch.cuda.synchronize()
+    t_diag = time.perf_counter()
+    diag_val_loss, diag_val_bpb = eval_val(
+        args, compiled_model, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"DIAGNOSTIC post_ema val_loss:{diag_val_loss:.4f} val_bpb:{diag_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_diag):.0f}ms"
+    )
+    full_state_dict = base_model.state_dict()
+    export_sd = {k: v for k, v in full_state_dict.items() if "mtp_heads" not in k}
+    excluded_mtp = sum(int(t.numel()) for k, t in full_state_dict.items() if "mtp_heads" in k)
+    if excluded_mtp > 0:
+        log0(f"export_excluding_mtp_params:{excluded_mtp}")
+    if master_process:
+        torch.save(export_sd, "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+    # Unbank 3D tensors into individual 2D tensors for quantization
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    unbanked_sd = _unbank_state_dict(sd_cpu, args.num_layers)
+    quant_result, quant_meta = mixed_quantize_int6(unbanked_sd, {"mlp", "attn"})
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = lzma.compress(quant_raw, preset=6)
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = len(quant_blob)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+lzma: {quant_file_bytes} bytes")
+        log0(f"Total submission size int6+lzma: {quant_file_bytes + code_bytes} bytes")
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(lzma.decompress(quant_blob_disk)),
+        map_location="cpu",
+    )
+    deq_unbanked = dequantize_mixed_int6(quant_state["w"], quant_state["m"], unbanked_sd)
+    # Re-bank the dequantized tensors
+    deq_state = _rebank_state_dict(deq_unbanked, args.num_layers, sd_cpu)
+    eval_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=0, mtp_loss_weight=0.0,
+        bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims, ln_scale=args.ln_scale, dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention, value_residual=args.value_residual,
+    ).to(device).bfloat16()
+    eval_model.qo_bank.data = eval_model.qo_bank.data.float()
+    eval_model.kv_bank.data = eval_model.kv_bank.data.float()
+    eval_model.mlp_up_bank.data = eval_model.mlp_up_bank.data.float()
+    eval_model.mlp_down_bank.data = eval_model.mlp_down_bank.data.float()
+    for m in eval_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(eval_model)
+    eval_model.load_state_dict(deq_state, strict=True)
+    compiled_eval = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args, compiled_eval, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        eval_seq_len=effective_eval_seq_len,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+    sw_seq_len = effective_eval_seq_len
+    if args.eval_stride > 0 and args.eval_stride < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+        log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+    if args.eval_stride != 64 and 64 < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide64 = time.perf_counter()
+        sw64_val_loss, sw64_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=64,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window_s64 val_loss:{sw64_val_loss:.4f} val_bpb:{sw64_val_bpb:.4f} "
+            f"stride:64 eval_time:{1000.0 * (time.perf_counter() - t_slide64):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_s64_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+        log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+    # Legal score-first TTT (PR #461 recipe)
+    if args.ttt_enabled:
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_loss, ttt_bpb = eval_val_sliding_ttt(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, log0=log0,
+        )
+        torch.cuda.synchronize()
+        log0(f"legal_ttt val_loss:{ttt_loss:.4f} val_bpb:{ttt_bpb:.4f} "
+             f"eval_time:{1000.0 * (time.perf_counter() - t_ttt):.0f}ms")
+        log0(f"legal_ttt_exact val_loss:{ttt_loss:.8f} val_bpb:{ttt_bpb:.8f}")
+    if distributed:
+        dist.destroy_process_group()
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
+Running Python 3.10.14 (main, May  6 2024, 19:42:50) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128
+Fri Mar 27 04:07:26 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.4     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA A100-SXM4-80GB          On  |   00000000:27:00.0 Off |                   On |
+| N/A   38C    P0             99W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA A100-SXM4-80GB          On  |   00000000:2A:00.0 Off |                   On |
+| N/A   33C    P0             89W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA A100-SXM4-80GB          On  |   00000000:51:00.0 Off |                   On |
+| N/A   34C    P0            101W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA A100-SXM4-80GB          On  |   00000000:9E:00.0 Off |                   On |
+| N/A   38C    P0             99W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA A100-SXM4-80GB          On  |   00000000:A4:00.0 Off |                   On |
+| N/A   33C    P0             96W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA A100-SXM4-80GB          On  |   00000000:CA:00.0 Off |                   On |
+| N/A   37C    P0             97W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| MIG devices:                                                                            |
++------------------+----------------------------------+-----------+-----------------------+
+| GPU  GI  CI  MIG |                     Memory-Usage |        Vol|      Shared           |
+|      ID  ID  Dev |                       BAR1-Usage | SM     Unc| CE ENC DEC OFA JPG    |
+|                  |                                  |        ECC|                       |
+|==================+==================================+===========+=======================|
+|  0    2   0   0  |             355MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 2MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  1    1   0   0  |             355MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 2MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  1    2   0   1  |              38MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 0MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  2    1   0   0  |             355MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 2MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  3    2   0   0  |             355MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 2MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  4    2   0   0  |              38MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 0MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  5    1   0   0  |              38MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 0MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  5    2   0   1  |              38MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 0MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   3537273      C   /opt/conda/bin/python3                          0MiB |
+|    1   N/A  N/A   3537274      C   /opt/conda/bin/python3                          0MiB |
+|    2   N/A  N/A   3537275      C   /opt/conda/bin/python3                          0MiB |
+|    3   N/A  N/A   3537276      C   /opt/conda/bin/python3                          0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26928220
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_4 active_layers:[7, 8, 9, 10]
+world_size:4 grad_accum_steps:2
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:0.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9304 val_bpb:4.1046 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9317 train_time:850ms step_avg:849.64ms
+step:2/20000 train_loss:8.6832 train_time:1394ms step_avg:696.84ms
+step:3/20000 train_loss:7.6849 train_time:2245ms step_avg:748.41ms
+step:4/20000 train_loss:7.1825 train_time:3097ms step_avg:774.24ms
+step:5/20000 train_loss:7.1342 train_time:3949ms step_avg:789.77ms
+step:6/20000 train_loss:7.1129 train_time:4801ms step_avg:800.14ms
+step:7/20000 train_loss:7.1092 train_time:5653ms step_avg:807.50ms
+step:8/20000 train_loss:6.9540 train_time:6505ms step_avg:813.11ms
+step:9/20000 train_loss:6.6136 train_time:7357ms step_avg:817.44ms
+step:10/20000 train_loss:6.2387 train_time:8218ms step_avg:821.76ms
+step:500/20000 train_loss:2.3635 train_time:414424ms step_avg:828.85ms
+step:1000/20000 train_loss:2.2672 train_time:828685ms step_avg:828.68ms
+step:1500/20000 train_loss:2.1838 train_time:1243209ms step_avg:828.81ms
+step:2000/20000 train_loss:2.0379 train_time:1657693ms step_avg:828.85ms
+step:2500/20000 train_loss:2.1580 train_time:2071960ms step_avg:828.78ms
+step:3000/20000 train_loss:2.1211 train_time:2486377ms step_avg:828.79ms
+step:3500/20000 train_loss:2.1881 train_time:2900521ms step_avg:828.72ms
+step:4000/20000 train_loss:2.1446 train_time:3314659ms step_avg:828.66ms
+step:4000/20000 val_loss:2.0755 val_bpb:1.2292 train_time:3315001ms step_avg:828.75ms
+step:4500/20000 train_loss:2.1098 train_time:3728932ms step_avg:828.65ms
+step:5000/20000 train_loss:2.0727 train_time:4143237ms step_avg:828.65ms
+step:5500/20000 train_loss:2.1133 train_time:4557500ms step_avg:828.64ms
+step:6000/20000 train_loss:2.0121 train_time:4971750ms step_avg:828.63ms
+step:6500/20000 train_loss:2.2772 train_time:5385925ms step_avg:828.60ms
+step:7000/20000 train_loss:1.9077 train_time:5800366ms step_avg:828.62ms
+step:7500/20000 train_loss:2.0332 train_time:6214436ms step_avg:828.59ms
+step:8000/20000 train_loss:1.9856 train_time:6628761ms step_avg:828.60ms
+step:8000/20000 val_loss:2.0333 val_bpb:1.2043 train_time:6629111ms step_avg:828.64ms
+step:8500/20000 train_loss:1.9662 train_time:7043229ms step_avg:828.62ms
+step:9000/20000 train_loss:2.0891 train_time:7457441ms step_avg:828.60ms
+step:9500/20000 train_loss:2.2474 train_time:7872123ms step_avg:828.64ms
+step:10000/20000 train_loss:2.0618 train_time:8286352ms step_avg:828.64ms
+step:10500/20000 train_loss:2.0948 train_time:8700592ms step_avg:828.63ms
+step:11000/20000 train_loss:1.9865 train_time:9115076ms step_avg:828.64ms
+step:11500/20000 train_loss:1.9466 train_time:9529240ms step_avg:828.63ms
+step:12000/20000 train_loss:1.9609 train_time:9943485ms step_avg:828.62ms
+step:12000/20000 val_loss:2.0241 val_bpb:1.1988 train_time:9943828ms step_avg:828.65ms
+step:12500/20000 train_loss:1.9691 train_time:10357780ms step_avg:828.62ms
+step:13000/20000 train_loss:1.9781 train_time:10772024ms step_avg:828.62ms
+step:13500/20000 train_loss:2.0928 train_time:11186188ms step_avg:828.61ms
+step:14000/20000 train_loss:1.8907 train_time:11600289ms step_avg:828.59ms
+step:14500/20000 train_loss:2.0651 train_time:12014544ms step_avg:828.59ms
+step:15000/20000 train_loss:2.0078 train_time:12428690ms step_avg:828.58ms
+step:15500/20000 train_loss:1.9744 train_time:12842898ms step_avg:828.57ms
+step:16000/20000 train_loss:2.0443 train_time:13257276ms step_avg:828.58ms
+step:16000/20000 val_loss:1.9697 val_bpb:1.1666 train_time:13257627ms step_avg:828.60ms
+step:16500/20000 train_loss:2.0235 train_time:13671525ms step_avg:828.58ms
+step:17000/20000 train_loss:2.0201 train_time:14085842ms step_avg:828.58ms
+step:17500/20000 train_loss:1.9946 train_time:14500144ms step_avg:828.58ms
+step:18000/20000 train_loss:1.8680 train_time:14914297ms step_avg:828.57ms
+swa:start step:18450
+step:18500/20000 train_loss:1.8339 train_time:15328815ms step_avg:828.58ms
+late_qat:enabled step:18831 scale:0.1499
+step:19000/20000 train_loss:1.8034 train_time:15744113ms step_avg:828.64ms
+step:19500/20000 train_loss:1.9822 train_time:16159354ms step_avg:828.68ms
+step:20000/20000 train_loss:1.8749 train_time:16574509ms step_avg:828.73ms
+step:20000/20000 val_loss:1.8748 val_bpb:1.1104 train_time:16574910ms step_avg:828.75ms
+peak memory allocated: 22092 MiB reserved: 22340 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.8738 val_bpb:1.1098 eval_time:19704ms
+Serialized model: 106027446 bytes
+Code size: 90361 bytes
+Serialized model int6+lzma: 14987572 bytes
+Total submission size int6+lzma: 15077933 bytes
+final_int6_roundtrip val_loss:1.8998 val_bpb:1.1252 eval_time:24388ms
+final_int6_roundtrip_exact val_loss:1.89979453 val_bpb:1.12516533
+final_int6_sliding_window val_loss:1.8604 val_bpb:1.1018 stride:64 eval_time:664624ms
+final_int6_sliding_window_exact val_loss:1.86041005 val_bpb:1.10184254
+final_int8_zlib_roundtrip_exact val_loss:1.86041005 val_bpb:1.10184254
+ttt_sliding:start chunks=1893 chunk_tokens=32768 total_windows=969088 stride=64 ttt_lr=0.002 ttt_epochs=3 freeze_blocks=0
+ttt_sliding:params unfrozen=26928220 frozen=0
+  ttt_chunk [1/1893] bpb=1.148962 time=1.1s
+  ttt_chunk [11/1893] bpb=1.106649 time=11.9s
+  ttt_chunk [21/1893] bpb=1.109183 time=22.7s
+  ttt_chunk [31/1893] bpb=1.112465 time=33.4s
+  ttt_chunk [41/1893] bpb=1.101158 time=44.2s
+  ttt_chunk [51/1893] bpb=1.097352 time=55.0s
+  ttt_chunk [61/1893] bpb=1.102163 time=65.7s
+  ttt_chunk [71/1893] bpb=1.099272 time=76.5s
+  ttt_chunk [81/1893] bpb=1.099287 time=87.3s
+  ttt_chunk [91/1893] bpb=1.097889 time=98.1s
+  ttt_chunk [101/1893] bpb=1.100512 time=108.9s
+  ttt_chunk [111/1893] bpb=1.101752 time=119.7s
+  ttt_chunk [121/1893] bpb=1.098599 time=130.4s
+  ttt_chunk [131/1893] bpb=1.098481 time=141.2s
+  ttt_chunk [141/1893] bpb=1.098188 time=152.0s
+  ttt_chunk [151/1893] bpb=1.101303 time=162.8s
+  ttt_chunk [161/1893] bpb=1.102934 time=173.6s
+  ttt_chunk [171/1893] bpb=1.103556 time=184.3s
+  ttt_chunk [181/1893] bpb=1.103556 time=195.1s
+  ttt_chunk [191/1893] bpb=1.106780 time=205.9s
+  ttt_chunk [201/1893] bpb=1.107089 time=216.7s
+  ttt_chunk [211/1893] bpb=1.104621 time=227.4s
+  ttt_chunk [221/1893] bpb=1.106682 time=238.2s
+  ttt_chunk [231/1893] bpb=1.106153 time=249.0s
+  ttt_chunk [241/1893] bpb=1.105951 time=259.8s
+  ttt_chunk [251/1893] bpb=1.104500 time=270.5s
+  ttt_chunk [261/1893] bpb=1.102854 time=281.3s
+  ttt_chunk [271/1893] bpb=1.101507 time=292.1s
+  ttt_chunk [281/1893] bpb=1.103788 time=302.9s
+  ttt_chunk [291/1893] bpb=1.104513 time=313.6s
+  ttt_chunk [301/1893] bpb=1.105062 time=324.4s
+  ttt_chunk [311/1893] bpb=1.106585 time=335.2s
+  ttt_chunk [321/1893] bpb=1.108036 time=346.0s
+  ttt_chunk [331/1893] bpb=1.107902 time=356.7s
+  ttt_chunk [341/1893] bpb=1.108209 time=367.5s
+  ttt_chunk [351/1893] bpb=1.109486 time=378.3s
+  ttt_chunk [361/1893] bpb=1.110674 time=389.1s
+  ttt_chunk [371/1893] bpb=1.110192 time=399.9s
+  ttt_chunk [381/1893] bpb=1.110144 time=410.6s
+  ttt_chunk [391/1893] bpb=1.109733 time=421.4s
+  ttt_chunk [401/1893] bpb=1.108356 time=432.2s
+  ttt_chunk [411/1893] bpb=1.107227 time=442.9s
+  ttt_chunk [421/1893] bpb=1.106719 time=453.7s
+  ttt_chunk [431/1893] bpb=1.107374 time=464.5s
+  ttt_chunk [441/1893] bpb=1.107195 time=475.3s
+  ttt_chunk [451/1893] bpb=1.106903 time=486.1s
+  ttt_chunk [461/1893] bpb=1.106178 time=496.8s
+  ttt_chunk [471/1893] bpb=1.105772 time=507.6s
+  ttt_chunk [481/1893] bpb=1.105518 time=518.4s
+  ttt_chunk [491/1893] bpb=1.105211 time=529.2s
+  ttt_chunk [501/1893] bpb=1.104631 time=539.9s
+  ttt_chunk [511/1893] bpb=1.104022 time=550.7s
+  ttt_chunk [521/1893] bpb=1.102977 time=561.5s
+  ttt_chunk [531/1893] bpb=1.103083 time=572.2s
+  ttt_chunk [541/1893] bpb=1.103047 time=583.0s
+  ttt_chunk [551/1893] bpb=1.101880 time=593.8s
+  ttt_chunk [561/1893] bpb=1.102420 time=604.6s
+  ttt_chunk [571/1893] bpb=1.101740 time=615.3s
+  ttt_chunk [581/1893] bpb=1.101206 time=626.1s
+  ttt_chunk [591/1893] bpb=1.100569 time=636.9s
+  ttt_chunk [601/1893] bpb=1.101233 time=647.7s
+  ttt_chunk [611/1893] bpb=1.100826 time=658.5s
+  ttt_chunk [621/1893] bpb=1.100733 time=669.2s
+  ttt_chunk [631/1893] bpb=1.101122 time=680.0s
+  ttt_chunk [641/1893] bpb=1.100907 time=690.8s
+  ttt_chunk [651/1893] bpb=1.100916 time=701.6s
+  ttt_chunk [661/1893] bpb=1.100822 time=712.3s
+  ttt_chunk [671/1893] bpb=1.100437 time=723.1s
+  ttt_chunk [681/1893] bpb=1.100704 time=733.9s
+  ttt_chunk [691/1893] bpb=1.101402 time=744.7s
+  ttt_chunk [701/1893] bpb=1.100649 time=755.4s
+  ttt_chunk [711/1893] bpb=1.101214 time=766.2s
+  ttt_chunk [721/1893] bpb=1.100855 time=777.0s
+  ttt_chunk [731/1893] bpb=1.101286 time=787.8s
+  ttt_chunk [741/1893] bpb=1.101246 time=798.6s
+  ttt_chunk [751/1893] bpb=1.100906 time=809.3s
+  ttt_chunk [761/1893] bpb=1.100754 time=820.1s
+  ttt_chunk [771/1893] bpb=1.100535 time=830.9s
+  ttt_chunk [781/1893] bpb=1.101052 time=841.6s
+  ttt_chunk [791/1893] bpb=1.100729 time=852.4s
+  ttt_chunk [801/1893] bpb=1.100817 time=863.2s
+  ttt_chunk [811/1893] bpb=1.100349 time=874.0s
+  ttt_chunk [821/1893] bpb=1.100161 time=884.7s
+  ttt_chunk [831/1893] bpb=1.099731 time=895.5s
+  ttt_chunk [841/1893] bpb=1.099163 time=906.3s
+  ttt_chunk [851/1893] bpb=1.099062 time=917.1s
+  ttt_chunk [861/1893] bpb=1.099192 time=927.9s
+  ttt_chunk [871/1893] bpb=1.099234 time=938.6s
+  ttt_chunk [881/1893] bpb=1.099269 time=949.4s
+  ttt_chunk [891/1893] bpb=1.099098 time=960.2s
+  ttt_chunk [901/1893] bpb=1.099091 time=971.0s
+  ttt_chunk [911/1893] bpb=1.099081 time=981.7s
+  ttt_chunk [921/1893] bpb=1.099457 time=992.5s
+  ttt_chunk [931/1893] bpb=1.099302 time=1003.3s
+  ttt_chunk [941/1893] bpb=1.099197 time=1014.1s
+  ttt_chunk [951/1893] bpb=1.099211 time=1024.8s
+  ttt_chunk [961/1893] bpb=1.098954 time=1035.6s
+  ttt_chunk [971/1893] bpb=1.099679 time=1046.4s
+  ttt_chunk [981/1893] bpb=1.099805 time=1057.1s
+  ttt_chunk [991/1893] bpb=1.099714 time=1067.9s
+  ttt_chunk [1001/1893] bpb=1.099874 time=1078.7s
+  ttt_chunk [1011/1893] bpb=1.100135 time=1089.5s
+  ttt_chunk [1021/1893] bpb=1.100290 time=1100.2s
+  ttt_chunk [1031/1893] bpb=1.100826 time=1111.0s
+  ttt_chunk [1041/1893] bpb=1.100503 time=1121.8s
+  ttt_chunk [1051/1893] bpb=1.100230 time=1132.6s
+  ttt_chunk [1061/1893] bpb=1.100500 time=1143.3s
+  ttt_chunk [1071/1893] bpb=1.100973 time=1154.1s
+  ttt_chunk [1081/1893] bpb=1.100979 time=1164.9s
+  ttt_chunk [1091/1893] bpb=1.101374 time=1175.7s
+  ttt_chunk [1101/1893] bpb=1.101517 time=1186.4s
+  ttt_chunk [1111/1893] bpb=1.101291 time=1197.2s
+  ttt_chunk [1121/1893] bpb=1.101240 time=1208.0s
+  ttt_chunk [1131/1893] bpb=1.101147 time=1218.8s
+  ttt_chunk [1141/1893] bpb=1.101001 time=1229.5s
+  ttt_chunk [1151/1893] bpb=1.101048 time=1240.3s
+  ttt_chunk [1161/1893] bpb=1.100357 time=1251.1s
+  ttt_chunk [1171/1893] bpb=1.100923 time=1261.9s
+  ttt_chunk [1181/1893] bpb=1.100425 time=1272.6s
+  ttt_chunk [1191/1893] bpb=1.100132 time=1283.4s
+  ttt_chunk [1201/1893] bpb=1.100718 time=1294.2s
+  ttt_chunk [1211/1893] bpb=1.100113 time=1304.9s
+  ttt_chunk [1221/1893] bpb=1.099789 time=1315.7s
+  ttt_chunk [1231/1893] bpb=1.099716 time=1326.5s
+  ttt_chunk [1241/1893] bpb=1.099538 time=1337.3s
+  ttt_chunk [1251/1893] bpb=1.099298 time=1348.0s
+  ttt_chunk [1261/1893] bpb=1.099230 time=1358.8s
+  ttt_chunk [1271/1893] bpb=1.099030 time=1369.6s
+  ttt_chunk [1281/1893] bpb=1.098825 time=1380.4s
+  ttt_chunk [1291/1893] bpb=1.098638 time=1391.1s
+  ttt_chunk [1301/1893] bpb=1.098263 time=1401.9s
+  ttt_chunk [1311/1893] bpb=1.097961 time=1412.7s
+  ttt_chunk [1321/1893] bpb=1.097795 time=1423.4s
+  ttt_chunk [1331/1893] bpb=1.097718 time=1434.2s
+  ttt_chunk [1341/1893] bpb=1.097600 time=1445.0s
+  ttt_chunk [1351/1893] bpb=1.097546 time=1455.8s
+  ttt_chunk [1361/1893] bpb=1.097752 time=1466.5s
+  ttt_chunk [1371/1893] bpb=1.097602 time=1477.3s
+  ttt_chunk [1381/1893] bpb=1.097542 time=1488.1s
+  ttt_chunk [1391/1893] bpb=1.097027 time=1498.8s
+  ttt_chunk [1401/1893] bpb=1.097052 time=1509.6s
+  ttt_chunk [1411/1893] bpb=1.097076 time=1520.4s
+  ttt_chunk [1421/1893] bpb=1.097336 time=1531.2s
+  ttt_chunk [1431/1893] bpb=1.097182 time=1541.9s
+  ttt_chunk [1441/1893] bpb=1.097860 time=1552.7s
+  ttt_chunk [1451/1893] bpb=1.097967 time=1563.5s
+  ttt_chunk [1461/1893] bpb=1.097711 time=1574.2s
+  ttt_chunk [1471/1893] bpb=1.098624 time=1585.0s
+  ttt_chunk [1481/1893] bpb=1.098435 time=1595.8s
+  ttt_chunk [1491/1893] bpb=1.098445 time=1606.5s
+  ttt_chunk [1501/1893] bpb=1.098608 time=1617.3s
+  ttt_chunk [1511/1893] bpb=1.098687 time=1628.1s
+  ttt_chunk [1521/1893] bpb=1.098715 time=1638.9s
+  ttt_chunk [1531/1893] bpb=1.098533 time=1649.6s
+  ttt_chunk [1541/1893] bpb=1.098501 time=1660.4s
+  ttt_chunk [1551/1893] bpb=1.098854 time=1671.2s
+  ttt_chunk [1561/1893] bpb=1.098993 time=1681.9s
+  ttt_chunk [1571/1893] bpb=1.099120 time=1692.7s
+  ttt_chunk [1581/1893] bpb=1.099236 time=1703.5s
+  ttt_chunk [1591/1893] bpb=1.099189 time=1714.3s
+  ttt_chunk [1601/1893] bpb=1.099373 time=1725.0s
+  ttt_chunk [1611/1893] bpb=1.099446 time=1735.8s
+  ttt_chunk [1621/1893] bpb=1.099315 time=1746.6s
+  ttt_chunk [1631/1893] bpb=1.099486 time=1757.4s
+  ttt_chunk [1641/1893] bpb=1.099365 time=1768.1s
+  ttt_chunk [1651/1893] bpb=1.099269 time=1778.9s
+  ttt_chunk [1661/1893] bpb=1.099155 time=1789.7s
+  ttt_chunk [1671/1893] bpb=1.099519 time=1800.4s
+  ttt_chunk [1681/1893] bpb=1.099767 time=1811.2s
+  ttt_chunk [1691/1893] bpb=1.099741 time=1822.0s
+  ttt_chunk [1701/1893] bpb=1.099731 time=1832.8s
+  ttt_chunk [1711/1893] bpb=1.099572 time=1843.5s
+  ttt_chunk [1721/1893] bpb=1.099426 time=1854.3s
+  ttt_chunk [1731/1893] bpb=1.099378 time=1865.1s
+  ttt_chunk [1741/1893] bpb=1.099166 time=1875.8s
+  ttt_chunk [1751/1893] bpb=1.099024 time=1886.6s
+  ttt_chunk [1761/1893] bpb=1.099109 time=1897.4s
+  ttt_chunk [1771/1893] bpb=1.099028 time=1908.2s
+  ttt_chunk [1781/1893] bpb=1.098987 time=1918.9s
+  ttt_chunk [1791/1893] bpb=1.098601 time=1929.7s
+  ttt_chunk [1801/1893] bpb=1.098603 time=1940.5s
+  ttt_chunk [1811/1893] bpb=1.098432 time=1951.3s
+  ttt_chunk [1821/1893] bpb=1.098469 time=1962.0s
+  ttt_chunk [1831/1893] bpb=1.098074 time=1972.8s
+  ttt_chunk [1841/1893] bpb=1.098044 time=1983.6s
+  ttt_chunk [1851/1893] bpb=1.097814 time=1994.3s
+  ttt_chunk [1861/1893] bpb=1.097345 time=2005.1s
+  ttt_chunk [1871/1893] bpb=1.097193 time=2015.9s
+  ttt_chunk [1881/1893] bpb=1.096820 time=2026.7s
+  ttt_chunk [1891/1893] bpb=1.096650 time=2037.4s
+  ttt_chunk [1893/1893] bpb=1.096669 time=2039.2s
+ttt_sliding:done val_loss=1.850081 val_bpb=1.095725 elapsed=2039.2s
+legal_ttt val_loss:1.8501 val_bpb:1.0957 eval_time:2039891ms
+legal_ttt_exact val_loss:1.85008136 val_bpb:1.09572529

--- a/records/track_non_record_16mb/2026-03-28_ExtendedCompute_50K_11hours_4xA100MIG_ScalingAnalysis/train_step20k_seed42.txt
+++ b/records/track_non_record_16mb/2026-03-28_ExtendedCompute_50K_11hours_4xA100MIG_ScalingAnalysis/train_step20k_seed42.txt
@@ -1,0 +1,2241 @@
+logs/run_recordsota_nonrecord_seed42.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26928220
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_4 active_layers:[7, 8, 9, 10]
+world_size:4 grad_accum_steps:2
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:0.000
+seed:42
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9293 val_bpb:4.1039 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9305 train_time:851ms step_avg:850.55ms
+step:2/20000 train_loss:8.6548 train_time:1395ms step_avg:697.55ms
+step:3/20000 train_loss:7.6769 train_time:2247ms step_avg:749.06ms
+step:4/20000 train_loss:7.1975 train_time:3099ms step_avg:774.78ms
+step:5/20000 train_loss:7.1772 train_time:3951ms step_avg:790.29ms
+step:6/20000 train_loss:7.1087 train_time:4812ms step_avg:801.97ms
+step:7/20000 train_loss:7.1576 train_time:5664ms step_avg:809.18ms
+step:8/20000 train_loss:6.9941 train_time:6516ms step_avg:814.55ms
+step:9/20000 train_loss:6.6553 train_time:7368ms step_avg:818.72ms
+step:10/20000 train_loss:6.2949 train_time:8221ms step_avg:822.10ms
+step:500/20000 train_loss:2.3555 train_time:414338ms step_avg:828.68ms
+step:1000/20000 train_loss:2.2641 train_time:828509ms step_avg:828.51ms
+step:1500/20000 train_loss:2.1807 train_time:1243119ms step_avg:828.75ms
+step:2000/20000 train_loss:2.0310 train_time:1657855ms step_avg:828.93ms
+step:2500/20000 train_loss:2.1602 train_time:2071904ms step_avg:828.76ms
+step:3000/20000 train_loss:2.1249 train_time:2486661ms step_avg:828.89ms
+step:3500/20000 train_loss:2.1866 train_time:2901085ms step_avg:828.88ms
+step:4000/20000 train_loss:2.1438 train_time:3315094ms step_avg:828.77ms
+step:4000/20000 val_loss:2.0753 val_bpb:1.2291 train_time:3315444ms step_avg:828.86ms
+step:4500/20000 train_loss:2.1118 train_time:3729527ms step_avg:828.78ms
+step:5000/20000 train_loss:2.0683 train_time:4143751ms step_avg:828.75ms
+step:5500/20000 train_loss:2.1134 train_time:4558181ms step_avg:828.76ms
+step:6000/20000 train_loss:2.0092 train_time:4972372ms step_avg:828.73ms
+step:6500/20000 train_loss:2.2744 train_time:5386385ms step_avg:828.67ms
+step:7000/20000 train_loss:1.9078 train_time:5800678ms step_avg:828.67ms
+step:7500/20000 train_loss:2.0298 train_time:6214909ms step_avg:828.65ms
+step:8000/20000 train_loss:1.9822 train_time:6629167ms step_avg:828.65ms
+step:8000/20000 val_loss:2.0339 val_bpb:1.2046 train_time:6629524ms step_avg:828.69ms
+step:8500/20000 train_loss:1.9647 train_time:7043393ms step_avg:828.63ms
+step:9000/20000 train_loss:2.0911 train_time:7457618ms step_avg:828.62ms
+step:9500/20000 train_loss:2.2465 train_time:7872112ms step_avg:828.64ms
+step:10000/20000 train_loss:2.0596 train_time:8286348ms step_avg:828.63ms
+step:10500/20000 train_loss:2.0969 train_time:8700627ms step_avg:828.63ms
+step:11000/20000 train_loss:1.9872 train_time:9114964ms step_avg:828.63ms
+step:11500/20000 train_loss:1.9445 train_time:9529091ms step_avg:828.62ms
+step:12000/20000 train_loss:1.9632 train_time:9943448ms step_avg:828.62ms
+step:12000/20000 val_loss:2.0250 val_bpb:1.1993 train_time:9943791ms step_avg:828.65ms
+step:12500/20000 train_loss:1.9705 train_time:10357662ms step_avg:828.61ms
+step:13000/20000 train_loss:1.9775 train_time:10771664ms step_avg:828.59ms
+step:13500/20000 train_loss:2.0946 train_time:11185822ms step_avg:828.58ms
+step:14000/20000 train_loss:1.8907 train_time:11599963ms step_avg:828.57ms
+step:14500/20000 train_loss:2.0646 train_time:12013997ms step_avg:828.55ms
+step:15000/20000 train_loss:2.0088 train_time:12428064ms step_avg:828.54ms
+step:15500/20000 train_loss:1.9760 train_time:12842082ms step_avg:828.52ms
+step:16000/20000 train_loss:2.0462 train_time:13256277ms step_avg:828.52ms
+step:16000/20000 val_loss:1.9703 val_bpb:1.1669 train_time:13256627ms step_avg:828.54ms
+step:16500/20000 train_loss:2.0226 train_time:13670137ms step_avg:828.49ms
+step:17000/20000 train_loss:2.0200 train_time:14084149ms step_avg:828.48ms
+step:17500/20000 train_loss:1.9948 train_time:14498193ms step_avg:828.47ms
+step:18000/20000 train_loss:1.8682 train_time:14912122ms step_avg:828.45ms
+swa:start step:18450
+step:18500/20000 train_loss:1.8336 train_time:15326272ms step_avg:828.45ms
+late_qat:enabled step:18831 scale:0.1499
+step:19000/20000 train_loss:1.8044 train_time:15740755ms step_avg:828.46ms
+step:19500/20000 train_loss:1.9852 train_time:16155668ms step_avg:828.50ms
+step:20000/20000 train_loss:1.8751 train_time:16569987ms step_avg:828.50ms
+step:20000/20000 val_loss:1.8757 val_bpb:1.1109 train_time:16570369ms step_avg:828.52ms
+peak memory allocated: 22092 MiB reserved: 22340 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.8746 val_bpb:1.1103 eval_time:19693ms
+Serialized model: 106027446 bytes
+Code size: 90361 bytes
+Serialized model int6+lzma: 15046784 bytes
+Total submission size int6+lzma: 15137145 bytes
+final_int6_roundtrip val_loss:1.9002 val_bpb:1.1254 eval_time:24369ms
+final_int6_roundtrip_exact val_loss:1.90023350 val_bpb:1.12542531
+final_int6_sliding_window val_loss:1.8607 val_bpb:1.1020 stride:64 eval_time:664078ms
+final_int6_sliding_window_exact val_loss:1.86067988 val_bpb:1.10200235
+final_int8_zlib_roundtrip_exact val_loss:1.86067988 val_bpb:1.10200235
+ttt_sliding:start chunks=1893 chunk_tokens=32768 total_windows=969088 stride=64 ttt_lr=0.002 ttt_epochs=3 freeze_blocks=0
+ttt_sliding:params unfrozen=26928220 frozen=0
+  ttt_chunk [1/1893] bpb=1.149221 time=1.1s
+  ttt_chunk [11/1893] bpb=1.105427 time=11.9s
+  ttt_chunk [21/1893] bpb=1.108997 time=22.7s
+  ttt_chunk [31/1893] bpb=1.112744 time=33.4s
+  ttt_chunk [41/1893] bpb=1.101277 time=44.2s
+  ttt_chunk [51/1893] bpb=1.097692 time=55.0s
+  ttt_chunk [61/1893] bpb=1.102242 time=65.7s
+  ttt_chunk [71/1893] bpb=1.099299 time=76.5s
+  ttt_chunk [81/1893] bpb=1.099418 time=87.3s
+  ttt_chunk [91/1893] bpb=1.098337 time=98.0s
+  ttt_chunk [101/1893] bpb=1.101032 time=108.8s
+  ttt_chunk [111/1893] bpb=1.102383 time=119.6s
+  ttt_chunk [121/1893] bpb=1.099256 time=130.4s
+  ttt_chunk [131/1893] bpb=1.098961 time=141.1s
+  ttt_chunk [141/1893] bpb=1.098637 time=151.9s
+  ttt_chunk [151/1893] bpb=1.101853 time=162.7s
+  ttt_chunk [161/1893] bpb=1.103510 time=173.4s
+  ttt_chunk [171/1893] bpb=1.104085 time=184.2s
+  ttt_chunk [181/1893] bpb=1.104153 time=195.0s
+  ttt_chunk [191/1893] bpb=1.107342 time=205.7s
+  ttt_chunk [201/1893] bpb=1.107569 time=216.5s
+  ttt_chunk [211/1893] bpb=1.105080 time=227.3s
+  ttt_chunk [221/1893] bpb=1.107111 time=238.1s
+  ttt_chunk [231/1893] bpb=1.106532 time=248.8s
+  ttt_chunk [241/1893] bpb=1.106343 time=259.6s
+  ttt_chunk [251/1893] bpb=1.104851 time=270.4s
+  ttt_chunk [261/1893] bpb=1.103214 time=281.1s
+  ttt_chunk [271/1893] bpb=1.101864 time=291.9s
+  ttt_chunk [281/1893] bpb=1.104208 time=302.7s
+  ttt_chunk [291/1893] bpb=1.104921 time=313.4s
+  ttt_chunk [301/1893] bpb=1.105511 time=324.2s
+  ttt_chunk [311/1893] bpb=1.107095 time=335.0s
+  ttt_chunk [321/1893] bpb=1.108590 time=345.7s
+  ttt_chunk [331/1893] bpb=1.108461 time=356.5s
+  ttt_chunk [341/1893] bpb=1.108724 time=367.3s
+  ttt_chunk [351/1893] bpb=1.110014 time=378.0s
+  ttt_chunk [361/1893] bpb=1.111235 time=388.8s
+  ttt_chunk [371/1893] bpb=1.110810 time=399.6s
+  ttt_chunk [381/1893] bpb=1.110775 time=410.3s
+  ttt_chunk [391/1893] bpb=1.110407 time=421.1s
+  ttt_chunk [401/1893] bpb=1.109049 time=431.9s
+  ttt_chunk [411/1893] bpb=1.107960 time=442.6s
+  ttt_chunk [421/1893] bpb=1.107430 time=453.4s
+  ttt_chunk [431/1893] bpb=1.108117 time=464.2s
+  ttt_chunk [441/1893] bpb=1.107977 time=474.9s
+  ttt_chunk [451/1893] bpb=1.107702 time=485.7s
+  ttt_chunk [461/1893] bpb=1.106981 time=496.5s
+  ttt_chunk [471/1893] bpb=1.106584 time=507.2s
+  ttt_chunk [481/1893] bpb=1.106271 time=518.0s
+  ttt_chunk [491/1893] bpb=1.105997 time=528.8s
+  ttt_chunk [501/1893] bpb=1.105439 time=539.6s
+  ttt_chunk [511/1893] bpb=1.104831 time=550.3s
+  ttt_chunk [521/1893] bpb=1.103810 time=561.2s
+  ttt_chunk [531/1893] bpb=1.103933 time=571.9s
+  ttt_chunk [541/1893] bpb=1.103845 time=582.7s
+  ttt_chunk [551/1893] bpb=1.102632 time=593.5s
+  ttt_chunk [561/1893] bpb=1.103166 time=604.2s
+  ttt_chunk [571/1893] bpb=1.102478 time=615.0s
+  ttt_chunk [581/1893] bpb=1.101930 time=625.8s
+  ttt_chunk [591/1893] bpb=1.101262 time=636.5s
+  ttt_chunk [601/1893] bpb=1.101952 time=647.3s
+  ttt_chunk [611/1893] bpb=1.101538 time=658.1s
+  ttt_chunk [621/1893] bpb=1.101453 time=668.9s
+  ttt_chunk [631/1893] bpb=1.101855 time=679.6s
+  ttt_chunk [641/1893] bpb=1.101660 time=690.4s
+  ttt_chunk [651/1893] bpb=1.101678 time=701.2s
+  ttt_chunk [661/1893] bpb=1.101577 time=711.9s
+  ttt_chunk [671/1893] bpb=1.101226 time=722.7s
+  ttt_chunk [681/1893] bpb=1.101501 time=733.5s
+  ttt_chunk [691/1893] bpb=1.102163 time=744.2s
+  ttt_chunk [701/1893] bpb=1.101383 time=755.0s
+  ttt_chunk [711/1893] bpb=1.101968 time=765.8s
+  ttt_chunk [721/1893] bpb=1.101606 time=776.6s
+  ttt_chunk [731/1893] bpb=1.102036 time=787.3s
+  ttt_chunk [741/1893] bpb=1.101977 time=798.1s
+  ttt_chunk [751/1893] bpb=1.101623 time=808.9s
+  ttt_chunk [761/1893] bpb=1.101455 time=819.6s
+  ttt_chunk [771/1893] bpb=1.101210 time=830.4s
+  ttt_chunk [781/1893] bpb=1.101740 time=841.2s
+  ttt_chunk [791/1893] bpb=1.101420 time=851.9s
+  ttt_chunk [801/1893] bpb=1.101479 time=862.7s
+  ttt_chunk [811/1893] bpb=1.100996 time=873.5s
+  ttt_chunk [821/1893] bpb=1.100793 time=884.3s
+  ttt_chunk [831/1893] bpb=1.100359 time=895.0s
+  ttt_chunk [841/1893] bpb=1.099773 time=905.8s
+  ttt_chunk [851/1893] bpb=1.099667 time=916.6s
+  ttt_chunk [861/1893] bpb=1.099807 time=927.3s
+  ttt_chunk [871/1893] bpb=1.099860 time=938.1s
+  ttt_chunk [881/1893] bpb=1.099862 time=948.9s
+  ttt_chunk [891/1893] bpb=1.099699 time=959.6s
+  ttt_chunk [901/1893] bpb=1.099687 time=970.4s
+  ttt_chunk [911/1893] bpb=1.099686 time=981.2s
+  ttt_chunk [921/1893] bpb=1.100066 time=991.9s
+  ttt_chunk [931/1893] bpb=1.099886 time=1002.7s
+  ttt_chunk [941/1893] bpb=1.099777 time=1013.5s
+  ttt_chunk [951/1893] bpb=1.099765 time=1024.2s
+  ttt_chunk [961/1893] bpb=1.099516 time=1035.0s
+  ttt_chunk [971/1893] bpb=1.100237 time=1045.8s
+  ttt_chunk [981/1893] bpb=1.100402 time=1056.5s
+  ttt_chunk [991/1893] bpb=1.100302 time=1067.3s
+  ttt_chunk [1001/1893] bpb=1.100447 time=1078.1s
+  ttt_chunk [1011/1893] bpb=1.100704 time=1088.9s
+  ttt_chunk [1021/1893] bpb=1.100855 time=1099.6s
+  ttt_chunk [1031/1893] bpb=1.101407 time=1110.4s
+  ttt_chunk [1041/1893] bpb=1.101071 time=1121.2s
+  ttt_chunk [1051/1893] bpb=1.100782 time=1131.9s
+  ttt_chunk [1061/1893] bpb=1.101022 time=1142.7s
+  ttt_chunk [1071/1893] bpb=1.101493 time=1153.4s
+  ttt_chunk [1081/1893] bpb=1.101509 time=1164.2s
+  ttt_chunk [1091/1893] bpb=1.101914 time=1175.0s
+  ttt_chunk [1101/1893] bpb=1.102047 time=1185.8s
+  ttt_chunk [1111/1893] bpb=1.101822 time=1196.5s
+  ttt_chunk [1121/1893] bpb=1.101747 time=1207.3s
+  ttt_chunk [1131/1893] bpb=1.101647 time=1218.1s
+  ttt_chunk [1141/1893] bpb=1.101496 time=1228.8s
+  ttt_chunk [1151/1893] bpb=1.101538 time=1239.6s
+  ttt_chunk [1161/1893] bpb=1.100850 time=1250.4s
+  ttt_chunk [1171/1893] bpb=1.101414 time=1261.1s
+  ttt_chunk [1181/1893] bpb=1.100908 time=1271.9s
+  ttt_chunk [1191/1893] bpb=1.100618 time=1282.7s
+  ttt_chunk [1201/1893] bpb=1.101200 time=1293.4s
+  ttt_chunk [1211/1893] bpb=1.100606 time=1304.2s
+  ttt_chunk [1221/1893] bpb=1.100309 time=1315.0s
+  ttt_chunk [1231/1893] bpb=1.100236 time=1325.8s
+  ttt_chunk [1241/1893] bpb=1.100026 time=1336.5s
+  ttt_chunk [1251/1893] bpb=1.099790 time=1347.3s
+  ttt_chunk [1261/1893] bpb=1.099730 time=1358.1s
+  ttt_chunk [1271/1893] bpb=1.099522 time=1368.8s
+  ttt_chunk [1281/1893] bpb=1.099310 time=1379.6s
+  ttt_chunk [1291/1893] bpb=1.099133 time=1390.3s
+  ttt_chunk [1301/1893] bpb=1.098747 time=1401.1s
+  ttt_chunk [1311/1893] bpb=1.098432 time=1411.9s
+  ttt_chunk [1321/1893] bpb=1.098267 time=1422.6s
+  ttt_chunk [1331/1893] bpb=1.098192 time=1433.4s
+  ttt_chunk [1341/1893] bpb=1.098083 time=1444.2s
+  ttt_chunk [1351/1893] bpb=1.098029 time=1455.0s
+  ttt_chunk [1361/1893] bpb=1.098231 time=1465.7s
+  ttt_chunk [1371/1893] bpb=1.098089 time=1476.5s
+  ttt_chunk [1381/1893] bpb=1.098019 time=1487.3s
+  ttt_chunk [1391/1893] bpb=1.097495 time=1498.0s
+  ttt_chunk [1401/1893] bpb=1.097514 time=1508.8s
+  ttt_chunk [1411/1893] bpb=1.097548 time=1519.6s
+  ttt_chunk [1421/1893] bpb=1.097802 time=1530.3s
+  ttt_chunk [1431/1893] bpb=1.097657 time=1541.1s
+  ttt_chunk [1441/1893] bpb=1.098321 time=1551.9s
+  ttt_chunk [1451/1893] bpb=1.098447 time=1562.6s
+  ttt_chunk [1461/1893] bpb=1.098192 time=1573.4s
+  ttt_chunk [1471/1893] bpb=1.099100 time=1584.2s
+  ttt_chunk [1481/1893] bpb=1.098893 time=1594.9s
+  ttt_chunk [1491/1893] bpb=1.098882 time=1605.7s
+  ttt_chunk [1501/1893] bpb=1.099047 time=1616.5s
+  ttt_chunk [1511/1893] bpb=1.099129 time=1627.2s
+  ttt_chunk [1521/1893] bpb=1.099154 time=1638.0s
+  ttt_chunk [1531/1893] bpb=1.098978 time=1648.8s
+  ttt_chunk [1541/1893] bpb=1.098944 time=1659.6s
+  ttt_chunk [1551/1893] bpb=1.099287 time=1670.3s
+  ttt_chunk [1561/1893] bpb=1.099428 time=1681.1s
+  ttt_chunk [1571/1893] bpb=1.099561 time=1691.9s
+  ttt_chunk [1581/1893] bpb=1.099680 time=1702.6s
+  ttt_chunk [1591/1893] bpb=1.099632 time=1713.4s
+  ttt_chunk [1601/1893] bpb=1.099814 time=1724.2s
+  ttt_chunk [1611/1893] bpb=1.099890 time=1734.9s
+  ttt_chunk [1621/1893] bpb=1.099746 time=1745.7s
+  ttt_chunk [1631/1893] bpb=1.099923 time=1756.5s
+  ttt_chunk [1641/1893] bpb=1.099803 time=1767.2s
+  ttt_chunk [1651/1893] bpb=1.099721 time=1778.0s
+  ttt_chunk [1661/1893] bpb=1.099604 time=1788.8s
+  ttt_chunk [1671/1893] bpb=1.099950 time=1799.6s
+  ttt_chunk [1681/1893] bpb=1.100198 time=1810.3s
+  ttt_chunk [1691/1893] bpb=1.100167 time=1821.1s
+  ttt_chunk [1701/1893] bpb=1.100167 time=1831.9s
+  ttt_chunk [1711/1893] bpb=1.100005 time=1842.6s
+  ttt_chunk [1721/1893] bpb=1.099862 time=1853.4s
+  ttt_chunk [1731/1893] bpb=1.099816 time=1864.2s
+  ttt_chunk [1741/1893] bpb=1.099595 time=1874.9s
+  ttt_chunk [1751/1893] bpb=1.099450 time=1885.7s
+  ttt_chunk [1761/1893] bpb=1.099527 time=1896.5s
+  ttt_chunk [1771/1893] bpb=1.099457 time=1907.2s
+  ttt_chunk [1781/1893] bpb=1.099414 time=1918.0s
+  ttt_chunk [1791/1893] bpb=1.099023 time=1928.8s
+  ttt_chunk [1801/1893] bpb=1.099031 time=1939.5s
+  ttt_chunk [1811/1893] bpb=1.098867 time=1950.3s
+  ttt_chunk [1821/1893] bpb=1.098905 time=1961.1s
+  ttt_chunk [1831/1893] bpb=1.098518 time=1971.9s
+  ttt_chunk [1841/1893] bpb=1.098497 time=1982.6s
+  ttt_chunk [1851/1893] bpb=1.098282 time=1993.4s
+  ttt_chunk [1861/1893] bpb=1.097807 time=2004.2s
+  ttt_chunk [1871/1893] bpb=1.097656 time=2014.9s
+  ttt_chunk [1881/1893] bpb=1.097279 time=2025.7s
+  ttt_chunk [1891/1893] bpb=1.097109 time=2036.5s
+  ttt_chunk [1893/1893] bpb=1.097126 time=2038.2s
+ttt_sliding:done val_loss=1.850831 val_bpb=1.096169 elapsed=2038.3s
+legal_ttt val_loss:1.8508 val_bpb:1.0962 eval_time:2038958ms
+legal_ttt_exact val_loss:1.85083110 val_bpb:1.09616933
+batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# --- Quantization helpers ---
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,dtg_gate,ve_layer_scales,ve_shared.scale,attn_gate,vr_lambda",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+# --- Data loading ---
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# --- Transformer modules ---
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                scale = (row_max / 31.0).clamp_min(1.0 / 31.0)
+                w_q = (torch.clamp(torch.round(w32 / scale[:, None]), -32, 31) * scale[:, None]).to(x.dtype)
+            w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024, rope_dims: int = 0):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / (base ** (torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (rd / (rd - 2)))
+                inv_freq = 1.0 / (new_base ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd))
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int = 0) -> Tensor:
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        # No CastedLinear -- weights come from banks
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rope_dims = 0  # set by GPT.__init__ for partial RoPE
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False  # set by GPT.__init__ for deep layers only
+        # Gated attention and value residual (non-banked small params)
+        self.gated_attention = gated_attention
+        if gated_attention:
+            self.attn_gate = nn.Linear(dim, num_heads, bias=True)
+            nn.init.zeros_(self.attn_gate.weight)
+            nn.init.constant_(self.attn_gate.bias, 4.0)
+        self.value_residual = value_residual
+        if value_residual:
+            self.vr_lambda = nn.Parameter(torch.tensor([0.5, 0.5], dtype=torch.float32))
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        """Efficient XSA: subtract self-value projection via GQA-aware reshape (no repeat_interleave).
+        y: [B, T, H, D], v: [B, T, Hkv, D]. H must be divisible by Hkv."""
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)        # [B, T, Hkv, group, D]
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)    # [B, T, Hkv, 1, D] -- broadcast ready
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+    def forward(self, x: Tensor, q_w: Tensor, k_w: Tensor, v_w: Tensor, out_w: Tensor, v_embed: Tensor | None = None, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        bsz, seqlen, dim = x.shape
+        q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype))
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        raw_v = v if self.value_residual else None
+        if self.value_residual and v0 is not None:
+            lam = self.vr_lambda.to(dtype=v.dtype)
+            v = lam[0] * v0 + lam[1] * v
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if _HAS_FA3:
+            y = flash_attn_3_func(q, k, v, causal=True)
+        else:
+            # SDPA expects (B, H, T, D), FA3 uses (B, T, H, D)
+            y = F.scaled_dot_product_attention(
+                q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
+                is_causal=True,
+                enable_gqa=(self.num_kv_heads != self.num_heads),
+            ).transpose(1, 2)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        if self.gated_attention:
+            # gate shape: (bsz, seqlen, num_heads) -> (bsz, seqlen, num_heads, 1) for B,T,H,D layout
+            gate = torch.sigmoid(self.attn_gate(x)).unsqueeze(-1)
+            y = y * gate
+        y = y.reshape(bsz, seqlen, dim)
+        return F.linear(y, out_w.to(x.dtype)), raw_v
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class ValueEmbedding(nn.Module):
+    """Reinject token identity into attention values at specific layers.
+    Each table maps vocab tokens to a low-dim embedding, projected to model_dim."""
+    def __init__(self, vocab_size: int, ve_dim: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, ve_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(ve_dim, model_dim, bias=False) if ve_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(token_ids)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        # No CastedLinear -- weights come from banks
+    def forward(self, x: Tensor, up_w: Tensor, down_w: Tensor) -> Tensor:
+        x = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5)
+        return F.linear(x.square(), down_w.to(x.dtype))
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        layer_idx: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+                                        gated_attention=gated_attention, value_residual=value_residual)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+        if dtg:
+            self.dtg_gate = nn.Linear(dim, 1, bias=True)
+            nn.init.zeros_(self.dtg_gate.weight)
+            nn.init.constant_(self.dtg_gate.bias, 2.0)
+        else:
+            self.dtg_gate = None
+    def forward(self, x: Tensor, x0: Tensor, q_w: Tensor, k_w: Tensor, v_w: Tensor, out_w: Tensor, up_w: Tensor, down_w: Tensor, v_embed: Tensor | None = None, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out, raw_v = self.attn(self.attn_norm(x_in) * self.ln_scale_factor, q_w, k_w, v_w, out_w, v_embed=v_embed, v0=v0)
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        if self.dtg_gate is not None:
+            gate = torch.sigmoid(self.dtg_gate(x_in.detach()))
+            x_out = x_in + gate * (x_out - x_in)
+        return x_out, raw_v
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        mtp_num_heads: int = 0,
+        mtp_loss_weight: float = 0.1,
+        bigram_vocab_size: int = 0,
+        bigram_dim: int = 128,
+        xsa_last_n: int = 0,
+        rope_dims: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        ve_enabled: bool = False,
+        ve_dim: int = 128,
+        ve_layers: str = "9,10",
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self._ve_target_dim = num_kv_heads * (model_dim // num_heads)  # kv_dim for value projection
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.value_residual = value_residual
+        self.mtp_num_heads = mtp_num_heads
+        self.mtp_loss_weight = mtp_loss_weight
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.smear = SmearGate(model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        # Parameter banks: contiguous 3D tensors for batched optimizer
+        head_dim = model_dim // num_heads
+        kv_dim = num_kv_heads * head_dim
+        mlp_dim = int(mlp_mult * model_dim)
+        self.num_layers = num_layers
+        self.qo_bank = nn.Parameter(torch.empty(2 * num_layers, model_dim, model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * num_layers, kv_dim, model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(num_layers, mlp_dim, model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(num_layers, model_dim, mlp_dim))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                    layer_idx=i,
+                    ln_scale=ln_scale,
+                    dtg=dtg,
+                    gated_attention=gated_attention,
+                    value_residual=value_residual,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        if rope_dims > 0:
+            head_dim = model_dim // num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = rope_dims
+                block.attn.rotary = Rotary(head_dim, base=rope_base, train_seq_len=1024, rope_dims=rope_dims)
+        self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+        kv_dim_ve = self._ve_target_dim
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim_ve)
+            self.ve_layer_scales = nn.ParameterList(
+                [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices]
+            )
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.value_embeds = nn.ModuleList()  # keep empty for compat
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.mtp_heads = nn.ModuleList(
+            [CastedLinear(model_dim, vocab_size, bias=False) for _ in range(mtp_num_heads)]
+        )
+        for head in self.mtp_heads:
+            head._zero_init = True
+        if xsa_last_n > 0:
+            for i in range(max(0, num_layers - xsa_last_n), num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self._init_weights()
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        # Init banks: orthogonal, with proj layers scaled down and out/down zero-init
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)        # Q
+            nn.init.zeros_(self.qo_bank.data[n + i])                    # Out (zero init)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)        # K
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)    # V
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)    # MLP up
+            nn.init.zeros_(self.mlp_down_bank.data[i])                  # MLP down (zero init)
+            # Scale proj layers (out_proj and mlp_down are "proj" layers)
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        # Init remaining nn.Linear modules (bigram proj, mtp heads, lm_head)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+    def _get_ve(self, layer_idx: int, input_ids: Tensor, ve_cache: dict | None = None) -> Tensor | None:
+        """Get value embedding for a specific layer using shared table + per-layer scale."""
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if ve_cache is not None and 've' not in ve_cache:
+            ve_cache['ve'] = self.ve_shared(input_ids)
+        ve_base = ve_cache['ve'] if ve_cache is not None else self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_base * self.ve_layer_scales[ve_idx].to(dtype=ve_base.dtype)
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x, raw_v = self.blocks[i](x, x0,
+                self.qo_bank[i], self.kv_bank[i], self.kv_bank[n + i],
+                self.qo_bank[n + i], self.mlp_up_bank[i], self.mlp_down_bank[i],
+                v_embed=ve, v0=v0)
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x, _ = self.blocks[bi](x, x0,
+                self.qo_bank[bi], self.kv_bank[bi], self.kv_bank[n + bi],
+                self.qo_bank[n + bi], self.mlp_up_bank[bi], self.mlp_down_bank[bi],
+                v_embed=ve, v0=v0)
+        x = self.final_norm(x)
+        x_flat = x.reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x_flat, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x_flat)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        main_loss = F.cross_entropy(logits.float(), targets, reduction="mean")
+        if self.training and self.mtp_num_heads > 0 and self.mtp_loss_weight > 0.0:
+            _, seqlen, dim = x.shape
+            mtp_loss_sum = x.new_zeros(())
+            mtp_loss_count = 0
+            for k, mtp_head in enumerate(self.mtp_heads):
+                valid_t = seqlen - (k + 1)
+                if valid_t <= 0:
+                    continue
+                mtp_hidden = x[:, :valid_t, :].reshape(-1, dim)
+                mtp_targets = target_ids[:, k + 1 :].reshape(-1)
+                mtp_logits_proj = mtp_head(mtp_hidden)
+                mtp_logits = self.logit_softcap * torch.tanh(mtp_logits_proj / self.logit_softcap)
+                mtp_loss_sum = mtp_loss_sum + F.cross_entropy(mtp_logits.float(), mtp_targets, reduction="mean")
+                mtp_loss_count += 1
+            if mtp_loss_count > 0:
+                main_loss = main_loss + self.mtp_loss_weight * (mtp_loss_sum / mtp_loss_count)
+        return main_loss
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Return logits (bsz, seq_len, vocab) without computing loss."""
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x, raw_v = self.blocks[i](x, x0,
+                self.qo_bank[i], self.kv_bank[i], self.kv_bank[n + i],
+                self.qo_bank[n + i], self.mlp_up_bank[i], self.mlp_down_bank[i],
+                v_embed=ve, v0=v0)
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x, _ = self.blocks[bi](x, x0,
+                self.qo_bank[bi], self.kv_bank[bi], self.kv_bank[n + bi],
+                self.qo_bank[n + bi], self.mlp_up_bank[bi], self.mlp_down_bank[bi],
+                v_embed=ve, v0=v0)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+# --- Sliding window evaluation ---
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context."""
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= 1]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    base_model.eval()
+    compiled_logits = torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = compiled_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+def eval_val_sliding_ttt(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    stride: int, batch_seqs: int = 32, log0=print,
+) -> tuple[float, float]:
+    """Legal score-first TTT (PR #461 recipe): score each chunk with sliding windows,
+    then train on it. Every token scored BEFORE any update that could use it."""
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = args.ttt_chunk_tokens
+
+    # Pre-compute all window starts
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+
+    # Assign each window to a chunk based on the first token it scores
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    chunk_windows: list[list[int]] = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        end = min(ws + seq_len, total_tokens)
+        wlen = end - ws
+        s = 0 if ws == 0 else max(wlen - stride, 0)
+        scored_start = ws + s
+        ci = min(scored_start // ttt_chunk, num_chunks - 1)
+        chunk_windows[ci].append(ws)
+
+    log0(f"ttt_sliding:start chunks={num_chunks} chunk_tokens={ttt_chunk} "
+         f"total_windows={len(window_starts)} stride={stride} "
+         f"ttt_lr={args.ttt_lr} ttt_epochs={args.ttt_epochs} "
+         f"freeze_blocks={args.ttt_freeze_blocks}")
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Freeze first N blocks
+    frozen_block_ids = set(range(min(args.ttt_freeze_blocks, len(base_model.blocks))))
+    ttt_params = []
+    for name, p in base_model.named_parameters():
+        freeze = False
+        for bi in frozen_block_ids:
+            if f"blocks.{bi}." in name:
+                freeze = True
+                break
+        if freeze:
+            p.requires_grad_(False)
+        else:
+            p.requires_grad_(True)
+            ttt_params.append(p)
+
+    log0(f"ttt_sliding:params unfrozen={sum(p.numel() for p in ttt_params)} "
+         f"frozen={sum(p.numel() for p in base_model.parameters() if not p.requires_grad)}")
+
+    optimizer = torch.optim.SGD(ttt_params, lr=args.ttt_lr, momentum=args.ttt_momentum)
+    t0 = time.perf_counter()
+
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows:
+            continue
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+
+        # --- Phase 1: SCORE this chunk's windows (inference_mode) ---
+        my_s = (len(windows) * rank) // world_size
+        my_e = (len(windows) * (rank + 1)) // world_size
+        my_windows = windows[my_s:my_e]
+
+        base_model.eval()
+        with torch.inference_mode():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi:bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens: list[int] = []
+                for i, ws in enumerate(batch_ws):
+                    end = min(ws + seq_len, total_tokens)
+                    wlen = end - ws
+                    wlens.append(wlen)
+                    chunk_tok = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                    x_batch[i, :wlen] = chunk_tok[:-1]
+                    y_batch[i, :wlen] = chunk_tok[1:]
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model.forward_logits(x_batch)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y_batch.reshape(-1), reduction="none",
+                ).reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]
+                    s = 0 if ws == 0 else max(wlen - stride, 0)
+                    scored_nll = nll[i, s:wlen].to(torch.float64)
+                    loss_sum += scored_nll.sum()
+                    token_count += float(wlen - s)
+                    tgt, prev = y_batch[i, s:wlen], x_batch[i, s:wlen]
+                    tb = base_bytes_lut[tgt].to(torch.float64)
+                    tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                    byte_count += tb.sum()
+
+        # --- Phase 2: TRAIN on this chunk (already scored = legal) ---
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and args.ttt_epochs > 0:
+            base_model.train()
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if chunk_seqs > 0:
+                cos_lr = args.ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                for pg in optimizer.param_groups:
+                    pg['lr'] = cos_lr
+                my_seq_s = (chunk_seqs * rank) // world_size
+                my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+                my_chunk_seqs = my_seq_e - my_seq_s
+                for _ep in range(args.ttt_epochs):
+                    for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                        be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                        actual_bs = my_seq_s + bs
+                        start_tok = chunk_start + actual_bs * seq_len
+                        end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                        if end_tok > val_tokens.numel():
+                            continue
+                        local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                        x = local[:-1].reshape(-1, seq_len)
+                        y = local[1:].reshape(-1, seq_len)
+                        optimizer.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            loss = base_model(x, y)
+                        loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        torch.nn.utils.clip_grad_norm_(ttt_params, args.ttt_grad_clip)
+                        optimizer.step()
+
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            log0(f"  ttt_chunk [{ci+1}/{num_chunks}] bpb={rbpb:.6f} time={elapsed:.1f}s")
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+    log0(f"ttt_sliding:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+         f"elapsed={time.perf_counter() - t0:.1f}s")
+    return val_loss, val_bpb
+
+
+# --- GPTQ-lite int6 quantization ---
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+def quantize_int6_per_row(t: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        best_q, best_s, best_err = None, None, float('inf')
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            if pct < 1.0:
+                row_clip = torch.quantile(t32.abs(), pct, dim=1)
+            else:
+                row_clip = t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+            recon = q.float() * s.float()[:, None]
+            err = (t32 - recon).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_s, best_err = q, s, err
+        return best_q, best_s
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+
+def _unbank_state_dict(sd: dict[str, Tensor], num_layers: int) -> dict[str, Tensor]:
+    """Convert 3D bank tensors into individual 2D tensors with standard names."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    for name, tensor in sd.items():
+        if name == "qo_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_q.weight"] = tensor[i]
+                out[f"blocks.{i}.attn.proj.weight"] = tensor[n + i]
+        elif name == "kv_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_k.weight"] = tensor[i]
+                out[f"blocks.{i}.attn.c_v.weight"] = tensor[n + i]
+        elif name == "mlp_up_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.fc.weight"] = tensor[i]
+        elif name == "mlp_down_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.proj.weight"] = tensor[i]
+        else:
+            out[name] = tensor
+    return out
+
+def _rebank_state_dict(sd: dict[str, Tensor], num_layers: int, template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    """Convert individual 2D tensors back into 3D bank tensors."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    # Reconstruct banks from individual weight keys
+    qo_slices = [None] * (2 * n)
+    kv_slices = [None] * (2 * n)
+    up_slices = [None] * n
+    down_slices = [None] * n
+    consumed = set()
+    for i in range(n):
+        qk = f"blocks.{i}.attn.c_q.weight"
+        if qk in sd:
+            qo_slices[i] = sd[qk]
+            consumed.add(qk)
+        ok = f"blocks.{i}.attn.proj.weight"
+        if ok in sd:
+            qo_slices[n + i] = sd[ok]
+            consumed.add(ok)
+        kk = f"blocks.{i}.attn.c_k.weight"
+        if kk in sd:
+            kv_slices[i] = sd[kk]
+            consumed.add(kk)
+        vk = f"blocks.{i}.attn.c_v.weight"
+        if vk in sd:
+            kv_slices[n + i] = sd[vk]
+            consumed.add(vk)
+        fk = f"blocks.{i}.mlp.fc.weight"
+        if fk in sd:
+            up_slices[i] = sd[fk]
+            consumed.add(fk)
+        dk = f"blocks.{i}.mlp.proj.weight"
+        if dk in sd:
+            down_slices[i] = sd[dk]
+            consumed.add(dk)
+    out["qo_bank"] = torch.stack(qo_slices).to(dtype=template_sd["qo_bank"].dtype)
+    out["kv_bank"] = torch.stack(kv_slices).to(dtype=template_sd["kv_bank"].dtype)
+    out["mlp_up_bank"] = torch.stack(up_slices).to(dtype=template_sd["mlp_up_bank"].dtype)
+    out["mlp_down_bank"] = torch.stack(down_slices).to(dtype=template_sd["mlp_down_bank"].dtype)
+    for name, tensor in sd.items():
+        if name not in consumed:
+            out[name] = tensor
+    return out
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    num_layers_total = max(
+        (int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")),
+        default=0,
+    ) + 1
+    late_k_layers = set(range(num_layers_total - 2, num_layers_total))
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+# --- Training ---
+
+def main() -> None:
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    # zeropower_via_newtonschulz5 runs eagerly with bmm -- do NOT compile
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    # With MIG fix above, each process only sees its assigned GPU as device 0
+    device = torch.device("cuda", 0)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    effective_eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+    CastedLinear._qat_enabled = args.qat_enabled
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=args.mtp_num_heads,
+        mtp_loss_weight=args.mtp_loss_weight,
+        bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims,
+        ln_scale=args.ln_scale,
+        dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled,
+        ve_dim=args.ve_dim,
+        ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention,
+        value_residual=args.value_residual,
+    ).to(device).bfloat16()
+    # Banks stay FP32 (like CastedLinear weights), cast to BF16 in forward
+    base_model.qo_bank.data = base_model.qo_bank.data.float()
+    base_model.kv_bank.data = base_model.kv_bank.data.float()
+    base_model.mlp_up_bank.data = base_model.mlp_up_bank.data.float()
+    base_model.mlp_down_bank.data = base_model.mlp_down_bank.data.float()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    # No DDP -- Parallel Muon handles bank grad communication via reduce-scatter,
+    # and non-bank grads are manually all-reduced before Adam steps.
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model = compiled_model
+
+    # Optimizer split:
+    # - 4 parameter banks -> Muon (batched Newton-Schulz)
+    # - token embedding -> Adam
+    # - scalars/control tensors -> Adam
+    # - bigram proj, mtp heads, VE proj -> Adam (small matrix params not worth banking)
+    matrix_params = [
+        base_model.qo_bank, base_model.kv_bank,
+        base_model.mlp_up_bank, base_model.mlp_down_bank,
+    ]
+    block_named_params = list(base_model.blocks.named_parameters())
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_params.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None:
+            scalar_params.append(base_model.bigram.proj.weight)
+    if base_model.ve_shared is not None:
+        tok_params.append({"params": [base_model.ve_shared.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.ve_shared.proj is not None:
+            scalar_params.append(base_model.ve_shared.proj.weight)
+        scalar_params.append(base_model.ve_shared.scale)
+        for s in base_model.ve_layer_scales:
+            scalar_params.append(s)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    # Non-bank params that need manual all-reduce (replicated across GPUs)
+    replicated_params = list(optimizer_tok.param_groups[0]["params"])
+    for pg in optimizer_tok.param_groups[1:]:
+        replicated_params.extend(pg["params"])
+    replicated_params.extend(scalar_params)
+
+    optimizer_head = None
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        replicated_params.append(base_model.lm_head.weight)
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if optimizer_head is not None:
+        optimizers.append(optimizer_head)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    mtp_params = sum(p.numel() for p in base_model.mtp_heads.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"mtp_num_heads:{args.mtp_num_heads} mtp_loss_weight:{args.mtp_loss_weight} mtp_params:{mtp_params}")
+    xsa_layers = [i for i, b in enumerate(base_model.blocks) if b.attn.use_xsa]
+    log0(f"XSA:last_{args.xsa_last_n} active_layers:{xsa_layers}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            # All-reduce all grads for warmup (simple, not optimized)
+            if distributed:
+                for p in base_model.parameters():
+                    if p.grad is not None:
+                        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    from collections import deque
+    lawa_queue: deque[dict[str, Tensor]] = deque(maxlen=args.lawa_k)
+    ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    ema_decay = 0.997
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        if args.late_qat_threshold > 0 and scale < args.late_qat_threshold and not CastedLinear._qat_enabled:
+            CastedLinear._qat_enabled = True
+            log0(f"late_qat:enabled step:{step} scale:{scale:.4f}")
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        # === 3-phase overlapped optimizer step ===
+        # Phase 1: Launch async reduce-scatter for banks (biggest first)
+        optimizer_muon.launch_reduce_scatters()
+        # Phase 2: All-reduce non-bank grads + step Adam (while bank RS is in-flight)
+        if distributed:
+            for p in replicated_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+        optimizer_tok.step()
+        optimizer_scalar.step()
+        if optimizer_head is not None:
+            optimizer_head.step()
+        # Phase 3: Wait for RS, local NS5, all-gather (banks processed last)
+        optimizer_muon.step()
+        zero_grad_all()
+        # EMA update
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(t.detach().float(), alpha=1.0 - ema_decay)
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        if args.swa_enabled and scale < 0.2 and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+        if args.lawa_enabled and step % args.lawa_freq == 0:
+            lawa_queue.append({name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()})
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+    # Apply weight averaging
+    if args.lawa_enabled and len(lawa_queue) > 1:
+        log0(f"lawa:applying LAWA averaging k={len(lawa_queue)}")
+        current_state = base_model.state_dict()
+        avg_state = {name: torch.zeros(t.shape, dtype=torch.float32, device='cpu') for name, t in current_state.items()}
+        for snap in lawa_queue:
+            for name in avg_state:
+                avg_state[name] += snap[name].float()
+        for name in avg_state:
+            avg_state[name] /= len(lawa_queue)
+            avg_state[name] = avg_state[name].to(dtype=current_state[name].dtype)
+        base_model.load_state_dict(avg_state, strict=True)
+    else:
+        log0("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+        base_model.load_state_dict(avg_state, strict=True)
+    torch.cuda.synchronize()
+    t_diag = time.perf_counter()
+    diag_val_loss, diag_val_bpb = eval_val(
+        args, compiled_model, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"DIAGNOSTIC post_ema val_loss:{diag_val_loss:.4f} val_bpb:{diag_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_diag):.0f}ms"
+    )
+    full_state_dict = base_model.state_dict()
+    export_sd = {k: v for k, v in full_state_dict.items() if "mtp_heads" not in k}
+    excluded_mtp = sum(int(t.numel()) for k, t in full_state_dict.items() if "mtp_heads" in k)
+    if excluded_mtp > 0:
+        log0(f"export_excluding_mtp_params:{excluded_mtp}")
+    if master_process:
+        torch.save(export_sd, "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+    # Unbank 3D tensors into individual 2D tensors for quantization
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    unbanked_sd = _unbank_state_dict(sd_cpu, args.num_layers)
+    quant_result, quant_meta = mixed_quantize_int6(unbanked_sd, {"mlp", "attn"})
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = lzma.compress(quant_raw, preset=6)
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = len(quant_blob)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+lzma: {quant_file_bytes} bytes")
+        log0(f"Total submission size int6+lzma: {quant_file_bytes + code_bytes} bytes")
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(lzma.decompress(quant_blob_disk)),
+        map_location="cpu",
+    )
+    deq_unbanked = dequantize_mixed_int6(quant_state["w"], quant_state["m"], unbanked_sd)
+    # Re-bank the dequantized tensors
+    deq_state = _rebank_state_dict(deq_unbanked, args.num_layers, sd_cpu)
+    eval_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=0, mtp_loss_weight=0.0,
+        bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims, ln_scale=args.ln_scale, dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention, value_residual=args.value_residual,
+    ).to(device).bfloat16()
+    eval_model.qo_bank.data = eval_model.qo_bank.data.float()
+    eval_model.kv_bank.data = eval_model.kv_bank.data.float()
+    eval_model.mlp_up_bank.data = eval_model.mlp_up_bank.data.float()
+    eval_model.mlp_down_bank.data = eval_model.mlp_down_bank.data.float()
+    for m in eval_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(eval_model)
+    eval_model.load_state_dict(deq_state, strict=True)
+    compiled_eval = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args, compiled_eval, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        eval_seq_len=effective_eval_seq_len,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+    sw_seq_len = effective_eval_seq_len
+    if args.eval_stride > 0 and args.eval_stride < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+        log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+    if args.eval_stride != 64 and 64 < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide64 = time.perf_counter()
+        sw64_val_loss, sw64_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=64,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window_s64 val_loss:{sw64_val_loss:.4f} val_bpb:{sw64_val_bpb:.4f} "
+            f"stride:64 eval_time:{1000.0 * (time.perf_counter() - t_slide64):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_s64_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+        log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+    # Legal score-first TTT (PR #461 recipe)
+    if args.ttt_enabled:
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_loss, ttt_bpb = eval_val_sliding_ttt(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, log0=log0,
+        )
+        torch.cuda.synchronize()
+        log0(f"legal_ttt val_loss:{ttt_loss:.4f} val_bpb:{ttt_bpb:.4f} "
+             f"eval_time:{1000.0 * (time.perf_counter() - t_ttt):.0f}ms")
+        log0(f"legal_ttt_exact val_loss:{ttt_loss:.8f} val_bpb:{ttt_bpb:.8f}")
+    if distributed:
+        dist.destroy_process_group()
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
+Running Python 3.10.14 (main, May  6 2024, 19:42:50) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128
+Fri Mar 27 09:32:41 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.4     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA A100-SXM4-80GB          On  |   00000000:27:00.0 Off |                   On |
+| N/A   43C    P0            101W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA A100-SXM4-80GB          On  |   00000000:2A:00.0 Off |                   On |
+| N/A   36C    P0             91W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA A100-SXM4-80GB          On  |   00000000:51:00.0 Off |                   On |
+| N/A   36C    P0            103W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA A100-SXM4-80GB          On  |   00000000:9E:00.0 Off |                   On |
+| N/A   40C    P0            100W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA A100-SXM4-80GB          On  |   00000000:A4:00.0 Off |                   On |
+| N/A   32C    P0             95W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA A100-SXM4-80GB          On  |   00000000:CA:00.0 Off |                   On |
+| N/A   37C    P0             97W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| MIG devices:                                                                            |
++------------------+----------------------------------+-----------+-----------------------+
+| GPU  GI  CI  MIG |                     Memory-Usage |        Vol|      Shared           |
+|      ID  ID  Dev |                       BAR1-Usage | SM     Unc| CE ENC DEC OFA JPG    |
+|                  |                                  |        ECC|                       |
+|==================+==================================+===========+=======================|
+|  0    2   0   0  |             355MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 2MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  1    1   0   0  |             355MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 2MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  1    2   0   1  |              38MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 0MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  2    1   0   0  |             355MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 2MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  3    2   0   0  |             355MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 2MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  4    2   0   0  |              38MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 0MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  5    1   0   0  |              38MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 0MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  5    2   0   1  |              38MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 0MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   3538291      C   /opt/conda/bin/python3                          0MiB |
+|    1   N/A  N/A   3538292      C   /opt/conda/bin/python3                          0MiB |
+|    2   N/A  N/A   3538293      C   /opt/conda/bin/python3                          0MiB |
+|    3   N/A  N/A   3538294      C   /opt/conda/bin/python3                          0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26928220
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_4 active_layers:[7, 8, 9, 10]
+world_size:4 grad_accum_steps:2
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:0.000
+seed:42
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9293 val_bpb:4.1039 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9305 train_time:851ms step_avg:850.55ms
+step:2/20000 train_loss:8.6548 train_time:1395ms step_avg:697.55ms
+step:3/20000 train_loss:7.6769 train_time:2247ms step_avg:749.06ms
+step:4/20000 train_loss:7.1975 train_time:3099ms step_avg:774.78ms
+step:5/20000 train_loss:7.1772 train_time:3951ms step_avg:790.29ms
+step:6/20000 train_loss:7.1087 train_time:4812ms step_avg:801.97ms
+step:7/20000 train_loss:7.1576 train_time:5664ms step_avg:809.18ms
+step:8/20000 train_loss:6.9941 train_time:6516ms step_avg:814.55ms
+step:9/20000 train_loss:6.6553 train_time:7368ms step_avg:818.72ms
+step:10/20000 train_loss:6.2949 train_time:8221ms step_avg:822.10ms
+step:500/20000 train_loss:2.3555 train_time:414338ms step_avg:828.68ms
+step:1000/20000 train_loss:2.2641 train_time:828509ms step_avg:828.51ms
+step:1500/20000 train_loss:2.1807 train_time:1243119ms step_avg:828.75ms
+step:2000/20000 train_loss:2.0310 train_time:1657855ms step_avg:828.93ms
+step:2500/20000 train_loss:2.1602 train_time:2071904ms step_avg:828.76ms
+step:3000/20000 train_loss:2.1249 train_time:2486661ms step_avg:828.89ms
+step:3500/20000 train_loss:2.1866 train_time:2901085ms step_avg:828.88ms
+step:4000/20000 train_loss:2.1438 train_time:3315094ms step_avg:828.77ms
+step:4000/20000 val_loss:2.0753 val_bpb:1.2291 train_time:3315444ms step_avg:828.86ms
+step:4500/20000 train_loss:2.1118 train_time:3729527ms step_avg:828.78ms
+step:5000/20000 train_loss:2.0683 train_time:4143751ms step_avg:828.75ms
+step:5500/20000 train_loss:2.1134 train_time:4558181ms step_avg:828.76ms
+step:6000/20000 train_loss:2.0092 train_time:4972372ms step_avg:828.73ms
+step:6500/20000 train_loss:2.2744 train_time:5386385ms step_avg:828.67ms
+step:7000/20000 train_loss:1.9078 train_time:5800678ms step_avg:828.67ms
+step:7500/20000 train_loss:2.0298 train_time:6214909ms step_avg:828.65ms
+step:8000/20000 train_loss:1.9822 train_time:6629167ms step_avg:828.65ms
+step:8000/20000 val_loss:2.0339 val_bpb:1.2046 train_time:6629524ms step_avg:828.69ms
+step:8500/20000 train_loss:1.9647 train_time:7043393ms step_avg:828.63ms
+step:9000/20000 train_loss:2.0911 train_time:7457618ms step_avg:828.62ms
+step:9500/20000 train_loss:2.2465 train_time:7872112ms step_avg:828.64ms
+step:10000/20000 train_loss:2.0596 train_time:8286348ms step_avg:828.63ms
+step:10500/20000 train_loss:2.0969 train_time:8700627ms step_avg:828.63ms
+step:11000/20000 train_loss:1.9872 train_time:9114964ms step_avg:828.63ms
+step:11500/20000 train_loss:1.9445 train_time:9529091ms step_avg:828.62ms
+step:12000/20000 train_loss:1.9632 train_time:9943448ms step_avg:828.62ms
+step:12000/20000 val_loss:2.0250 val_bpb:1.1993 train_time:9943791ms step_avg:828.65ms
+step:12500/20000 train_loss:1.9705 train_time:10357662ms step_avg:828.61ms
+step:13000/20000 train_loss:1.9775 train_time:10771664ms step_avg:828.59ms
+step:13500/20000 train_loss:2.0946 train_time:11185822ms step_avg:828.58ms
+step:14000/20000 train_loss:1.8907 train_time:11599963ms step_avg:828.57ms
+step:14500/20000 train_loss:2.0646 train_time:12013997ms step_avg:828.55ms
+step:15000/20000 train_loss:2.0088 train_time:12428064ms step_avg:828.54ms
+step:15500/20000 train_loss:1.9760 train_time:12842082ms step_avg:828.52ms
+step:16000/20000 train_loss:2.0462 train_time:13256277ms step_avg:828.52ms
+step:16000/20000 val_loss:1.9703 val_bpb:1.1669 train_time:13256627ms step_avg:828.54ms
+step:16500/20000 train_loss:2.0226 train_time:13670137ms step_avg:828.49ms
+step:17000/20000 train_loss:2.0200 train_time:14084149ms step_avg:828.48ms
+step:17500/20000 train_loss:1.9948 train_time:14498193ms step_avg:828.47ms
+step:18000/20000 train_loss:1.8682 train_time:14912122ms step_avg:828.45ms
+swa:start step:18450
+step:18500/20000 train_loss:1.8336 train_time:15326272ms step_avg:828.45ms
+late_qat:enabled step:18831 scale:0.1499
+step:19000/20000 train_loss:1.8044 train_time:15740755ms step_avg:828.46ms
+step:19500/20000 train_loss:1.9852 train_time:16155668ms step_avg:828.50ms
+step:20000/20000 train_loss:1.8751 train_time:16569987ms step_avg:828.50ms
+step:20000/20000 val_loss:1.8757 val_bpb:1.1109 train_time:16570369ms step_avg:828.52ms
+peak memory allocated: 22092 MiB reserved: 22340 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.8746 val_bpb:1.1103 eval_time:19693ms
+Serialized model: 106027446 bytes
+Code size: 90361 bytes
+Serialized model int6+lzma: 15046784 bytes
+Total submission size int6+lzma: 15137145 bytes
+final_int6_roundtrip val_loss:1.9002 val_bpb:1.1254 eval_time:24369ms
+final_int6_roundtrip_exact val_loss:1.90023350 val_bpb:1.12542531
+final_int6_sliding_window val_loss:1.8607 val_bpb:1.1020 stride:64 eval_time:664078ms
+final_int6_sliding_window_exact val_loss:1.86067988 val_bpb:1.10200235
+final_int8_zlib_roundtrip_exact val_loss:1.86067988 val_bpb:1.10200235
+ttt_sliding:start chunks=1893 chunk_tokens=32768 total_windows=969088 stride=64 ttt_lr=0.002 ttt_epochs=3 freeze_blocks=0
+ttt_sliding:params unfrozen=26928220 frozen=0
+  ttt_chunk [1/1893] bpb=1.149221 time=1.1s
+  ttt_chunk [11/1893] bpb=1.105427 time=11.9s
+  ttt_chunk [21/1893] bpb=1.108997 time=22.7s
+  ttt_chunk [31/1893] bpb=1.112744 time=33.4s
+  ttt_chunk [41/1893] bpb=1.101277 time=44.2s
+  ttt_chunk [51/1893] bpb=1.097692 time=55.0s
+  ttt_chunk [61/1893] bpb=1.102242 time=65.7s
+  ttt_chunk [71/1893] bpb=1.099299 time=76.5s
+  ttt_chunk [81/1893] bpb=1.099418 time=87.3s
+  ttt_chunk [91/1893] bpb=1.098337 time=98.0s
+  ttt_chunk [101/1893] bpb=1.101032 time=108.8s
+  ttt_chunk [111/1893] bpb=1.102383 time=119.6s
+  ttt_chunk [121/1893] bpb=1.099256 time=130.4s
+  ttt_chunk [131/1893] bpb=1.098961 time=141.1s
+  ttt_chunk [141/1893] bpb=1.098637 time=151.9s
+  ttt_chunk [151/1893] bpb=1.101853 time=162.7s
+  ttt_chunk [161/1893] bpb=1.103510 time=173.4s
+  ttt_chunk [171/1893] bpb=1.104085 time=184.2s
+  ttt_chunk [181/1893] bpb=1.104153 time=195.0s
+  ttt_chunk [191/1893] bpb=1.107342 time=205.7s
+  ttt_chunk [201/1893] bpb=1.107569 time=216.5s
+  ttt_chunk [211/1893] bpb=1.105080 time=227.3s
+  ttt_chunk [221/1893] bpb=1.107111 time=238.1s
+  ttt_chunk [231/1893] bpb=1.106532 time=248.8s
+  ttt_chunk [241/1893] bpb=1.106343 time=259.6s
+  ttt_chunk [251/1893] bpb=1.104851 time=270.4s
+  ttt_chunk [261/1893] bpb=1.103214 time=281.1s
+  ttt_chunk [271/1893] bpb=1.101864 time=291.9s
+  ttt_chunk [281/1893] bpb=1.104208 time=302.7s
+  ttt_chunk [291/1893] bpb=1.104921 time=313.4s
+  ttt_chunk [301/1893] bpb=1.105511 time=324.2s
+  ttt_chunk [311/1893] bpb=1.107095 time=335.0s
+  ttt_chunk [321/1893] bpb=1.108590 time=345.7s
+  ttt_chunk [331/1893] bpb=1.108461 time=356.5s
+  ttt_chunk [341/1893] bpb=1.108724 time=367.3s
+  ttt_chunk [351/1893] bpb=1.110014 time=378.0s
+  ttt_chunk [361/1893] bpb=1.111235 time=388.8s
+  ttt_chunk [371/1893] bpb=1.110810 time=399.6s
+  ttt_chunk [381/1893] bpb=1.110775 time=410.3s
+  ttt_chunk [391/1893] bpb=1.110407 time=421.1s
+  ttt_chunk [401/1893] bpb=1.109049 time=431.9s
+  ttt_chunk [411/1893] bpb=1.107960 time=442.6s
+  ttt_chunk [421/1893] bpb=1.107430 time=453.4s
+  ttt_chunk [431/1893] bpb=1.108117 time=464.2s
+  ttt_chunk [441/1893] bpb=1.107977 time=474.9s
+  ttt_chunk [451/1893] bpb=1.107702 time=485.7s
+  ttt_chunk [461/1893] bpb=1.106981 time=496.5s
+  ttt_chunk [471/1893] bpb=1.106584 time=507.2s
+  ttt_chunk [481/1893] bpb=1.106271 time=518.0s
+  ttt_chunk [491/1893] bpb=1.105997 time=528.8s
+  ttt_chunk [501/1893] bpb=1.105439 time=539.6s
+  ttt_chunk [511/1893] bpb=1.104831 time=550.3s
+  ttt_chunk [521/1893] bpb=1.103810 time=561.2s
+  ttt_chunk [531/1893] bpb=1.103933 time=571.9s
+  ttt_chunk [541/1893] bpb=1.103845 time=582.7s
+  ttt_chunk [551/1893] bpb=1.102632 time=593.5s
+  ttt_chunk [561/1893] bpb=1.103166 time=604.2s
+  ttt_chunk [571/1893] bpb=1.102478 time=615.0s
+  ttt_chunk [581/1893] bpb=1.101930 time=625.8s
+  ttt_chunk [591/1893] bpb=1.101262 time=636.5s
+  ttt_chunk [601/1893] bpb=1.101952 time=647.3s
+  ttt_chunk [611/1893] bpb=1.101538 time=658.1s
+  ttt_chunk [621/1893] bpb=1.101453 time=668.9s
+  ttt_chunk [631/1893] bpb=1.101855 time=679.6s
+  ttt_chunk [641/1893] bpb=1.101660 time=690.4s
+  ttt_chunk [651/1893] bpb=1.101678 time=701.2s
+  ttt_chunk [661/1893] bpb=1.101577 time=711.9s
+  ttt_chunk [671/1893] bpb=1.101226 time=722.7s
+  ttt_chunk [681/1893] bpb=1.101501 time=733.5s
+  ttt_chunk [691/1893] bpb=1.102163 time=744.2s
+  ttt_chunk [701/1893] bpb=1.101383 time=755.0s
+  ttt_chunk [711/1893] bpb=1.101968 time=765.8s
+  ttt_chunk [721/1893] bpb=1.101606 time=776.6s
+  ttt_chunk [731/1893] bpb=1.102036 time=787.3s
+  ttt_chunk [741/1893] bpb=1.101977 time=798.1s
+  ttt_chunk [751/1893] bpb=1.101623 time=808.9s
+  ttt_chunk [761/1893] bpb=1.101455 time=819.6s
+  ttt_chunk [771/1893] bpb=1.101210 time=830.4s
+  ttt_chunk [781/1893] bpb=1.101740 time=841.2s
+  ttt_chunk [791/1893] bpb=1.101420 time=851.9s
+  ttt_chunk [801/1893] bpb=1.101479 time=862.7s
+  ttt_chunk [811/1893] bpb=1.100996 time=873.5s
+  ttt_chunk [821/1893] bpb=1.100793 time=884.3s
+  ttt_chunk [831/1893] bpb=1.100359 time=895.0s
+  ttt_chunk [841/1893] bpb=1.099773 time=905.8s
+  ttt_chunk [851/1893] bpb=1.099667 time=916.6s
+  ttt_chunk [861/1893] bpb=1.099807 time=927.3s
+  ttt_chunk [871/1893] bpb=1.099860 time=938.1s
+  ttt_chunk [881/1893] bpb=1.099862 time=948.9s
+  ttt_chunk [891/1893] bpb=1.099699 time=959.6s
+  ttt_chunk [901/1893] bpb=1.099687 time=970.4s
+  ttt_chunk [911/1893] bpb=1.099686 time=981.2s
+  ttt_chunk [921/1893] bpb=1.100066 time=991.9s
+  ttt_chunk [931/1893] bpb=1.099886 time=1002.7s
+  ttt_chunk [941/1893] bpb=1.099777 time=1013.5s
+  ttt_chunk [951/1893] bpb=1.099765 time=1024.2s
+  ttt_chunk [961/1893] bpb=1.099516 time=1035.0s
+  ttt_chunk [971/1893] bpb=1.100237 time=1045.8s
+  ttt_chunk [981/1893] bpb=1.100402 time=1056.5s
+  ttt_chunk [991/1893] bpb=1.100302 time=1067.3s
+  ttt_chunk [1001/1893] bpb=1.100447 time=1078.1s
+  ttt_chunk [1011/1893] bpb=1.100704 time=1088.9s
+  ttt_chunk [1021/1893] bpb=1.100855 time=1099.6s
+  ttt_chunk [1031/1893] bpb=1.101407 time=1110.4s
+  ttt_chunk [1041/1893] bpb=1.101071 time=1121.2s
+  ttt_chunk [1051/1893] bpb=1.100782 time=1131.9s
+  ttt_chunk [1061/1893] bpb=1.101022 time=1142.7s
+  ttt_chunk [1071/1893] bpb=1.101493 time=1153.4s
+  ttt_chunk [1081/1893] bpb=1.101509 time=1164.2s
+  ttt_chunk [1091/1893] bpb=1.101914 time=1175.0s
+  ttt_chunk [1101/1893] bpb=1.102047 time=1185.8s
+  ttt_chunk [1111/1893] bpb=1.101822 time=1196.5s
+  ttt_chunk [1121/1893] bpb=1.101747 time=1207.3s
+  ttt_chunk [1131/1893] bpb=1.101647 time=1218.1s
+  ttt_chunk [1141/1893] bpb=1.101496 time=1228.8s
+  ttt_chunk [1151/1893] bpb=1.101538 time=1239.6s
+  ttt_chunk [1161/1893] bpb=1.100850 time=1250.4s
+  ttt_chunk [1171/1893] bpb=1.101414 time=1261.1s
+  ttt_chunk [1181/1893] bpb=1.100908 time=1271.9s
+  ttt_chunk [1191/1893] bpb=1.100618 time=1282.7s
+  ttt_chunk [1201/1893] bpb=1.101200 time=1293.4s
+  ttt_chunk [1211/1893] bpb=1.100606 time=1304.2s
+  ttt_chunk [1221/1893] bpb=1.100309 time=1315.0s
+  ttt_chunk [1231/1893] bpb=1.100236 time=1325.8s
+  ttt_chunk [1241/1893] bpb=1.100026 time=1336.5s
+  ttt_chunk [1251/1893] bpb=1.099790 time=1347.3s
+  ttt_chunk [1261/1893] bpb=1.099730 time=1358.1s
+  ttt_chunk [1271/1893] bpb=1.099522 time=1368.8s
+  ttt_chunk [1281/1893] bpb=1.099310 time=1379.6s
+  ttt_chunk [1291/1893] bpb=1.099133 time=1390.3s
+  ttt_chunk [1301/1893] bpb=1.098747 time=1401.1s
+  ttt_chunk [1311/1893] bpb=1.098432 time=1411.9s
+  ttt_chunk [1321/1893] bpb=1.098267 time=1422.6s
+  ttt_chunk [1331/1893] bpb=1.098192 time=1433.4s
+  ttt_chunk [1341/1893] bpb=1.098083 time=1444.2s
+  ttt_chunk [1351/1893] bpb=1.098029 time=1455.0s
+  ttt_chunk [1361/1893] bpb=1.098231 time=1465.7s
+  ttt_chunk [1371/1893] bpb=1.098089 time=1476.5s
+  ttt_chunk [1381/1893] bpb=1.098019 time=1487.3s
+  ttt_chunk [1391/1893] bpb=1.097495 time=1498.0s
+  ttt_chunk [1401/1893] bpb=1.097514 time=1508.8s
+  ttt_chunk [1411/1893] bpb=1.097548 time=1519.6s
+  ttt_chunk [1421/1893] bpb=1.097802 time=1530.3s
+  ttt_chunk [1431/1893] bpb=1.097657 time=1541.1s
+  ttt_chunk [1441/1893] bpb=1.098321 time=1551.9s
+  ttt_chunk [1451/1893] bpb=1.098447 time=1562.6s
+  ttt_chunk [1461/1893] bpb=1.098192 time=1573.4s
+  ttt_chunk [1471/1893] bpb=1.099100 time=1584.2s
+  ttt_chunk [1481/1893] bpb=1.098893 time=1594.9s
+  ttt_chunk [1491/1893] bpb=1.098882 time=1605.7s
+  ttt_chunk [1501/1893] bpb=1.099047 time=1616.5s
+  ttt_chunk [1511/1893] bpb=1.099129 time=1627.2s
+  ttt_chunk [1521/1893] bpb=1.099154 time=1638.0s
+  ttt_chunk [1531/1893] bpb=1.098978 time=1648.8s
+  ttt_chunk [1541/1893] bpb=1.098944 time=1659.6s
+  ttt_chunk [1551/1893] bpb=1.099287 time=1670.3s
+  ttt_chunk [1561/1893] bpb=1.099428 time=1681.1s
+  ttt_chunk [1571/1893] bpb=1.099561 time=1691.9s
+  ttt_chunk [1581/1893] bpb=1.099680 time=1702.6s
+  ttt_chunk [1591/1893] bpb=1.099632 time=1713.4s
+  ttt_chunk [1601/1893] bpb=1.099814 time=1724.2s
+  ttt_chunk [1611/1893] bpb=1.099890 time=1734.9s
+  ttt_chunk [1621/1893] bpb=1.099746 time=1745.7s
+  ttt_chunk [1631/1893] bpb=1.099923 time=1756.5s
+  ttt_chunk [1641/1893] bpb=1.099803 time=1767.2s
+  ttt_chunk [1651/1893] bpb=1.099721 time=1778.0s
+  ttt_chunk [1661/1893] bpb=1.099604 time=1788.8s
+  ttt_chunk [1671/1893] bpb=1.099950 time=1799.6s
+  ttt_chunk [1681/1893] bpb=1.100198 time=1810.3s
+  ttt_chunk [1691/1893] bpb=1.100167 time=1821.1s
+  ttt_chunk [1701/1893] bpb=1.100167 time=1831.9s
+  ttt_chunk [1711/1893] bpb=1.100005 time=1842.6s
+  ttt_chunk [1721/1893] bpb=1.099862 time=1853.4s
+  ttt_chunk [1731/1893] bpb=1.099816 time=1864.2s
+  ttt_chunk [1741/1893] bpb=1.099595 time=1874.9s
+  ttt_chunk [1751/1893] bpb=1.099450 time=1885.7s
+  ttt_chunk [1761/1893] bpb=1.099527 time=1896.5s
+  ttt_chunk [1771/1893] bpb=1.099457 time=1907.2s
+  ttt_chunk [1781/1893] bpb=1.099414 time=1918.0s
+  ttt_chunk [1791/1893] bpb=1.099023 time=1928.8s
+  ttt_chunk [1801/1893] bpb=1.099031 time=1939.5s
+  ttt_chunk [1811/1893] bpb=1.098867 time=1950.3s
+  ttt_chunk [1821/1893] bpb=1.098905 time=1961.1s
+  ttt_chunk [1831/1893] bpb=1.098518 time=1971.9s
+  ttt_chunk [1841/1893] bpb=1.098497 time=1982.6s
+  ttt_chunk [1851/1893] bpb=1.098282 time=1993.4s
+  ttt_chunk [1861/1893] bpb=1.097807 time=2004.2s
+  ttt_chunk [1871/1893] bpb=1.097656 time=2014.9s
+  ttt_chunk [1881/1893] bpb=1.097279 time=2025.7s
+  ttt_chunk [1891/1893] bpb=1.097109 time=2036.5s
+  ttt_chunk [1893/1893] bpb=1.097126 time=2038.2s
+ttt_sliding:done val_loss=1.850831 val_bpb=1.096169 elapsed=2038.3s
+legal_ttt val_loss:1.8508 val_bpb:1.0962 eval_time:2038958ms
+legal_ttt_exact val_loss:1.85083110 val_bpb:1.09616933

--- a/records/track_non_record_16mb/2026-03-28_ExtendedCompute_50K_11hours_4xA100MIG_ScalingAnalysis/train_step50k_seed1337.txt
+++ b/records/track_non_record_16mb/2026-03-28_ExtendedCompute_50K_11hours_4xA100MIG_ScalingAnalysis/train_step50k_seed1337.txt
@@ -1,0 +1,2260 @@
+logs/scaling_50k_seed1337.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26928220
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_4 active_layers:[7, 8, 9, 10]
+world_size:4 grad_accum_steps:2
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:50000 warmup_steps:20 max_wallclock_seconds:0.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/50000 val_loss:6.9304 val_bpb:4.1046 artifact_bytes:4577902 model_int6_lzma:4486400 train_time:0ms step_avg:0.02ms
+step:1/50000 train_loss:6.9317 train_time:1023ms step_avg:1022.65ms
+step:2/50000 train_loss:8.6832 train_time:1567ms step_avg:783.57ms
+step:3/50000 train_loss:7.6849 train_time:2419ms step_avg:806.34ms
+step:4/50000 train_loss:7.1826 train_time:3279ms step_avg:819.82ms
+step:5/50000 train_loss:7.1343 train_time:4131ms step_avg:826.29ms
+step:6/50000 train_loss:7.1132 train_time:4984ms step_avg:830.61ms
+step:7/50000 train_loss:7.1096 train_time:5836ms step_avg:833.65ms
+step:8/50000 train_loss:6.9542 train_time:6688ms step_avg:835.94ms
+step:9/50000 train_loss:6.6144 train_time:7540ms step_avg:837.75ms
+step:10/50000 train_loss:6.2392 train_time:8392ms step_avg:839.20ms
+step:500/50000 train_loss:2.3566 train_time:414391ms step_avg:828.78ms
+step:1000/50000 train_loss:2.2649 train_time:828718ms step_avg:828.72ms
+step:1500/50000 train_loss:2.1835 train_time:1242997ms step_avg:828.66ms
+step:2000/50000 train_loss:2.0346 train_time:1657066ms step_avg:828.53ms
+step:2500/50000 train_loss:2.1555 train_time:2071255ms step_avg:828.50ms
+step:2500/50000 val_loss:2.1197 val_bpb:1.2554 artifact_bytes:13062362 model_int6_lzma:12970860 train_time:2071607ms step_avg:828.64ms
+step:3000/50000 train_loss:2.1230 train_time:2486329ms step_avg:828.78ms
+step:3500/50000 train_loss:2.1888 train_time:2900436ms step_avg:828.70ms
+step:4000/50000 train_loss:2.1608 train_time:3314653ms step_avg:828.66ms
+step:4500/50000 train_loss:2.1304 train_time:3729010ms step_avg:828.67ms
+step:5000/50000 train_loss:2.0927 train_time:4142940ms step_avg:828.59ms
+step:5000/50000 val_loss:2.0751 val_bpb:1.2290 artifact_bytes:14137046 model_int6_lzma:14045544 train_time:4143282ms step_avg:828.66ms
+step:5500/50000 train_loss:2.1367 train_time:4561300ms step_avg:829.33ms
+step:6000/50000 train_loss:2.0319 train_time:4975437ms step_avg:829.24ms
+step:6500/50000 train_loss:2.3011 train_time:5389560ms step_avg:829.16ms
+step:7000/50000 train_loss:1.9272 train_time:5803732ms step_avg:829.10ms
+step:7500/50000 train_loss:2.0523 train_time:6217640ms step_avg:829.02ms
+step:7500/50000 val_loss:2.0601 val_bpb:1.2201 artifact_bytes:15465582 model_int6_lzma:15374080 train_time:6217998ms step_avg:829.07ms
+step:8000/50000 train_loss:2.0043 train_time:6635416ms step_avg:829.43ms
+step:8500/50000 train_loss:1.9835 train_time:7049580ms step_avg:829.36ms
+step:9000/50000 train_loss:2.0981 train_time:7463731ms step_avg:829.30ms
+step:9500/50000 train_loss:2.2500 train_time:7878137ms step_avg:829.28ms
+step:10000/50000 train_loss:2.0623 train_time:8292109ms step_avg:829.21ms
+step:10000/50000 val_loss:2.0298 val_bpb:1.2022 artifact_bytes:17185494 model_int6_lzma:17093992 train_time:8292463ms step_avg:829.25ms
+step:10500/50000 train_loss:2.0985 train_time:8706332ms step_avg:829.17ms
+step:11000/50000 train_loss:1.9900 train_time:9120685ms step_avg:829.15ms
+step:11500/50000 train_loss:1.9463 train_time:9534878ms step_avg:829.12ms
+step:12000/50000 train_loss:1.9647 train_time:9948914ms step_avg:829.08ms
+step:12500/50000 train_loss:1.9733 train_time:10363165ms step_avg:829.05ms
+step:12500/50000 val_loss:2.0239 val_bpb:1.1987 artifact_bytes:17195458 model_int6_lzma:17103956 train_time:10363511ms step_avg:829.08ms
+step:13000/50000 train_loss:1.9893 train_time:10777330ms step_avg:829.03ms
+step:13500/50000 train_loss:2.1058 train_time:11191724ms step_avg:829.02ms
+step:14000/50000 train_loss:1.9129 train_time:11605951ms step_avg:829.00ms
+step:14500/50000 train_loss:2.0925 train_time:12020167ms step_avg:828.98ms
+step:15000/50000 train_loss:2.0414 train_time:12434266ms step_avg:828.95ms
+step:15000/50000 val_loss:2.0153 val_bpb:1.1936 artifact_bytes:17238818 model_int6_lzma:17147316 train_time:12434621ms step_avg:828.97ms
+step:15500/50000 train_loss:2.0143 train_time:12849006ms step_avg:828.97ms
+step:16000/50000 train_loss:2.0965 train_time:13263279ms step_avg:828.95ms
+step:16500/50000 train_loss:2.0796 train_time:13677134ms step_avg:828.92ms
+step:17000/50000 train_loss:2.0793 train_time:14090858ms step_avg:828.87ms
+step:17500/50000 train_loss:2.0703 train_time:14505088ms step_avg:828.86ms
+step:17500/50000 val_loss:2.0123 val_bpb:1.1918 artifact_bytes:17178826 model_int6_lzma:17087324 train_time:14505424ms step_avg:828.88ms
+step:18000/50000 train_loss:1.9518 train_time:14920145ms step_avg:828.90ms
+step:18500/50000 train_loss:1.9218 train_time:15334455ms step_avg:828.89ms
+step:19000/50000 train_loss:1.9064 train_time:15748579ms step_avg:828.87ms
+step:19500/50000 train_loss:2.1016 train_time:16162691ms step_avg:828.86ms
+step:20000/50000 train_loss:2.0155 train_time:16576715ms step_avg:828.84ms
+step:20000/50000 val_loss:2.0102 val_bpb:1.1905 artifact_bytes:17182262 model_int6_lzma:17090760 train_time:16577058ms step_avg:828.85ms
+step:20500/50000 train_loss:2.0779 train_time:16990982ms step_avg:828.83ms
+step:21000/50000 train_loss:1.9839 train_time:17405163ms step_avg:828.82ms
+step:21500/50000 train_loss:2.0096 train_time:17819403ms step_avg:828.81ms
+step:22000/50000 train_loss:2.0285 train_time:18233536ms step_avg:828.80ms
+step:22500/50000 train_loss:2.0467 train_time:18647640ms step_avg:828.78ms
+step:22500/50000 val_loss:2.0092 val_bpb:1.1900 artifact_bytes:17168362 model_int6_lzma:17076860 train_time:18647994ms step_avg:828.80ms
+step:23000/50000 train_loss:1.9741 train_time:19063091ms step_avg:828.83ms
+step:23500/50000 train_loss:2.0698 train_time:19477367ms step_avg:828.82ms
+step:24000/50000 train_loss:1.9651 train_time:19891565ms step_avg:828.82ms
+step:24500/50000 train_loss:2.0126 train_time:20305658ms step_avg:828.80ms
+step:25000/50000 train_loss:2.0209 train_time:20719923ms step_avg:828.80ms
+step:25000/50000 val_loss:2.0089 val_bpb:1.1898 artifact_bytes:17167526 model_int6_lzma:17076024 train_time:20720282ms step_avg:828.81ms
+step:25500/50000 train_loss:2.0290 train_time:21135316ms step_avg:828.84ms
+step:26000/50000 train_loss:2.0744 train_time:21549311ms step_avg:828.82ms
+step:26500/50000 train_loss:2.0755 train_time:21963268ms step_avg:828.80ms
+step:27000/50000 train_loss:1.9917 train_time:22377137ms step_avg:828.78ms
+step:27500/50000 train_loss:1.9870 train_time:22791091ms step_avg:828.77ms
+step:27500/50000 val_loss:2.0054 val_bpb:1.1877 artifact_bytes:17158910 model_int6_lzma:17067408 train_time:22791427ms step_avg:828.78ms
+step:28000/50000 train_loss:1.8265 train_time:23207952ms step_avg:828.86ms
+step:28500/50000 train_loss:2.0216 train_time:23621876ms step_avg:828.84ms
+step:29000/50000 train_loss:2.0337 train_time:24035834ms step_avg:828.82ms
+step:29500/50000 train_loss:2.0410 train_time:24449558ms step_avg:828.80ms
+step:30000/50000 train_loss:1.9772 train_time:24863967ms step_avg:828.80ms
+step:30000/50000 val_loss:2.0026 val_bpb:1.1861 artifact_bytes:17148538 model_int6_lzma:17057036 train_time:24864321ms step_avg:828.81ms
+step:30500/50000 train_loss:2.0227 train_time:25280953ms step_avg:828.88ms
+step:31000/50000 train_loss:2.0236 train_time:25694982ms step_avg:828.87ms
+step:31500/50000 train_loss:1.9577 train_time:26109139ms step_avg:828.86ms
+step:32000/50000 train_loss:2.0406 train_time:26522737ms step_avg:828.84ms
+step:32500/50000 train_loss:1.9898 train_time:26936766ms step_avg:828.82ms
+step:32500/50000 val_loss:1.9930 val_bpb:1.1804 artifact_bytes:17016594 model_int6_lzma:16925092 train_time:26937120ms step_avg:828.83ms
+step:33000/50000 train_loss:1.9735 train_time:27354051ms step_avg:828.91ms
+step:33500/50000 train_loss:1.9539 train_time:27767883ms step_avg:828.89ms
+step:34000/50000 train_loss:2.0578 train_time:28182056ms step_avg:828.88ms
+step:34500/50000 train_loss:1.9867 train_time:28595937ms step_avg:828.87ms
+step:35000/50000 train_loss:1.9751 train_time:29010008ms step_avg:828.86ms
+step:35000/50000 val_loss:1.9822 val_bpb:1.1740 artifact_bytes:16753850 model_int6_lzma:16662348 train_time:29010353ms step_avg:828.87ms
+step:35500/50000 train_loss:2.0141 train_time:29428063ms step_avg:828.96ms
+step:36000/50000 train_loss:1.9957 train_time:29841900ms step_avg:828.94ms
+step:36500/50000 train_loss:2.0234 train_time:30255712ms step_avg:828.92ms
+step:37000/50000 train_loss:1.8832 train_time:30669416ms step_avg:828.90ms
+step:37500/50000 train_loss:2.0084 train_time:31083261ms step_avg:828.89ms
+step:37500/50000 val_loss:1.9702 val_bpb:1.1669 artifact_bytes:16422374 model_int6_lzma:16330872 train_time:31083616ms step_avg:828.90ms
+step:38000/50000 train_loss:1.9965 train_time:31497684ms step_avg:828.89ms
+step:38500/50000 train_loss:1.9659 train_time:31911447ms step_avg:828.87ms
+step:39000/50000 train_loss:1.8706 train_time:32325400ms step_avg:828.86ms
+step:39500/50000 train_loss:1.9308 train_time:32739167ms step_avg:828.84ms
+step:40000/50000 train_loss:1.9201 train_time:33153087ms step_avg:828.83ms
+step:40000/50000 val_loss:1.9556 val_bpb:1.1582 artifact_bytes:16034950 model_int6_lzma:15943448 train_time:33153441ms step_avg:828.84ms
+step:40500/50000 train_loss:2.3030 train_time:33568094ms step_avg:828.84ms
+step:41000/50000 train_loss:1.8509 train_time:33981981ms step_avg:828.83ms
+step:41500/50000 train_loss:1.7751 train_time:34396141ms step_avg:828.82ms
+step:42000/50000 train_loss:1.9640 train_time:34810273ms step_avg:828.82ms
+step:42500/50000 train_loss:1.9338 train_time:35224133ms step_avg:828.80ms
+step:42500/50000 val_loss:1.9395 val_bpb:1.1487 artifact_bytes:15698694 model_int6_lzma:15607192 train_time:35224478ms step_avg:828.81ms
+step:43000/50000 train_loss:2.0258 train_time:35642593ms step_avg:828.90ms
+step:43500/50000 train_loss:2.1260 train_time:36056389ms step_avg:828.88ms
+step:44000/50000 train_loss:1.8069 train_time:36470177ms step_avg:828.87ms
+step:44500/50000 train_loss:1.8500 train_time:36883956ms step_avg:828.85ms
+step:45000/50000 train_loss:1.9481 train_time:37297763ms step_avg:828.84ms
+step:45000/50000 val_loss:1.9147 val_bpb:1.1340 artifact_bytes:15144098 model_int6_lzma:15052596 train_time:37298113ms step_avg:828.85ms
+step:45500/50000 train_loss:1.9780 train_time:37716132ms step_avg:828.93ms
+step:46000/50000 train_loss:1.8996 train_time:38129711ms step_avg:828.91ms
+swa:start step:46150
+step:46500/50000 train_loss:1.8117 train_time:38544019ms step_avg:828.90ms
+step:47000/50000 train_loss:1.9247 train_time:38958530ms step_avg:828.90ms
+late_qat:enabled step:47076 scale:0.1499
+step:47500/50000 train_loss:1.8909 train_time:39372954ms step_avg:828.90ms
+step:47500/50000 val_loss:1.8854 val_bpb:1.1167 artifact_bytes:14726650 model_int6_lzma:14635148 train_time:39373341ms step_avg:828.91ms
+step:48000/50000 train_loss:1.8819 train_time:39791819ms step_avg:829.00ms
+step:48500/50000 train_loss:1.8370 train_time:40206398ms step_avg:829.00ms
+step:49000/50000 train_loss:1.7870 train_time:40621323ms step_avg:829.01ms
+step:49500/50000 train_loss:1.8224 train_time:41036021ms step_avg:829.01ms
+step:50000/50000 train_loss:1.8391 train_time:41450533ms step_avg:829.01ms
+step:50000/50000 val_loss:1.8475 val_bpb:1.0942 artifact_bytes:14330478 model_int6_lzma:14238976 train_time:41450929ms step_avg:829.02ms
+peak memory allocated: 22092 MiB reserved: 22340 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.8469 val_bpb:1.0939 eval_time:23715ms
+Serialized model: 106027446 bytes
+Code size: 91502 bytes
+Serialized model int6+lzma: 14257144 bytes
+Total submission size int6+lzma: 14348646 bytes
+final_int6_roundtrip val_loss:1.8963 val_bpb:1.1231 eval_time:24360ms
+final_int6_roundtrip_exact val_loss:1.89626397 val_bpb:1.12307434
+final_int6_sliding_window val_loss:1.8566 val_bpb:1.0996 stride:64 eval_time:663400ms
+final_int6_sliding_window_exact val_loss:1.85662085 val_bpb:1.09959836
+final_int8_zlib_roundtrip_exact val_loss:1.85662085 val_bpb:1.09959836
+ttt_sliding:start chunks=1893 chunk_tokens=32768 total_windows=969088 stride=64 ttt_lr=0.002 ttt_epochs=3 freeze_blocks=0
+ttt_sliding:params unfrozen=26928220 frozen=0
+  ttt_chunk [1/1893] bpb=1.143264 time=1.1s
+  ttt_chunk [11/1893] bpb=1.102386 time=11.9s
+  ttt_chunk [21/1893] bpb=1.104574 time=22.6s
+  ttt_chunk [31/1893] bpb=1.106762 time=33.4s
+  ttt_chunk [41/1893] bpb=1.094977 time=44.2s
+  ttt_chunk [51/1893] bpb=1.090986 time=54.9s
+  ttt_chunk [61/1893] bpb=1.095411 time=65.7s
+  ttt_chunk [71/1893] bpb=1.092186 time=76.5s
+  ttt_chunk [81/1893] bpb=1.092049 time=87.3s
+  ttt_chunk [91/1893] bpb=1.090636 time=98.0s
+  ttt_chunk [101/1893] bpb=1.093373 time=108.8s
+  ttt_chunk [111/1893] bpb=1.094380 time=119.6s
+  ttt_chunk [121/1893] bpb=1.090917 time=130.3s
+  ttt_chunk [131/1893] bpb=1.090511 time=141.1s
+  ttt_chunk [141/1893] bpb=1.090135 time=151.9s
+  ttt_chunk [151/1893] bpb=1.093283 time=162.6s
+  ttt_chunk [161/1893] bpb=1.094916 time=173.4s
+  ttt_chunk [171/1893] bpb=1.095509 time=184.2s
+  ttt_chunk [181/1893] bpb=1.095422 time=194.9s
+  ttt_chunk [191/1893] bpb=1.098575 time=205.7s
+  ttt_chunk [201/1893] bpb=1.098760 time=216.5s
+  ttt_chunk [211/1893] bpb=1.096088 time=227.3s
+  ttt_chunk [221/1893] bpb=1.098044 time=238.0s
+  ttt_chunk [231/1893] bpb=1.097377 time=248.8s
+  ttt_chunk [241/1893] bpb=1.097047 time=259.6s
+  ttt_chunk [251/1893] bpb=1.095568 time=270.4s
+  ttt_chunk [261/1893] bpb=1.093933 time=281.1s
+  ttt_chunk [271/1893] bpb=1.092596 time=291.9s
+  ttt_chunk [281/1893] bpb=1.094857 time=302.7s
+  ttt_chunk [291/1893] bpb=1.095580 time=313.4s
+  ttt_chunk [301/1893] bpb=1.096123 time=324.2s
+  ttt_chunk [311/1893] bpb=1.097615 time=335.0s
+  ttt_chunk [321/1893] bpb=1.099057 time=345.8s
+  ttt_chunk [331/1893] bpb=1.098819 time=356.5s
+  ttt_chunk [341/1893] bpb=1.099094 time=367.3s
+  ttt_chunk [351/1893] bpb=1.100367 time=378.1s
+  ttt_chunk [361/1893] bpb=1.101515 time=388.8s
+  ttt_chunk [371/1893] bpb=1.100995 time=399.6s
+  ttt_chunk [381/1893] bpb=1.100931 time=410.4s
+  ttt_chunk [391/1893] bpb=1.100561 time=421.2s
+  ttt_chunk [401/1893] bpb=1.099187 time=431.9s
+  ttt_chunk [411/1893] bpb=1.098041 time=442.7s
+  ttt_chunk [421/1893] bpb=1.097510 time=453.5s
+  ttt_chunk [431/1893] bpb=1.098206 time=464.3s
+  ttt_chunk [441/1893] bpb=1.098037 time=475.0s
+  ttt_chunk [451/1893] bpb=1.097717 time=485.8s
+  ttt_chunk [461/1893] bpb=1.097002 time=496.6s
+  ttt_chunk [471/1893] bpb=1.096618 time=507.3s
+  ttt_chunk [481/1893] bpb=1.096311 time=518.1s
+  ttt_chunk [491/1893] bpb=1.095995 time=528.9s
+  ttt_chunk [501/1893] bpb=1.095459 time=539.7s
+  ttt_chunk [511/1893] bpb=1.094842 time=550.4s
+  ttt_chunk [521/1893] bpb=1.093730 time=561.2s
+  ttt_chunk [531/1893] bpb=1.093812 time=572.0s
+  ttt_chunk [541/1893] bpb=1.093750 time=582.7s
+  ttt_chunk [551/1893] bpb=1.092578 time=593.5s
+  ttt_chunk [561/1893] bpb=1.093122 time=604.3s
+  ttt_chunk [571/1893] bpb=1.092406 time=615.1s
+  ttt_chunk [581/1893] bpb=1.091865 time=625.8s
+  ttt_chunk [591/1893] bpb=1.091172 time=636.6s
+  ttt_chunk [601/1893] bpb=1.091831 time=647.4s
+  ttt_chunk [611/1893] bpb=1.091385 time=658.2s
+  ttt_chunk [621/1893] bpb=1.091308 time=668.9s
+  ttt_chunk [631/1893] bpb=1.091699 time=679.7s
+  ttt_chunk [641/1893] bpb=1.091471 time=690.4s
+  ttt_chunk [651/1893] bpb=1.091489 time=701.2s
+  ttt_chunk [661/1893] bpb=1.091359 time=712.0s
+  ttt_chunk [671/1893] bpb=1.090971 time=722.8s
+  ttt_chunk [681/1893] bpb=1.091218 time=733.5s
+  ttt_chunk [691/1893] bpb=1.091894 time=744.3s
+  ttt_chunk [701/1893] bpb=1.091104 time=755.1s
+  ttt_chunk [711/1893] bpb=1.091702 time=765.8s
+  ttt_chunk [721/1893] bpb=1.091323 time=776.6s
+  ttt_chunk [731/1893] bpb=1.091750 time=787.4s
+  ttt_chunk [741/1893] bpb=1.091690 time=798.2s
+  ttt_chunk [751/1893] bpb=1.091341 time=808.9s
+  ttt_chunk [761/1893] bpb=1.091177 time=819.7s
+  ttt_chunk [771/1893] bpb=1.090948 time=830.5s
+  ttt_chunk [781/1893] bpb=1.091445 time=841.2s
+  ttt_chunk [791/1893] bpb=1.091118 time=852.0s
+  ttt_chunk [801/1893] bpb=1.091173 time=862.8s
+  ttt_chunk [811/1893] bpb=1.090683 time=873.6s
+  ttt_chunk [821/1893] bpb=1.090471 time=884.3s
+  ttt_chunk [831/1893] bpb=1.089997 time=895.1s
+  ttt_chunk [841/1893] bpb=1.089406 time=905.9s
+  ttt_chunk [851/1893] bpb=1.089279 time=916.7s
+  ttt_chunk [861/1893] bpb=1.089409 time=927.4s
+  ttt_chunk [871/1893] bpb=1.089437 time=938.2s
+  ttt_chunk [881/1893] bpb=1.089446 time=949.0s
+  ttt_chunk [891/1893] bpb=1.089263 time=959.7s
+  ttt_chunk [901/1893] bpb=1.089245 time=970.5s
+  ttt_chunk [911/1893] bpb=1.089239 time=981.3s
+  ttt_chunk [921/1893] bpb=1.089612 time=992.0s
+  ttt_chunk [931/1893] bpb=1.089451 time=1002.8s
+  ttt_chunk [941/1893] bpb=1.089356 time=1013.6s
+  ttt_chunk [951/1893] bpb=1.089337 time=1024.3s
+  ttt_chunk [961/1893] bpb=1.089082 time=1035.1s
+  ttt_chunk [971/1893] bpb=1.089790 time=1045.9s
+  ttt_chunk [981/1893] bpb=1.089929 time=1056.7s
+  ttt_chunk [991/1893] bpb=1.089809 time=1067.5s
+  ttt_chunk [1001/1893] bpb=1.089976 time=1078.2s
+  ttt_chunk [1011/1893] bpb=1.090238 time=1089.0s
+  ttt_chunk [1021/1893] bpb=1.090390 time=1099.8s
+  ttt_chunk [1031/1893] bpb=1.090917 time=1110.6s
+  ttt_chunk [1041/1893] bpb=1.090578 time=1121.3s
+  ttt_chunk [1051/1893] bpb=1.090273 time=1132.1s
+  ttt_chunk [1061/1893] bpb=1.090511 time=1142.9s
+  ttt_chunk [1071/1893] bpb=1.090954 time=1153.6s
+  ttt_chunk [1081/1893] bpb=1.090943 time=1164.4s
+  ttt_chunk [1091/1893] bpb=1.091356 time=1175.2s
+  ttt_chunk [1101/1893] bpb=1.091488 time=1186.0s
+  ttt_chunk [1111/1893] bpb=1.091260 time=1196.7s
+  ttt_chunk [1121/1893] bpb=1.091181 time=1207.5s
+  ttt_chunk [1131/1893] bpb=1.091072 time=1218.3s
+  ttt_chunk [1141/1893] bpb=1.090937 time=1229.0s
+  ttt_chunk [1151/1893] bpb=1.090970 time=1239.8s
+  ttt_chunk [1161/1893] bpb=1.090188 time=1250.6s
+  ttt_chunk [1171/1893] bpb=1.090766 time=1261.4s
+  ttt_chunk [1181/1893] bpb=1.090269 time=1272.1s
+  ttt_chunk [1191/1893] bpb=1.089988 time=1282.9s
+  ttt_chunk [1201/1893] bpb=1.090561 time=1293.7s
+  ttt_chunk [1211/1893] bpb=1.089962 time=1304.4s
+  ttt_chunk [1221/1893] bpb=1.089661 time=1315.2s
+  ttt_chunk [1231/1893] bpb=1.089599 time=1326.0s
+  ttt_chunk [1241/1893] bpb=1.089410 time=1336.8s
+  ttt_chunk [1251/1893] bpb=1.089171 time=1347.5s
+  ttt_chunk [1261/1893] bpb=1.089113 time=1358.3s
+  ttt_chunk [1271/1893] bpb=1.088914 time=1369.1s
+  ttt_chunk [1281/1893] bpb=1.088710 time=1379.9s
+  ttt_chunk [1291/1893] bpb=1.088523 time=1390.6s
+  ttt_chunk [1301/1893] bpb=1.088161 time=1401.4s
+  ttt_chunk [1311/1893] bpb=1.087859 time=1412.2s
+  ttt_chunk [1321/1893] bpb=1.087701 time=1423.0s
+  ttt_chunk [1331/1893] bpb=1.087611 time=1433.7s
+  ttt_chunk [1341/1893] bpb=1.087498 time=1444.5s
+  ttt_chunk [1351/1893] bpb=1.087448 time=1455.3s
+  ttt_chunk [1361/1893] bpb=1.087658 time=1466.0s
+  ttt_chunk [1371/1893] bpb=1.087513 time=1476.8s
+  ttt_chunk [1381/1893] bpb=1.087452 time=1487.6s
+  ttt_chunk [1391/1893] bpb=1.086938 time=1498.4s
+  ttt_chunk [1401/1893] bpb=1.086952 time=1509.2s
+  ttt_chunk [1411/1893] bpb=1.086986 time=1519.9s
+  ttt_chunk [1421/1893] bpb=1.087243 time=1530.7s
+  ttt_chunk [1431/1893] bpb=1.087094 time=1541.5s
+  ttt_chunk [1441/1893] bpb=1.087766 time=1552.2s
+  ttt_chunk [1451/1893] bpb=1.087875 time=1563.0s
+  ttt_chunk [1461/1893] bpb=1.087616 time=1573.8s
+  ttt_chunk [1471/1893] bpb=1.088508 time=1584.6s
+  ttt_chunk [1481/1893] bpb=1.088318 time=1595.3s
+  ttt_chunk [1491/1893] bpb=1.088295 time=1606.1s
+  ttt_chunk [1501/1893] bpb=1.088428 time=1616.9s
+  ttt_chunk [1511/1893] bpb=1.088500 time=1627.7s
+  ttt_chunk [1521/1893] bpb=1.088516 time=1638.4s
+  ttt_chunk [1531/1893] bpb=1.088335 time=1649.2s
+  ttt_chunk [1541/1893] bpb=1.088300 time=1660.0s
+  ttt_chunk [1551/1893] bpb=1.088644 time=1670.8s
+  ttt_chunk [1561/1893] bpb=1.088779 time=1681.5s
+  ttt_chunk [1571/1893] bpb=1.088893 time=1692.3s
+  ttt_chunk [1581/1893] bpb=1.088999 time=1703.1s
+  ttt_chunk [1591/1893] bpb=1.088948 time=1713.9s
+  ttt_chunk [1601/1893] bpb=1.089129 time=1724.6s
+  ttt_chunk [1611/1893] bpb=1.089211 time=1735.4s
+  ttt_chunk [1621/1893] bpb=1.089078 time=1746.2s
+  ttt_chunk [1631/1893] bpb=1.089247 time=1756.9s
+  ttt_chunk [1641/1893] bpb=1.089113 time=1767.7s
+  ttt_chunk [1651/1893] bpb=1.089025 time=1778.5s
+  ttt_chunk [1661/1893] bpb=1.088917 time=1789.3s
+  ttt_chunk [1671/1893] bpb=1.089273 time=1800.0s
+  ttt_chunk [1681/1893] bpb=1.089519 time=1810.8s
+  ttt_chunk [1691/1893] bpb=1.089483 time=1821.6s
+  ttt_chunk [1701/1893] bpb=1.089475 time=1832.3s
+  ttt_chunk [1711/1893] bpb=1.089308 time=1843.1s
+  ttt_chunk [1721/1893] bpb=1.089158 time=1853.9s
+  ttt_chunk [1731/1893] bpb=1.089108 time=1864.6s
+  ttt_chunk [1741/1893] bpb=1.088877 time=1875.4s
+  ttt_chunk [1751/1893] bpb=1.088730 time=1886.2s
+  ttt_chunk [1761/1893] bpb=1.088814 time=1897.0s
+  ttt_chunk [1771/1893] bpb=1.088740 time=1907.7s
+  ttt_chunk [1781/1893] bpb=1.088687 time=1918.5s
+  ttt_chunk [1791/1893] bpb=1.088300 time=1929.3s
+  ttt_chunk [1801/1893] bpb=1.088297 time=1940.0s
+  ttt_chunk [1811/1893] bpb=1.088139 time=1950.8s
+  ttt_chunk [1821/1893] bpb=1.088176 time=1961.6s
+  ttt_chunk [1831/1893] bpb=1.087789 time=1972.3s
+  ttt_chunk [1841/1893] bpb=1.087730 time=1983.1s
+  ttt_chunk [1851/1893] bpb=1.087510 time=1993.9s
+  ttt_chunk [1861/1893] bpb=1.087051 time=2004.6s
+  ttt_chunk [1871/1893] bpb=1.086903 time=2015.4s
+  ttt_chunk [1881/1893] bpb=1.086533 time=2026.2s
+  ttt_chunk [1891/1893] bpb=1.086383 time=2037.0s
+  ttt_chunk [1893/1893] bpb=1.086404 time=2038.7s
+ttt_sliding:done val_loss=1.832524 val_bpb=1.085327 elapsed=2038.8s
+legal_ttt val_loss:1.8325 val_bpb:1.0853 eval_time:2039427ms
+legal_ttt_exact val_loss:1.83252444 val_bpb:1.08532707
+.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# --- Transformer modules ---
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                scale = (row_max / 31.0).clamp_min(1.0 / 31.0)
+                w_q = (torch.clamp(torch.round(w32 / scale[:, None]), -32, 31) * scale[:, None]).to(x.dtype)
+            w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024, rope_dims: int = 0):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / (base ** (torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (rd / (rd - 2)))
+                inv_freq = 1.0 / (new_base ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd))
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int = 0) -> Tensor:
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        # No CastedLinear -- weights come from banks
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rope_dims = 0  # set by GPT.__init__ for partial RoPE
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False  # set by GPT.__init__ for deep layers only
+        # Gated attention and value residual (non-banked small params)
+        self.gated_attention = gated_attention
+        if gated_attention:
+            self.attn_gate = nn.Linear(dim, num_heads, bias=True)
+            nn.init.zeros_(self.attn_gate.weight)
+            nn.init.constant_(self.attn_gate.bias, 4.0)
+        self.value_residual = value_residual
+        if value_residual:
+            self.vr_lambda = nn.Parameter(torch.tensor([0.5, 0.5], dtype=torch.float32))
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        """Efficient XSA: subtract self-value projection via GQA-aware reshape (no repeat_interleave).
+        y: [B, T, H, D], v: [B, T, Hkv, D]. H must be divisible by Hkv."""
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)        # [B, T, Hkv, group, D]
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)    # [B, T, Hkv, 1, D] -- broadcast ready
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+    def forward(self, x: Tensor, q_w: Tensor, k_w: Tensor, v_w: Tensor, out_w: Tensor, v_embed: Tensor | None = None, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        bsz, seqlen, dim = x.shape
+        q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype))
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        raw_v = v if self.value_residual else None
+        if self.value_residual and v0 is not None:
+            lam = self.vr_lambda.to(dtype=v.dtype)
+            v = lam[0] * v0 + lam[1] * v
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if _HAS_FA3:
+            y = flash_attn_3_func(q, k, v, causal=True)
+        else:
+            # SDPA expects (B, H, T, D), FA3 uses (B, T, H, D)
+            y = F.scaled_dot_product_attention(
+                q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2),
+                is_causal=True,
+                enable_gqa=(self.num_kv_heads != self.num_heads),
+            ).transpose(1, 2)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        if self.gated_attention:
+            # gate shape: (bsz, seqlen, num_heads) -> (bsz, seqlen, num_heads, 1) for B,T,H,D layout
+            gate = torch.sigmoid(self.attn_gate(x)).unsqueeze(-1)
+            y = y * gate
+        y = y.reshape(bsz, seqlen, dim)
+        return F.linear(y, out_w.to(x.dtype)), raw_v
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class ValueEmbedding(nn.Module):
+    """Reinject token identity into attention values at specific layers.
+    Each table maps vocab tokens to a low-dim embedding, projected to model_dim."""
+    def __init__(self, vocab_size: int, ve_dim: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, ve_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(ve_dim, model_dim, bias=False) if ve_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(token_ids)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        # No CastedLinear -- weights come from banks
+    def forward(self, x: Tensor, up_w: Tensor, down_w: Tensor) -> Tensor:
+        x = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5)
+        return F.linear(x.square(), down_w.to(x.dtype))
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        layer_idx: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+                                        gated_attention=gated_attention, value_residual=value_residual)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+        if dtg:
+            self.dtg_gate = nn.Linear(dim, 1, bias=True)
+            nn.init.zeros_(self.dtg_gate.weight)
+            nn.init.constant_(self.dtg_gate.bias, 2.0)
+        else:
+            self.dtg_gate = None
+    def forward(self, x: Tensor, x0: Tensor, q_w: Tensor, k_w: Tensor, v_w: Tensor, out_w: Tensor, up_w: Tensor, down_w: Tensor, v_embed: Tensor | None = None, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out, raw_v = self.attn(self.attn_norm(x_in) * self.ln_scale_factor, q_w, k_w, v_w, out_w, v_embed=v_embed, v0=v0)
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        if self.dtg_gate is not None:
+            gate = torch.sigmoid(self.dtg_gate(x_in.detach()))
+            x_out = x_in + gate * (x_out - x_in)
+        return x_out, raw_v
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        mtp_num_heads: int = 0,
+        mtp_loss_weight: float = 0.1,
+        bigram_vocab_size: int = 0,
+        bigram_dim: int = 128,
+        xsa_last_n: int = 0,
+        rope_dims: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        ve_enabled: bool = False,
+        ve_dim: int = 128,
+        ve_layers: str = "9,10",
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self._ve_target_dim = num_kv_heads * (model_dim // num_heads)  # kv_dim for value projection
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.value_residual = value_residual
+        self.mtp_num_heads = mtp_num_heads
+        self.mtp_loss_weight = mtp_loss_weight
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.smear = SmearGate(model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        # Parameter banks: contiguous 3D tensors for batched optimizer
+        head_dim = model_dim // num_heads
+        kv_dim = num_kv_heads * head_dim
+        mlp_dim = int(mlp_mult * model_dim)
+        self.num_layers = num_layers
+        self.qo_bank = nn.Parameter(torch.empty(2 * num_layers, model_dim, model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * num_layers, kv_dim, model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(num_layers, mlp_dim, model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(num_layers, model_dim, mlp_dim))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                    layer_idx=i,
+                    ln_scale=ln_scale,
+                    dtg=dtg,
+                    gated_attention=gated_attention,
+                    value_residual=value_residual,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        if rope_dims > 0:
+            head_dim = model_dim // num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = rope_dims
+                block.attn.rotary = Rotary(head_dim, base=rope_base, train_seq_len=1024, rope_dims=rope_dims)
+        self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+        kv_dim_ve = self._ve_target_dim
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim_ve)
+            self.ve_layer_scales = nn.ParameterList(
+                [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices]
+            )
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.value_embeds = nn.ModuleList()  # keep empty for compat
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.mtp_heads = nn.ModuleList(
+            [CastedLinear(model_dim, vocab_size, bias=False) for _ in range(mtp_num_heads)]
+        )
+        for head in self.mtp_heads:
+            head._zero_init = True
+        if xsa_last_n > 0:
+            for i in range(max(0, num_layers - xsa_last_n), num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self._init_weights()
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        # Init banks: orthogonal, with proj layers scaled down and out/down zero-init
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)        # Q
+            nn.init.zeros_(self.qo_bank.data[n + i])                    # Out (zero init)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)        # K
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)    # V
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)    # MLP up
+            nn.init.zeros_(self.mlp_down_bank.data[i])                  # MLP down (zero init)
+            # Scale proj layers (out_proj and mlp_down are "proj" layers)
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        # Init remaining nn.Linear modules (bigram proj, mtp heads, lm_head)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+    def _get_ve(self, layer_idx: int, input_ids: Tensor, ve_cache: dict | None = None) -> Tensor | None:
+        """Get value embedding for a specific layer using shared table + per-layer scale."""
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if ve_cache is not None and 've' not in ve_cache:
+            ve_cache['ve'] = self.ve_shared(input_ids)
+        ve_base = ve_cache['ve'] if ve_cache is not None else self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_base * self.ve_layer_scales[ve_idx].to(dtype=ve_base.dtype)
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x, raw_v = self.blocks[i](x, x0,
+                self.qo_bank[i], self.kv_bank[i], self.kv_bank[n + i],
+                self.qo_bank[n + i], self.mlp_up_bank[i], self.mlp_down_bank[i],
+                v_embed=ve, v0=v0)
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x, _ = self.blocks[bi](x, x0,
+                self.qo_bank[bi], self.kv_bank[bi], self.kv_bank[n + bi],
+                self.qo_bank[n + bi], self.mlp_up_bank[bi], self.mlp_down_bank[bi],
+                v_embed=ve, v0=v0)
+        x = self.final_norm(x)
+        x_flat = x.reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x_flat, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x_flat)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        main_loss = F.cross_entropy(logits.float(), targets, reduction="mean")
+        if self.training and self.mtp_num_heads > 0 and self.mtp_loss_weight > 0.0:
+            _, seqlen, dim = x.shape
+            mtp_loss_sum = x.new_zeros(())
+            mtp_loss_count = 0
+            for k, mtp_head in enumerate(self.mtp_heads):
+                valid_t = seqlen - (k + 1)
+                if valid_t <= 0:
+                    continue
+                mtp_hidden = x[:, :valid_t, :].reshape(-1, dim)
+                mtp_targets = target_ids[:, k + 1 :].reshape(-1)
+                mtp_logits_proj = mtp_head(mtp_hidden)
+                mtp_logits = self.logit_softcap * torch.tanh(mtp_logits_proj / self.logit_softcap)
+                mtp_loss_sum = mtp_loss_sum + F.cross_entropy(mtp_logits.float(), mtp_targets, reduction="mean")
+                mtp_loss_count += 1
+            if mtp_loss_count > 0:
+                main_loss = main_loss + self.mtp_loss_weight * (mtp_loss_sum / mtp_loss_count)
+        return main_loss
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Return logits (bsz, seq_len, vocab) without computing loss."""
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x, raw_v = self.blocks[i](x, x0,
+                self.qo_bank[i], self.kv_bank[i], self.kv_bank[n + i],
+                self.qo_bank[n + i], self.mlp_up_bank[i], self.mlp_down_bank[i],
+                v_embed=ve, v0=v0)
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x, _ = self.blocks[bi](x, x0,
+                self.qo_bank[bi], self.kv_bank[bi], self.kv_bank[n + bi],
+                self.qo_bank[n + bi], self.mlp_up_bank[bi], self.mlp_down_bank[bi],
+                v_embed=ve, v0=v0)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+# --- Sliding window evaluation ---
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context."""
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= 1]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    base_model.eval()
+    compiled_logits = torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = compiled_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+def eval_val_sliding_ttt(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    stride: int, batch_seqs: int = 32, log0=print,
+) -> tuple[float, float]:
+    """Legal score-first TTT (PR #461 recipe): score each chunk with sliding windows,
+    then train on it. Every token scored BEFORE any update that could use it."""
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = args.ttt_chunk_tokens
+
+    # Pre-compute all window starts
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+
+    # Assign each window to a chunk based on the first token it scores
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    chunk_windows: list[list[int]] = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        end = min(ws + seq_len, total_tokens)
+        wlen = end - ws
+        s = 0 if ws == 0 else max(wlen - stride, 0)
+        scored_start = ws + s
+        ci = min(scored_start // ttt_chunk, num_chunks - 1)
+        chunk_windows[ci].append(ws)
+
+    log0(f"ttt_sliding:start chunks={num_chunks} chunk_tokens={ttt_chunk} "
+         f"total_windows={len(window_starts)} stride={stride} "
+         f"ttt_lr={args.ttt_lr} ttt_epochs={args.ttt_epochs} "
+         f"freeze_blocks={args.ttt_freeze_blocks}")
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Freeze first N blocks
+    frozen_block_ids = set(range(min(args.ttt_freeze_blocks, len(base_model.blocks))))
+    ttt_params = []
+    for name, p in base_model.named_parameters():
+        freeze = False
+        for bi in frozen_block_ids:
+            if f"blocks.{bi}." in name:
+                freeze = True
+                break
+        if freeze:
+            p.requires_grad_(False)
+        else:
+            p.requires_grad_(True)
+            ttt_params.append(p)
+
+    log0(f"ttt_sliding:params unfrozen={sum(p.numel() for p in ttt_params)} "
+         f"frozen={sum(p.numel() for p in base_model.parameters() if not p.requires_grad)}")
+
+    optimizer = torch.optim.SGD(ttt_params, lr=args.ttt_lr, momentum=args.ttt_momentum)
+    t0 = time.perf_counter()
+
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows:
+            continue
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+
+        # --- Phase 1: SCORE this chunk's windows (inference_mode) ---
+        my_s = (len(windows) * rank) // world_size
+        my_e = (len(windows) * (rank + 1)) // world_size
+        my_windows = windows[my_s:my_e]
+
+        base_model.eval()
+        with torch.inference_mode():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi:bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens: list[int] = []
+                for i, ws in enumerate(batch_ws):
+                    end = min(ws + seq_len, total_tokens)
+                    wlen = end - ws
+                    wlens.append(wlen)
+                    chunk_tok = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                    x_batch[i, :wlen] = chunk_tok[:-1]
+                    y_batch[i, :wlen] = chunk_tok[1:]
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model.forward_logits(x_batch)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y_batch.reshape(-1), reduction="none",
+                ).reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]
+                    s = 0 if ws == 0 else max(wlen - stride, 0)
+                    scored_nll = nll[i, s:wlen].to(torch.float64)
+                    loss_sum += scored_nll.sum()
+                    token_count += float(wlen - s)
+                    tgt, prev = y_batch[i, s:wlen], x_batch[i, s:wlen]
+                    tb = base_bytes_lut[tgt].to(torch.float64)
+                    tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                    byte_count += tb.sum()
+
+        # --- Phase 2: TRAIN on this chunk (already scored = legal) ---
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and args.ttt_epochs > 0:
+            base_model.train()
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if chunk_seqs > 0:
+                cos_lr = args.ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                for pg in optimizer.param_groups:
+                    pg['lr'] = cos_lr
+                my_seq_s = (chunk_seqs * rank) // world_size
+                my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+                my_chunk_seqs = my_seq_e - my_seq_s
+                for _ep in range(args.ttt_epochs):
+                    for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                        be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                        actual_bs = my_seq_s + bs
+                        start_tok = chunk_start + actual_bs * seq_len
+                        end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                        if end_tok > val_tokens.numel():
+                            continue
+                        local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                        x = local[:-1].reshape(-1, seq_len)
+                        y = local[1:].reshape(-1, seq_len)
+                        optimizer.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            loss = base_model(x, y)
+                        loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        torch.nn.utils.clip_grad_norm_(ttt_params, args.ttt_grad_clip)
+                        optimizer.step()
+
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            log0(f"  ttt_chunk [{ci+1}/{num_chunks}] bpb={rbpb:.6f} time={elapsed:.1f}s")
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+    log0(f"ttt_sliding:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+         f"elapsed={time.perf_counter() - t0:.1f}s")
+    return val_loss, val_bpb
+
+
+# --- GPTQ-lite int6 quantization ---
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+def quantize_int6_per_row(t: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        best_q, best_s, best_err = None, None, float('inf')
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            if pct < 1.0:
+                row_clip = torch.quantile(t32.abs(), pct, dim=1)
+            else:
+                row_clip = t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+            recon = q.float() * s.float()[:, None]
+            err = (t32 - recon).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_s, best_err = q, s, err
+        return best_q, best_s
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+
+def _unbank_state_dict(sd: dict[str, Tensor], num_layers: int) -> dict[str, Tensor]:
+    """Convert 3D bank tensors into individual 2D tensors with standard names."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    for name, tensor in sd.items():
+        if name == "qo_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_q.weight"] = tensor[i]
+                out[f"blocks.{i}.attn.proj.weight"] = tensor[n + i]
+        elif name == "kv_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_k.weight"] = tensor[i]
+                out[f"blocks.{i}.attn.c_v.weight"] = tensor[n + i]
+        elif name == "mlp_up_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.fc.weight"] = tensor[i]
+        elif name == "mlp_down_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.proj.weight"] = tensor[i]
+        else:
+            out[name] = tensor
+    return out
+
+def _rebank_state_dict(sd: dict[str, Tensor], num_layers: int, template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    """Convert individual 2D tensors back into 3D bank tensors."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    # Reconstruct banks from individual weight keys
+    qo_slices = [None] * (2 * n)
+    kv_slices = [None] * (2 * n)
+    up_slices = [None] * n
+    down_slices = [None] * n
+    consumed = set()
+    for i in range(n):
+        qk = f"blocks.{i}.attn.c_q.weight"
+        if qk in sd:
+            qo_slices[i] = sd[qk]
+            consumed.add(qk)
+        ok = f"blocks.{i}.attn.proj.weight"
+        if ok in sd:
+            qo_slices[n + i] = sd[ok]
+            consumed.add(ok)
+        kk = f"blocks.{i}.attn.c_k.weight"
+        if kk in sd:
+            kv_slices[i] = sd[kk]
+            consumed.add(kk)
+        vk = f"blocks.{i}.attn.c_v.weight"
+        if vk in sd:
+            kv_slices[n + i] = sd[vk]
+            consumed.add(vk)
+        fk = f"blocks.{i}.mlp.fc.weight"
+        if fk in sd:
+            up_slices[i] = sd[fk]
+            consumed.add(fk)
+        dk = f"blocks.{i}.mlp.proj.weight"
+        if dk in sd:
+            down_slices[i] = sd[dk]
+            consumed.add(dk)
+    out["qo_bank"] = torch.stack(qo_slices).to(dtype=template_sd["qo_bank"].dtype)
+    out["kv_bank"] = torch.stack(kv_slices).to(dtype=template_sd["kv_bank"].dtype)
+    out["mlp_up_bank"] = torch.stack(up_slices).to(dtype=template_sd["mlp_up_bank"].dtype)
+    out["mlp_down_bank"] = torch.stack(down_slices).to(dtype=template_sd["mlp_down_bank"].dtype)
+    for name, tensor in sd.items():
+        if name not in consumed:
+            out[name] = tensor
+    return out
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    num_layers_total = max(
+        (int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")),
+        default=0,
+    ) + 1
+    late_k_layers = set(range(num_layers_total - 2, num_layers_total))
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+# --- Training ---
+
+def main() -> None:
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    # zeropower_via_newtonschulz5 runs eagerly with bmm -- do NOT compile
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    # With MIG fix above, each process only sees its assigned GPU as device 0
+    device = torch.device("cuda", 0)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    effective_eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+    CastedLinear._qat_enabled = args.qat_enabled
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=args.mtp_num_heads,
+        mtp_loss_weight=args.mtp_loss_weight,
+        bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims,
+        ln_scale=args.ln_scale,
+        dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled,
+        ve_dim=args.ve_dim,
+        ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention,
+        value_residual=args.value_residual,
+    ).to(device).bfloat16()
+    # Banks stay FP32 (like CastedLinear weights), cast to BF16 in forward
+    base_model.qo_bank.data = base_model.qo_bank.data.float()
+    base_model.kv_bank.data = base_model.kv_bank.data.float()
+    base_model.mlp_up_bank.data = base_model.mlp_up_bank.data.float()
+    base_model.mlp_down_bank.data = base_model.mlp_down_bank.data.float()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    # No DDP -- Parallel Muon handles bank grad communication via reduce-scatter,
+    # and non-bank grads are manually all-reduced before Adam steps.
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model = compiled_model
+
+    # Optimizer split:
+    # - 4 parameter banks -> Muon (batched Newton-Schulz)
+    # - token embedding -> Adam
+    # - scalars/control tensors -> Adam
+    # - bigram proj, mtp heads, VE proj -> Adam (small matrix params not worth banking)
+    matrix_params = [
+        base_model.qo_bank, base_model.kv_bank,
+        base_model.mlp_up_bank, base_model.mlp_down_bank,
+    ]
+    block_named_params = list(base_model.blocks.named_parameters())
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_params.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None:
+            scalar_params.append(base_model.bigram.proj.weight)
+    if base_model.ve_shared is not None:
+        tok_params.append({"params": [base_model.ve_shared.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.ve_shared.proj is not None:
+            scalar_params.append(base_model.ve_shared.proj.weight)
+        scalar_params.append(base_model.ve_shared.scale)
+        for s in base_model.ve_layer_scales:
+            scalar_params.append(s)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    # Non-bank params that need manual all-reduce (replicated across GPUs)
+    replicated_params = list(optimizer_tok.param_groups[0]["params"])
+    for pg in optimizer_tok.param_groups[1:]:
+        replicated_params.extend(pg["params"])
+    replicated_params.extend(scalar_params)
+
+    optimizer_head = None
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        replicated_params.append(base_model.lm_head.weight)
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if optimizer_head is not None:
+        optimizers.append(optimizer_head)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    mtp_params = sum(p.numel() for p in base_model.mtp_heads.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"mtp_num_heads:{args.mtp_num_heads} mtp_loss_weight:{args.mtp_loss_weight} mtp_params:{mtp_params}")
+    xsa_layers = [i for i, b in enumerate(base_model.blocks) if b.attn.use_xsa]
+    log0(f"XSA:last_{args.xsa_last_n} active_layers:{xsa_layers}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            # All-reduce all grads for warmup (simple, not optimized)
+            if distributed:
+                for p in base_model.parameters():
+                    if p.grad is not None:
+                        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    from collections import deque
+    lawa_queue: deque[dict[str, Tensor]] = deque(maxlen=args.lawa_k)
+    ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    ema_decay = 0.997
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            # Estimate artifact size (int6+lzma) at each validation step
+            try:
+                sd_snap = {k: v.detach().cpu() for k, v in base_model.state_dict().items()
+                           if "mtp_heads" not in k}
+                unbanked_snap = _unbank_state_dict(sd_snap, args.num_layers)
+                q_snap, m_snap = mixed_quantize_int6(unbanked_snap, {"mlp", "attn"})
+                snap_buf = io.BytesIO()
+                torch.save({"w": q_snap, "m": m_snap}, snap_buf)
+                snap_compressed = len(lzma.compress(snap_buf.getvalue(), preset=6))
+                snap_code_bytes = len(code.encode("utf-8"))
+                snap_total = snap_compressed + snap_code_bytes
+                log0(
+                    f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                    f"artifact_bytes:{snap_total} model_int6_lzma:{snap_compressed} "
+                    f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+                )
+            except Exception as e:
+                log0(
+                    f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                    f"artifact_size:error({e}) "
+                    f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+                )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        if args.late_qat_threshold > 0 and scale < args.late_qat_threshold and not CastedLinear._qat_enabled:
+            CastedLinear._qat_enabled = True
+            log0(f"late_qat:enabled step:{step} scale:{scale:.4f}")
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        # === 3-phase overlapped optimizer step ===
+        # Phase 1: Launch async reduce-scatter for banks (biggest first)
+        optimizer_muon.launch_reduce_scatters()
+        # Phase 2: All-reduce non-bank grads + step Adam (while bank RS is in-flight)
+        if distributed:
+            for p in replicated_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+        optimizer_tok.step()
+        optimizer_scalar.step()
+        if optimizer_head is not None:
+            optimizer_head.step()
+        # Phase 3: Wait for RS, local NS5, all-gather (banks processed last)
+        optimizer_muon.step()
+        zero_grad_all()
+        # EMA update
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(t.detach().float(), alpha=1.0 - ema_decay)
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        if args.swa_enabled and scale < 0.2 and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+        if args.lawa_enabled and step % args.lawa_freq == 0:
+            lawa_queue.append({name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()})
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+    # Apply weight averaging
+    if args.lawa_enabled and len(lawa_queue) > 1:
+        log0(f"lawa:applying LAWA averaging k={len(lawa_queue)}")
+        current_state = base_model.state_dict()
+        avg_state = {name: torch.zeros(t.shape, dtype=torch.float32, device='cpu') for name, t in current_state.items()}
+        for snap in lawa_queue:
+            for name in avg_state:
+                avg_state[name] += snap[name].float()
+        for name in avg_state:
+            avg_state[name] /= len(lawa_queue)
+            avg_state[name] = avg_state[name].to(dtype=current_state[name].dtype)
+        base_model.load_state_dict(avg_state, strict=True)
+    else:
+        log0("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+        base_model.load_state_dict(avg_state, strict=True)
+    torch.cuda.synchronize()
+    t_diag = time.perf_counter()
+    diag_val_loss, diag_val_bpb = eval_val(
+        args, compiled_model, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"DIAGNOSTIC post_ema val_loss:{diag_val_loss:.4f} val_bpb:{diag_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_diag):.0f}ms"
+    )
+    full_state_dict = base_model.state_dict()
+    export_sd = {k: v for k, v in full_state_dict.items() if "mtp_heads" not in k}
+    excluded_mtp = sum(int(t.numel()) for k, t in full_state_dict.items() if "mtp_heads" in k)
+    if excluded_mtp > 0:
+        log0(f"export_excluding_mtp_params:{excluded_mtp}")
+    if master_process:
+        torch.save(export_sd, "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+    # Unbank 3D tensors into individual 2D tensors for quantization
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    unbanked_sd = _unbank_state_dict(sd_cpu, args.num_layers)
+    quant_result, quant_meta = mixed_quantize_int6(unbanked_sd, {"mlp", "attn"})
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = lzma.compress(quant_raw, preset=6)
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = len(quant_blob)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+lzma: {quant_file_bytes} bytes")
+        log0(f"Total submission size int6+lzma: {quant_file_bytes + code_bytes} bytes")
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(lzma.decompress(quant_blob_disk)),
+        map_location="cpu",
+    )
+    deq_unbanked = dequantize_mixed_int6(quant_state["w"], quant_state["m"], unbanked_sd)
+    # Re-bank the dequantized tensors
+    deq_state = _rebank_state_dict(deq_unbanked, args.num_layers, sd_cpu)
+    eval_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=0, mtp_loss_weight=0.0,
+        bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims, ln_scale=args.ln_scale, dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention, value_residual=args.value_residual,
+    ).to(device).bfloat16()
+    eval_model.qo_bank.data = eval_model.qo_bank.data.float()
+    eval_model.kv_bank.data = eval_model.kv_bank.data.float()
+    eval_model.mlp_up_bank.data = eval_model.mlp_up_bank.data.float()
+    eval_model.mlp_down_bank.data = eval_model.mlp_down_bank.data.float()
+    for m in eval_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(eval_model)
+    eval_model.load_state_dict(deq_state, strict=True)
+    compiled_eval = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args, compiled_eval, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        eval_seq_len=effective_eval_seq_len,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+    sw_seq_len = effective_eval_seq_len
+    if args.eval_stride > 0 and args.eval_stride < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+        log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+    if args.eval_stride != 64 and 64 < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide64 = time.perf_counter()
+        sw64_val_loss, sw64_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=64,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window_s64 val_loss:{sw64_val_loss:.4f} val_bpb:{sw64_val_bpb:.4f} "
+            f"stride:64 eval_time:{1000.0 * (time.perf_counter() - t_slide64):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_s64_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+        log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+    # Legal score-first TTT (PR #461 recipe)
+    if args.ttt_enabled:
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_loss, ttt_bpb = eval_val_sliding_ttt(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, log0=log0,
+        )
+        torch.cuda.synchronize()
+        log0(f"legal_ttt val_loss:{ttt_loss:.4f} val_bpb:{ttt_bpb:.4f} "
+             f"eval_time:{1000.0 * (time.perf_counter() - t_ttt):.0f}ms")
+        log0(f"legal_ttt_exact val_loss:{ttt_loss:.8f} val_bpb:{ttt_bpb:.8f}")
+    if distributed:
+        dist.destroy_process_group()
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
+Running Python 3.10.14 (main, May  6 2024, 19:42:50) [GCC 11.2.0]
+Running PyTorch 2.10.0+cu128
+Fri Mar 27 15:38:32 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 550.127.08             Driver Version: 550.127.08     CUDA Version: 12.4     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA A100-SXM4-80GB          On  |   00000000:27:00.0 Off |                   On |
+| N/A   37C    P0             98W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA A100-SXM4-80GB          On  |   00000000:2A:00.0 Off |                   On |
+| N/A   33C    P0             91W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA A100-SXM4-80GB          On  |   00000000:51:00.0 Off |                   On |
+| N/A   34C    P0            101W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA A100-SXM4-80GB          On  |   00000000:9E:00.0 Off |                   On |
+| N/A   37C    P0             99W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA A100-SXM4-80GB          On  |   00000000:A4:00.0 Off |                   On |
+| N/A   32C    P0             95W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA A100-SXM4-80GB          On  |   00000000:CA:00.0 Off |                   On |
+| N/A   37C    P0             97W /  400W |                  N/A   |     N/A      Default |
+|                                         |                        |              Enabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| MIG devices:                                                                            |
++------------------+----------------------------------+-----------+-----------------------+
+| GPU  GI  CI  MIG |                     Memory-Usage |        Vol|      Shared           |
+|      ID  ID  Dev |                       BAR1-Usage | SM     Unc| CE ENC DEC OFA JPG    |
+|                  |                                  |        ECC|                       |
+|==================+==================================+===========+=======================|
+|  0    2   0   0  |             355MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 2MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  1    1   0   0  |             355MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 2MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  1    2   0   1  |              38MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 0MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  2    1   0   0  |             355MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 2MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  3    2   0   0  |             355MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 2MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  4    2   0   0  |              38MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 0MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  5    1   0   0  |              38MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 0MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+|  5    2   0   1  |              38MiB / 40192MiB    | 42      0 |  3   0    2    0    0 |
+|                  |                 0MiB / 65535MiB  |           |                       |
++------------------+----------------------------------+-----------+-----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A   3539864      C   /opt/conda/bin/python3                          0MiB |
+|    1   N/A  N/A   3539865      C   /opt/conda/bin/python3                          0MiB |
+|    2   N/A  N/A   3539866      C   /opt/conda/bin/python3                          0MiB |
+|    3   N/A  N/A   3539867      C   /opt/conda/bin/python3                          0MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26928220
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_4 active_layers:[7, 8, 9, 10]
+world_size:4 grad_accum_steps:2
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:50000 warmup_steps:20 max_wallclock_seconds:0.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/50000 val_loss:6.9304 val_bpb:4.1046 artifact_bytes:4577902 model_int6_lzma:4486400 train_time:0ms step_avg:0.02ms
+step:1/50000 train_loss:6.9317 train_time:1023ms step_avg:1022.65ms
+step:2/50000 train_loss:8.6832 train_time:1567ms step_avg:783.57ms
+step:3/50000 train_loss:7.6849 train_time:2419ms step_avg:806.34ms
+step:4/50000 train_loss:7.1826 train_time:3279ms step_avg:819.82ms
+step:5/50000 train_loss:7.1343 train_time:4131ms step_avg:826.29ms
+step:6/50000 train_loss:7.1132 train_time:4984ms step_avg:830.61ms
+step:7/50000 train_loss:7.1096 train_time:5836ms step_avg:833.65ms
+step:8/50000 train_loss:6.9542 train_time:6688ms step_avg:835.94ms
+step:9/50000 train_loss:6.6144 train_time:7540ms step_avg:837.75ms
+step:10/50000 train_loss:6.2392 train_time:8392ms step_avg:839.20ms
+step:500/50000 train_loss:2.3566 train_time:414391ms step_avg:828.78ms
+step:1000/50000 train_loss:2.2649 train_time:828718ms step_avg:828.72ms
+step:1500/50000 train_loss:2.1835 train_time:1242997ms step_avg:828.66ms
+step:2000/50000 train_loss:2.0346 train_time:1657066ms step_avg:828.53ms
+step:2500/50000 train_loss:2.1555 train_time:2071255ms step_avg:828.50ms
+step:2500/50000 val_loss:2.1197 val_bpb:1.2554 artifact_bytes:13062362 model_int6_lzma:12970860 train_time:2071607ms step_avg:828.64ms
+step:3000/50000 train_loss:2.1230 train_time:2486329ms step_avg:828.78ms
+step:3500/50000 train_loss:2.1888 train_time:2900436ms step_avg:828.70ms
+step:4000/50000 train_loss:2.1608 train_time:3314653ms step_avg:828.66ms
+step:4500/50000 train_loss:2.1304 train_time:3729010ms step_avg:828.67ms
+step:5000/50000 train_loss:2.0927 train_time:4142940ms step_avg:828.59ms
+step:5000/50000 val_loss:2.0751 val_bpb:1.2290 artifact_bytes:14137046 model_int6_lzma:14045544 train_time:4143282ms step_avg:828.66ms
+step:5500/50000 train_loss:2.1367 train_time:4561300ms step_avg:829.33ms
+step:6000/50000 train_loss:2.0319 train_time:4975437ms step_avg:829.24ms
+step:6500/50000 train_loss:2.3011 train_time:5389560ms step_avg:829.16ms
+step:7000/50000 train_loss:1.9272 train_time:5803732ms step_avg:829.10ms
+step:7500/50000 train_loss:2.0523 train_time:6217640ms step_avg:829.02ms
+step:7500/50000 val_loss:2.0601 val_bpb:1.2201 artifact_bytes:15465582 model_int6_lzma:15374080 train_time:6217998ms step_avg:829.07ms
+step:8000/50000 train_loss:2.0043 train_time:6635416ms step_avg:829.43ms
+step:8500/50000 train_loss:1.9835 train_time:7049580ms step_avg:829.36ms
+step:9000/50000 train_loss:2.0981 train_time:7463731ms step_avg:829.30ms
+step:9500/50000 train_loss:2.2500 train_time:7878137ms step_avg:829.28ms
+step:10000/50000 train_loss:2.0623 train_time:8292109ms step_avg:829.21ms
+step:10000/50000 val_loss:2.0298 val_bpb:1.2022 artifact_bytes:17185494 model_int6_lzma:17093992 train_time:8292463ms step_avg:829.25ms
+step:10500/50000 train_loss:2.0985 train_time:8706332ms step_avg:829.17ms
+step:11000/50000 train_loss:1.9900 train_time:9120685ms step_avg:829.15ms
+step:11500/50000 train_loss:1.9463 train_time:9534878ms step_avg:829.12ms
+step:12000/50000 train_loss:1.9647 train_time:9948914ms step_avg:829.08ms
+step:12500/50000 train_loss:1.9733 train_time:10363165ms step_avg:829.05ms
+step:12500/50000 val_loss:2.0239 val_bpb:1.1987 artifact_bytes:17195458 model_int6_lzma:17103956 train_time:10363511ms step_avg:829.08ms
+step:13000/50000 train_loss:1.9893 train_time:10777330ms step_avg:829.03ms
+step:13500/50000 train_loss:2.1058 train_time:11191724ms step_avg:829.02ms
+step:14000/50000 train_loss:1.9129 train_time:11605951ms step_avg:829.00ms
+step:14500/50000 train_loss:2.0925 train_time:12020167ms step_avg:828.98ms
+step:15000/50000 train_loss:2.0414 train_time:12434266ms step_avg:828.95ms
+step:15000/50000 val_loss:2.0153 val_bpb:1.1936 artifact_bytes:17238818 model_int6_lzma:17147316 train_time:12434621ms step_avg:828.97ms
+step:15500/50000 train_loss:2.0143 train_time:12849006ms step_avg:828.97ms
+step:16000/50000 train_loss:2.0965 train_time:13263279ms step_avg:828.95ms
+step:16500/50000 train_loss:2.0796 train_time:13677134ms step_avg:828.92ms
+step:17000/50000 train_loss:2.0793 train_time:14090858ms step_avg:828.87ms
+step:17500/50000 train_loss:2.0703 train_time:14505088ms step_avg:828.86ms
+step:17500/50000 val_loss:2.0123 val_bpb:1.1918 artifact_bytes:17178826 model_int6_lzma:17087324 train_time:14505424ms step_avg:828.88ms
+step:18000/50000 train_loss:1.9518 train_time:14920145ms step_avg:828.90ms
+step:18500/50000 train_loss:1.9218 train_time:15334455ms step_avg:828.89ms
+step:19000/50000 train_loss:1.9064 train_time:15748579ms step_avg:828.87ms
+step:19500/50000 train_loss:2.1016 train_time:16162691ms step_avg:828.86ms
+step:20000/50000 train_loss:2.0155 train_time:16576715ms step_avg:828.84ms
+step:20000/50000 val_loss:2.0102 val_bpb:1.1905 artifact_bytes:17182262 model_int6_lzma:17090760 train_time:16577058ms step_avg:828.85ms
+step:20500/50000 train_loss:2.0779 train_time:16990982ms step_avg:828.83ms
+step:21000/50000 train_loss:1.9839 train_time:17405163ms step_avg:828.82ms
+step:21500/50000 train_loss:2.0096 train_time:17819403ms step_avg:828.81ms
+step:22000/50000 train_loss:2.0285 train_time:18233536ms step_avg:828.80ms
+step:22500/50000 train_loss:2.0467 train_time:18647640ms step_avg:828.78ms
+step:22500/50000 val_loss:2.0092 val_bpb:1.1900 artifact_bytes:17168362 model_int6_lzma:17076860 train_time:18647994ms step_avg:828.80ms
+step:23000/50000 train_loss:1.9741 train_time:19063091ms step_avg:828.83ms
+step:23500/50000 train_loss:2.0698 train_time:19477367ms step_avg:828.82ms
+step:24000/50000 train_loss:1.9651 train_time:19891565ms step_avg:828.82ms
+step:24500/50000 train_loss:2.0126 train_time:20305658ms step_avg:828.80ms
+step:25000/50000 train_loss:2.0209 train_time:20719923ms step_avg:828.80ms
+step:25000/50000 val_loss:2.0089 val_bpb:1.1898 artifact_bytes:17167526 model_int6_lzma:17076024 train_time:20720282ms step_avg:828.81ms
+step:25500/50000 train_loss:2.0290 train_time:21135316ms step_avg:828.84ms
+step:26000/50000 train_loss:2.0744 train_time:21549311ms step_avg:828.82ms
+step:26500/50000 train_loss:2.0755 train_time:21963268ms step_avg:828.80ms
+step:27000/50000 train_loss:1.9917 train_time:22377137ms step_avg:828.78ms
+step:27500/50000 train_loss:1.9870 train_time:22791091ms step_avg:828.77ms
+step:27500/50000 val_loss:2.0054 val_bpb:1.1877 artifact_bytes:17158910 model_int6_lzma:17067408 train_time:22791427ms step_avg:828.78ms
+step:28000/50000 train_loss:1.8265 train_time:23207952ms step_avg:828.86ms
+step:28500/50000 train_loss:2.0216 train_time:23621876ms step_avg:828.84ms
+step:29000/50000 train_loss:2.0337 train_time:24035834ms step_avg:828.82ms
+step:29500/50000 train_loss:2.0410 train_time:24449558ms step_avg:828.80ms
+step:30000/50000 train_loss:1.9772 train_time:24863967ms step_avg:828.80ms
+step:30000/50000 val_loss:2.0026 val_bpb:1.1861 artifact_bytes:17148538 model_int6_lzma:17057036 train_time:24864321ms step_avg:828.81ms
+step:30500/50000 train_loss:2.0227 train_time:25280953ms step_avg:828.88ms
+step:31000/50000 train_loss:2.0236 train_time:25694982ms step_avg:828.87ms
+step:31500/50000 train_loss:1.9577 train_time:26109139ms step_avg:828.86ms
+step:32000/50000 train_loss:2.0406 train_time:26522737ms step_avg:828.84ms
+step:32500/50000 train_loss:1.9898 train_time:26936766ms step_avg:828.82ms
+step:32500/50000 val_loss:1.9930 val_bpb:1.1804 artifact_bytes:17016594 model_int6_lzma:16925092 train_time:26937120ms step_avg:828.83ms
+step:33000/50000 train_loss:1.9735 train_time:27354051ms step_avg:828.91ms
+step:33500/50000 train_loss:1.9539 train_time:27767883ms step_avg:828.89ms
+step:34000/50000 train_loss:2.0578 train_time:28182056ms step_avg:828.88ms
+step:34500/50000 train_loss:1.9867 train_time:28595937ms step_avg:828.87ms
+step:35000/50000 train_loss:1.9751 train_time:29010008ms step_avg:828.86ms
+step:35000/50000 val_loss:1.9822 val_bpb:1.1740 artifact_bytes:16753850 model_int6_lzma:16662348 train_time:29010353ms step_avg:828.87ms
+step:35500/50000 train_loss:2.0141 train_time:29428063ms step_avg:828.96ms
+step:36000/50000 train_loss:1.9957 train_time:29841900ms step_avg:828.94ms
+step:36500/50000 train_loss:2.0234 train_time:30255712ms step_avg:828.92ms
+step:37000/50000 train_loss:1.8832 train_time:30669416ms step_avg:828.90ms
+step:37500/50000 train_loss:2.0084 train_time:31083261ms step_avg:828.89ms
+step:37500/50000 val_loss:1.9702 val_bpb:1.1669 artifact_bytes:16422374 model_int6_lzma:16330872 train_time:31083616ms step_avg:828.90ms
+step:38000/50000 train_loss:1.9965 train_time:31497684ms step_avg:828.89ms
+step:38500/50000 train_loss:1.9659 train_time:31911447ms step_avg:828.87ms
+step:39000/50000 train_loss:1.8706 train_time:32325400ms step_avg:828.86ms
+step:39500/50000 train_loss:1.9308 train_time:32739167ms step_avg:828.84ms
+step:40000/50000 train_loss:1.9201 train_time:33153087ms step_avg:828.83ms
+step:40000/50000 val_loss:1.9556 val_bpb:1.1582 artifact_bytes:16034950 model_int6_lzma:15943448 train_time:33153441ms step_avg:828.84ms
+step:40500/50000 train_loss:2.3030 train_time:33568094ms step_avg:828.84ms
+step:41000/50000 train_loss:1.8509 train_time:33981981ms step_avg:828.83ms
+step:41500/50000 train_loss:1.7751 train_time:34396141ms step_avg:828.82ms
+step:42000/50000 train_loss:1.9640 train_time:34810273ms step_avg:828.82ms
+step:42500/50000 train_loss:1.9338 train_time:35224133ms step_avg:828.80ms
+step:42500/50000 val_loss:1.9395 val_bpb:1.1487 artifact_bytes:15698694 model_int6_lzma:15607192 train_time:35224478ms step_avg:828.81ms
+step:43000/50000 train_loss:2.0258 train_time:35642593ms step_avg:828.90ms
+step:43500/50000 train_loss:2.1260 train_time:36056389ms step_avg:828.88ms
+step:44000/50000 train_loss:1.8069 train_time:36470177ms step_avg:828.87ms
+step:44500/50000 train_loss:1.8500 train_time:36883956ms step_avg:828.85ms
+step:45000/50000 train_loss:1.9481 train_time:37297763ms step_avg:828.84ms
+step:45000/50000 val_loss:1.9147 val_bpb:1.1340 artifact_bytes:15144098 model_int6_lzma:15052596 train_time:37298113ms step_avg:828.85ms
+step:45500/50000 train_loss:1.9780 train_time:37716132ms step_avg:828.93ms
+step:46000/50000 train_loss:1.8996 train_time:38129711ms step_avg:828.91ms
+swa:start step:46150
+step:46500/50000 train_loss:1.8117 train_time:38544019ms step_avg:828.90ms
+step:47000/50000 train_loss:1.9247 train_time:38958530ms step_avg:828.90ms
+late_qat:enabled step:47076 scale:0.1499
+step:47500/50000 train_loss:1.8909 train_time:39372954ms step_avg:828.90ms
+step:47500/50000 val_loss:1.8854 val_bpb:1.1167 artifact_bytes:14726650 model_int6_lzma:14635148 train_time:39373341ms step_avg:828.91ms
+step:48000/50000 train_loss:1.8819 train_time:39791819ms step_avg:829.00ms
+step:48500/50000 train_loss:1.8370 train_time:40206398ms step_avg:829.00ms
+step:49000/50000 train_loss:1.7870 train_time:40621323ms step_avg:829.01ms
+step:49500/50000 train_loss:1.8224 train_time:41036021ms step_avg:829.01ms
+step:50000/50000 train_loss:1.8391 train_time:41450533ms step_avg:829.01ms
+step:50000/50000 val_loss:1.8475 val_bpb:1.0942 artifact_bytes:14330478 model_int6_lzma:14238976 train_time:41450929ms step_avg:829.02ms
+peak memory allocated: 22092 MiB reserved: 22340 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.8469 val_bpb:1.0939 eval_time:23715ms
+Serialized model: 106027446 bytes
+Code size: 91502 bytes
+Serialized model int6+lzma: 14257144 bytes
+Total submission size int6+lzma: 14348646 bytes
+final_int6_roundtrip val_loss:1.8963 val_bpb:1.1231 eval_time:24360ms
+final_int6_roundtrip_exact val_loss:1.89626397 val_bpb:1.12307434
+final_int6_sliding_window val_loss:1.8566 val_bpb:1.0996 stride:64 eval_time:663400ms
+final_int6_sliding_window_exact val_loss:1.85662085 val_bpb:1.09959836
+final_int8_zlib_roundtrip_exact val_loss:1.85662085 val_bpb:1.09959836
+ttt_sliding:start chunks=1893 chunk_tokens=32768 total_windows=969088 stride=64 ttt_lr=0.002 ttt_epochs=3 freeze_blocks=0
+ttt_sliding:params unfrozen=26928220 frozen=0
+  ttt_chunk [1/1893] bpb=1.143264 time=1.1s
+  ttt_chunk [11/1893] bpb=1.102386 time=11.9s
+  ttt_chunk [21/1893] bpb=1.104574 time=22.6s
+  ttt_chunk [31/1893] bpb=1.106762 time=33.4s
+  ttt_chunk [41/1893] bpb=1.094977 time=44.2s
+  ttt_chunk [51/1893] bpb=1.090986 time=54.9s
+  ttt_chunk [61/1893] bpb=1.095411 time=65.7s
+  ttt_chunk [71/1893] bpb=1.092186 time=76.5s
+  ttt_chunk [81/1893] bpb=1.092049 time=87.3s
+  ttt_chunk [91/1893] bpb=1.090636 time=98.0s
+  ttt_chunk [101/1893] bpb=1.093373 time=108.8s
+  ttt_chunk [111/1893] bpb=1.094380 time=119.6s
+  ttt_chunk [121/1893] bpb=1.090917 time=130.3s
+  ttt_chunk [131/1893] bpb=1.090511 time=141.1s
+  ttt_chunk [141/1893] bpb=1.090135 time=151.9s
+  ttt_chunk [151/1893] bpb=1.093283 time=162.6s
+  ttt_chunk [161/1893] bpb=1.094916 time=173.4s
+  ttt_chunk [171/1893] bpb=1.095509 time=184.2s
+  ttt_chunk [181/1893] bpb=1.095422 time=194.9s
+  ttt_chunk [191/1893] bpb=1.098575 time=205.7s
+  ttt_chunk [201/1893] bpb=1.098760 time=216.5s
+  ttt_chunk [211/1893] bpb=1.096088 time=227.3s
+  ttt_chunk [221/1893] bpb=1.098044 time=238.0s
+  ttt_chunk [231/1893] bpb=1.097377 time=248.8s
+  ttt_chunk [241/1893] bpb=1.097047 time=259.6s
+  ttt_chunk [251/1893] bpb=1.095568 time=270.4s
+  ttt_chunk [261/1893] bpb=1.093933 time=281.1s
+  ttt_chunk [271/1893] bpb=1.092596 time=291.9s
+  ttt_chunk [281/1893] bpb=1.094857 time=302.7s
+  ttt_chunk [291/1893] bpb=1.095580 time=313.4s
+  ttt_chunk [301/1893] bpb=1.096123 time=324.2s
+  ttt_chunk [311/1893] bpb=1.097615 time=335.0s
+  ttt_chunk [321/1893] bpb=1.099057 time=345.8s
+  ttt_chunk [331/1893] bpb=1.098819 time=356.5s
+  ttt_chunk [341/1893] bpb=1.099094 time=367.3s
+  ttt_chunk [351/1893] bpb=1.100367 time=378.1s
+  ttt_chunk [361/1893] bpb=1.101515 time=388.8s
+  ttt_chunk [371/1893] bpb=1.100995 time=399.6s
+  ttt_chunk [381/1893] bpb=1.100931 time=410.4s
+  ttt_chunk [391/1893] bpb=1.100561 time=421.2s
+  ttt_chunk [401/1893] bpb=1.099187 time=431.9s
+  ttt_chunk [411/1893] bpb=1.098041 time=442.7s
+  ttt_chunk [421/1893] bpb=1.097510 time=453.5s
+  ttt_chunk [431/1893] bpb=1.098206 time=464.3s
+  ttt_chunk [441/1893] bpb=1.098037 time=475.0s
+  ttt_chunk [451/1893] bpb=1.097717 time=485.8s
+  ttt_chunk [461/1893] bpb=1.097002 time=496.6s
+  ttt_chunk [471/1893] bpb=1.096618 time=507.3s
+  ttt_chunk [481/1893] bpb=1.096311 time=518.1s
+  ttt_chunk [491/1893] bpb=1.095995 time=528.9s
+  ttt_chunk [501/1893] bpb=1.095459 time=539.7s
+  ttt_chunk [511/1893] bpb=1.094842 time=550.4s
+  ttt_chunk [521/1893] bpb=1.093730 time=561.2s
+  ttt_chunk [531/1893] bpb=1.093812 time=572.0s
+  ttt_chunk [541/1893] bpb=1.093750 time=582.7s
+  ttt_chunk [551/1893] bpb=1.092578 time=593.5s
+  ttt_chunk [561/1893] bpb=1.093122 time=604.3s
+  ttt_chunk [571/1893] bpb=1.092406 time=615.1s
+  ttt_chunk [581/1893] bpb=1.091865 time=625.8s
+  ttt_chunk [591/1893] bpb=1.091172 time=636.6s
+  ttt_chunk [601/1893] bpb=1.091831 time=647.4s
+  ttt_chunk [611/1893] bpb=1.091385 time=658.2s
+  ttt_chunk [621/1893] bpb=1.091308 time=668.9s
+  ttt_chunk [631/1893] bpb=1.091699 time=679.7s
+  ttt_chunk [641/1893] bpb=1.091471 time=690.4s
+  ttt_chunk [651/1893] bpb=1.091489 time=701.2s
+  ttt_chunk [661/1893] bpb=1.091359 time=712.0s
+  ttt_chunk [671/1893] bpb=1.090971 time=722.8s
+  ttt_chunk [681/1893] bpb=1.091218 time=733.5s
+  ttt_chunk [691/1893] bpb=1.091894 time=744.3s
+  ttt_chunk [701/1893] bpb=1.091104 time=755.1s
+  ttt_chunk [711/1893] bpb=1.091702 time=765.8s
+  ttt_chunk [721/1893] bpb=1.091323 time=776.6s
+  ttt_chunk [731/1893] bpb=1.091750 time=787.4s
+  ttt_chunk [741/1893] bpb=1.091690 time=798.2s
+  ttt_chunk [751/1893] bpb=1.091341 time=808.9s
+  ttt_chunk [761/1893] bpb=1.091177 time=819.7s
+  ttt_chunk [771/1893] bpb=1.090948 time=830.5s
+  ttt_chunk [781/1893] bpb=1.091445 time=841.2s
+  ttt_chunk [791/1893] bpb=1.091118 time=852.0s
+  ttt_chunk [801/1893] bpb=1.091173 time=862.8s
+  ttt_chunk [811/1893] bpb=1.090683 time=873.6s
+  ttt_chunk [821/1893] bpb=1.090471 time=884.3s
+  ttt_chunk [831/1893] bpb=1.089997 time=895.1s
+  ttt_chunk [841/1893] bpb=1.089406 time=905.9s
+  ttt_chunk [851/1893] bpb=1.089279 time=916.7s
+  ttt_chunk [861/1893] bpb=1.089409 time=927.4s
+  ttt_chunk [871/1893] bpb=1.089437 time=938.2s
+  ttt_chunk [881/1893] bpb=1.089446 time=949.0s
+  ttt_chunk [891/1893] bpb=1.089263 time=959.7s
+  ttt_chunk [901/1893] bpb=1.089245 time=970.5s
+  ttt_chunk [911/1893] bpb=1.089239 time=981.3s
+  ttt_chunk [921/1893] bpb=1.089612 time=992.0s
+  ttt_chunk [931/1893] bpb=1.089451 time=1002.8s
+  ttt_chunk [941/1893] bpb=1.089356 time=1013.6s
+  ttt_chunk [951/1893] bpb=1.089337 time=1024.3s
+  ttt_chunk [961/1893] bpb=1.089082 time=1035.1s
+  ttt_chunk [971/1893] bpb=1.089790 time=1045.9s
+  ttt_chunk [981/1893] bpb=1.089929 time=1056.7s
+  ttt_chunk [991/1893] bpb=1.089809 time=1067.5s
+  ttt_chunk [1001/1893] bpb=1.089976 time=1078.2s
+  ttt_chunk [1011/1893] bpb=1.090238 time=1089.0s
+  ttt_chunk [1021/1893] bpb=1.090390 time=1099.8s
+  ttt_chunk [1031/1893] bpb=1.090917 time=1110.6s
+  ttt_chunk [1041/1893] bpb=1.090578 time=1121.3s
+  ttt_chunk [1051/1893] bpb=1.090273 time=1132.1s
+  ttt_chunk [1061/1893] bpb=1.090511 time=1142.9s
+  ttt_chunk [1071/1893] bpb=1.090954 time=1153.6s
+  ttt_chunk [1081/1893] bpb=1.090943 time=1164.4s
+  ttt_chunk [1091/1893] bpb=1.091356 time=1175.2s
+  ttt_chunk [1101/1893] bpb=1.091488 time=1186.0s
+  ttt_chunk [1111/1893] bpb=1.091260 time=1196.7s
+  ttt_chunk [1121/1893] bpb=1.091181 time=1207.5s
+  ttt_chunk [1131/1893] bpb=1.091072 time=1218.3s
+  ttt_chunk [1141/1893] bpb=1.090937 time=1229.0s
+  ttt_chunk [1151/1893] bpb=1.090970 time=1239.8s
+  ttt_chunk [1161/1893] bpb=1.090188 time=1250.6s
+  ttt_chunk [1171/1893] bpb=1.090766 time=1261.4s
+  ttt_chunk [1181/1893] bpb=1.090269 time=1272.1s
+  ttt_chunk [1191/1893] bpb=1.089988 time=1282.9s
+  ttt_chunk [1201/1893] bpb=1.090561 time=1293.7s
+  ttt_chunk [1211/1893] bpb=1.089962 time=1304.4s
+  ttt_chunk [1221/1893] bpb=1.089661 time=1315.2s
+  ttt_chunk [1231/1893] bpb=1.089599 time=1326.0s
+  ttt_chunk [1241/1893] bpb=1.089410 time=1336.8s
+  ttt_chunk [1251/1893] bpb=1.089171 time=1347.5s
+  ttt_chunk [1261/1893] bpb=1.089113 time=1358.3s
+  ttt_chunk [1271/1893] bpb=1.088914 time=1369.1s
+  ttt_chunk [1281/1893] bpb=1.088710 time=1379.9s
+  ttt_chunk [1291/1893] bpb=1.088523 time=1390.6s
+  ttt_chunk [1301/1893] bpb=1.088161 time=1401.4s
+  ttt_chunk [1311/1893] bpb=1.087859 time=1412.2s
+  ttt_chunk [1321/1893] bpb=1.087701 time=1423.0s
+  ttt_chunk [1331/1893] bpb=1.087611 time=1433.7s
+  ttt_chunk [1341/1893] bpb=1.087498 time=1444.5s
+  ttt_chunk [1351/1893] bpb=1.087448 time=1455.3s
+  ttt_chunk [1361/1893] bpb=1.087658 time=1466.0s
+  ttt_chunk [1371/1893] bpb=1.087513 time=1476.8s
+  ttt_chunk [1381/1893] bpb=1.087452 time=1487.6s
+  ttt_chunk [1391/1893] bpb=1.086938 time=1498.4s
+  ttt_chunk [1401/1893] bpb=1.086952 time=1509.2s
+  ttt_chunk [1411/1893] bpb=1.086986 time=1519.9s
+  ttt_chunk [1421/1893] bpb=1.087243 time=1530.7s
+  ttt_chunk [1431/1893] bpb=1.087094 time=1541.5s
+  ttt_chunk [1441/1893] bpb=1.087766 time=1552.2s
+  ttt_chunk [1451/1893] bpb=1.087875 time=1563.0s
+  ttt_chunk [1461/1893] bpb=1.087616 time=1573.8s
+  ttt_chunk [1471/1893] bpb=1.088508 time=1584.6s
+  ttt_chunk [1481/1893] bpb=1.088318 time=1595.3s
+  ttt_chunk [1491/1893] bpb=1.088295 time=1606.1s
+  ttt_chunk [1501/1893] bpb=1.088428 time=1616.9s
+  ttt_chunk [1511/1893] bpb=1.088500 time=1627.7s
+  ttt_chunk [1521/1893] bpb=1.088516 time=1638.4s
+  ttt_chunk [1531/1893] bpb=1.088335 time=1649.2s
+  ttt_chunk [1541/1893] bpb=1.088300 time=1660.0s
+  ttt_chunk [1551/1893] bpb=1.088644 time=1670.8s
+  ttt_chunk [1561/1893] bpb=1.088779 time=1681.5s
+  ttt_chunk [1571/1893] bpb=1.088893 time=1692.3s
+  ttt_chunk [1581/1893] bpb=1.088999 time=1703.1s
+  ttt_chunk [1591/1893] bpb=1.088948 time=1713.9s
+  ttt_chunk [1601/1893] bpb=1.089129 time=1724.6s
+  ttt_chunk [1611/1893] bpb=1.089211 time=1735.4s
+  ttt_chunk [1621/1893] bpb=1.089078 time=1746.2s
+  ttt_chunk [1631/1893] bpb=1.089247 time=1756.9s
+  ttt_chunk [1641/1893] bpb=1.089113 time=1767.7s
+  ttt_chunk [1651/1893] bpb=1.089025 time=1778.5s
+  ttt_chunk [1661/1893] bpb=1.088917 time=1789.3s
+  ttt_chunk [1671/1893] bpb=1.089273 time=1800.0s
+  ttt_chunk [1681/1893] bpb=1.089519 time=1810.8s
+  ttt_chunk [1691/1893] bpb=1.089483 time=1821.6s
+  ttt_chunk [1701/1893] bpb=1.089475 time=1832.3s
+  ttt_chunk [1711/1893] bpb=1.089308 time=1843.1s
+  ttt_chunk [1721/1893] bpb=1.089158 time=1853.9s
+  ttt_chunk [1731/1893] bpb=1.089108 time=1864.6s
+  ttt_chunk [1741/1893] bpb=1.088877 time=1875.4s
+  ttt_chunk [1751/1893] bpb=1.088730 time=1886.2s
+  ttt_chunk [1761/1893] bpb=1.088814 time=1897.0s
+  ttt_chunk [1771/1893] bpb=1.088740 time=1907.7s
+  ttt_chunk [1781/1893] bpb=1.088687 time=1918.5s
+  ttt_chunk [1791/1893] bpb=1.088300 time=1929.3s
+  ttt_chunk [1801/1893] bpb=1.088297 time=1940.0s
+  ttt_chunk [1811/1893] bpb=1.088139 time=1950.8s
+  ttt_chunk [1821/1893] bpb=1.088176 time=1961.6s
+  ttt_chunk [1831/1893] bpb=1.087789 time=1972.3s
+  ttt_chunk [1841/1893] bpb=1.087730 time=1983.1s
+  ttt_chunk [1851/1893] bpb=1.087510 time=1993.9s
+  ttt_chunk [1861/1893] bpb=1.087051 time=2004.6s
+  ttt_chunk [1871/1893] bpb=1.086903 time=2015.4s
+  ttt_chunk [1881/1893] bpb=1.086533 time=2026.2s
+  ttt_chunk [1891/1893] bpb=1.086383 time=2037.0s
+  ttt_chunk [1893/1893] bpb=1.086404 time=2038.7s
+ttt_sliding:done val_loss=1.832524 val_bpb=1.085327 elapsed=2038.8s
+legal_ttt val_loss:1.8325 val_bpb:1.0853 eval_time:2039427ms
+legal_ttt_exact val_loss:1.83252444 val_bpb:1.08532707


### PR DESCRIPTION
## Summary

This submission is a **non-record submission**. It studies how the current record-track SOTA ([PR #549](https://github.com/openai/parameter-golf/pull/549) by @abaybektursun) scales under extended compute, removing the 10-minute wall-clock constraint. The same architecture and code are trained for 20K–50K steps (5.5-11.5 hours training) on 4×A100 MIG instances (approximately 10× slower per step than 8×H100 SXM).

## Results

### Best run: 50K steps and 11.5 hours (4×A100 MIG, seed 1337)

| Phase | val_loss | val_bpb | Artifact |
|-------|----------|---------|----------|
| Pre-TTT (EMA) | 1.8469 | 1.0939 | 14,348,646 |
| Int6 roundtrip | 1.8963 | 1.1231 | 14,348,646 |
| Sliding window (s=64) | 1.8566 | 1.0996 | 14,348,646 |
| **Legal TTT** | **1.8325** | **1.0853** | **14,348,646** |

### 20K steps and 5.5 hours (4×A100 MIG, 2-seed comparison)

| Seed | step_avg | steps | Pre-TTT bpb | **Post-TTT bpb** | TTT gain | Artifact |
|------|----------|-------|-------------|-----------------|----------|----------|
| 1337 | 828.7ms | 20,000 | 1.1018 | **1.0957** | -0.0061 | 15,077,933 |
| 42 | 828.8ms | 20,000 | 1.1020 | **1.0962** | -0.0058 | 15,137,145 |
| **Mean** | **828.8ms** | **20,000** | **1.1019** | **1.0960 (std 0.0004)** | **-0.0060** | **15,107,539**|

## Plots 

### BPB vs Steps (ASCII plot)
```
BPB
4.10 |*
     |
     |
     |
2.50 |
     |
1.26 | *
1.23 |  *
1.22 |   *
1.20 |    *
1.19 |     * * * * *
1.18 |             * *
1.17 |               *
1.16 |                *
1.15 |                 *
1.13 |                  *
1.12 |                   *
1.09 |                    *
     +----+----+----+----+----+-> steps (K)
     0   10   20   30   40   50

     |<early >|<--- plateau --->|<warmdown>|
      (rapid)                    (sharp drop)
```

### Artifact Size vs Steps (ASCII plot)

```
MB
17.2 |         * * * * * * * * * * * *
16.8 |                               *
16.4 |                                *
16.0 |------------------------------------*--------  16MB limit
15.7 |                                    *
15.1 |                                     *
14.7 |     *                                *
14.1 |  *                                    *
13.1 | *
 4.6 |*
     +----+----+----+----+----+-> steps (K)
     0   10   20   30   40   50

     |<-fits->|<--- OVER 16MB ------>|<fits->|
```