### PR TITLE
Non-record: knowledge distillation teacher-student submission

### DIFF
--- a/records/track_non_record_16mb/2026-03-28_Knowledge_Distillation_Teacher_Student/README.md
+++ b/records/track_non_record_16mb/2026-03-28_Knowledge_Distillation_Teacher_Student/README.md
@@ -1,0 +1,90 @@
+# Non-record: Knowledge distillation (teacher → student)
+
+This folder is a **non-record** submission for Parameter Golf. The idea is simple: train a **bigger teacher** on real next-token targets, then train a **smaller student** using a mix of the usual cross-entropy and a **soft “teacher” signal** (KL-style loss with temperature). Only the **student** counts toward the 16MB submission limit; the teacher is training-time only.
+
+I have not seen another public entry in this repo that uses this exact two-model distillation setup for the challenge, so I am sharing it as an experiment others can build on.
+
+## Plain-English summary
+
+- **Teacher:** more layers and width; learns normally with standard loss.
+- **Student:** smaller; its loss is  
+  `alpha × (loss vs real next token) + (1 − alpha) × (match teacher’s soft predictions)`.
+- **Temperature** softens the teacher’s probabilities so the student gets richer hints than “only the one correct token.”
+
+Hyperparameters `TEMPERATURE` and `ALPHA` come from environment variables (defaults 4.0 and 0.5).
+
+## What I ran (honest results)
+
+| Experiment | Steps | Teacher | Student | val_bpb | Quantized bpb | Size | Notes |
+|------------|-------|---------|---------|---------|----------------|------|--------|
+| Baseline (no distill) | 200 | none | 9L 512D | 2.3351 | — | 10.3MB | Original `train_gpt.py`, no teacher |
+| Distill tiny | 10 | 4L 256D | 3L 128D | 3.7707 | 3.7715 | 0.7MB | Smoke test |
+| Distill medium | 200 | 6L 384D | 4L 256D | 2.5427 | 2.5432 | 2.47MB | MLX / Mac |
+| Distill medium | 500 | 6L 384D | 4L 256D | 2.2717 | 2.2752 | 2.57MB | MLX / Mac |
+| Distill medium | 1000 | 6L 384D | 4L 256D | 2.1348 | 2.1359 | 2.64MB | MLX / Mac |
+| H100 partial | ~600 | 12L 768D | 6L 384D | **1.7195** | pending | ~5MB | RunPod; run stopped early (billing) |
+| H100 full (goal) | 20000 | 12L 768D | 6L 384D | *not completed* | *not completed* | ~6MB est. | **Rough guess** ~1.20–1.25 BPB — *not* measured end-to-end |
+
+The number in **`submission.json`** is the best **recorded** validation BPB from a real (partial) cloud run: **1.7195**. The “~1.20–1.25” row is only an extrapolation from the trend on smaller runs; I am **not** claiming that as a verified score.
+
+## How to reproduce (8×H100, SP1024)
+
+You need the usual FineWeb SP1024 shards and tokenizer from the main repo README.
+
+Example command (adjust `RUN_ID` and paths to match your machine):
+
+```bash
+RUN_ID=distill_12L768_to_6L384_sp1024 \
+DATA_PATH=./data/datasets/fineweb10B_sp1024/ \
+TOKENIZER_PATH=./data/tokenizers/fineweb_1024_bpe.model \
+VOCAB_SIZE=1024 \
+TRAIN_SEQ_LEN=1024 \
+TRAIN_BATCH_TOKENS=524288 \
+ITERATIONS=20000 \
+MAX_WALLCLOCK_SECONDS=600 \
+VAL_LOSS_EVERY=200 \
+WARMUP_STEPS=20 \
+TIE_EMBEDDINGS=1 \
+NUM_LAYERS=6 \
+MODEL_DIM=384 \
+NUM_HEADS=6 \
+NUM_KV_HEADS=2 \
+TEACHER_NUM_LAYERS=12 \
+TEACHER_MODEL_DIM=768 \
+TEACHER_NUM_HEADS=12 \
+TEACHER_NUM_KV_HEADS=4 \
+TEMPERATURE=4.0 \
+ALPHA=0.5 \
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+Single-GPU smoke (smaller batch):
+
+```bash
+RUN_ID=distill_smoke \
+ITERATIONS=50 \
+TRAIN_BATCH_TOKENS=8192 \
+VAL_LOSS_EVERY=0 \
+VAL_BATCH_SIZE=8192 \
+DATA_PATH=./data/datasets/fineweb10B_sp1024/ \
+TOKENIZER_PATH=./data/tokenizers/fineweb_1024_bpe.model \
+VOCAB_SIZE=1024 \
+torchrun --standalone --nproc_per_node=1 train_gpt.py
+```
+
+## Files in this folder
+
+| File | Purpose |
+|------|---------|
+| `train_gpt.py` | Training script (distillation). Named `train_gpt.py` to match submission rules. |
+| `train.log` | Combined log notes from my runs (partial cloud log + table). Replace with one full automated log after a complete 8×H100 job if you want a single clean artifact. |
+| `submission.json` | Metadata for reviewers. |
+| `requirements.txt` | Python deps reference (same spirit as root repo). |
+
+## Limitations
+
+- Distillation needs **two** models in memory → more VRAM than baseline training.
+- My best **8×H100** run did **not** finish 20k steps; stronger numbers need a full rerun.
+- I did **not** change the challenge tokenizer or dataset; metrics are standard `val_bpb` from the script.
+
+Thank you for reading — hope this helps anyone exploring teacher–student ideas under the 16MB cap.

--- a/records/track_non_record_16mb/2026-03-28_Knowledge_Distillation_Teacher_Student/requirements.txt
+++ b/records/track_non_record_16mb/2026-03-28_Knowledge_Distillation_Teacher_Student/requirements.txt
@@ -1,0 +1,10 @@
+numpy
+tqdm
+torch
+huggingface-hub
+kernels
+setuptools
+typing-extensions==4.15.0
+datasets
+tiktoken
+sentencepiece

--- a/records/track_non_record_16mb/2026-03-28_Knowledge_Distillation_Teacher_Student/submission.json
+++ b/records/track_non_record_16mb/2026-03-28_Knowledge_Distillation_Teacher_Student/submission.json
@@ -1,0 +1,19 @@
+{
+  "author": "Jeneeshkumar Surani",
+  "github_id": "Jeneesh1014",
+  "name": "Knowledge distillation: 12L teacher → 6L student (non-record)",
+  "blurb": "Non-record submission: teacher–student distillation for Parameter Golf. A larger teacher (12L 768d, tied embeddings, not submitted) trains on CE while a smaller student (6L 384d) trains with alpha*CE + (1-alpha)*KL on softened teacher logits (TEMPERATURE=4, ALPHA=0.5). Best reported val_bpb from a partial RunPod run is 1.7195 (~step 600); full 20k-step 8xH100 run not completed due to billing. Mac/MLX medium runs and baseline table documented in README.",
+  "date": "2026-03-28T00:00:00Z",
+  "track": "non-record-16mb",
+  "val_loss": null,
+  "val_bpb": 1.7195,
+  "pre_quant_val_loss": null,
+  "pre_quant_val_bpb": 1.7195,
+  "step_stop": 600,
+  "wallclock_seconds": null,
+  "bytes_total": null,
+  "bytes_model_int8_zlib": null,
+  "bytes_code": null,
+  "gpu": "RunPod partial H100 multi-step; MLX Mac for medium experiments",
+  "notes": "submission.json val_bpb reflects partial cloud run only; see README for full experiment table and limitations."
+}

--- a/records/track_non_record_16mb/2026-03-28_Knowledge_Distillation_Teacher_Student/train.log
+++ b/records/track_non_record_16mb/2026-03-28_Knowledge_Distillation_Teacher_Student/train.log
@@ -1,0 +1,32 @@
+# Combined experiment log — Knowledge distillation (non-record submission)
+# This file documents multiple runs (baseline, MLX, partial RunPod). It is not a single
+# uninterrupted 8xH100 20k-step training capture. For a strict single-run log, rerun on 8xH100 and
+# paste the script's full stdout/stderr + logs/<RUN_ID>.txt here.
+
+## Baseline (no distillation)
+# Source: stock train_gpt.py, 200 steps
+# val_bpb: 2.3351
+# Student: 9L 512D, ~10.3MB serialized context (as noted by author)
+
+## Distill tiny (smoke)
+# Steps: 10 | Teacher 4L 256D | Student 3L 128D
+# val_bpb: 3.7707 | quantized val_bpb: 3.7715 | ~0.7MB
+
+## Distill medium — MLX / Mac
+# Teacher 6L 384D | Student 4L 256D
+# step:200  val_bpb: 2.5427  quantized: 2.5432  size: ~2.47MB
+# step:500  val_bpb: 2.2717  quantized: 2.2752  size: ~2.57MB
+# step:1000 val_bpb: 2.1348  quantized: 2.1359  size: ~2.64MB
+
+## Distill large teacher — RunPod H100 (partial)
+# Teacher 12L 768D | Student 6L 384D
+# Training interrupted ~step 600 (billing). Validation from script reported:
+step:600/20000 val_bpb:1.7195 train_time:(partial run — see RunPod console)
+# Post-quant roundtrip val_bpb: not captured before stop
+# Estimated student size on disk: ~5MB class (author note)
+
+## Extrapolation (NOT logged — do not treat as official score)
+# Full 20000-step 8xH100: author estimate ~1.20–1.25 val_bpb based on trend — UNVERIFIED
+
+## Reproduce (8xH100)
+# See README.md for full env var command using train_gpt.py in this folder.

--- a/records/track_non_record_16mb/2026-03-28_Knowledge_Distillation_Teacher_Student/train_gpt.py
+++ b/records/track_non_record_16mb/2026-03-28_Knowledge_Distillation_Teacher_Student/train_gpt.py
@@ -1,0 +1,1273 @@
+"""
+Knowledge distillation for Parameter Golf (non-record submission).
+
+Teacher–student training: a larger teacher (not submitted) trains on standard CE;
+a smaller student trains with alpha*CE + (1-alpha)*KL on teacher soft targets.
+
+This file is named train_gpt.py to match challenge submission layout; CUDA / PyTorch.
+Snapshot: records/track_non_record_16mb/2026-03-28_Knowledge_Distillation_Teacher_Student/
+"""
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# ==============================================================================
+# COMPUTE DTYPE
+# ==============================================================================
+
+COMPUTE_DTYPE = torch.bfloat16
+
+# ==============================================================================
+# HYPERPARAMETERS
+# ==============================================================================
+
+class Hyperparameters:
+    # Data / tokenizer.
+    data_path: str = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    tokenizer_path: str = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id: str = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed: int = int(os.environ.get("SEED", 1337))
+
+    # Validation.
+    val_batch_size: int = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every: int = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every: int = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations: int = int(os.environ.get("ITERATIONS", 20_000))
+    warmdown_iters: int = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps: int = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens: int = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len: int = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    max_wallclock_seconds: float = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init: float = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # STUDENT model shape (smaller — this gets submitted).
+    vocab_size: int = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers: int = int(os.environ.get("NUM_LAYERS", 6))
+    model_dim: int = int(os.environ.get("MODEL_DIM", 384))
+    num_heads: int = int(os.environ.get("NUM_HEADS", 6))
+    num_kv_heads: int = int(os.environ.get("NUM_KV_HEADS", 2))
+    mlp_mult: int = int(os.environ.get("MLP_MULT", 2))
+    tie_embeddings: bool = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    tied_embed_init_std: float = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    logit_softcap: float = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    rope_base: float = float(os.environ.get("ROPE_BASE", 10000.0))
+
+    # TEACHER model shape (bigger — never submitted).
+    teacher_num_layers: int = int(os.environ.get("TEACHER_NUM_LAYERS", 12))
+    teacher_model_dim: int = int(os.environ.get("TEACHER_MODEL_DIM", 768))
+    teacher_num_heads: int = int(os.environ.get("TEACHER_NUM_HEADS", 12))
+    teacher_num_kv_heads: int = int(os.environ.get("TEACHER_NUM_KV_HEADS", 4))
+
+    # Distillation loss settings.
+    temperature: float = float(os.environ.get("TEMPERATURE", 4.0))
+    alpha: float = float(os.environ.get("ALPHA", 0.5))
+
+    # Optimizer.
+    embed_lr: float = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr: float = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr: float = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std: float = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr: float = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr: float = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum: float = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps: int = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start: float = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps: int = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1: float = float(os.environ.get("BETA1", 0.9))
+    beta2: float = float(os.environ.get("BETA2", 0.95))
+    adam_eps: float = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm: float = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+
+    @property
+    def train_files(self) -> str:
+        return os.path.join(self.data_path, "fineweb_train_*.bin")
+
+    @property
+    def val_files(self) -> str:
+        return os.path.join(self.data_path, "fineweb_val_*.bin")
+
+    def lr_mul(self, step: int, elapsed_ms: float) -> float:
+        if self.warmdown_iters <= 0:
+            return 1.0
+        max_wallclock_ms = 1000.0 * self.max_wallclock_seconds if self.max_wallclock_seconds > 0 else None
+        if max_wallclock_ms is None:
+            warmdown_start = max(self.iterations - self.warmdown_iters, 0)
+            return max((self.iterations - step) / max(self.warmdown_iters, 1), 0.0) if warmdown_start <= step < self.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = self.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+
+# ==============================================================================
+# CONTROL TENSOR PATTERNS (copied from train_gpt.py)
+# ==============================================================================
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+
+# ==============================================================================
+# MUON OPTIMIZER (from train_gpt.py)
+# ==============================================================================
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True):
+        super().__init__(params, dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov))
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# ==============================================================================
+# QUANTIZATION (from train_gpt.py)
+# ==============================================================================
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# ==============================================================================
+# DATA LOADING (from train_gpt.py)
+# ==============================================================================
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+
+# ==============================================================================
+# SENTENCEPIECE BPB UTILITIES (from train_gpt.py)
+# ==============================================================================
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+# ==============================================================================
+# TRANSFORMER MODULES (from train_gpt.py — unchanged)
+# ==============================================================================
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, self.weight.to(x.dtype), bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int, rope_base: float, qk_gain_init: float):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        if self.num_kv_heads != self.num_heads:
+            repeat = self.num_heads // self.num_kv_heads
+            k = k.repeat_interleave(repeat, dim=1)
+            v = v.repeat_interleave(repeat, dim=1)
+        y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True)
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int, rope_base: float, qk_gain_init: float):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+# ==============================================================================
+# DISTILLATION LOSS
+# ==============================================================================
+
+def distillation_loss(
+    student_logits: Tensor,
+    teacher_logits: Tensor,
+    targets: Tensor,
+    temperature: float = 4.0,
+    alpha: float = 0.5,
+) -> Tensor:
+    """
+    Combines two signals:
+      1. CE loss  — student learns from real next tokens
+      2. KL loss  — student learns from teacher soft predictions
+
+    alpha=1.0 → pure CE (no distillation)
+    alpha=0.0 → pure KL (no ground truth)
+    alpha=0.5 → equal mix (default)
+    """
+    # ── Part 1: CE vs real labels ──────────────────────────────────
+    ce_loss = F.cross_entropy(student_logits, targets, reduction="mean")
+
+    # ── Part 2: KL vs teacher soft labels ─────────────────────────
+    student_log_soft = F.log_softmax(student_logits / temperature, dim=-1)
+    teacher_soft = F.softmax(teacher_logits / temperature, dim=-1)
+
+    # KL(teacher || student) = sum(teacher * (log_teacher - log_student))
+    kl_loss = F.kl_div(student_log_soft, teacher_soft, reduction="batchmean")
+
+    # T^2 scaling: Hinton et al. 2015 — keeps gradient magnitudes balanced
+    kl_loss = kl_loss * (temperature ** 2)
+
+    return alpha * ce_loss + (1.0 - alpha) * kl_loss
+
+
+# ==============================================================================
+# GPT MODEL (extended with distillation support)
+# ==============================================================================
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.model_dim = model_dim
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList([
+            Block(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init)
+            for _ in range(num_layers)
+        ])
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+
+    def _forward_hidden(self, input_ids: Tensor) -> Tensor:
+        """Shared encoder-decoder trunk — returns final hidden states."""
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+        return self.final_norm(x)
+
+    def _hidden_to_logits(self, x: Tensor) -> Tensor:
+        """Project hidden states → softcapped logits."""
+        x_flat = x.reshape(-1, x.size(-1))
+        if self.tie_embeddings:
+            logits_proj = F.linear(x_flat, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head required when tie_embeddings=False")
+            logits_proj = self.lm_head(x_flat)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        """Standard CE loss — used for teacher training and validation."""
+        x = self._forward_hidden(input_ids)
+        logits = self._hidden_to_logits(x).float()
+        targets = target_ids.reshape(-1)
+        return F.cross_entropy(logits, targets, reduction="mean")
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Returns raw softcapped logits — used to extract teacher soft labels."""
+        x = self._forward_hidden(input_ids)
+        return self._hidden_to_logits(x)
+
+    def forward_distill(
+        self,
+        input_ids: Tensor,
+        target_ids: Tensor,
+        teacher_logits: Tensor,
+        temperature: float,
+        alpha: float,
+    ) -> Tensor:
+        """
+        Distillation loss for the student:
+        alpha * CE(student, real) + (1-alpha) * KL(student, teacher_soft)
+        """
+        x = self._forward_hidden(input_ids)
+        student_logits = self._hidden_to_logits(x).float()
+        targets = target_ids.reshape(-1)
+        return distillation_loss(student_logits, teacher_logits, targets, temperature, alpha)
+
+class DistillWrapper(nn.Module):
+    """Routes forward() to forward_distill when teacher_logits is provided."""
+    def __init__(self, model: GPT):
+        super().__init__()
+        self.model = model
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        target_ids: Tensor,
+        teacher_logits: Tensor | None = None,
+        temperature: float = 4.0,
+        alpha: float = 0.5,
+    ) -> Tensor:
+        if teacher_logits is not None:
+            return self.model.forward_distill(
+                input_ids, target_ids, teacher_logits, temperature, alpha
+            )
+        return self.model(input_ids, target_ids)
+
+# ==============================================================================
+# OPTIMIZER BUILDER (mirrors train_gpt.py)
+# ==============================================================================
+
+def build_optimizers(
+    base_model: GPT,
+    args: Hyperparameters,
+    is_teacher: bool = False,
+) -> tuple[list[torch.optim.Optimizer], Muon]:
+    """
+    Returns (all_optimizers, muon_optimizer).
+    Muon is returned separately so we can update its momentum during warmup.
+    """
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params, lr=args.matrix_lr,
+        momentum=args.muon_momentum, backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    return optimizers, optimizer_muon
+
+
+# ==============================================================================
+# VALIDATION (from train_gpt.py)
+# ==============================================================================
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    
+    # SLIDING WINDOW SETTINGS
+    # stride=64 means we slide 64 tokens at a time
+    # each position gets evaluated with maximum context
+    stride = 64                      # how many tokens to slide each step
+    window = args.train_seq_len      # 1024 — the full context window
+    
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(f"VAL_BATCH_SIZE too small")
+    
+    total_tokens = val_tokens.numel() - 1
+    seq_start = (total_tokens * rank) // world_size
+    seq_end = (total_tokens * (rank + 1)) // world_size
+
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.no_grad():
+        pos = seq_start
+        while pos < seq_end:
+            # Figure out the window
+            # We want tokens [pos-window+stride : pos+stride]
+            # but the ONLY tokens we SCORE are the last `stride` tokens
+            # Everything before is just context
+            
+            ctx_start = max(0, pos - window + stride)
+            ctx_end = min(pos + stride, seq_end) + 1
+            
+            if ctx_end - ctx_start < 2:
+                pos += stride
+                continue
+            
+            local = val_tokens[ctx_start:ctx_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            
+            # How many tokens are "context only" (not scored)
+            score_start_in_window = pos - ctx_start
+            
+            x = local[:-1].unsqueeze(0)   # [1, seq_len]
+            y = local[1:].unsqueeze(0)    # [1, seq_len]
+            
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                # Unwrap DDP → DistillWrapper → GPT
+                inner = model.module.model if hasattr(model, 'module') else model.model
+                hidden = inner._forward_hidden(x)
+                logits = inner._hidden_to_logits(hidden)
+                logits = logits.float()
+                targets = y.reshape(-1)
+                per_token_loss = F.cross_entropy(
+                    logits, targets, reduction="none"
+                )
+            
+            # Only score the NEW tokens (not the context)
+            scored_losses = per_token_loss[score_start_in_window:]
+            scored_targets = targets[score_start_in_window:]
+            scored_prev = x.reshape(-1)[score_start_in_window:]
+            
+            n_scored = scored_losses.numel()
+            if n_scored > 0:
+                val_loss_sum += scored_losses.sum().to(torch.float64)
+                val_token_count += n_scored
+                
+                token_bytes = base_bytes_lut[scored_targets].to(dtype=torch.int16)
+                token_bytes += (
+                    has_leading_space_lut[scored_targets] & 
+                    ~is_boundary_token_lut[scored_prev]
+                ).to(dtype=torch.int16)
+                val_byte_count += token_bytes.to(torch.float64).sum()
+            
+            pos += stride
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+# ==============================================================================
+# MAIN
+# ==============================================================================
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # ── Distributed + CUDA setup ───────────────────────────────────────────────
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # ── Seed + tokenizer ───────────────────────────────────────────────────────
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only supports SentencePiece .model: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(f"VOCAB_SIZE={args.vocab_size} != tokenizer vocab_size={int(sp.vocab_size())}")
+
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(sp, args.vocab_size, device)
+
+    # ── TEACHER model (bigger, trains on real data, NEVER submitted) ───────────
+    base_teacher = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.teacher_num_layers,
+        model_dim=args.teacher_model_dim,
+        num_heads=args.teacher_num_heads,
+        num_kv_heads=args.teacher_num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=True,           # teacher always tied
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+    ).to(device).bfloat16()
+    for module in base_teacher.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_teacher)
+    compiled_teacher = base_teacher
+    teacher: nn.Module = DDP(compiled_teacher, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_teacher
+
+    # ── STUDENT model (smaller, gets quantized and submitted) ──────────────────
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    student_wrapper = DistillWrapper(base_model)
+    compiled_model = student_wrapper
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    # ── Optimizers ─────────────────────────────────────────────────────────────
+    teacher_optimizers, teacher_optimizer_muon = build_optimizers(base_teacher, args)
+    student_optimizers, student_optimizer_muon = build_optimizers(base_model, args)
+
+    n_student = sum(p.numel() for p in base_model.parameters())
+    n_teacher = sum(p.numel() for p in base_teacher.parameters())
+    log0(f"distillation:enabled temperature:{args.temperature} alpha:{args.alpha}")
+    log0(f"teacher_params:{n_teacher} layers:{args.teacher_num_layers} dim:{args.teacher_model_dim}")
+    log0(f"student_params:{n_student} layers:{args.num_layers} dim:{args.model_dim}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} iterations:{args.iterations}")
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:tokens:{val_tokens.numel() - 1}")
+
+    # ── Data + LR schedule ─────────────────────────────────────────────────────
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def zero_grad_all(opts: list[torch.optim.Optimizer]) -> None:
+        for opt in opts:
+            opt.zero_grad(set_to_none=True)
+
+    def apply_lr(opts: list[torch.optim.Optimizer], scale: float) -> None:
+        for opt in opts:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+    # ── Warmup ─────────────────────────────────────────────────────────────────
+    if args.warmup_steps > 0:
+        initial_student_state = {k: v.detach().cpu().clone() for k, v in base_model.state_dict().items()}
+        initial_teacher_state = {k: v.detach().cpu().clone() for k, v in base_teacher.state_dict().items()}
+        initial_student_opt = [copy.deepcopy(opt.state_dict()) for opt in student_optimizers]
+        initial_teacher_opt = [copy.deepcopy(opt.state_dict()) for opt in teacher_optimizers]
+
+        model.train()
+        teacher.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all(teacher_optimizers)
+            zero_grad_all(student_optimizers)
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    teacher.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+
+                # Teacher warmup: normal CE
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    t_loss = teacher(x, y)
+                (t_loss * grad_scale).backward()
+
+                # Get teacher logits (no grad)
+                with torch.no_grad():
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                        t_logits = base_teacher.forward_logits(x).float().detach()
+
+                # Student warmup: distillation loss
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                  s_loss = model(x, y, t_logits, args.temperature, args.alpha)
+                (s_loss * grad_scale).backward()
+
+            for opt in teacher_optimizers:
+                opt.step()
+            for opt in student_optimizers:
+                opt.step()
+            zero_grad_all(teacher_optimizers)
+            zero_grad_all(student_optimizers)
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+
+        # Restore init state
+        base_model.load_state_dict(initial_student_state, strict=True)
+        base_teacher.load_state_dict(initial_teacher_state, strict=True)
+        for opt, state in zip(student_optimizers, initial_student_opt, strict=True):
+            opt.load_state_dict(state)
+        for opt, state in zip(teacher_optimizers, initial_teacher_opt, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all(student_optimizers)
+        zero_grad_all(teacher_optimizers)
+        if distributed:
+            model.require_backward_grad_sync = True
+            teacher.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # ── Main training loop ─────────────────────────────────────────────────────
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        # ── Validation (student only) ───────────────────────────────────────
+        if last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0):
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms step:{step}/{args.iterations}")
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = args.lr_mul(step, elapsed_ms)
+        apply_lr(teacher_optimizers, scale)
+        apply_lr(student_optimizers, scale)
+
+        # Muon momentum warmup
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in teacher_optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for group in student_optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        zero_grad_all(teacher_optimizers)
+        zero_grad_all(student_optimizers)
+
+        teacher_loss_acc = torch.zeros((), device=device)
+        student_loss_acc = torch.zeros((), device=device)
+
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                teacher.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+
+            # ── READ tokens ONCE — both models see identical batch ──────────
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+
+            # ── TEACHER: learn from real labels ─────────────────────────────
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                t_loss = teacher(x, y)
+            teacher_loss_acc += t_loss.detach()
+            (t_loss * grad_scale).backward()
+
+            # ── TEACHER LOGITS: extract soft predictions (no grad) ──────────
+            with torch.no_grad():
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    t_logits = base_teacher.forward_logits(x).float().detach()
+            # .detach() + inference_mode: student loss cannot flow into teacher
+
+            # ── STUDENT: learn from real labels + teacher soft labels ────────
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                s_loss = model(x, y, t_logits, args.temperature, args.alpha)
+            student_loss_acc += s_loss.detach()
+            (s_loss * grad_scale).backward()
+
+        teacher_loss_acc /= grad_accum_steps
+        student_loss_acc /= grad_accum_steps
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_teacher.parameters(), args.grad_clip_norm)
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+
+        for opt in teacher_optimizers:
+            opt.step()
+        for opt in student_optimizers:
+            opt.step()
+        zero_grad_all(teacher_optimizers)
+        zero_grad_all(student_optimizers)
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+
+        if args.train_log_every > 0 and (
+            step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None
+        ):
+            log0(
+                f"step:{step}/{args.iterations} "
+                f"student_loss:{student_loss_acc.item():.4f} "
+                f"teacher_loss:{teacher_loss_acc.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms "
+                f"step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # ==========================================================================
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # Save STUDENT only — teacher is never submitted
+    # ==========================================================================
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"serialized_student_model: {model_bytes} bytes")
+        log0(f"code_size: {code_bytes} bytes")
+        log0(f"total_submission_size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"serialized_model_int8_zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} "
+            f"raw_torch:{quant_raw_bytes} "
+            f"payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"total_submission_size_int8_zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+
+    # ── Roundtrip validation: load quantized weights back and re-eval ──────────
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(
+        f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}"
+    )
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Summary

Non-record submission adding a **teacher–student distillation** experiment under:

`records/track_non_record_16mb/2026-03-28_Knowledge_Distillation_Teacher_Student/`

A **larger teacher** (12L / 768d in the main cloud experiment; other sizes in the README table) trains with normal cross-entropy. A **smaller student** trains with:

`alpha * CE(labels) + (1 - alpha) * KL(teacher_soft || student_soft)`

with temperature scaling (`TEMPERATURE`, `ALPHA` env vars). Only the **student** is intended for the 16MB artifact; the teacher is training-time only.

### Why non-record

This does **not** claim a new SOTA. The best **reported** validation metric in `submission.json` is **val_bpb = 1.7195** from a **partial** RunPod run (~step 600, job stopped early). Full 20k-step / 8×H100 training was not finished. The README is explicit about what is measured vs extrapolated.

### Files

- `train_gpt.py` — distillation training script (named to match submission expectations)
- `README.md` — approach, honest results table, reproduce commands
- `submission.json` — metadata
- `train.log` — combined notes from multiple runs (not a single uninterrupted 8×H100 log; noted in README)
- `requirements.txt` — dependency reference

### How to run

See `README.md` for full `torchrun` commands (8×H100 and 1×GPU smoke).

### Checklist

- [x] Adds only the new folder under `records/track_non_record_16mb/`
- [x] No tokenizer/dataset changes
- [x] Results and limitations documented clearly in README + submission.json