### PR TITLE
Submission/hybrid RWKV token shift

### DIFF
--- a/records/track_non_record_16mb/2026-03-28_HybridRWKV_TokenShift_ShortWindowAttn/README.md
+++ b/records/track_non_record_16mb/2026-03-28_HybridRWKV_TokenShift_ShortWindowAttn/README.md
@@ -1,0 +1,66 @@
+# Hybrid RWKV Token-Shift + Short Window Attention
+
+**Author:** Dillon Blake
+**val_bpb:** 1.2252 (3-seed mean) | **Artifact size:** ~15.86 MB | **Hardware:** 8x H100 SXM | **Params:** 17.0M
+
+## Results
+
+| Seed | Steps | val_loss | val_bpb | Artifact Size |
+|------|-------|----------|---------|---------------|
+| 0    | 14,683 | 2.0689  | 1.2253  | 15,859,562 B  |
+| 1337 | 14,716 | 2.0682  | 1.2249  | 15,863,546 B  |
+| 42   | 14,736 | 2.0691  | 1.2254  | 15,862,343 B  |
+| **Mean** | | **2.0687** | **1.2252** | |
+
+## Architecture
+
+- **Layers:** 11 (3 attention + 8 token-shift)
+- **Model dim:** 512
+- **Heads:** 8 (4 KV heads, GQA)
+- **MLP:** 3x expansion, LeakyReLU squared
+- **Sequence length:** 1024
+- **Vocab:** 1024 (SentencePiece BPE)
+- **Quantization:** Int6 + zlib compression
+
+## Approach
+
+Recently, I have become increasingly interested in hybrid transformer architectures. With this, I wanted to apply some of what I have learned and experimented with to parameter golf. Some of my favorite techniques for hybrid architectures are mamba and gated delta nets. In my early experiments I tried replacing the vast majority of attention layers with these more efficient alternatives. However, at this scale (especially when keeping sequence lengths at 2048) I found flash attention 3 to be much faster. However, I did observe that loss per training step was lower with the hybrid architectures. This makes sense as research suggests that many layers actually just focus on more local context. I believe that with more training time, a classic transformer with softmax attention would have learned this, but the inductive bias of knowing that only some layers needed long range dependencies allowed the model to skip the step in training where it learns not to attend to much earlier tokens in the context for most layers. However, due to the speed of flash attention 3, the increased steps in training and more data seen were more important.
+
+With these observations, my next step was to explore how I could make the mechanisms behind the improved per step loss faster in order to match or exceed the number of steps completed with flash attention 3. A notable trial was differential attention. I theorized that the mechanism that improved the loss per step for hybrid models was that models need to learn to forget. I believed that differential attention would allow me to emulate the lossy memory of hybrid layers while still using the well optimized flash attention 3 on the hopper architecture. This produced mixed results. I tried a mixture of 1-1 differential attention, 1 differential head for every 3 normal heads, 1 for every four normal heads, and even isolating differential attention to certain layers, but it did not compellingly replicate the improved loss per step. I think at a larger scale this could be interesting potentially on scenarios like having models admit when they don’t know, but I did not find it helpful at this small scale. 
+
+After this, I tried to narrow down the fastest potential ways to apply local mixing with extreme efficiency. I ended up with two candidates that seemed to work well. The first method was simply having attention with short windows. I found that leaving only a few layers using full context attention with the rest using very short (128 token) windows worked very well and sped up training. This makes sense, as methods like Mamba hybrid models use an approximately 1:9 ratio of attention to Mamba layers, and the short attention can be thought of as an approximation of the Mamba layer. However, I believe the more interesting finding was actually the benefits of using RWKV style local mixing. Using all RWKV 6 layers with the flash linear attention library demonstrated the need for attention, with its slower learning. However, more notably it greatly slowed down training even with a sequence length of 8192. 
+RWKV has two components to each layer: token mixing and channel mixing. Inspired by some of the other methods like SmearGate, I chose to try adapting just the token mixing part to replace attention. To do this, I use learned per-dimension interpolation weights (passed through sigmoid) to create a weighted blend of the current token and the previous token. Two separate interpolation vectors are learned: one for the receptance (R) branch and one for the key (K) branch. The blended K representation is projected and passed through squared ReLU, then projected again to produce a value. The R branch produces a sigmoid gate that controls how much of this value passes through to the residual stream. Because it only looked one token back, this operation was extremely fast. I tested looking 3 and 5 tokens back as well, but looking 1 back was found to be optimal. In addition, as an ablation I removed the FFN after the token mixing and found the mlp does indeed still provide important transformations before the next layer. 
+Although this did not produce a record, I believe this token mixing approach continues to show the strengths of hybrid models. Although decode speed was not part of this competition, I believe this architecture would be very fast and require significantly less overhead. I did a short, definitely not thorough, sweep of a couple configurations of classic transformer layers vs token mixing layers and I ended up landing on having most layers use this simple token mixing method inspired from RWKV, with only 3 of 11 layers retaining quadratic attention (spaced across the middle and back at positions 4, 7, and 10). For the attention layers, I used short window attention (128 tokens) for layers 4 and 7, while the last attention layer (layer 10) kept full context.
+
+I would like to continue to explore these hybrid architectures because I think there is a lot of room for growth still. I will submit a request for the medium tier of Runpod credits so hopefully I can continue this work. Although most of this work focused on ultra cheap hybrid architectures, I did have a few other minor findings:
+1. Removing the Unet style connections between layers improved performance
+2. Longer context helped, but only to a point. I found the sweet spot to be around 4096-8192 tokens in earlier experiments, though the final submission used a sequence length of 1024.
+
+In addition to the hybrid architecture, the submission incorporates a number of other techniques that contributed to the final result:
+- **Bigram hash embedding**: A hashed bigram embedding that captures local token-pair context and is added to the token embeddings.
+- **SmearGate**: After the bigram embedding is added and RMS norm is applied, a learned gate blends each token's representation with the previous token's before the first layer.
+- **Value embedding**: A shared value embedding table projected into KV-head space, applied with a learned per-layer scale to attention layer 10. (Layer 9, a token-shift layer, also receives the value embedding but its TokenShiftMix ignores it.)
+- **XSA (cross-head suppression of attention)**: Enabled on attention layers within the last 4 layer indices (i.e., layers 7 and 10, since layer 4 falls outside this range), this projects the attention output away from the value direction to encourage heads to learn diverse representations.
+- **Partial RoPE**: Only 16 out of 64 head dimensions receive rotary position embeddings, leaving the rest position-agnostic.
+- **LeakyReLU squared activation**: The MLP uses LeakyReLU (slope 0.5) followed by squaring, rather than the more standard SwiGLU.
+- **Muon optimizer**: A momentum-based optimizer using Newton-Schulz orthogonalization for matrix-shaped parameters, paired with Adam (with weight decay) for scalar and embedding parameters.
+- **Int6 quantization with zlib compression**: Weights are quantized to int6 range (stored as int8) with per-row scales and zlib compressed to meet the 16MB size constraint.
+- **EMA with late QAT**: Exponential moving average of weights with quantization-aware training applied late in training.
+- **Logit softcapping**: Output logits are soft-capped at 30.0 to stabilize training.
+
+## Run Command
+
+```bash
+SEED=1337 \
+TRAIN_SEQ_LEN=1024 \
+TRAIN_BATCH_TOKENS=524288 \
+MATRIX_LR=0.04 \
+SCALAR_LR=0.04 \
+EMBED_LR=0.05 \
+MAX_WALLCLOCK_SECONDS=600 \
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+Thanks for putting on this competition! I hope to continue some more experiments and share more if I am able to get some more Runpod credits.
+
+

--- a/records/track_non_record_16mb/2026-03-28_HybridRWKV_TokenShift_ShortWindowAttn/requirements.txt
+++ b/records/track_non_record_16mb/2026-03-28_HybridRWKV_TokenShift_ShortWindowAttn/requirements.txt
@@ -1,0 +1,10 @@
+numpy
+tqdm
+torch
+huggingface-hub
+kernels
+setuptools
+typing-extensions==4.15.0
+datasets
+tiktoken
+sentencepiece

--- a/records/track_non_record_16mb/2026-03-28_HybridRWKV_TokenShift_ShortWindowAttn/submission.json
+++ b/records/track_non_record_16mb/2026-03-28_HybridRWKV_TokenShift_ShortWindowAttn/submission.json
@@ -1,0 +1,10 @@
+{
+  "track": "non_record_16mb",
+  "date": "2026-03-28",
+  "name": "Hybrid RWKV Token-Shift + Short Window Attention",
+  "author": "Dillon Blake",
+  "github_id": "dillonblake",
+  "val_bpb": 1.2252,
+  "val_loss": 2.0687,
+  "bytes_total": 15863546
+}

--- a/records/track_non_record_16mb/2026-03-28_HybridRWKV_TokenShift_ShortWindowAttn/train_gpt.py
+++ b/records/track_non_record_16mb/2026-03-28_HybridRWKV_TokenShift_ShortWindowAttn/train_gpt.py
@@ -1,0 +1,1209 @@
+"""
+Winning architecture: 11-layer hybrid transformer with 3 quadratic attention layers
+and 8 RWKV-style token-shift layers. ~16M params, 512 dim.
+Supports multi-GPU via DDP. Launch with:
+    torchrun --nproc_per_node=8 train.py
+"""
+
+from __future__ import annotations
+
+import copy
+import gc
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# Flash Attention 3
+from kernels import get_kernel
+_cap = torch.cuda.get_device_capability()
+_fa3_repo = "varunneal/flash-attention-3" if _cap == (9, 0) else "kernels-community/flash-attn3"
+fa3 = get_kernel(_fa3_repo).flash_attn_interface
+
+# ---------------------------------------------------------------------------
+# Hyperparameters
+# ---------------------------------------------------------------------------
+
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 50))
+
+    # Training length
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3500))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 300.0))
+
+    # Architecture
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    mlp_mult = int(os.environ.get("MLP_MULT", 3))
+    tie_embeddings = True
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 4096))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 262_144))
+
+    # Hybrid layer config
+    attn_layers = [4, 7, 10]
+    window_pattern = "VVVVVVVVVVL"  # V=128, L=full context
+
+    # SOTA techniques
+    bigram_vocab_size = 2048
+    bigram_dim = 128
+    xsa_last_n = 4
+    partial_rope_dims = 16
+    leaky_relu_slope = 0.5
+    ve_dim = 128
+    ve_layers = [9, 10]
+
+    # Optimizer
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.030))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.025))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.035))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_wd = float(os.environ.get("MUON_WD", 0.04))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.04))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+
+    # EMA / QAT
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+    late_qat_threshold = float(os.environ.get("LATE_QAT_THRESHOLD", 0.15))
+
+
+# ---------------------------------------------------------------------------
+# Muon Optimizer
+# ---------------------------------------------------------------------------
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, wd: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, wd=wd),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            wd = group.get("wd", 0.0)
+            curr = 0
+            for p in params:
+                if wd > 0:
+                    p.mul_(1 - lr * wd)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# ---------------------------------------------------------------------------
+# Quantization (int6 range, stored as int8, zlib compressed)
+# ---------------------------------------------------------------------------
+
+CONTROL_TENSOR_NAME_PATTERNS = (
+    "attn_scale", "mlp_scale", "resid_mix", "q_gain", "skip_weight",
+    "smear", "mix_r", "mix_k", "gate", "scale",
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT6_CLIP_PERCENTILE = 99.99984
+INT6_CLIP_Q = INT6_CLIP_PERCENTILE / 100.0
+
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+
+def quantize_float_tensor_int6(t: Tensor) -> tuple[Tensor, Tensor]:
+    """Int6 quantization: range [-32, 31] stored as int8."""
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT6_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale_val = (clip_abs / 31.0).clamp_min(1.0 / 31.0)
+        q = torch.clamp(torch.round(clipped / scale_val[:, None]), -32, 31).to(torch.int8).contiguous()
+        return q, scale_val.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT6_CLIP_Q).item()) if t32.numel() else 0.0
+    scale_val = torch.tensor(clip_abs / 31.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(
+        torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale_val), -32, 31
+    ).to(torch.int8).contiguous()
+    return q, scale_val
+
+
+def quantize_state_dict_int6(state_dict: dict[str, Tensor]):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "baseline_tensor_bytes", "int6_payload_bytes"), 0
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            passthrough[name] = t
+            stats["int6_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int6_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        q, s = quantize_float_tensor_int6(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int6_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int6_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+
+def dequantize_state_dict_int6(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            out[name] = (q.float() * float(s.item())).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Data Loading
+# ---------------------------------------------------------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+
+# ---------------------------------------------------------------------------
+# Evaluation (BPB metric)
+# ---------------------------------------------------------------------------
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+# ---------------------------------------------------------------------------
+# Model Components
+# ---------------------------------------------------------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    """Weights stored fp32 for optimizer, cast to input dtype for compute. Supports QAT."""
+    _qat_enabled: bool = False
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                s = (row_max / 31.0).clamp_min(1.0 / 31.0)
+                w_q = (torch.clamp(torch.round(w32 / s[:, None]), -32, 31) * s[:, None]).to(x.dtype)
+            w = w + (w_q - w).detach()  # straight-through estimator
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+# ---------------------------------------------------------------------------
+# Rotary Embeddings (Partial RoPE)
+# ---------------------------------------------------------------------------
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 4096):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb_partial(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int) -> Tensor:
+    """Apply RoPE only to the first rope_dims dimensions."""
+    if rope_dims >= x.size(-1):
+        half = x.size(-1) // 2
+        x1, x2 = x[..., :half], x[..., half:]
+        return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+    # Partial: only rotate first rope_dims dims
+    half = rope_dims // 2
+    x_rope = x[..., :rope_dims]
+    x_pass = x[..., rope_dims:]
+    x1, x2 = x_rope[..., :half], x_rope[..., half:]
+    x_rotated = torch.cat((x1 * cos[..., :half] + x2 * sin[..., :half],
+                           x1 * (-sin[..., :half]) + x2 * cos[..., :half]), dim=-1)
+    return torch.cat((x_rotated, x_pass), dim=-1)
+
+
+# ---------------------------------------------------------------------------
+# Bigram Hash Embedding
+# ---------------------------------------------------------------------------
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False)
+        nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+# ---------------------------------------------------------------------------
+# SmearGate
+# ---------------------------------------------------------------------------
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+
+# ---------------------------------------------------------------------------
+# TokenShiftMix (RWKV-style)
+# ---------------------------------------------------------------------------
+
+class TokenShiftMix(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.mix_r = nn.Parameter(torch.ones(dim) * 0.5)
+        self.mix_k = nn.Parameter(torch.ones(dim) * 0.5)
+        self.W_r = CastedLinear(dim, dim, bias=False)
+        self.W_k = CastedLinear(dim, dim, bias=False)
+        self.W_v = CastedLinear(dim, dim, bias=False)
+        self.W_v._zero_init = True
+
+    def forward(self, x: Tensor, window_size=None, v_embed=None) -> Tensor:
+        B, T, C = x.shape
+        x_prev = F.pad(x[:, :-1, :], (0, 0, 1, 0))
+
+        mix_r = torch.sigmoid(self.mix_r.to(dtype=x.dtype))[None, None, :]
+        mix_k = torch.sigmoid(self.mix_k.to(dtype=x.dtype))[None, None, :]
+        xr = mix_r * x + (1 - mix_r) * x_prev
+        xk = mix_k * x + (1 - mix_k) * x_prev
+
+        r = torch.sigmoid(self.W_r(xr))
+        k = torch.relu(self.W_k(xk)).square()
+        v = self.W_v(k)
+        return r * v
+
+
+# ---------------------------------------------------------------------------
+# Causal Self-Attention (with FA3, partial RoPE, XSA, value embedding)
+# ---------------------------------------------------------------------------
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        partial_rope_dims: int = 16,
+    ):
+        super().__init__()
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        self.rope_dims = partial_rope_dims
+        kv_dim = num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        """Project attention output away from value direction."""
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj_val = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj_val).reshape(B, T, H, D)
+
+    def forward(self, x: Tensor, window_size: tuple[int, int], v_embed: Tensor | None = None) -> Tensor:
+        B, T, C = x.shape
+        q = self.c_q(x).reshape(B, T, self.num_heads, self.head_dim)
+        k = self.c_k(x).reshape(B, T, self.num_kv_heads, self.head_dim)
+        v = self.c_v(x)
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(B, T, self.num_kv_heads, self.head_dim)
+
+        # QK norm
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+
+        # Partial RoPE
+        cos, sin = self.rotary(T, x.device, q.dtype)
+        q = apply_rotary_emb_partial(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb_partial(k, cos, sin, self.rope_dims)
+
+        # Per-head Q scaling
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+
+        # Flash Attention 3 with sliding window
+        y = fa3.flash_attn_func(q, k, v, causal=True, window_size=window_size)
+
+        # XSA: project away from value direction
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+
+        y = y.contiguous().reshape(B, T, C)
+        return self.proj(y)
+
+
+# ---------------------------------------------------------------------------
+# MLP (LeakyReLU squared)
+# ---------------------------------------------------------------------------
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int, leaky_slope: float = 0.5):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+        self.leaky_slope = leaky_slope
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = F.leaky_relu(self.fc(x), self.leaky_slope)
+        return self.proj(x.square())
+
+
+# ---------------------------------------------------------------------------
+# Block (Attention Layer)
+# ---------------------------------------------------------------------------
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        layer_idx: int,
+        partial_rope_dims: int = 16,
+        leaky_slope: float = 0.5,
+        ln_scale: bool = True,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init, partial_rope_dims)
+        self.mlp = MLP(dim, mlp_mult, leaky_slope)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+
+    def forward(self, x: Tensor, x0: Tensor, window_size: tuple[int, int], v_embed: Tensor | None = None) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x_in) * self.ln_scale_factor, window_size, v_embed=v_embed)
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor)
+        return x_out
+
+
+# ---------------------------------------------------------------------------
+# AltBlock (Token-Shift Layer)
+# ---------------------------------------------------------------------------
+
+class AltBlock(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int, leaky_slope: float = 0.5):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.mixer = TokenShiftMix(dim)
+        self.mlp = MLP(dim, mlp_mult, leaky_slope)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor, window_size: tuple[int, int], v_embed: Tensor | None = None) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.mixer(self.attn_norm(x_in), window_size, v_embed)
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out))
+        return x_out
+
+
+# ---------------------------------------------------------------------------
+# GPT Model (Hybrid Transformer)
+# ---------------------------------------------------------------------------
+
+class GPT(nn.Module):
+    def __init__(self, args: Hyperparameters):
+        super().__init__()
+        self.args = args
+        dim = args.model_dim
+        self.logit_softcap = args.logit_softcap
+
+        # Embeddings
+        self.tok_emb = nn.Embedding(args.vocab_size, dim)
+        self.bigram = BigramHashEmbedding(args.bigram_vocab_size, args.bigram_dim, dim)
+        self.smear = SmearGate(dim)
+
+        # Value Embedding (shared, with per-layer scales)
+        kv_dim = args.num_kv_heads * (dim // args.num_heads)
+        self.ve_embed = nn.Embedding(args.vocab_size, args.ve_dim)
+        self.ve_proj = CastedLinear(args.ve_dim, kv_dim, bias=False)
+        self.ve_scales = nn.ParameterDict({
+            str(i): nn.Parameter(torch.ones(1, dtype=torch.float32) * 0.1)
+            for i in args.ve_layers
+        })
+
+        # Build hybrid layers
+        self.window_sizes = self._compute_window_sizes(args)
+        self.blocks = nn.ModuleList()
+        for i in range(args.num_layers):
+            if i in args.attn_layers:
+                block = Block(
+                    dim, args.num_heads, args.num_kv_heads, args.mlp_mult,
+                    args.rope_base, args.qk_gain_init, i,
+                    args.partial_rope_dims, args.leaky_relu_slope,
+                )
+                # Enable XSA on attention layers within the last xsa_last_n layers
+                if i >= args.num_layers - args.xsa_last_n:
+                    block.attn.use_xsa = True
+            else:
+                block = AltBlock(dim, args.mlp_mult, args.leaky_relu_slope)
+            self.blocks.append(block)
+
+        self.final_norm = RMSNorm()
+        self._init_weights()
+
+    def _compute_window_sizes(self, args: Hyperparameters) -> list[tuple[int, int]]:
+        pattern = args.window_pattern.upper()
+        window_sizes = []
+        for i in range(args.num_layers):
+            c = pattern[i % len(pattern)]
+            if c == 'V':
+                window_sizes.append((128, 128))
+            elif c == 'L':
+                window_sizes.append((args.train_seq_len, args.train_seq_len))
+            else:
+                window_sizes.append((args.train_seq_len, args.train_seq_len))
+        # Force last layer to full context
+        window_sizes[-1] = (args.train_seq_len, args.train_seq_len)
+        return window_sizes
+
+    def _init_weights(self) -> None:
+        dim = self.args.model_dim
+        num_layers = self.args.num_layers
+
+        # Tied embedding: small normal
+        nn.init.normal_(self.tok_emb.weight, mean=0.0, std=0.005)
+
+        # VE embedding
+        nn.init.normal_(self.ve_embed.weight, mean=0.0, std=0.02)
+        nn.init.zeros_(self.ve_proj.weight)
+
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj." in name or name.endswith(".proj"):
+                        module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        args = self.args
+        B, T = input_ids.shape
+
+        # Embedding pipeline
+        x = self.tok_emb(input_ids)
+        x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+
+        # Precompute VE for layers that need it
+        ve_base = None
+        if args.ve_layers:
+            ve_base = self.ve_proj(self.ve_embed(input_ids))  # (B, T, kv_dim)
+
+        # Forward through hybrid layers
+        for i, block in enumerate(self.blocks):
+            v_embed = None
+            if ve_base is not None and str(i) in self.ve_scales:
+                v_embed = ve_base * self.ve_scales[str(i)].to(dtype=ve_base.dtype)
+            x = block(x, x0, self.window_sizes[i], v_embed=v_embed)
+
+        # Output head
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        logits = F.linear(x, self.tok_emb.weight)  # tied embeddings
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+
+# ---------------------------------------------------------------------------
+# Training
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # Distributed + CUDA setup
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Compute grad accumulation steps
+    tokens_per_micro = (args.train_batch_tokens // world_size)
+    device_batch_size = tokens_per_micro // args.train_seq_len
+    if device_batch_size < 1:
+        device_batch_size = 1
+    actual_tokens_per_step = device_batch_size * args.train_seq_len * world_size
+    grad_accum_steps = max(1, args.train_batch_tokens // actual_tokens_per_step)
+    grad_scale = 1.0 / grad_accum_steps
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(f"World size: {world_size}, Grad accum: {grad_accum_steps}, Device batch: {device_batch_size}")
+
+    # Tokenizer + validation setup
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+
+    # Model setup
+    base_model = GPT(args).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+
+    compiled_model = torch.compile(base_model, dynamic=False)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    # Optimizer setup
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p for name, p in block_named_params
+        if p.ndim == 2 and not any(pat in name for pat in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p for name, p in block_named_params
+        if p.ndim < 2 or any(pat in name for pat in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+
+    # Embedding params: tok_emb + bigram + ve_embed
+    embed_params = [base_model.tok_emb.weight, base_model.bigram.embed.weight, base_model.ve_embed.weight]
+    # Scalar control params not in blocks
+    other_scalar_params = [
+        base_model.bigram.scale,
+        base_model.smear.gate,
+    ]
+    for key in base_model.ve_scales:
+        other_scalar_params.append(base_model.ve_scales[key])
+    scalar_params.extend(other_scalar_params)
+
+    # VE proj and bigram proj are matrix params
+    ve_proj_params = [p for p in base_model.ve_proj.parameters() if p.ndim == 2]
+    bigram_proj_params = [p for p in base_model.bigram.proj.parameters() if p.ndim == 2]
+    matrix_params.extend(ve_proj_params)
+    matrix_params.extend(bigram_proj_params)
+
+    optimizer_embed = torch.optim.Adam(
+        [{"params": embed_params, "lr": args.embed_lr, "base_lr": args.embed_lr}],
+        betas=(args.beta1, args.beta2),
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        wd=args.muon_wd,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_embed, optimizer_muon, optimizer_scalar]
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model params: {n_params:,} ({n_params / 1e6:.1f}M)")
+    log0(f"Attention layers: {args.attn_layers}")
+    log0(f"Window pattern: {args.window_pattern}")
+    log0(f"Train seq len: {args.train_seq_len}")
+    log0(f"Train batch tokens: {args.train_batch_tokens:,}")
+    log0(f"Max wallclock: {args.max_wallclock_seconds}s")
+
+    # Data loader
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            return 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # EMA state
+    ema_state: dict[str, Tensor] = {}
+    for name, t in base_model.state_dict().items():
+        ema_state[name] = t.detach().float().clone()
+
+    # Warmup (primes torch.compile, then reset)
+    if args.warmup_steps > 0:
+        initial_model_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        initial_ema = {name: t.clone() for name, t in ema_state.items()}
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if warmup_step + 1 == args.warmup_steps or (warmup_step + 1) % 5 == 0:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        # Reset everything
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        ema_state = initial_ema
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # Main training loop
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+
+        # Enable QAT near end of training
+        CastedLinear._qat_enabled = scale < args.late_qat_threshold
+
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        # Muon momentum warmup
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        # LR schedule
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        # Grad clipping
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        # EMA update
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(args.ema_decay).add_(t.detach().float(), alpha=1.0 - args.ema_decay)
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log = args.train_log_every > 0 and (step <= 10 or step % args.train_log_every == 0)
+        if should_log:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"lr_scale:{scale:.3f} train_time:{approx_training_time_ms:.0f}ms "
+                f"step_avg:{approx_training_time_ms / step:.1f}ms"
+            )
+
+        # GC management
+        if step == 1:
+            gc.collect()
+            gc.freeze()
+            gc.disable()
+
+        # Wallclock cap sync
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(f"Training complete. Steps: {step}")
+    log0(f"Peak VRAM: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB")
+
+    # Apply EMA weights
+    log0("Applying EMA weights...")
+    current_state = base_model.state_dict()
+    avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+    base_model.load_state_dict(avg_state, strict=True)
+
+    # Eval before quantization
+    if master_process:
+        torch.cuda.synchronize()
+        val_loss, val_bpb = eval_val(
+            args, model, rank, world_size, device, grad_accum_steps,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        )
+        log0(f"EMA val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f}")
+
+    # Quantize + compress
+    quant_obj, quant_stats = quantize_state_dict_int6(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int6.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Compressed model: {quant_file_bytes:,} bytes")
+        log0(f"Code size: {code_bytes:,} bytes")
+        log0(f"Total artifact: {quant_file_bytes + code_bytes:,} bytes")
+
+    # Roundtrip validation
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int6(quant_state), strict=True)
+
+    torch.cuda.synchronize()
+    q_val_loss, q_val_bpb = eval_val(
+        args, model, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    log0(f"Roundtrip int6+zlib val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f}")
+    log0(f"Roundtrip exact val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-03-28_HybridRWKV_TokenShift_ShortWindowAttn/train_seed0.log
+++ b/records/track_non_record_16mb/2026-03-28_HybridRWKV_TokenShift_ShortWindowAttn/train_seed0.log
@@ -1,0 +1,143 @@
+W0327 08:07:55.537000 2031 torch/distributed/run.py:774] 
+W0327 08:07:55.537000 2031 torch/distributed/run.py:774] *****************************************
+W0327 08:07:55.537000 2031 torch/distributed/run.py:774] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0327 08:07:55.537000 2031 torch/distributed/run.py:774] *****************************************
+logs/c7a7ada5-e008-4826-a7d6-d265250f566b.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:17059912
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=True(FA3) flash=False mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:524288 train_seq_len:1024 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:0
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9368 val_bpb:4.1084 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9369 train_time:35ms step_avg:35.09ms
+step:2/20000 train_loss:17.0275 train_time:70ms step_avg:35.02ms
+step:3/20000 train_loss:8.9494 train_time:109ms step_avg:36.19ms
+step:4/20000 train_loss:6.6209 train_time:148ms step_avg:36.91ms
+step:5/20000 train_loss:6.6141 train_time:189ms step_avg:37.79ms
+step:6/20000 train_loss:7.4188 train_time:232ms step_avg:38.63ms
+step:7/20000 train_loss:6.3968 train_time:269ms step_avg:38.42ms
+step:8/20000 train_loss:6.1943 train_time:308ms step_avg:38.52ms
+step:9/20000 train_loss:6.0812 train_time:348ms step_avg:38.66ms
+step:10/20000 train_loss:6.0010 train_time:388ms step_avg:38.79ms
+step:200/20000 train_loss:2.8393 train_time:8120ms step_avg:40.60ms
+step:400/20000 train_loss:2.3568 train_time:16270ms step_avg:40.68ms
+step:600/20000 train_loss:2.5462 train_time:24511ms step_avg:40.85ms
+step:800/20000 train_loss:2.2922 train_time:32670ms step_avg:40.84ms
+step:1000/20000 train_loss:2.3681 train_time:40859ms step_avg:40.86ms
+step:1000/20000 val_loss:2.3312 val_bpb:1.3807 train_time:40870ms step_avg:40.87ms
+step:1200/20000 train_loss:2.3861 train_time:49068ms step_avg:40.89ms
+step:1400/20000 train_loss:2.4282 train_time:57275ms step_avg:40.91ms
+step:1600/20000 train_loss:2.0988 train_time:65491ms step_avg:40.93ms
+step:1800/20000 train_loss:2.1955 train_time:73710ms step_avg:40.95ms
+step:2000/20000 train_loss:2.2503 train_time:81935ms step_avg:40.97ms
+step:2000/20000 val_loss:2.2343 val_bpb:1.3233 train_time:81944ms step_avg:40.97ms
+step:2200/20000 train_loss:2.0735 train_time:90156ms step_avg:40.98ms
+step:2400/20000 train_loss:2.2033 train_time:98371ms step_avg:40.99ms
+step:2600/20000 train_loss:2.4158 train_time:106588ms step_avg:41.00ms
+step:2800/20000 train_loss:2.2356 train_time:114791ms step_avg:41.00ms
+step:3000/20000 train_loss:2.2276 train_time:122998ms step_avg:41.00ms
+step:3000/20000 val_loss:2.1941 val_bpb:1.2995 train_time:123011ms step_avg:41.00ms
+step:3200/20000 train_loss:2.1897 train_time:131217ms step_avg:41.01ms
+step:3400/20000 train_loss:2.1590 train_time:139418ms step_avg:41.01ms
+step:3600/20000 train_loss:2.1150 train_time:147618ms step_avg:41.00ms
+step:3800/20000 train_loss:2.2176 train_time:155793ms step_avg:41.00ms
+step:4000/20000 train_loss:2.1632 train_time:163989ms step_avg:41.00ms
+step:4000/20000 val_loss:2.1694 val_bpb:1.2849 train_time:163998ms step_avg:41.00ms
+step:4200/20000 train_loss:2.1702 train_time:172295ms step_avg:41.02ms
+step:4400/20000 train_loss:2.1122 train_time:180473ms step_avg:41.02ms
+step:4600/20000 train_loss:1.9719 train_time:188658ms step_avg:41.01ms
+step:4800/20000 train_loss:2.2648 train_time:196822ms step_avg:41.00ms
+step:5000/20000 train_loss:2.0337 train_time:204989ms step_avg:41.00ms
+step:5000/20000 val_loss:2.1527 val_bpb:1.2750 train_time:204999ms step_avg:41.00ms
+step:5200/20000 train_loss:2.1731 train_time:213143ms step_avg:40.99ms
+step:5400/20000 train_loss:2.1910 train_time:221305ms step_avg:40.98ms
+step:5600/20000 train_loss:2.1823 train_time:229471ms step_avg:40.98ms
+step:5800/20000 train_loss:2.1428 train_time:237632ms step_avg:40.97ms
+step:6000/20000 train_loss:2.2191 train_time:245796ms step_avg:40.97ms
+step:6000/20000 val_loss:2.1426 val_bpb:1.2690 train_time:245804ms step_avg:40.97ms
+step:6200/20000 train_loss:2.0903 train_time:253954ms step_avg:40.96ms
+step:6400/20000 train_loss:2.1607 train_time:262090ms step_avg:40.95ms
+step:6600/20000 train_loss:2.1170 train_time:270237ms step_avg:40.94ms
+step:6800/20000 train_loss:2.1923 train_time:278408ms step_avg:40.94ms
+step:7000/20000 train_loss:2.2221 train_time:286563ms step_avg:40.94ms
+step:7000/20000 val_loss:2.1321 val_bpb:1.2627 train_time:286571ms step_avg:40.94ms
+step:7200/20000 train_loss:2.2013 train_time:294712ms step_avg:40.93ms
+step:7400/20000 train_loss:2.1184 train_time:302869ms step_avg:40.93ms
+step:7600/20000 train_loss:2.0021 train_time:311021ms step_avg:40.92ms
+step:7800/20000 train_loss:2.1472 train_time:319179ms step_avg:40.92ms
+step:8000/20000 train_loss:2.1139 train_time:327338ms step_avg:40.92ms
+step:8000/20000 val_loss:2.1229 val_bpb:1.2573 train_time:327347ms step_avg:40.92ms
+step:8200/20000 train_loss:2.1870 train_time:335484ms step_avg:40.91ms
+step:8400/20000 train_loss:2.1323 train_time:343764ms step_avg:40.92ms
+step:8600/20000 train_loss:2.1405 train_time:351920ms step_avg:40.92ms
+step:8800/20000 train_loss:2.1041 train_time:360084ms step_avg:40.92ms
+step:9000/20000 train_loss:2.0279 train_time:368247ms step_avg:40.92ms
+step:9000/20000 val_loss:2.1177 val_bpb:1.2542 train_time:368256ms step_avg:40.92ms
+step:9200/20000 train_loss:2.0823 train_time:376380ms step_avg:40.91ms
+step:9400/20000 train_loss:2.1308 train_time:384531ms step_avg:40.91ms
+step:9600/20000 train_loss:2.1503 train_time:392689ms step_avg:40.91ms
+step:9800/20000 train_loss:2.0725 train_time:400848ms step_avg:40.90ms
+step:10000/20000 train_loss:2.1141 train_time:409003ms step_avg:40.90ms
+step:10000/20000 val_loss:2.1123 val_bpb:1.2510 train_time:409012ms step_avg:40.90ms
+step:10200/20000 train_loss:2.0649 train_time:417159ms step_avg:40.90ms
+step:10400/20000 train_loss:2.1021 train_time:425310ms step_avg:40.90ms
+step:10600/20000 train_loss:1.9784 train_time:433471ms step_avg:40.89ms
+step:10800/20000 train_loss:2.1851 train_time:441631ms step_avg:40.89ms
+step:11000/20000 train_loss:2.1142 train_time:449776ms step_avg:40.89ms
+step:11000/20000 val_loss:2.1054 val_bpb:1.2469 train_time:449791ms step_avg:40.89ms
+step:11200/20000 train_loss:2.0713 train_time:457921ms step_avg:40.89ms
+step:11400/20000 train_loss:2.0556 train_time:466071ms step_avg:40.88ms
+step:11600/20000 train_loss:2.0636 train_time:474243ms step_avg:40.88ms
+step:11800/20000 train_loss:2.0955 train_time:482408ms step_avg:40.88ms
+step:12000/20000 train_loss:2.0734 train_time:490558ms step_avg:40.88ms
+step:12000/20000 val_loss:2.1008 val_bpb:1.2442 train_time:490567ms step_avg:40.88ms
+step:12200/20000 train_loss:2.2160 train_time:498715ms step_avg:40.88ms
+step:12400/20000 train_loss:1.8614 train_time:506993ms step_avg:40.89ms
+step:12600/20000 train_loss:2.0946 train_time:515139ms step_avg:40.88ms
+step:12800/20000 train_loss:2.1143 train_time:523289ms step_avg:40.88ms
+step:13000/20000 train_loss:2.1906 train_time:531447ms step_avg:40.88ms
+step:13000/20000 val_loss:2.0996 val_bpb:1.2435 train_time:531457ms step_avg:40.88ms
+step:13200/20000 train_loss:2.2019 train_time:539591ms step_avg:40.88ms
+step:13400/20000 train_loss:2.0754 train_time:547736ms step_avg:40.88ms
+step:13600/20000 train_loss:1.9447 train_time:555896ms step_avg:40.87ms
+step:13800/20000 train_loss:2.0304 train_time:564048ms step_avg:40.87ms
+step:14000/20000 train_loss:2.0831 train_time:572208ms step_avg:40.87ms
+step:14000/20000 val_loss:2.0781 val_bpb:1.2307 train_time:572218ms step_avg:40.87ms
+step:14200/20000 train_loss:2.1588 train_time:580360ms step_avg:40.87ms
+step:14400/20000 train_loss:2.0539 train_time:588514ms step_avg:40.87ms
+step:14600/20000 train_loss:2.1072 train_time:596673ms step_avg:40.87ms
+step:14683/20000 val_loss:2.0560 val_bpb:1.2177 train_time:600018ms step_avg:40.86ms
+stopping_early: wallclock_cap train_time:600018ms step:14683/20000
+peak memory allocated: 10182 MiB reserved: 10814 MiB
+Serialized model: 67224983 bytes
+Code size: 47691 bytes
+Total submission size: 67272674 bytes
+Serialized model int8+zlib: 15811871 bytes (payload:17178912 raw_torch:17224025 payload_ratio:3.91x)
+Total submission size int8+zlib: 15859562 bytes
+final_int8_zlib_roundtrip val_loss:2.0689 val_bpb:1.2253 eval_time:1328ms
+final_int8_zlib_roundtrip_exact val_loss:2.06889123 val_bpb:1.22531392

--- a/records/track_non_record_16mb/2026-03-28_HybridRWKV_TokenShift_ShortWindowAttn/train_seed1337.log
+++ b/records/track_non_record_16mb/2026-03-28_HybridRWKV_TokenShift_ShortWindowAttn/train_seed1337.log
@@ -1,0 +1,202 @@
+W0327 07:27:03.749000 47887 torch/distributed/run.py:774] 
+W0327 07:27:03.749000 47887 torch/distributed/run.py:774] *****************************************
+W0327 07:27:03.749000 47887 torch/distributed/run.py:774] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0327 07:27:03.749000 47887 torch/distributed/run.py:774] *****************************************
+logs/bench_seed1337.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:17059912
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=True(FA3) flash=False mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:524288 train_seq_len:1024 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9357 val_bpb:4.1077 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9370 train_time:32ms step_avg:31.61ms
+step:2/20000 train_loss:16.8366 train_time:67ms step_avg:33.57ms
+step:3/20000 train_loss:8.7597 train_time:107ms step_avg:35.66ms
+step:4/20000 train_loss:6.6384 train_time:148ms step_avg:36.89ms
+step:5/20000 train_loss:6.6122 train_time:188ms step_avg:37.52ms
+step:6/20000 train_loss:7.4222 train_time:227ms step_avg:37.84ms
+step:7/20000 train_loss:6.3506 train_time:267ms step_avg:38.10ms
+step:8/20000 train_loss:6.1581 train_time:307ms step_avg:38.35ms
+step:9/20000 train_loss:6.0679 train_time:346ms step_avg:38.47ms
+step:10/20000 train_loss:5.9744 train_time:386ms step_avg:38.58ms
+step:200/20000 train_loss:2.8514 train_time:8114ms step_avg:40.57ms
+step:200/20000 val_loss:2.8467 val_bpb:1.6860 train_time:8126ms step_avg:40.63ms
+step:400/20000 train_loss:2.3520 train_time:16256ms step_avg:40.64ms
+step:400/20000 val_loss:2.5631 val_bpb:1.5180 train_time:16266ms step_avg:40.67ms
+step:600/20000 train_loss:2.5486 train_time:24399ms step_avg:40.67ms
+step:600/20000 val_loss:2.4516 val_bpb:1.4520 train_time:24411ms step_avg:40.68ms
+step:800/20000 train_loss:2.2961 train_time:32556ms step_avg:40.70ms
+step:800/20000 val_loss:2.3833 val_bpb:1.4115 train_time:32567ms step_avg:40.71ms
+step:1000/20000 train_loss:2.3768 train_time:40735ms step_avg:40.73ms
+step:1000/20000 val_loss:2.3370 val_bpb:1.3841 train_time:40747ms step_avg:40.75ms
+step:1200/20000 train_loss:2.3891 train_time:48919ms step_avg:40.77ms
+step:1200/20000 val_loss:2.3072 val_bpb:1.3665 train_time:48930ms step_avg:40.77ms
+step:1400/20000 train_loss:2.4309 train_time:57124ms step_avg:40.80ms
+step:1400/20000 val_loss:2.2828 val_bpb:1.3520 train_time:57135ms step_avg:40.81ms
+step:1600/20000 train_loss:2.0963 train_time:65330ms step_avg:40.83ms
+step:1600/20000 val_loss:2.2680 val_bpb:1.3433 train_time:65341ms step_avg:40.84ms
+step:1800/20000 train_loss:2.1979 train_time:73541ms step_avg:40.86ms
+step:1800/20000 val_loss:2.2520 val_bpb:1.3338 train_time:73552ms step_avg:40.86ms
+step:2000/20000 train_loss:2.2467 train_time:81749ms step_avg:40.87ms
+step:2000/20000 val_loss:2.2372 val_bpb:1.3250 train_time:81760ms step_avg:40.88ms
+step:2200/20000 train_loss:2.0736 train_time:90005ms step_avg:40.91ms
+step:2200/20000 val_loss:2.2278 val_bpb:1.3194 train_time:90028ms step_avg:40.92ms
+step:2400/20000 train_loss:2.2037 train_time:98218ms step_avg:40.92ms
+step:2400/20000 val_loss:2.2174 val_bpb:1.3133 train_time:98229ms step_avg:40.93ms
+step:2600/20000 train_loss:2.4125 train_time:106411ms step_avg:40.93ms
+step:2600/20000 val_loss:2.2201 val_bpb:1.3149 train_time:106422ms step_avg:40.93ms
+step:2800/20000 train_loss:2.2361 train_time:114592ms step_avg:40.93ms
+step:2800/20000 val_loss:2.2030 val_bpb:1.3048 train_time:114603ms step_avg:40.93ms
+step:3000/20000 train_loss:2.2257 train_time:122776ms step_avg:40.93ms
+step:3000/20000 val_loss:2.1955 val_bpb:1.3003 train_time:122786ms step_avg:40.93ms
+step:3200/20000 train_loss:2.1922 train_time:130958ms step_avg:40.92ms
+step:3200/20000 val_loss:2.1902 val_bpb:1.2971 train_time:130969ms step_avg:40.93ms
+step:3400/20000 train_loss:2.1575 train_time:139121ms step_avg:40.92ms
+step:3400/20000 val_loss:2.1874 val_bpb:1.2955 train_time:139132ms step_avg:40.92ms
+step:3600/20000 train_loss:2.1134 train_time:147285ms step_avg:40.91ms
+step:3600/20000 val_loss:2.1795 val_bpb:1.2909 train_time:147296ms step_avg:40.92ms
+step:3800/20000 train_loss:2.2218 train_time:155458ms step_avg:40.91ms
+step:3800/20000 val_loss:2.1754 val_bpb:1.2884 train_time:155469ms step_avg:40.91ms
+step:4000/20000 train_loss:2.1663 train_time:163621ms step_avg:40.91ms
+step:4000/20000 val_loss:2.1712 val_bpb:1.2859 train_time:163631ms step_avg:40.91ms
+step:4200/20000 train_loss:2.1762 train_time:171909ms step_avg:40.93ms
+step:4200/20000 val_loss:2.1668 val_bpb:1.2833 train_time:171918ms step_avg:40.93ms
+step:4400/20000 train_loss:2.1171 train_time:180051ms step_avg:40.92ms
+step:4400/20000 val_loss:2.1672 val_bpb:1.2835 train_time:180061ms step_avg:40.92ms
+step:4600/20000 train_loss:1.9710 train_time:188187ms step_avg:40.91ms
+step:4600/20000 val_loss:2.1626 val_bpb:1.2808 train_time:188210ms step_avg:40.92ms
+step:4800/20000 train_loss:2.2660 train_time:196341ms step_avg:40.90ms
+step:4800/20000 val_loss:2.1584 val_bpb:1.2783 train_time:196351ms step_avg:40.91ms
+step:5000/20000 train_loss:2.0276 train_time:204473ms step_avg:40.89ms
+step:5000/20000 val_loss:2.1538 val_bpb:1.2756 train_time:204482ms step_avg:40.90ms
+step:5200/20000 train_loss:2.1720 train_time:212600ms step_avg:40.88ms
+step:5200/20000 val_loss:2.1544 val_bpb:1.2759 train_time:212612ms step_avg:40.89ms
+step:5400/20000 train_loss:2.1865 train_time:220760ms step_avg:40.88ms
+step:5400/20000 val_loss:2.1497 val_bpb:1.2732 train_time:220771ms step_avg:40.88ms
+step:5600/20000 train_loss:2.1827 train_time:228915ms step_avg:40.88ms
+step:5600/20000 val_loss:2.1498 val_bpb:1.2732 train_time:228924ms step_avg:40.88ms
+step:5800/20000 train_loss:2.1446 train_time:237061ms step_avg:40.87ms
+step:5800/20000 val_loss:2.1472 val_bpb:1.2717 train_time:237072ms step_avg:40.87ms
+step:6000/20000 train_loss:2.2227 train_time:245213ms step_avg:40.87ms
+step:6000/20000 val_loss:2.1437 val_bpb:1.2696 train_time:245224ms step_avg:40.87ms
+step:6200/20000 train_loss:2.0877 train_time:253353ms step_avg:40.86ms
+step:6200/20000 val_loss:2.1428 val_bpb:1.2691 train_time:253364ms step_avg:40.87ms
+step:6400/20000 train_loss:2.1599 train_time:261497ms step_avg:40.86ms
+step:6400/20000 val_loss:2.1392 val_bpb:1.2670 train_time:261508ms step_avg:40.86ms
+step:6600/20000 train_loss:2.1235 train_time:269641ms step_avg:40.85ms
+step:6600/20000 val_loss:2.1360 val_bpb:1.2650 train_time:269651ms step_avg:40.86ms
+step:6800/20000 train_loss:2.1911 train_time:277784ms step_avg:40.85ms
+step:6800/20000 val_loss:2.1352 val_bpb:1.2646 train_time:277794ms step_avg:40.85ms
+step:7000/20000 train_loss:2.2267 train_time:285924ms step_avg:40.85ms
+step:7000/20000 val_loss:2.1328 val_bpb:1.2631 train_time:285934ms step_avg:40.85ms
+step:7200/20000 train_loss:2.1969 train_time:294065ms step_avg:40.84ms
+step:7200/20000 val_loss:2.1328 val_bpb:1.2632 train_time:294077ms step_avg:40.84ms
+step:7400/20000 train_loss:2.1186 train_time:302210ms step_avg:40.84ms
+step:7400/20000 val_loss:2.1291 val_bpb:1.2610 train_time:302220ms step_avg:40.84ms
+step:7600/20000 train_loss:2.0002 train_time:310350ms step_avg:40.84ms
+step:7600/20000 val_loss:2.1282 val_bpb:1.2604 train_time:310361ms step_avg:40.84ms
+step:7800/20000 train_loss:2.1462 train_time:318493ms step_avg:40.83ms
+step:7800/20000 val_loss:2.1253 val_bpb:1.2587 train_time:318503ms step_avg:40.83ms
+step:8000/20000 train_loss:2.1161 train_time:326647ms step_avg:40.83ms
+step:8000/20000 val_loss:2.1231 val_bpb:1.2574 train_time:326658ms step_avg:40.83ms
+step:8200/20000 train_loss:2.1907 train_time:334777ms step_avg:40.83ms
+step:8200/20000 val_loss:2.1218 val_bpb:1.2566 train_time:334786ms step_avg:40.83ms
+step:8400/20000 train_loss:2.1357 train_time:343023ms step_avg:40.84ms
+step:8400/20000 val_loss:2.1217 val_bpb:1.2566 train_time:343034ms step_avg:40.84ms
+step:8600/20000 train_loss:2.1405 train_time:351153ms step_avg:40.83ms
+step:8600/20000 val_loss:2.1181 val_bpb:1.2544 train_time:351164ms step_avg:40.83ms
+step:8800/20000 train_loss:2.1009 train_time:359291ms step_avg:40.83ms
+step:8800/20000 val_loss:2.1176 val_bpb:1.2542 train_time:359302ms step_avg:40.83ms
+step:9000/20000 train_loss:2.0255 train_time:367419ms step_avg:40.82ms
+step:9000/20000 val_loss:2.1176 val_bpb:1.2542 train_time:367429ms step_avg:40.83ms
+step:9200/20000 train_loss:2.0848 train_time:375536ms step_avg:40.82ms
+step:9200/20000 val_loss:2.1155 val_bpb:1.2529 train_time:375547ms step_avg:40.82ms
+step:9400/20000 train_loss:2.1353 train_time:383671ms step_avg:40.82ms
+step:9400/20000 val_loss:2.1141 val_bpb:1.2521 train_time:383682ms step_avg:40.82ms
+step:9600/20000 train_loss:2.1492 train_time:391817ms step_avg:40.81ms
+step:9600/20000 val_loss:2.1129 val_bpb:1.2514 train_time:391827ms step_avg:40.82ms
+step:9800/20000 train_loss:2.0714 train_time:399943ms step_avg:40.81ms
+step:9800/20000 val_loss:2.1126 val_bpb:1.2512 train_time:399954ms step_avg:40.81ms
+step:10000/20000 train_loss:2.1149 train_time:408082ms step_avg:40.81ms
+step:10000/20000 val_loss:2.1126 val_bpb:1.2512 train_time:408093ms step_avg:40.81ms
+step:10200/20000 train_loss:2.0669 train_time:416221ms step_avg:40.81ms
+step:10200/20000 val_loss:2.1089 val_bpb:1.2490 train_time:416231ms step_avg:40.81ms
+step:10400/20000 train_loss:2.1009 train_time:424351ms step_avg:40.80ms
+step:10400/20000 val_loss:2.1089 val_bpb:1.2490 train_time:424361ms step_avg:40.80ms
+step:10600/20000 train_loss:1.9735 train_time:432493ms step_avg:40.80ms
+step:10600/20000 val_loss:2.1088 val_bpb:1.2490 train_time:432503ms step_avg:40.80ms
+step:10800/20000 train_loss:2.1890 train_time:440635ms step_avg:40.80ms
+step:10800/20000 val_loss:2.1071 val_bpb:1.2479 train_time:440645ms step_avg:40.80ms
+step:11000/20000 train_loss:2.1146 train_time:448768ms step_avg:40.80ms
+step:11000/20000 val_loss:2.1054 val_bpb:1.2469 train_time:448779ms step_avg:40.80ms
+step:11200/20000 train_loss:2.0742 train_time:456900ms step_avg:40.79ms
+step:11200/20000 val_loss:2.1046 val_bpb:1.2465 train_time:456910ms step_avg:40.80ms
+step:11400/20000 train_loss:2.0571 train_time:465042ms step_avg:40.79ms
+step:11400/20000 val_loss:2.1051 val_bpb:1.2468 train_time:465052ms step_avg:40.79ms
+step:11600/20000 train_loss:2.0636 train_time:473163ms step_avg:40.79ms
+step:11600/20000 val_loss:2.1040 val_bpb:1.2461 train_time:473175ms step_avg:40.79ms
+step:11800/20000 train_loss:2.0938 train_time:481308ms step_avg:40.79ms
+step:11800/20000 val_loss:2.1021 val_bpb:1.2450 train_time:481320ms step_avg:40.79ms
+step:12000/20000 train_loss:2.0700 train_time:489453ms step_avg:40.79ms
+step:12000/20000 val_loss:2.1006 val_bpb:1.2441 train_time:489463ms step_avg:40.79ms
+step:12200/20000 train_loss:2.2185 train_time:497577ms step_avg:40.79ms
+step:12200/20000 val_loss:2.1003 val_bpb:1.2439 train_time:497587ms step_avg:40.79ms
+step:12400/20000 train_loss:1.8629 train_time:505820ms step_avg:40.79ms
+step:12400/20000 val_loss:2.1003 val_bpb:1.2439 train_time:505829ms step_avg:40.79ms
+step:12600/20000 train_loss:2.0883 train_time:513941ms step_avg:40.79ms
+step:12600/20000 val_loss:2.1012 val_bpb:1.2444 train_time:513952ms step_avg:40.79ms
+step:12800/20000 train_loss:2.1111 train_time:522071ms step_avg:40.79ms
+step:12800/20000 val_loss:2.0990 val_bpb:1.2432 train_time:522081ms step_avg:40.79ms
+step:13000/20000 train_loss:2.1916 train_time:530197ms step_avg:40.78ms
+step:13000/20000 val_loss:2.0994 val_bpb:1.2434 train_time:530208ms step_avg:40.79ms
+step:13200/20000 train_loss:2.2038 train_time:538323ms step_avg:40.78ms
+step:13200/20000 val_loss:2.0960 val_bpb:1.2413 train_time:538334ms step_avg:40.78ms
+step:13400/20000 train_loss:2.0801 train_time:546462ms step_avg:40.78ms
+step:13400/20000 val_loss:2.0963 val_bpb:1.2415 train_time:546474ms step_avg:40.78ms
+step:13600/20000 train_loss:1.9467 train_time:554597ms step_avg:40.78ms
+step:13600/20000 val_loss:2.0963 val_bpb:1.2415 train_time:554608ms step_avg:40.78ms
+step:13800/20000 train_loss:2.0290 train_time:562739ms step_avg:40.78ms
+step:13800/20000 val_loss:2.0855 val_bpb:1.2352 train_time:562750ms step_avg:40.78ms
+step:14000/20000 train_loss:2.0818 train_time:570868ms step_avg:40.78ms
+step:14000/20000 val_loss:2.0792 val_bpb:1.2314 train_time:570879ms step_avg:40.78ms
+step:14200/20000 train_loss:2.1595 train_time:578990ms step_avg:40.77ms
+step:14200/20000 val_loss:2.0725 val_bpb:1.2275 train_time:579001ms step_avg:40.77ms
+step:14400/20000 train_loss:2.0580 train_time:587115ms step_avg:40.77ms
+step:14400/20000 val_loss:2.0642 val_bpb:1.2226 train_time:587126ms step_avg:40.77ms
+step:14600/20000 train_loss:2.1048 train_time:595239ms step_avg:40.77ms
+step:14600/20000 val_loss:2.0576 val_bpb:1.2186 train_time:595251ms step_avg:40.77ms
+step:14716/20000 val_loss:2.0551 val_bpb:1.2172 train_time:600011ms step_avg:40.77ms
+stopping_early: wallclock_cap train_time:600011ms step:14716/20000
+peak memory allocated: 10182 MiB reserved: 10638 MiB
+Serialized model: 67224983 bytes
+Code size: 47691 bytes
+Total submission size: 67272674 bytes
+Serialized model int8+zlib: 15815855 bytes (payload:17178912 raw_torch:17224025 payload_ratio:3.91x)
+Total submission size int8+zlib: 15863546 bytes
+final_int8_zlib_roundtrip val_loss:2.0682 val_bpb:1.2249 eval_time:1323ms
+final_int8_zlib_roundtrip_exact val_loss:2.06815860 val_bpb:1.22488002

--- a/records/track_non_record_16mb/2026-03-28_HybridRWKV_TokenShift_ShortWindowAttn/train_seed42.log
+++ b/records/track_non_record_16mb/2026-03-28_HybridRWKV_TokenShift_ShortWindowAttn/train_seed42.log
@@ -1,0 +1,202 @@
+W0327 07:40:16.788000 50441 torch/distributed/run.py:774] 
+W0327 07:40:16.788000 50441 torch/distributed/run.py:774] *****************************************
+W0327 07:40:16.788000 50441 torch/distributed/run.py:774] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0327 07:40:16.788000 50441 torch/distributed/run.py:774] *****************************************
+logs/bench_seed42.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:17059912
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=True(FA3) flash=False mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:524288 train_seq_len:1024 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:42
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9374 val_bpb:4.1087 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9365 train_time:31ms step_avg:31.05ms
+step:2/20000 train_loss:16.8867 train_time:69ms step_avg:34.61ms
+step:3/20000 train_loss:8.7477 train_time:110ms step_avg:36.82ms
+step:4/20000 train_loss:6.6323 train_time:150ms step_avg:37.40ms
+step:5/20000 train_loss:6.6019 train_time:194ms step_avg:38.70ms
+step:6/20000 train_loss:7.4052 train_time:230ms step_avg:38.32ms
+step:7/20000 train_loss:6.3298 train_time:269ms step_avg:38.49ms
+step:8/20000 train_loss:6.1950 train_time:309ms step_avg:38.66ms
+step:9/20000 train_loss:6.0810 train_time:349ms step_avg:38.77ms
+step:10/20000 train_loss:5.9908 train_time:394ms step_avg:39.41ms
+step:200/20000 train_loss:2.8611 train_time:8129ms step_avg:40.65ms
+step:200/20000 val_loss:2.8360 val_bpb:1.6796 train_time:8141ms step_avg:40.70ms
+step:400/20000 train_loss:2.3659 train_time:16270ms step_avg:40.68ms
+step:400/20000 val_loss:2.5697 val_bpb:1.5219 train_time:16282ms step_avg:40.70ms
+step:600/20000 train_loss:2.5499 train_time:24405ms step_avg:40.67ms
+step:600/20000 val_loss:2.4525 val_bpb:1.4525 train_time:24416ms step_avg:40.69ms
+step:800/20000 train_loss:2.2990 train_time:32541ms step_avg:40.68ms
+step:800/20000 val_loss:2.3841 val_bpb:1.4120 train_time:32552ms step_avg:40.69ms
+step:1000/20000 train_loss:2.3769 train_time:40689ms step_avg:40.69ms
+step:1000/20000 val_loss:2.3379 val_bpb:1.3847 train_time:40702ms step_avg:40.70ms
+step:1200/20000 train_loss:2.3882 train_time:48836ms step_avg:40.70ms
+step:1200/20000 val_loss:2.3048 val_bpb:1.3650 train_time:48848ms step_avg:40.71ms
+step:1400/20000 train_loss:2.4383 train_time:56991ms step_avg:40.71ms
+step:1400/20000 val_loss:2.2825 val_bpb:1.3518 train_time:57002ms step_avg:40.72ms
+step:1600/20000 train_loss:2.0994 train_time:65171ms step_avg:40.73ms
+step:1600/20000 val_loss:2.2680 val_bpb:1.3433 train_time:65183ms step_avg:40.74ms
+step:1800/20000 train_loss:2.1981 train_time:73336ms step_avg:40.74ms
+step:1800/20000 val_loss:2.2518 val_bpb:1.3336 train_time:73348ms step_avg:40.75ms
+step:2000/20000 train_loss:2.2513 train_time:81508ms step_avg:40.75ms
+step:2000/20000 val_loss:2.2368 val_bpb:1.3247 train_time:81519ms step_avg:40.76ms
+step:2200/20000 train_loss:2.0725 train_time:89685ms step_avg:40.77ms
+step:2200/20000 val_loss:2.2269 val_bpb:1.3189 train_time:89696ms step_avg:40.77ms
+step:2400/20000 train_loss:2.1980 train_time:97851ms step_avg:40.77ms
+step:2400/20000 val_loss:2.2179 val_bpb:1.3136 train_time:97862ms step_avg:40.78ms
+step:2600/20000 train_loss:2.4174 train_time:106011ms step_avg:40.77ms
+step:2600/20000 val_loss:2.2218 val_bpb:1.3159 train_time:106023ms step_avg:40.78ms
+step:2800/20000 train_loss:2.2374 train_time:114171ms step_avg:40.78ms
+step:2800/20000 val_loss:2.2035 val_bpb:1.3051 train_time:114182ms step_avg:40.78ms
+step:3000/20000 train_loss:2.2294 train_time:122337ms step_avg:40.78ms
+step:3000/20000 val_loss:2.1965 val_bpb:1.3009 train_time:122348ms step_avg:40.78ms
+step:3200/20000 train_loss:2.1909 train_time:130496ms step_avg:40.78ms
+step:3200/20000 val_loss:2.1903 val_bpb:1.2972 train_time:130508ms step_avg:40.78ms
+step:3400/20000 train_loss:2.1623 train_time:138651ms step_avg:40.78ms
+step:3400/20000 val_loss:2.1879 val_bpb:1.2958 train_time:138662ms step_avg:40.78ms
+step:3600/20000 train_loss:2.1191 train_time:146806ms step_avg:40.78ms
+step:3600/20000 val_loss:2.1793 val_bpb:1.2907 train_time:146818ms step_avg:40.78ms
+step:3800/20000 train_loss:2.2237 train_time:154957ms step_avg:40.78ms
+step:3800/20000 val_loss:2.1763 val_bpb:1.2890 train_time:154969ms step_avg:40.78ms
+step:4000/20000 train_loss:2.1644 train_time:163107ms step_avg:40.78ms
+step:4000/20000 val_loss:2.1714 val_bpb:1.2860 train_time:163118ms step_avg:40.78ms
+step:4200/20000 train_loss:2.1713 train_time:171375ms step_avg:40.80ms
+step:4200/20000 val_loss:2.1672 val_bpb:1.2835 train_time:171385ms step_avg:40.81ms
+step:4400/20000 train_loss:2.1147 train_time:179515ms step_avg:40.80ms
+step:4400/20000 val_loss:2.1676 val_bpb:1.2838 train_time:179527ms step_avg:40.80ms
+step:4600/20000 train_loss:1.9716 train_time:187635ms step_avg:40.79ms
+step:4600/20000 val_loss:2.1629 val_bpb:1.2810 train_time:187651ms step_avg:40.79ms
+step:4800/20000 train_loss:2.2635 train_time:195772ms step_avg:40.79ms
+step:4800/20000 val_loss:2.1590 val_bpb:1.2787 train_time:195783ms step_avg:40.79ms
+step:5000/20000 train_loss:2.0338 train_time:203897ms step_avg:40.78ms
+step:5000/20000 val_loss:2.1542 val_bpb:1.2758 train_time:203908ms step_avg:40.78ms
+step:5200/20000 train_loss:2.1768 train_time:212032ms step_avg:40.78ms
+step:5200/20000 val_loss:2.1548 val_bpb:1.2762 train_time:212041ms step_avg:40.78ms
+step:5400/20000 train_loss:2.1871 train_time:220163ms step_avg:40.77ms
+step:5400/20000 val_loss:2.1504 val_bpb:1.2736 train_time:220171ms step_avg:40.77ms
+step:5600/20000 train_loss:2.1846 train_time:228297ms step_avg:40.77ms
+step:5600/20000 val_loss:2.1502 val_bpb:1.2734 train_time:228306ms step_avg:40.77ms
+step:5800/20000 train_loss:2.1463 train_time:236421ms step_avg:40.76ms
+step:5800/20000 val_loss:2.1485 val_bpb:1.2725 train_time:236432ms step_avg:40.76ms
+step:6000/20000 train_loss:2.2223 train_time:244557ms step_avg:40.76ms
+step:6000/20000 val_loss:2.1441 val_bpb:1.2699 train_time:244568ms step_avg:40.76ms
+step:6200/20000 train_loss:2.0898 train_time:252690ms step_avg:40.76ms
+step:6200/20000 val_loss:2.1433 val_bpb:1.2694 train_time:252700ms step_avg:40.76ms
+step:6400/20000 train_loss:2.1647 train_time:260826ms step_avg:40.75ms
+step:6400/20000 val_loss:2.1403 val_bpb:1.2676 train_time:260837ms step_avg:40.76ms
+step:6600/20000 train_loss:2.1212 train_time:268962ms step_avg:40.75ms
+step:6600/20000 val_loss:2.1369 val_bpb:1.2656 train_time:268974ms step_avg:40.75ms
+step:6800/20000 train_loss:2.1940 train_time:277083ms step_avg:40.75ms
+step:6800/20000 val_loss:2.1365 val_bpb:1.2653 train_time:277094ms step_avg:40.75ms
+step:7000/20000 train_loss:2.2285 train_time:285206ms step_avg:40.74ms
+step:7000/20000 val_loss:2.1332 val_bpb:1.2634 train_time:285216ms step_avg:40.75ms
+step:7200/20000 train_loss:2.2017 train_time:293349ms step_avg:40.74ms
+step:7200/20000 val_loss:2.1333 val_bpb:1.2635 train_time:293359ms step_avg:40.74ms
+step:7400/20000 train_loss:2.1226 train_time:301474ms step_avg:40.74ms
+step:7400/20000 val_loss:2.1303 val_bpb:1.2617 train_time:301484ms step_avg:40.74ms
+step:7600/20000 train_loss:2.0006 train_time:309614ms step_avg:40.74ms
+step:7600/20000 val_loss:2.1290 val_bpb:1.2609 train_time:309624ms step_avg:40.74ms
+step:7800/20000 train_loss:2.1496 train_time:317756ms step_avg:40.74ms
+step:7800/20000 val_loss:2.1261 val_bpb:1.2592 train_time:317766ms step_avg:40.74ms
+step:8000/20000 train_loss:2.1141 train_time:325881ms step_avg:40.74ms
+step:8000/20000 val_loss:2.1245 val_bpb:1.2583 train_time:325891ms step_avg:40.74ms
+step:8200/20000 train_loss:2.1876 train_time:334005ms step_avg:40.73ms
+step:8200/20000 val_loss:2.1227 val_bpb:1.2572 train_time:334015ms step_avg:40.73ms
+step:8400/20000 train_loss:2.1352 train_time:342263ms step_avg:40.75ms
+step:8400/20000 val_loss:2.1221 val_bpb:1.2568 train_time:342274ms step_avg:40.75ms
+step:8600/20000 train_loss:2.1421 train_time:350387ms step_avg:40.74ms
+step:8600/20000 val_loss:2.1195 val_bpb:1.2553 train_time:350397ms step_avg:40.74ms
+step:8800/20000 train_loss:2.0992 train_time:358508ms step_avg:40.74ms
+step:8800/20000 val_loss:2.1185 val_bpb:1.2547 train_time:358519ms step_avg:40.74ms
+step:9000/20000 train_loss:2.0272 train_time:366635ms step_avg:40.74ms
+step:9000/20000 val_loss:2.1196 val_bpb:1.2554 train_time:366646ms step_avg:40.74ms
+step:9200/20000 train_loss:2.0843 train_time:374754ms step_avg:40.73ms
+step:9200/20000 val_loss:2.1166 val_bpb:1.2536 train_time:374764ms step_avg:40.74ms
+step:9400/20000 train_loss:2.1321 train_time:382886ms step_avg:40.73ms
+step:9400/20000 val_loss:2.1149 val_bpb:1.2526 train_time:382898ms step_avg:40.73ms
+step:9600/20000 train_loss:2.1467 train_time:391018ms step_avg:40.73ms
+step:9600/20000 val_loss:2.1138 val_bpb:1.2519 train_time:391029ms step_avg:40.73ms
+step:9800/20000 train_loss:2.0716 train_time:399140ms step_avg:40.73ms
+step:9800/20000 val_loss:2.1136 val_bpb:1.2518 train_time:399152ms step_avg:40.73ms
+step:10000/20000 train_loss:2.1147 train_time:407267ms step_avg:40.73ms
+step:10000/20000 val_loss:2.1133 val_bpb:1.2516 train_time:407276ms step_avg:40.73ms
+step:10200/20000 train_loss:2.0671 train_time:415389ms step_avg:40.72ms
+step:10200/20000 val_loss:2.1096 val_bpb:1.2494 train_time:415398ms step_avg:40.73ms
+step:10400/20000 train_loss:2.0998 train_time:423513ms step_avg:40.72ms
+step:10400/20000 val_loss:2.1098 val_bpb:1.2495 train_time:423523ms step_avg:40.72ms
+step:10600/20000 train_loss:1.9736 train_time:431637ms step_avg:40.72ms
+step:10600/20000 val_loss:2.1099 val_bpb:1.2496 train_time:431647ms step_avg:40.72ms
+step:10800/20000 train_loss:2.1889 train_time:439758ms step_avg:40.72ms
+step:10800/20000 val_loss:2.1085 val_bpb:1.2488 train_time:439769ms step_avg:40.72ms
+step:11000/20000 train_loss:2.1163 train_time:447886ms step_avg:40.72ms
+step:11000/20000 val_loss:2.1067 val_bpb:1.2477 train_time:447896ms step_avg:40.72ms
+step:11200/20000 train_loss:2.0717 train_time:456011ms step_avg:40.72ms
+step:11200/20000 val_loss:2.1058 val_bpb:1.2472 train_time:456019ms step_avg:40.72ms
+step:11400/20000 train_loss:2.0543 train_time:464132ms step_avg:40.71ms
+step:11400/20000 val_loss:2.1058 val_bpb:1.2472 train_time:464142ms step_avg:40.71ms
+step:11600/20000 train_loss:2.0626 train_time:472337ms step_avg:40.72ms
+step:11600/20000 val_loss:2.1049 val_bpb:1.2466 train_time:472347ms step_avg:40.72ms
+step:11800/20000 train_loss:2.0955 train_time:480459ms step_avg:40.72ms
+step:11800/20000 val_loss:2.1027 val_bpb:1.2453 train_time:480469ms step_avg:40.72ms
+step:12000/20000 train_loss:2.0742 train_time:488593ms step_avg:40.72ms
+step:12000/20000 val_loss:2.1014 val_bpb:1.2446 train_time:488604ms step_avg:40.72ms
+step:12200/20000 train_loss:2.2201 train_time:496741ms step_avg:40.72ms
+step:12200/20000 val_loss:2.1011 val_bpb:1.2444 train_time:496750ms step_avg:40.72ms
+step:12400/20000 train_loss:1.8636 train_time:504990ms step_avg:40.72ms
+step:12400/20000 val_loss:2.1009 val_bpb:1.2443 train_time:504999ms step_avg:40.73ms
+step:12600/20000 train_loss:2.0978 train_time:513126ms step_avg:40.72ms
+step:12600/20000 val_loss:2.1019 val_bpb:1.2449 train_time:513138ms step_avg:40.73ms
+step:12800/20000 train_loss:2.1151 train_time:521247ms step_avg:40.72ms
+step:12800/20000 val_loss:2.1001 val_bpb:1.2438 train_time:521257ms step_avg:40.72ms
+step:13000/20000 train_loss:2.1937 train_time:529374ms step_avg:40.72ms
+step:13000/20000 val_loss:2.1001 val_bpb:1.2438 train_time:529382ms step_avg:40.72ms
+step:13200/20000 train_loss:2.2021 train_time:537496ms step_avg:40.72ms
+step:13200/20000 val_loss:2.0969 val_bpb:1.2419 train_time:537507ms step_avg:40.72ms
+step:13400/20000 train_loss:2.0827 train_time:545628ms step_avg:40.72ms
+step:13400/20000 val_loss:2.0971 val_bpb:1.2420 train_time:545640ms step_avg:40.72ms
+step:13600/20000 train_loss:1.9499 train_time:553768ms step_avg:40.72ms
+step:13600/20000 val_loss:2.0976 val_bpb:1.2423 train_time:553779ms step_avg:40.72ms
+step:13800/20000 train_loss:2.0316 train_time:561901ms step_avg:40.72ms
+step:13800/20000 val_loss:2.0875 val_bpb:1.2364 train_time:561913ms step_avg:40.72ms
+step:14000/20000 train_loss:2.0836 train_time:570046ms step_avg:40.72ms
+step:14000/20000 val_loss:2.0810 val_bpb:1.2325 train_time:570058ms step_avg:40.72ms
+step:14200/20000 train_loss:2.1619 train_time:578171ms step_avg:40.72ms
+step:14200/20000 val_loss:2.0743 val_bpb:1.2285 train_time:578182ms step_avg:40.72ms
+step:14400/20000 train_loss:2.0585 train_time:586302ms step_avg:40.72ms
+step:14400/20000 val_loss:2.0660 val_bpb:1.2236 train_time:586314ms step_avg:40.72ms
+step:14600/20000 train_loss:2.1082 train_time:594437ms step_avg:40.71ms
+step:14600/20000 val_loss:2.0595 val_bpb:1.2198 train_time:594449ms step_avg:40.72ms
+step:14736/20000 val_loss:2.0564 val_bpb:1.2179 train_time:600017ms step_avg:40.72ms
+stopping_early: wallclock_cap train_time:600017ms step:14736/20000
+peak memory allocated: 10182 MiB reserved: 10638 MiB
+Serialized model: 67224983 bytes
+Code size: 47691 bytes
+Total submission size: 67272674 bytes
+Serialized model int8+zlib: 15814652 bytes (payload:17178912 raw_torch:17224025 payload_ratio:3.91x)
+Total submission size int8+zlib: 15862343 bytes
+final_int8_zlib_roundtrip val_loss:2.0691 val_bpb:1.2254 eval_time:1313ms
+final_int8_zlib_roundtrip_exact val_loss:2.06909998 val_bpb:1.22543755


### PR DESCRIPTION
Non-record submission exploring hybrid transformer architectures that replace most attention layers with a lightweight RWKV-inspired token-shift mixing mechanism. The core idea is that most layers in a transformer only need local context, so full quadratic attention is wasteful for them. Instead, 8 of 11 layers use a simple token-shift operation that blends adjacent tokens via learned per-dimension interpolation weights, while only 3 layers retain quadratic attention with short (128-token) windows (except the final attention layer which keeps full context).
The architecture achieves a 3-seed mean val_bpb of 1.2252 with 17.0M parameters, int6 quantized and zlib compressed to ~15.86 MB. While this does not beat the current SOTA, I believe the token-shift approach is promising for its efficiency — particularly for inference, where the reduced attention overhead could significantly speed up decoding.
Beyond the hybrid architecture, the submission stacks several techniques from the leaderboard: SmearGate, bigram hash embeddings, value embeddings, XSA (cross-head suppression), partial RoPE (16/64 dims), LeakyReLU squared activation, Muon optimizer, EMA with late QAT, and logit softcapping. Full details and ablation notes are in the README.