### PR TITLE
Improve baseline with LeakyReLU² activation

### DIFF
--- a/train_gpt.py
+++ b/train_gpt.py
@@ -613,7 +613,7 @@ class MLP(nn.Module):
         self.proj._zero_init = True
 
     def forward(self, x: Tensor) -> Tensor:
-        x = torch.relu(self.fc(x))
+        x = F.leaky_relu(self.fc(x), negative_slope=0.5)
         return self.proj(x.square())
 
 


### PR DESCRIPTION
Replace ReLU² with LeakyReLU(0.5)² in MLP forward pass. This preserves negative gradient flow while maintaining the squared output characteristic, eliminating dead neurons.

Results on 2×RTX 5090 (600s):
- Baseline (ReLU²): 1.3822 bpb @ 1000 steps
- LeakyReLU²: 1.2947 bpb @ 1947 steps
- Improvement: -0.0875 bpb

Single line change, no complexity increase.