### PR TITLE
Non-record: random-map adapter train/eval ablations on 8xH100

### DIFF
--- a/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/README.md
+++ b/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/README.md
@@ -1,0 +1,108 @@
+# Non-Record Submission: Random-Map Adapter Train/Eval Ablations
+
+This folder captures an 8xH100 ablation study around low-parameter adapter mechanisms added to the stock 9-layer/512-dim baseline. The code snapshot adds two related ideas:
+
+1. train-time `random_diag` adapters on `q`, `v`, and `lm_head`
+2. document-aware evaluation adapters for test-time training, with both LoRA and random-map variants
+
+The main result is negative-but-useful: in this setup, the **LoRA TTT control** remained the best performer at **1.1917 val_bpb**, while the best fully random-map condition (**random-map train + random-map TTT**) reached **1.2008 val_bpb**. Both counted artifacts stayed under the 16MB cap.
+
+## Best Result
+
+- Best overall score: **1.1917 val_bpb** (`lora_ttt`)
+- Best random-map score: **1.2008 val_bpb** (`random_train_ttt`)
+- Counted artifact size (best run): **15,883,798 bytes**
+- Steps reached (best run): **13,507**
+- Hardware: **8xH100**
+- Wallclock cap: **600s**
+
+## What Changed in `train_gpt.py`
+
+- Added train-time random-map adapters via `TRAIN_ADAPTER_KIND=random_diag`
+- Added batched document-aware TTT evaluation with:
+  - `TTT_ADAPTER_KIND=lora`
+  - `TTT_ADAPTER_KIND=random_diag`
+- Targeted the same adapter sites across methods:
+  - attention `q`
+  - attention `v`
+  - `lm_head`
+- Used rank-8 adapters for all ablations
+- Used chunked score-first document evaluation (`TTT_CHUNK_SIZE=256`, `TTT_EVAL_SEQ_LEN=1024`, `TTT_BATCH_SIZE=64`)
+
+## Ablation Results
+
+| Ablation | Train adapter | Eval adapter | Roundtrip val_bpb | Final TTT val_bpb | Notes |
+|---|---|---:|---:|---:|---|
+| `baseline` | none | none | 1.2268 | — | Reference run; final roundtrip validated cleanly |
+| `lora_ttt` | none | LoRA | 1.2267 | **1.1917** | Best overall |
+| `random_train` | random-map | none | 1.2310 | — | Train-time random-map adapters alone hurt roundtrip score |
+| `random_train_ttt` | random-map | random-map | 1.2330 | **1.2008** | Best random-map condition |
+| `random_ttt` | none | random-map | — | — | Interrupted before completion |
+
+Useful deltas:
+
+- `lora_ttt` vs baseline roundtrip: **-0.0351 bpb**
+- `random_train_ttt` vs baseline roundtrip: **-0.0260 bpb**
+- `random_train_ttt` vs `lora_ttt`: **+0.0091 bpb**
+- `random_train` vs baseline roundtrip: **+0.0042 bpb**
+
+## Interpretation
+
+The random-map parameterization was viable enough to support meaningful document-time adaptation, but it did **not** beat the LoRA control in this implementation. The strongest random-map result came from combining train-time and eval-time random-map adapters, suggesting the representation is at least usable, but the train-time random-map adapters by themselves were slightly harmful.
+
+In short:
+
+- document-aware TTT is the main win here
+- LoRA remained the stronger adapter family
+- random-map adapters are interesting, but not yet competitive with the LoRA control
+
+## Comparison to Current Repo SOTA
+
+From the root `README.md` at the time of writing:
+
+- current 10-minute leaderboard SOTA: **1.1194**
+- historical LoRA TTT submission: **1.1928**
+- notable unlimited-compute non-record baseline: **1.2074**
+
+So this ablation set:
+
+- is **not** competitive with the current SOTA record
+- slightly improves on the earlier public LoRA TTT result (**1.1917 vs 1.1928**)
+- comfortably beats the previously listed 4-hour non-record baseline (**1.1917 vs 1.2074**), though that run targeted a different non-record setting
+
+## Known Issues / Negative Results
+
+- The `TTT_ADAPTER_KIND=none` path still calls the document-aware eval function at the end of the script, which crashes after the clean roundtrip validation lines because `adapter=None` returns a scalar loss instead of per-token losses. This affected `baseline` and `random_train`, but their counted roundtrip metrics were already emitted before the crash.
+- The `random_ttt` run was interrupted before completion, so there is no final scored result for that condition in this folder.
+
+## Reproduction
+
+Run all ablations from this directory:
+
+```bash
+python run_all_ablations.py
+```
+
+Or a single condition:
+
+```bash
+python run_all_ablations.py --only lora_ttt
+python run_all_ablations.py --only random_train_ttt
+```
+
+The wrapper launches:
+
+```bash
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+with a default wallclock cap of `600.0` seconds and the environment overrides defined in `run_all_ablations.py`.
+
+## Included Files
+
+- `train_gpt.py` — code snapshot for this ablation study
+- `run_all_ablations.py` — wrapper used to launch the ablations
+- `plot_ablation_losses.py` — summary/plot generation script
+- `ablations_summary.tsv` — parsed summary of the completed runs
+- `logs/*.log` — raw ablation logs
+- `submission.json` — submission metadata

--- a/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/ablations_summary.tsv
+++ b/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/ablations_summary.tsv
@@ -1,0 +1,6 @@
+slug	description	train_points	val_points	final_roundtrip_bpb	final_ttt_kind	final_ttt_bpb	log_path
+baseline	No train adapters and no TTT adapters	77	15	1.22680233			/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/ablations/logs/baseline.log
+lora_ttt	LoRA TTT control	77	15	1.22665282	lora	1.19170000	/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/ablations/logs/lora_ttt.log
+random_train	Random-map train only	72	14	1.23100429			/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/ablations/logs/random_train.log
+random_train_ttt	Random-map train + random-map TTT	72	14	1.23301621	random_diag	1.20080000	/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/ablations/logs/random_train_ttt.log
+random_ttt	Random-map TTT only	34	5				/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/ablations/logs/random_ttt.log

--- a/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/logs/baseline.log
+++ b/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/logs/baseline.log
@@ -1,0 +1,290 @@
+# slug=baseline
+# description=No train adapters and no TTT adapters
+# started_at=2026-03-31 00:54:38
+# command=/usr/local/bin/torchrun --standalone --nproc_per_node=8 train_gpt.py
+# env.DATA_PATH=/parameter-golf/data/datasets/fineweb10B_sp1024
+# env.MAX_WALLCLOCK_SECONDS=600.0
+# env.PYTHONUNBUFFERED=1
+# env.RUN_ID=abl_baseline_8xh100
+# env.SEED=1337
+# env.TOKENIZER_PATH=/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+# env.TRAIN_ADAPTER_KIND=none
+# env.TTT_ADAPTER_KIND=none
+# env.VAL_LOSS_EVERY=1000
+# env.VOCAB_SIZE=1024
+
+W0331 00:54:39.225000 2545 torch/distributed/run.py:803] 
+W0331 00:54:39.225000 2545 torch/distributed/run.py:803] *****************************************
+W0331 00:54:39.225000 2545 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0331 00:54:39.225000 2545 torch/distributed/run.py:803] *****************************************
+logs/abl_baseline_8xh100.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=/parameter-golf/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:17059912
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:524288 train_seq_len:1024 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+train_adapter kind:none rank:8 targets:q,v,lm_head params:0 lr:0.02 dist:rademacher seed:20260331
+ttt_adapter kind:none rank:8 lr:0.01 chunk:256 eval_seq:1024 batch:64
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9357 val_bpb:4.1077 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9370 train_time:32ms step_avg:31.50ms
+step:2/20000 train_loss:16.8367 train_time:77ms step_avg:38.56ms
+step:3/20000 train_loss:8.7610 train_time:122ms step_avg:40.76ms
+step:4/20000 train_loss:6.6383 train_time:166ms step_avg:41.38ms
+step:5/20000 train_loss:6.6119 train_time:212ms step_avg:42.30ms
+step:6/20000 train_loss:7.4222 train_time:256ms step_avg:42.67ms
+step:7/20000 train_loss:6.3502 train_time:300ms step_avg:42.80ms
+step:8/20000 train_loss:6.1577 train_time:344ms step_avg:42.95ms
+step:9/20000 train_loss:6.0674 train_time:388ms step_avg:43.08ms
+step:10/20000 train_loss:5.9743 train_time:431ms step_avg:43.13ms
+step:200/20000 train_loss:2.8528 train_time:8877ms step_avg:44.39ms
+step:400/20000 train_loss:2.3622 train_time:17751ms step_avg:44.38ms
+step:600/20000 train_loss:2.5478 train_time:26644ms step_avg:44.41ms
+step:800/20000 train_loss:2.2977 train_time:35547ms step_avg:44.43ms
+step:1000/20000 train_loss:2.3759 train_time:44467ms step_avg:44.47ms
+step:1000/20000 val_loss:2.3366 val_bpb:1.3839 train_time:44482ms step_avg:44.48ms
+step:1200/20000 train_loss:2.3897 train_time:53409ms step_avg:44.51ms
+step:1400/20000 train_loss:2.4295 train_time:62357ms step_avg:44.54ms
+step:1600/20000 train_loss:2.1032 train_time:71323ms step_avg:44.58ms
+step:1800/20000 train_loss:2.1993 train_time:80280ms step_avg:44.60ms
+step:2000/20000 train_loss:2.2495 train_time:89237ms step_avg:44.62ms
+step:2000/20000 val_loss:2.2368 val_bpb:1.3248 train_time:89252ms step_avg:44.63ms
+step:2200/20000 train_loss:2.0801 train_time:98184ms step_avg:44.63ms
+step:2400/20000 train_loss:2.1996 train_time:107139ms step_avg:44.64ms
+step:2600/20000 train_loss:2.4133 train_time:116078ms step_avg:44.65ms
+step:2800/20000 train_loss:2.2352 train_time:125008ms step_avg:44.65ms
+step:3000/20000 train_loss:2.2241 train_time:133944ms step_avg:44.65ms
+step:3000/20000 val_loss:2.1956 val_bpb:1.3004 train_time:133959ms step_avg:44.65ms
+step:3200/20000 train_loss:2.1891 train_time:142871ms step_avg:44.65ms
+step:3400/20000 train_loss:2.1601 train_time:151795ms step_avg:44.65ms
+step:3600/20000 train_loss:2.1208 train_time:160709ms step_avg:44.64ms
+step:3800/20000 train_loss:2.2237 train_time:169626ms step_avg:44.64ms
+step:4000/20000 train_loss:2.1630 train_time:178539ms step_avg:44.63ms
+step:4000/20000 val_loss:2.1703 val_bpb:1.2854 train_time:178553ms step_avg:44.64ms
+step:4200/20000 train_loss:2.1753 train_time:187519ms step_avg:44.65ms
+step:4400/20000 train_loss:2.1134 train_time:196422ms step_avg:44.64ms
+step:4600/20000 train_loss:1.9720 train_time:205329ms step_avg:44.64ms
+step:4800/20000 train_loss:2.2652 train_time:214239ms step_avg:44.63ms
+step:5000/20000 train_loss:2.0317 train_time:223226ms step_avg:44.65ms
+step:5000/20000 val_loss:2.1534 val_bpb:1.2754 train_time:223240ms step_avg:44.65ms
+step:5200/20000 train_loss:2.1732 train_time:232127ms step_avg:44.64ms
+step:5400/20000 train_loss:2.1884 train_time:241023ms step_avg:44.63ms
+step:5600/20000 train_loss:2.1829 train_time:249918ms step_avg:44.63ms
+step:5800/20000 train_loss:2.1475 train_time:258813ms step_avg:44.62ms
+step:6000/20000 train_loss:2.2244 train_time:267711ms step_avg:44.62ms
+step:6000/20000 val_loss:2.1440 val_bpb:1.2698 train_time:267724ms step_avg:44.62ms
+step:6200/20000 train_loss:2.0910 train_time:276607ms step_avg:44.61ms
+step:6400/20000 train_loss:2.1611 train_time:285507ms step_avg:44.61ms
+step:6600/20000 train_loss:2.1202 train_time:294399ms step_avg:44.61ms
+step:6800/20000 train_loss:2.1905 train_time:303288ms step_avg:44.60ms
+step:7000/20000 train_loss:2.2250 train_time:312184ms step_avg:44.60ms
+step:7000/20000 val_loss:2.1327 val_bpb:1.2631 train_time:312198ms step_avg:44.60ms
+step:7200/20000 train_loss:2.1978 train_time:321081ms step_avg:44.59ms
+step:7400/20000 train_loss:2.1183 train_time:329974ms step_avg:44.59ms
+step:7600/20000 train_loss:1.9976 train_time:338863ms step_avg:44.59ms
+step:7800/20000 train_loss:2.1459 train_time:347748ms step_avg:44.58ms
+step:8000/20000 train_loss:2.1176 train_time:356643ms step_avg:44.58ms
+step:8000/20000 val_loss:2.1230 val_bpb:1.2574 train_time:356657ms step_avg:44.58ms
+step:8200/20000 train_loss:2.1853 train_time:365537ms step_avg:44.58ms
+step:8400/20000 train_loss:2.1341 train_time:374498ms step_avg:44.58ms
+step:8600/20000 train_loss:2.1420 train_time:383378ms step_avg:44.58ms
+step:8800/20000 train_loss:2.1015 train_time:392271ms step_avg:44.58ms
+step:9000/20000 train_loss:2.0265 train_time:401161ms step_avg:44.57ms
+step:9000/20000 val_loss:2.1183 val_bpb:1.2545 train_time:401187ms step_avg:44.58ms
+step:9200/20000 train_loss:2.0844 train_time:410052ms step_avg:44.57ms
+step:9400/20000 train_loss:2.1320 train_time:418943ms step_avg:44.57ms
+step:9600/20000 train_loss:2.1485 train_time:427847ms step_avg:44.57ms
+step:9800/20000 train_loss:2.0722 train_time:436730ms step_avg:44.56ms
+step:10000/20000 train_loss:2.1135 train_time:445625ms step_avg:44.56ms
+step:10000/20000 val_loss:2.1125 val_bpb:1.2511 train_time:445651ms step_avg:44.57ms
+step:10200/20000 train_loss:2.0654 train_time:454515ms step_avg:44.56ms
+step:10400/20000 train_loss:2.0995 train_time:463401ms step_avg:44.56ms
+step:10600/20000 train_loss:1.9795 train_time:472295ms step_avg:44.56ms
+step:10800/20000 train_loss:2.1923 train_time:481180ms step_avg:44.55ms
+step:11000/20000 train_loss:2.1163 train_time:490071ms step_avg:44.55ms
+step:11000/20000 val_loss:2.1066 val_bpb:1.2476 train_time:490096ms step_avg:44.55ms
+step:11200/20000 train_loss:2.0655 train_time:498959ms step_avg:44.55ms
+step:11400/20000 train_loss:2.0551 train_time:507849ms step_avg:44.55ms
+step:11600/20000 train_loss:2.0634 train_time:516743ms step_avg:44.55ms
+step:11800/20000 train_loss:2.0978 train_time:525634ms step_avg:44.55ms
+step:12000/20000 train_loss:2.0713 train_time:534524ms step_avg:44.54ms
+step:12000/20000 val_loss:2.1009 val_bpb:1.2443 train_time:534550ms step_avg:44.55ms
+step:12200/20000 train_loss:2.2222 train_time:543409ms step_avg:44.54ms
+step:12400/20000 train_loss:1.8606 train_time:552372ms step_avg:44.55ms
+step:12600/20000 train_loss:2.0858 train_time:561263ms step_avg:44.54ms
+step:12800/20000 train_loss:2.0960 train_time:570152ms step_avg:44.54ms
+step:13000/20000 train_loss:2.1695 train_time:579043ms step_avg:44.54ms
+step:13000/20000 val_loss:2.0755 val_bpb:1.2292 train_time:579057ms step_avg:44.54ms
+step:13200/20000 train_loss:2.1786 train_time:587935ms step_avg:44.54ms
+step:13400/20000 train_loss:2.0450 train_time:596821ms step_avg:44.54ms
+step:13473/20000 val_loss:2.0599 val_bpb:1.2200 train_time:600055ms step_avg:44.54ms
+stopping_early: wallclock_cap train_time:600055ms step:13473/20000
+peak memory allocated: 10121 MiB reserved: 10370 MiB
+Serialized model: 67224983 bytes
+Code size: 65861 bytes
+Total submission size: 67290844 bytes
+Serialized model int8+zlib: 15817334 bytes (payload:17178912 raw_torch:17224025 payload_ratio:3.91x)
+Total submission size int8+zlib: 15883195 bytes
+final_int8_zlib_roundtrip val_loss:2.0714 val_bpb:1.2268 eval_time:1431ms
+final_int8_zlib_roundtrip_exact val_loss:2.07140435 val_bpb:1.22680233
+[rank0]: Traceback (most recent call last):
+[rank0]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1498, in <module>
+[rank0]:     main()
+[rank0]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1484, in main
+[rank0]:     ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+[rank0]:                                 ^^^^^^^^^^^^^^^^^^^^^
+[rank0]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1039, in eval_val_ttt_adapter
+[rank0]:     _accumulate_bpb(
+[rank0]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 933, in _accumulate_bpb
+[rank0]:     lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+[rank0]:           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank0]: IndexError: too many indices for tensor of dimension 0
+[rank6]: Traceback (most recent call last):
+[rank6]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1498, in <module>
+[rank6]:     main()
+[rank6]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1484, in main
+[rank6]:     ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+[rank6]:                                 ^^^^^^^^^^^^^^^^^^^^^
+[rank6]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1039, in eval_val_ttt_adapter
+[rank6]:     _accumulate_bpb(
+[rank6]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 933, in _accumulate_bpb
+[rank6]:     lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+[rank6]:           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank6]: IndexError: too many indices for tensor of dimension 0
+[rank2]: Traceback (most recent call last):
+[rank2]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1498, in <module>
+[rank2]:     main()
+[rank2]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1484, in main
+[rank2]:     ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+[rank2]:                                 ^^^^^^^^^^^^^^^^^^^^^
+[rank2]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1039, in eval_val_ttt_adapter
+[rank2]:     _accumulate_bpb(
+[rank2]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 933, in _accumulate_bpb
+[rank2]:     lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+[rank2]:           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank2]: IndexError: too many indices for tensor of dimension 0
+[rank4]: Traceback (most recent call last):
+[rank4]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1498, in <module>
+[rank4]:     main()
+[rank4]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1484, in main
+[rank4]:     ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+[rank4]:                                 ^^^^^^^^^^^^^^^^^^^^^
+[rank4]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1039, in eval_val_ttt_adapter
+[rank4]:     _accumulate_bpb(
+[rank4]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 933, in _accumulate_bpb
+[rank4]:     lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+[rank4]:           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank4]: IndexError: too many indices for tensor of dimension 0
+[rank7]: Traceback (most recent call last):
+[rank7]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1498, in <module>
+[rank7]:     main()
+[rank7]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1484, in main
+[rank7]:     ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+[rank7]:                                 ^^^^^^^^^^^^^^^^^^^^^
+[rank7]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1039, in eval_val_ttt_adapter
+[rank7]:     _accumulate_bpb(
+[rank7]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 933, in _accumulate_bpb
+[rank7]:     lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+[rank7]:           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank7]: IndexError: too many indices for tensor of dimension 0
+[rank3]: Traceback (most recent call last):
+[rank3]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1498, in <module>
+[rank3]:     main()
+[rank3]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1484, in main
+[rank3]:     ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+[rank3]:                                 ^^^^^^^^^^^^^^^^^^^^^
+[rank3]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1039, in eval_val_ttt_adapter
+[rank3]:     _accumulate_bpb(
+[rank3]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 933, in _accumulate_bpb
+[rank3]:     lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+[rank3]:           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank3]: IndexError: too many indices for tensor of dimension 0
+[rank5]: Traceback (most recent call last):
+[rank5]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1498, in <module>
+[rank5]:     main()
+[rank5]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1484, in main
+[rank5]:     ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+[rank5]:                                 ^^^^^^^^^^^^^^^^^^^^^
+[rank5]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1039, in eval_val_ttt_adapter
+[rank5]:     _accumulate_bpb(
+[rank5]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 933, in _accumulate_bpb
+[rank5]:     lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+[rank5]:           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank5]: IndexError: too many indices for tensor of dimension 0
+[rank1]: Traceback (most recent call last):
+[rank1]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1498, in <module>
+[rank1]:     main()
+[rank1]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1484, in main
+[rank1]:     ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+[rank1]:                                 ^^^^^^^^^^^^^^^^^^^^^
+[rank1]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1039, in eval_val_ttt_adapter
+[rank1]:     _accumulate_bpb(
+[rank1]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 933, in _accumulate_bpb
+[rank1]:     lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+[rank1]:           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank1]: IndexError: too many indices for tensor of dimension 0
+[rank0]:[W331 01:06:47.814696157 ProcessGroupNCCL.cpp:1524] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
+W0331 01:06:48.299000 2545 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 2643 closing signal SIGTERM
+W0331 01:06:48.301000 2545 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 2644 closing signal SIGTERM
+W0331 01:06:48.302000 2545 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 2645 closing signal SIGTERM
+W0331 01:06:48.303000 2545 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 2646 closing signal SIGTERM
+W0331 01:06:48.304000 2545 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 2647 closing signal SIGTERM
+W0331 01:06:48.304000 2545 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 2649 closing signal SIGTERM
+W0331 01:06:48.305000 2545 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 2650 closing signal SIGTERM
+E0331 01:06:49.270000 2545 torch/distributed/elastic/multiprocessing/api.py:882] failed (exitcode: 1) local_rank: 5 (pid: 2648) of binary: /usr/local/bin/python
+Traceback (most recent call last):
+  File "/usr/local/bin/torchrun", line 7, in <module>
+    sys.exit(main())
+             ^^^^^^
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 357, in wrapper
+    return f(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/run.py", line 936, in main
+    run(args)
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/run.py", line 927, in run
+    elastic_launch(
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/launcher/api.py", line 156, in __call__
+    return launch_agent(self._config, self._entrypoint, list(args))
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/launcher/api.py", line 293, in launch_agent
+    raise ChildFailedError(
+torch.distributed.elastic.multiprocessing.errors.ChildFailedError: 
+============================================================
+train_gpt.py FAILED
+------------------------------------------------------------
+Failures:
+  <NO_OTHER_FAILURES>
+------------------------------------------------------------
+Root Cause (first observed failure):
+[0]:
+  time      : 2026-03-31_01:06:48
+  host      : 477d5d130936
+  rank      : 5 (local_rank: 5)
+  exitcode  : 1 (pid: 2648)
+  error_file: <N/A>
+  traceback : To enable traceback see: https://pytorch.org/docs/stable/elastic/errors.html
+============================================================

--- a/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/logs/lora_ttt.log
+++ b/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/logs/lora_ttt.log
@@ -1,0 +1,156 @@
+# slug=lora_ttt
+# description=LoRA TTT control
+# started_at=2026-03-31 01:06:49
+# command=/usr/local/bin/torchrun --standalone --nproc_per_node=8 train_gpt.py
+# env.DATA_PATH=/parameter-golf/data/datasets/fineweb10B_sp1024
+# env.MAX_WALLCLOCK_SECONDS=600.0
+# env.PYTHONUNBUFFERED=1
+# env.RUN_ID=abl_lora_ttt_8xh100
+# env.SEED=1337
+# env.TOKENIZER_PATH=/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+# env.TRAIN_ADAPTER_KIND=none
+# env.TTT_ADAPTER_KIND=lora
+# env.TTT_ADAPTER_LR=0.01
+# env.TTT_ADAPTER_RANK=8
+# env.VAL_LOSS_EVERY=1000
+# env.VOCAB_SIZE=1024
+
+W0331 01:06:51.131000 34536 torch/distributed/run.py:803] 
+W0331 01:06:51.131000 34536 torch/distributed/run.py:803] *****************************************
+W0331 01:06:51.131000 34536 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0331 01:06:51.131000 34536 torch/distributed/run.py:803] *****************************************
+logs/abl_lora_ttt_8xh100.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=/parameter-golf/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:17059912
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:524288 train_seq_len:1024 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+train_adapter kind:none rank:8 targets:q,v,lm_head params:0 lr:0.02 dist:rademacher seed:20260331
+ttt_adapter kind:lora rank:8 lr:0.01 chunk:256 eval_seq:1024 batch:64
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9357 val_bpb:4.1077 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9370 train_time:24ms step_avg:24.04ms
+step:2/20000 train_loss:16.8367 train_time:66ms step_avg:32.82ms
+step:3/20000 train_loss:8.7610 train_time:109ms step_avg:36.40ms
+step:4/20000 train_loss:6.6384 train_time:153ms step_avg:38.25ms
+step:5/20000 train_loss:6.6119 train_time:197ms step_avg:39.35ms
+step:6/20000 train_loss:7.4222 train_time:241ms step_avg:40.10ms
+step:7/20000 train_loss:6.3502 train_time:285ms step_avg:40.65ms
+step:8/20000 train_loss:6.1576 train_time:328ms step_avg:41.06ms
+step:9/20000 train_loss:6.0674 train_time:372ms step_avg:41.34ms
+step:10/20000 train_loss:5.9743 train_time:416ms step_avg:41.60ms
+step:200/20000 train_loss:2.8504 train_time:8851ms step_avg:44.25ms
+step:400/20000 train_loss:2.3577 train_time:17705ms step_avg:44.26ms
+step:600/20000 train_loss:2.5430 train_time:26575ms step_avg:44.29ms
+step:800/20000 train_loss:2.2917 train_time:35462ms step_avg:44.33ms
+step:1000/20000 train_loss:2.3693 train_time:44341ms step_avg:44.34ms
+step:1000/20000 val_loss:2.3335 val_bpb:1.3820 train_time:44368ms step_avg:44.37ms
+step:1200/20000 train_loss:2.3889 train_time:53243ms step_avg:44.37ms
+step:1400/20000 train_loss:2.4294 train_time:62157ms step_avg:44.40ms
+step:1600/20000 train_loss:2.0979 train_time:71074ms step_avg:44.42ms
+step:1800/20000 train_loss:2.1993 train_time:79983ms step_avg:44.44ms
+step:2000/20000 train_loss:2.2487 train_time:88895ms step_avg:44.45ms
+step:2000/20000 val_loss:2.2347 val_bpb:1.3235 train_time:88911ms step_avg:44.46ms
+step:2200/20000 train_loss:2.0745 train_time:97807ms step_avg:44.46ms
+step:2400/20000 train_loss:2.1994 train_time:106709ms step_avg:44.46ms
+step:2600/20000 train_loss:2.4164 train_time:115613ms step_avg:44.47ms
+step:2800/20000 train_loss:2.2300 train_time:124515ms step_avg:44.47ms
+step:3000/20000 train_loss:2.2286 train_time:133410ms step_avg:44.47ms
+step:3000/20000 val_loss:2.1941 val_bpb:1.2995 train_time:133425ms step_avg:44.47ms
+step:3200/20000 train_loss:2.1908 train_time:142303ms step_avg:44.47ms
+step:3400/20000 train_loss:2.1565 train_time:151297ms step_avg:44.50ms
+step:3600/20000 train_loss:2.1114 train_time:160187ms step_avg:44.50ms
+step:3800/20000 train_loss:2.2238 train_time:169078ms step_avg:44.49ms
+step:4000/20000 train_loss:2.1662 train_time:177970ms step_avg:44.49ms
+step:4000/20000 val_loss:2.1708 val_bpb:1.2857 train_time:177986ms step_avg:44.50ms
+step:4200/20000 train_loss:2.1748 train_time:186934ms step_avg:44.51ms
+step:4400/20000 train_loss:2.1118 train_time:195822ms step_avg:44.50ms
+step:4600/20000 train_loss:1.9716 train_time:204702ms step_avg:44.50ms
+step:4800/20000 train_loss:2.2631 train_time:213586ms step_avg:44.50ms
+step:5000/20000 train_loss:2.0263 train_time:222460ms step_avg:44.49ms
+step:5000/20000 val_loss:2.1528 val_bpb:1.2750 train_time:222476ms step_avg:44.50ms
+step:5200/20000 train_loss:2.1730 train_time:231336ms step_avg:44.49ms
+step:5400/20000 train_loss:2.1843 train_time:240217ms step_avg:44.48ms
+step:5600/20000 train_loss:2.1847 train_time:249088ms step_avg:44.48ms
+step:5800/20000 train_loss:2.1437 train_time:257969ms step_avg:44.48ms
+step:6000/20000 train_loss:2.2218 train_time:266835ms step_avg:44.47ms
+step:6000/20000 val_loss:2.1430 val_bpb:1.2692 train_time:266851ms step_avg:44.48ms
+step:6200/20000 train_loss:2.0879 train_time:275707ms step_avg:44.47ms
+step:6400/20000 train_loss:2.1644 train_time:284582ms step_avg:44.47ms
+step:6600/20000 train_loss:2.1182 train_time:293459ms step_avg:44.46ms
+step:6800/20000 train_loss:2.1924 train_time:302335ms step_avg:44.46ms
+step:7000/20000 train_loss:2.2245 train_time:311201ms step_avg:44.46ms
+step:7000/20000 val_loss:2.1319 val_bpb:1.2626 train_time:311217ms step_avg:44.46ms
+step:7200/20000 train_loss:2.1999 train_time:320070ms step_avg:44.45ms
+step:7400/20000 train_loss:2.1199 train_time:328947ms step_avg:44.45ms
+step:7600/20000 train_loss:1.9972 train_time:337817ms step_avg:44.45ms
+step:7800/20000 train_loss:2.1465 train_time:346690ms step_avg:44.45ms
+step:8000/20000 train_loss:2.1135 train_time:355561ms step_avg:44.45ms
+step:8000/20000 val_loss:2.1226 val_bpb:1.2571 train_time:355577ms step_avg:44.45ms
+step:8200/20000 train_loss:2.1882 train_time:364435ms step_avg:44.44ms
+step:8400/20000 train_loss:2.1345 train_time:373372ms step_avg:44.45ms
+step:8600/20000 train_loss:2.1392 train_time:382253ms step_avg:44.45ms
+step:8800/20000 train_loss:2.0992 train_time:391141ms step_avg:44.45ms
+step:9000/20000 train_loss:2.0240 train_time:400010ms step_avg:44.45ms
+step:9000/20000 val_loss:2.1174 val_bpb:1.2540 train_time:400025ms step_avg:44.45ms
+step:9200/20000 train_loss:2.0851 train_time:408890ms step_avg:44.44ms
+step:9400/20000 train_loss:2.1322 train_time:417768ms step_avg:44.44ms
+step:9600/20000 train_loss:2.1456 train_time:426635ms step_avg:44.44ms
+step:9800/20000 train_loss:2.0717 train_time:435506ms step_avg:44.44ms
+step:10000/20000 train_loss:2.1128 train_time:444379ms step_avg:44.44ms
+step:10000/20000 val_loss:2.1119 val_bpb:1.2508 train_time:444394ms step_avg:44.44ms
+step:10200/20000 train_loss:2.0658 train_time:453263ms step_avg:44.44ms
+step:10400/20000 train_loss:2.0983 train_time:462136ms step_avg:44.44ms
+step:10600/20000 train_loss:1.9770 train_time:471009ms step_avg:44.43ms
+step:10800/20000 train_loss:2.1893 train_time:479876ms step_avg:44.43ms
+step:11000/20000 train_loss:2.1170 train_time:488754ms step_avg:44.43ms
+step:11000/20000 val_loss:2.1057 val_bpb:1.2471 train_time:488769ms step_avg:44.43ms
+step:11200/20000 train_loss:2.0699 train_time:497644ms step_avg:44.43ms
+step:11400/20000 train_loss:2.0573 train_time:506503ms step_avg:44.43ms
+step:11600/20000 train_loss:2.0612 train_time:515376ms step_avg:44.43ms
+step:11800/20000 train_loss:2.0933 train_time:524246ms step_avg:44.43ms
+step:12000/20000 train_loss:2.0705 train_time:533113ms step_avg:44.43ms
+step:12000/20000 val_loss:2.1008 val_bpb:1.2442 train_time:533129ms step_avg:44.43ms
+step:12200/20000 train_loss:2.2224 train_time:541991ms step_avg:44.43ms
+step:12400/20000 train_loss:1.8599 train_time:550932ms step_avg:44.43ms
+step:12600/20000 train_loss:2.0861 train_time:559801ms step_avg:44.43ms
+step:12800/20000 train_loss:2.0956 train_time:568663ms step_avg:44.43ms
+step:13000/20000 train_loss:2.1677 train_time:577536ms step_avg:44.43ms
+step:13000/20000 val_loss:2.0762 val_bpb:1.2296 train_time:577551ms step_avg:44.43ms
+step:13200/20000 train_loss:2.1739 train_time:586407ms step_avg:44.42ms
+step:13400/20000 train_loss:2.0466 train_time:595279ms step_avg:44.42ms
+step:13507/20000 val_loss:2.0591 val_bpb:1.2195 train_time:600012ms step_avg:44.42ms
+stopping_early: wallclock_cap train_time:600012ms step:13507/20000
+peak memory allocated: 10121 MiB reserved: 10440 MiB
+Serialized model: 67224983 bytes
+Code size: 65861 bytes
+Total submission size: 67290844 bytes
+Serialized model int8+zlib: 15817937 bytes (payload:17178912 raw_torch:17224025 payload_ratio:3.91x)
+Total submission size int8+zlib: 15883798 bytes
+final_int8_zlib_roundtrip val_loss:2.0712 val_bpb:1.2267 eval_time:1435ms
+final_int8_zlib_roundtrip_exact val_loss:2.07115191 val_bpb:1.22665282
+final_int8_ttt_adapter kind:lora val_loss:2.0122 val_bpb:1.1917 eval_time:61671ms

--- a/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/logs/random_train.log
+++ b/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/logs/random_train.log
@@ -1,0 +1,289 @@
+# slug=random_train
+# description=Random-map train only
+# started_at=2026-03-31 01:27:30
+# command=/usr/local/bin/torchrun --standalone --nproc_per_node=8 train_gpt.py
+# env.ADAPTER_RANDOM_DIST=rademacher
+# env.ADAPTER_SEED=20260331
+# env.DATA_PATH=/parameter-golf/data/datasets/fineweb10B_sp1024
+# env.MAX_WALLCLOCK_SECONDS=600.0
+# env.PYTHONUNBUFFERED=1
+# env.RUN_ID=abl_random_train_8xh100
+# env.SEED=1337
+# env.TOKENIZER_PATH=/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+# env.TRAIN_ADAPTER_KIND=random_diag
+# env.TRAIN_ADAPTER_LR=0.02
+# env.TRAIN_ADAPTER_RANK=8
+# env.TRAIN_ADAPTER_TARGETS=q,v,lm_head
+# env.TTT_ADAPTER_KIND=none
+# env.VAL_LOSS_EVERY=1000
+# env.VOCAB_SIZE=1024
+
+W0331 01:27:31.668000 37171 torch/distributed/run.py:803] 
+W0331 01:27:31.668000 37171 torch/distributed/run.py:803] *****************************************
+W0331 01:27:31.668000 37171 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0331 01:27:31.668000 37171 torch/distributed/run.py:803] *****************************************
+logs/abl_random_train_8xh100.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=/parameter-golf/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:17060064
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:524288 train_seq_len:1024 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+train_adapter kind:random_diag rank:8 targets:q,v,lm_head params:152 lr:0.02 dist:rademacher seed:20260331
+ttt_adapter kind:none rank:8 lr:0.01 chunk:256 eval_seq:1024 batch:64
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9357 val_bpb:4.1077 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9370 train_time:38ms step_avg:38.04ms
+step:2/20000 train_loss:16.8406 train_time:81ms step_avg:40.29ms
+step:3/20000 train_loss:8.7568 train_time:130ms step_avg:43.33ms
+step:4/20000 train_loss:6.6414 train_time:179ms step_avg:44.73ms
+step:5/20000 train_loss:6.6217 train_time:227ms step_avg:45.46ms
+step:6/20000 train_loss:7.4200 train_time:276ms step_avg:45.99ms
+step:7/20000 train_loss:6.3377 train_time:324ms step_avg:46.29ms
+step:8/20000 train_loss:6.1426 train_time:373ms step_avg:46.64ms
+step:9/20000 train_loss:6.0687 train_time:421ms step_avg:46.76ms
+step:10/20000 train_loss:5.9718 train_time:470ms step_avg:47.01ms
+step:200/20000 train_loss:2.8505 train_time:9644ms step_avg:48.22ms
+step:400/20000 train_loss:2.3541 train_time:19278ms step_avg:48.20ms
+step:600/20000 train_loss:2.5463 train_time:28918ms step_avg:48.20ms
+step:800/20000 train_loss:2.2973 train_time:38569ms step_avg:48.21ms
+step:1000/20000 train_loss:2.3732 train_time:48224ms step_avg:48.22ms
+step:1000/20000 val_loss:2.3345 val_bpb:1.3826 train_time:48238ms step_avg:48.24ms
+step:1200/20000 train_loss:2.3868 train_time:57975ms step_avg:48.31ms
+step:1400/20000 train_loss:2.4340 train_time:67658ms step_avg:48.33ms
+step:1600/20000 train_loss:2.0996 train_time:77345ms step_avg:48.34ms
+step:1800/20000 train_loss:2.2018 train_time:87028ms step_avg:48.35ms
+step:2000/20000 train_loss:2.2521 train_time:96723ms step_avg:48.36ms
+step:2000/20000 val_loss:2.2365 val_bpb:1.3246 train_time:96737ms step_avg:48.37ms
+step:2200/20000 train_loss:2.0763 train_time:106400ms step_avg:48.36ms
+step:2400/20000 train_loss:2.2014 train_time:116074ms step_avg:48.36ms
+step:2600/20000 train_loss:2.4160 train_time:125750ms step_avg:48.37ms
+step:2800/20000 train_loss:2.2349 train_time:135421ms step_avg:48.36ms
+step:3000/20000 train_loss:2.2269 train_time:145082ms step_avg:48.36ms
+step:3000/20000 val_loss:2.1959 val_bpb:1.3006 train_time:145097ms step_avg:48.37ms
+step:3200/20000 train_loss:2.1870 train_time:154740ms step_avg:48.36ms
+step:3400/20000 train_loss:2.1562 train_time:164400ms step_avg:48.35ms
+step:3600/20000 train_loss:2.1165 train_time:174048ms step_avg:48.35ms
+step:3800/20000 train_loss:2.2215 train_time:183707ms step_avg:48.34ms
+step:4000/20000 train_loss:2.1624 train_time:193361ms step_avg:48.34ms
+step:4000/20000 val_loss:2.1707 val_bpb:1.2856 train_time:193374ms step_avg:48.34ms
+step:4200/20000 train_loss:2.1759 train_time:203069ms step_avg:48.35ms
+step:4400/20000 train_loss:2.1118 train_time:212716ms step_avg:48.34ms
+step:4600/20000 train_loss:1.9697 train_time:222354ms step_avg:48.34ms
+step:4800/20000 train_loss:2.2647 train_time:231999ms step_avg:48.33ms
+step:5000/20000 train_loss:2.0255 train_time:241641ms step_avg:48.33ms
+step:5000/20000 val_loss:2.1543 val_bpb:1.2759 train_time:241658ms step_avg:48.33ms
+step:5200/20000 train_loss:2.1716 train_time:251289ms step_avg:48.32ms
+step:5400/20000 train_loss:2.1871 train_time:260939ms step_avg:48.32ms
+step:5600/20000 train_loss:2.1879 train_time:270582ms step_avg:48.32ms
+step:5800/20000 train_loss:2.1449 train_time:280228ms step_avg:48.32ms
+step:6000/20000 train_loss:2.2256 train_time:289884ms step_avg:48.31ms
+step:6000/20000 val_loss:2.1449 val_bpb:1.2704 train_time:289893ms step_avg:48.32ms
+step:6200/20000 train_loss:2.0893 train_time:299523ms step_avg:48.31ms
+step:6400/20000 train_loss:2.1639 train_time:309163ms step_avg:48.31ms
+step:6600/20000 train_loss:2.1208 train_time:318809ms step_avg:48.30ms
+step:6800/20000 train_loss:2.1910 train_time:328462ms step_avg:48.30ms
+step:7000/20000 train_loss:2.2257 train_time:338110ms step_avg:48.30ms
+step:7000/20000 val_loss:2.1335 val_bpb:1.2636 train_time:338124ms step_avg:48.30ms
+step:7200/20000 train_loss:2.2000 train_time:347751ms step_avg:48.30ms
+step:7400/20000 train_loss:2.1192 train_time:357396ms step_avg:48.30ms
+step:7600/20000 train_loss:1.9985 train_time:367039ms step_avg:48.29ms
+step:7800/20000 train_loss:2.1463 train_time:376684ms step_avg:48.29ms
+step:8000/20000 train_loss:2.1177 train_time:386338ms step_avg:48.29ms
+step:8000/20000 val_loss:2.1241 val_bpb:1.2580 train_time:386353ms step_avg:48.29ms
+step:8200/20000 train_loss:2.1877 train_time:395978ms step_avg:48.29ms
+step:8400/20000 train_loss:2.1384 train_time:405684ms step_avg:48.30ms
+step:8600/20000 train_loss:2.1396 train_time:415330ms step_avg:48.29ms
+step:8800/20000 train_loss:2.1012 train_time:424974ms step_avg:48.29ms
+step:9000/20000 train_loss:2.0293 train_time:434609ms step_avg:48.29ms
+step:9000/20000 val_loss:2.1191 val_bpb:1.2550 train_time:434625ms step_avg:48.29ms
+step:9200/20000 train_loss:2.0844 train_time:444255ms step_avg:48.29ms
+step:9400/20000 train_loss:2.1329 train_time:453898ms step_avg:48.29ms
+step:9600/20000 train_loss:2.1498 train_time:463539ms step_avg:48.29ms
+step:9800/20000 train_loss:2.0731 train_time:473181ms step_avg:48.28ms
+step:10000/20000 train_loss:2.1166 train_time:482824ms step_avg:48.28ms
+step:10000/20000 val_loss:2.1135 val_bpb:1.2517 train_time:482838ms step_avg:48.28ms
+step:10200/20000 train_loss:2.0701 train_time:492464ms step_avg:48.28ms
+step:10400/20000 train_loss:2.1002 train_time:502109ms step_avg:48.28ms
+step:10600/20000 train_loss:1.9751 train_time:511748ms step_avg:48.28ms
+step:10800/20000 train_loss:2.1862 train_time:521392ms step_avg:48.28ms
+step:11000/20000 train_loss:2.1161 train_time:531046ms step_avg:48.28ms
+step:11000/20000 val_loss:2.1071 val_bpb:1.2479 train_time:531061ms step_avg:48.28ms
+step:11200/20000 train_loss:2.0691 train_time:540687ms step_avg:48.28ms
+step:11400/20000 train_loss:2.0522 train_time:550336ms step_avg:48.28ms
+step:11600/20000 train_loss:2.0531 train_time:559986ms step_avg:48.27ms
+step:11800/20000 train_loss:2.0774 train_time:569625ms step_avg:48.27ms
+step:12000/20000 train_loss:2.0486 train_time:579266ms step_avg:48.27ms
+step:12000/20000 val_loss:2.0770 val_bpb:1.2301 train_time:579281ms step_avg:48.27ms
+step:12200/20000 train_loss:2.1936 train_time:588908ms step_avg:48.27ms
+step:12400/20000 train_loss:1.8285 train_time:598621ms step_avg:48.28ms
+step:12429/20000 val_loss:2.0632 val_bpb:1.2220 train_time:600021ms step_avg:48.28ms
+stopping_early: wallclock_cap train_time:600021ms step:12429/20000
+peak memory allocated: 10260 MiB reserved: 10442 MiB
+Serialized model: 67231989 bytes
+Code size: 65861 bytes
+Total submission size: 67297850 bytes
+Serialized model int8+zlib: 15813852 bytes (payload:17179520 raw_torch:17229811 payload_ratio:3.91x)
+Total submission size int8+zlib: 15879713 bytes
+final_int8_zlib_roundtrip val_loss:2.0785 val_bpb:1.2310 eval_time:1613ms
+final_int8_zlib_roundtrip_exact val_loss:2.07849918 val_bpb:1.23100429
+[rank0]: Traceback (most recent call last):
+[rank0]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1498, in <module>
+[rank0]:     main()
+[rank0]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1484, in main
+[rank0]:     ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+[rank0]:                                 ^^^^^^^^^^^^^^^^^^^^^
+[rank0]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1039, in eval_val_ttt_adapter
+[rank0]:     _accumulate_bpb(
+[rank0]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 933, in _accumulate_bpb
+[rank0]:     lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+[rank0]:           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank0]: IndexError: too many indices for tensor of dimension 0
+[rank6]: Traceback (most recent call last):
+[rank6]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1498, in <module>
+[rank6]:     main()
+[rank6]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1484, in main
+[rank6]:     ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+[rank6]:                                 ^^^^^^^^^^^^^^^^^^^^^
+[rank6]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1039, in eval_val_ttt_adapter
+[rank6]:     _accumulate_bpb(
+[rank6]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 933, in _accumulate_bpb
+[rank6]:     lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+[rank6]:           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank6]: IndexError: too many indices for tensor of dimension 0
+[rank4]: Traceback (most recent call last):
+[rank4]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1498, in <module>
+[rank4]:     main()
+[rank4]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1484, in main
+[rank4]:     ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+[rank4]:                                 ^^^^^^^^^^^^^^^^^^^^^
+[rank4]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1039, in eval_val_ttt_adapter
+[rank4]:     _accumulate_bpb(
+[rank4]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 933, in _accumulate_bpb
+[rank4]:     lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+[rank4]:           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank4]: IndexError: too many indices for tensor of dimension 0
+[rank1]: Traceback (most recent call last):
+[rank1]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1498, in <module>
+[rank1]:     main()
+[rank1]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1484, in main
+[rank1]:     ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+[rank1]:                                 ^^^^^^^^^^^^^^^^^^^^^
+[rank1]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1039, in eval_val_ttt_adapter
+[rank1]:     _accumulate_bpb(
+[rank1]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 933, in _accumulate_bpb
+[rank1]:     lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+[rank1]:           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank1]: IndexError: too many indices for tensor of dimension 0
+[rank3]: Traceback (most recent call last):
+[rank3]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1498, in <module>
+[rank3]:     main()
+[rank3]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1484, in main
+[rank3]:     ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+[rank3]:                                 ^^^^^^^^^^^^^^^^^^^^^
+[rank3]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1039, in eval_val_ttt_adapter
+[rank3]:     _accumulate_bpb(
+[rank3]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 933, in _accumulate_bpb
+[rank3]:     lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+[rank3]:           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank3]: IndexError: too many indices for tensor of dimension 0
+[rank5]: Traceback (most recent call last):
+[rank5]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1498, in <module>
+[rank5]:     main()
+[rank5]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1484, in main
+[rank5]:     ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+[rank5]:                                 ^^^^^^^^^^^^^^^^^^^^^
+[rank5]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1039, in eval_val_ttt_adapter
+[rank5]:     _accumulate_bpb(
+[rank5]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 933, in _accumulate_bpb
+[rank5]:     lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+[rank5]:           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank5]: IndexError: too many indices for tensor of dimension 0
+[rank7]: Traceback (most recent call last):
+[rank7]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1498, in <module>
+[rank7]:     main()
+[rank7]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1484, in main
+[rank7]:     ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+[rank7]:                                 ^^^^^^^^^^^^^^^^^^^^^
+[rank7]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1039, in eval_val_ttt_adapter
+[rank7]:     _accumulate_bpb(
+[rank7]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 933, in _accumulate_bpb
+[rank7]:     lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+[rank7]:           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank7]: IndexError: too many indices for tensor of dimension 0
+[rank2]: Traceback (most recent call last):
+[rank2]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1498, in <module>
+[rank2]:     main()
+[rank2]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1484, in main
+[rank2]:     ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+[rank2]:                                 ^^^^^^^^^^^^^^^^^^^^^
+[rank2]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 1039, in eval_val_ttt_adapter
+[rank2]:     _accumulate_bpb(
+[rank2]:   File "/parameter-golf/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py", line 933, in _accumulate_bpb
+[rank2]:     lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+[rank2]:           ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[rank2]: IndexError: too many indices for tensor of dimension 0
+[rank0]:[W331 01:39:40.647580718 ProcessGroupNCCL.cpp:1524] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
+W0331 01:39:41.273000 37171 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 37239 closing signal SIGTERM
+W0331 01:39:41.275000 37171 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 37240 closing signal SIGTERM
+W0331 01:39:41.277000 37171 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 37241 closing signal SIGTERM
+W0331 01:39:41.278000 37171 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 37242 closing signal SIGTERM
+W0331 01:39:41.279000 37171 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 37243 closing signal SIGTERM
+W0331 01:39:41.280000 37171 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 37244 closing signal SIGTERM
+W0331 01:39:41.281000 37171 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 37246 closing signal SIGTERM
+E0331 01:39:42.211000 37171 torch/distributed/elastic/multiprocessing/api.py:882] failed (exitcode: 1) local_rank: 6 (pid: 37245) of binary: /usr/local/bin/python
+Traceback (most recent call last):
+  File "/usr/local/bin/torchrun", line 7, in <module>
+    sys.exit(main())
+             ^^^^^^
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 357, in wrapper
+    return f(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/run.py", line 936, in main
+    run(args)
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/run.py", line 927, in run
+    elastic_launch(
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/launcher/api.py", line 156, in __call__
+    return launch_agent(self._config, self._entrypoint, list(args))
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/launcher/api.py", line 293, in launch_agent
+    raise ChildFailedError(
+torch.distributed.elastic.multiprocessing.errors.ChildFailedError: 
+============================================================
+train_gpt.py FAILED
+------------------------------------------------------------
+Failures:
+  <NO_OTHER_FAILURES>
+------------------------------------------------------------
+Root Cause (first observed failure):
+[0]:
+  time      : 2026-03-31_01:39:41
+  host      : 477d5d130936
+  rank      : 6 (local_rank: 6)
+  exitcode  : 1 (pid: 37245)
+  error_file: <N/A>
+  traceback : To enable traceback see: https://pytorch.org/docs/stable/elastic/errors.html
+============================================================

--- a/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/logs/random_train_ttt.log
+++ b/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/logs/random_train_ttt.log
@@ -1,0 +1,155 @@
+# slug=random_train_ttt
+# description=Random-map train + random-map TTT
+# started_at=2026-03-31 01:40:59
+# command=/usr/local/bin/torchrun --standalone --nproc_per_node=8 train_gpt.py
+# env.ADAPTER_RANDOM_DIST=rademacher
+# env.ADAPTER_SEED=20260331
+# env.DATA_PATH=/parameter-golf/data/datasets/fineweb10B_sp1024
+# env.MAX_WALLCLOCK_SECONDS=600.0
+# env.PYTHONUNBUFFERED=1
+# env.RUN_ID=abl_random_train_ttt_8xh100
+# env.SEED=1337
+# env.TOKENIZER_PATH=/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+# env.TRAIN_ADAPTER_KIND=random_diag
+# env.TRAIN_ADAPTER_LR=0.02
+# env.TRAIN_ADAPTER_RANK=8
+# env.TRAIN_ADAPTER_TARGETS=q,v,lm_head
+# env.TTT_ADAPTER_KIND=random_diag
+# env.TTT_ADAPTER_LR=0.01
+# env.TTT_ADAPTER_RANK=8
+# env.VAL_LOSS_EVERY=1000
+# env.VOCAB_SIZE=1024
+
+W0331 01:41:00.823000 57282 torch/distributed/run.py:803] 
+W0331 01:41:00.823000 57282 torch/distributed/run.py:803] *****************************************
+W0331 01:41:00.823000 57282 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0331 01:41:00.823000 57282 torch/distributed/run.py:803] *****************************************
+logs/abl_random_train_ttt_8xh100.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=/parameter-golf/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:17060064
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:524288 train_seq_len:1024 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+train_adapter kind:random_diag rank:8 targets:q,v,lm_head params:152 lr:0.02 dist:rademacher seed:20260331
+ttt_adapter kind:random_diag rank:8 lr:0.01 chunk:256 eval_seq:1024 batch:64
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9357 val_bpb:4.1077 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9370 train_time:35ms step_avg:34.54ms
+step:2/20000 train_loss:16.8406 train_time:87ms step_avg:43.42ms
+step:3/20000 train_loss:8.7568 train_time:135ms step_avg:44.93ms
+step:4/20000 train_loss:6.6413 train_time:182ms step_avg:45.45ms
+step:5/20000 train_loss:6.6218 train_time:230ms step_avg:46.00ms
+step:6/20000 train_loss:7.4198 train_time:279ms step_avg:46.44ms
+step:7/20000 train_loss:6.3379 train_time:326ms step_avg:46.51ms
+step:8/20000 train_loss:6.1425 train_time:378ms step_avg:47.20ms
+step:9/20000 train_loss:6.0683 train_time:421ms step_avg:46.81ms
+step:10/20000 train_loss:5.9716 train_time:469ms step_avg:46.94ms
+step:200/20000 train_loss:2.8566 train_time:9642ms step_avg:48.21ms
+step:400/20000 train_loss:2.3499 train_time:19294ms step_avg:48.23ms
+step:600/20000 train_loss:2.5513 train_time:28928ms step_avg:48.21ms
+step:800/20000 train_loss:2.2915 train_time:38576ms step_avg:48.22ms
+step:1000/20000 train_loss:2.3751 train_time:48229ms step_avg:48.23ms
+step:1000/20000 val_loss:2.3367 val_bpb:1.3839 train_time:48246ms step_avg:48.25ms
+step:1200/20000 train_loss:2.3884 train_time:57908ms step_avg:48.26ms
+step:1400/20000 train_loss:2.4311 train_time:67595ms step_avg:48.28ms
+step:1600/20000 train_loss:2.1014 train_time:77285ms step_avg:48.30ms
+step:1800/20000 train_loss:2.1976 train_time:86969ms step_avg:48.32ms
+step:2000/20000 train_loss:2.2539 train_time:96659ms step_avg:48.33ms
+step:2000/20000 val_loss:2.2361 val_bpb:1.3243 train_time:96676ms step_avg:48.34ms
+step:2200/20000 train_loss:2.0745 train_time:106336ms step_avg:48.33ms
+step:2400/20000 train_loss:2.1993 train_time:116007ms step_avg:48.34ms
+step:2600/20000 train_loss:2.4203 train_time:125670ms step_avg:48.33ms
+step:2800/20000 train_loss:2.2371 train_time:135339ms step_avg:48.34ms
+step:3000/20000 train_loss:2.2278 train_time:144989ms step_avg:48.33ms
+step:3000/20000 val_loss:2.1952 val_bpb:1.3001 train_time:145005ms step_avg:48.34ms
+step:3200/20000 train_loss:2.1882 train_time:154641ms step_avg:48.33ms
+step:3400/20000 train_loss:2.1580 train_time:164288ms step_avg:48.32ms
+step:3600/20000 train_loss:2.1163 train_time:173947ms step_avg:48.32ms
+step:3800/20000 train_loss:2.2236 train_time:183591ms step_avg:48.31ms
+step:4000/20000 train_loss:2.1640 train_time:193237ms step_avg:48.31ms
+step:4000/20000 val_loss:2.1709 val_bpb:1.2858 train_time:193253ms step_avg:48.31ms
+step:4200/20000 train_loss:2.1733 train_time:202947ms step_avg:48.32ms
+step:4400/20000 train_loss:2.1127 train_time:212586ms step_avg:48.32ms
+step:4600/20000 train_loss:1.9760 train_time:222230ms step_avg:48.31ms
+step:4800/20000 train_loss:2.2636 train_time:231869ms step_avg:48.31ms
+step:5000/20000 train_loss:2.0317 train_time:241510ms step_avg:48.30ms
+step:5000/20000 val_loss:2.1539 val_bpb:1.2757 train_time:241527ms step_avg:48.31ms
+step:5200/20000 train_loss:2.1749 train_time:251148ms step_avg:48.30ms
+step:5400/20000 train_loss:2.1857 train_time:260792ms step_avg:48.29ms
+step:5600/20000 train_loss:2.1864 train_time:270430ms step_avg:48.29ms
+step:5800/20000 train_loss:2.1452 train_time:280073ms step_avg:48.29ms
+step:6000/20000 train_loss:2.2221 train_time:289704ms step_avg:48.28ms
+step:6000/20000 val_loss:2.1453 val_bpb:1.2705 train_time:289720ms step_avg:48.29ms
+step:6200/20000 train_loss:2.0911 train_time:299353ms step_avg:48.28ms
+step:6400/20000 train_loss:2.1636 train_time:308986ms step_avg:48.28ms
+step:6600/20000 train_loss:2.1245 train_time:318625ms step_avg:48.28ms
+step:6800/20000 train_loss:2.1885 train_time:328262ms step_avg:48.27ms
+step:7000/20000 train_loss:2.2253 train_time:337899ms step_avg:48.27ms
+step:7000/20000 val_loss:2.1337 val_bpb:1.2637 train_time:337916ms step_avg:48.27ms
+step:7200/20000 train_loss:2.1996 train_time:347532ms step_avg:48.27ms
+step:7400/20000 train_loss:2.1171 train_time:357168ms step_avg:48.27ms
+step:7600/20000 train_loss:1.9992 train_time:366796ms step_avg:48.26ms
+step:7800/20000 train_loss:2.1476 train_time:376444ms step_avg:48.26ms
+step:8000/20000 train_loss:2.1209 train_time:386077ms step_avg:48.26ms
+step:8000/20000 val_loss:2.1244 val_bpb:1.2582 train_time:386093ms step_avg:48.26ms
+step:8200/20000 train_loss:2.1856 train_time:395716ms step_avg:48.26ms
+step:8400/20000 train_loss:2.1365 train_time:405417ms step_avg:48.26ms
+step:8600/20000 train_loss:2.1399 train_time:415046ms step_avg:48.26ms
+step:8800/20000 train_loss:2.1006 train_time:424682ms step_avg:48.26ms
+step:9000/20000 train_loss:2.0300 train_time:434321ms step_avg:48.26ms
+step:9000/20000 val_loss:2.1189 val_bpb:1.2549 train_time:434337ms step_avg:48.26ms
+step:9200/20000 train_loss:2.0874 train_time:443968ms step_avg:48.26ms
+step:9400/20000 train_loss:2.1318 train_time:453605ms step_avg:48.26ms
+step:9600/20000 train_loss:2.1494 train_time:463244ms step_avg:48.25ms
+step:9800/20000 train_loss:2.0749 train_time:472877ms step_avg:48.25ms
+step:10000/20000 train_loss:2.1189 train_time:482608ms step_avg:48.26ms
+step:10000/20000 val_loss:2.1139 val_bpb:1.2520 train_time:482625ms step_avg:48.26ms
+step:10200/20000 train_loss:2.0684 train_time:492238ms step_avg:48.26ms
+step:10400/20000 train_loss:2.1015 train_time:501882ms step_avg:48.26ms
+step:10600/20000 train_loss:1.9782 train_time:511513ms step_avg:48.26ms
+step:10800/20000 train_loss:2.1882 train_time:521150ms step_avg:48.25ms
+step:11000/20000 train_loss:2.1161 train_time:530780ms step_avg:48.25ms
+step:11000/20000 val_loss:2.1070 val_bpb:1.2479 train_time:530797ms step_avg:48.25ms
+step:11200/20000 train_loss:2.0680 train_time:540418ms step_avg:48.25ms
+step:11400/20000 train_loss:2.0541 train_time:550048ms step_avg:48.25ms
+step:11600/20000 train_loss:2.0562 train_time:559686ms step_avg:48.25ms
+step:11800/20000 train_loss:2.0801 train_time:569319ms step_avg:48.25ms
+step:12000/20000 train_loss:2.0508 train_time:578961ms step_avg:48.25ms
+step:12000/20000 val_loss:2.0768 val_bpb:1.2300 train_time:578975ms step_avg:48.25ms
+step:12200/20000 train_loss:2.1933 train_time:588591ms step_avg:48.25ms
+step:12400/20000 train_loss:1.8300 train_time:598294ms step_avg:48.25ms
+step:12436/20000 val_loss:2.0627 val_bpb:1.2217 train_time:600031ms step_avg:48.25ms
+stopping_early: wallclock_cap train_time:600031ms step:12436/20000
+peak memory allocated: 10260 MiB reserved: 10362 MiB
+Serialized model: 67231989 bytes
+Code size: 65861 bytes
+Total submission size: 67297850 bytes
+Serialized model int8+zlib: 15816948 bytes (payload:17179520 raw_torch:17229811 payload_ratio:3.91x)
+Total submission size int8+zlib: 15882809 bytes
+final_int8_zlib_roundtrip val_loss:2.0819 val_bpb:1.2330 eval_time:1625ms
+final_int8_zlib_roundtrip_exact val_loss:2.08189622 val_bpb:1.23301621
+final_int8_ttt_adapter kind:random_diag val_loss:2.0275 val_bpb:1.2008 eval_time:64236ms

--- a/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/logs/random_ttt.log
+++ b/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/logs/random_ttt.log
@@ -1,0 +1,154 @@
+# slug=random_ttt
+# description=Random-map TTT only
+# started_at=2026-03-31 01:19:02
+# command=/usr/local/bin/torchrun --standalone --nproc_per_node=8 train_gpt.py
+# env.ADAPTER_RANDOM_DIST=rademacher
+# env.ADAPTER_SEED=20260331
+# env.DATA_PATH=/parameter-golf/data/datasets/fineweb10B_sp1024
+# env.MAX_WALLCLOCK_SECONDS=600.0
+# env.PYTHONUNBUFFERED=1
+# env.RUN_ID=abl_random_ttt_8xh100
+# env.SEED=1337
+# env.TOKENIZER_PATH=/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+# env.TRAIN_ADAPTER_KIND=none
+# env.TTT_ADAPTER_KIND=random_diag
+# env.TTT_ADAPTER_LR=0.01
+# env.TTT_ADAPTER_RANK=8
+# env.VAL_LOSS_EVERY=1000
+# env.VOCAB_SIZE=1024
+
+W0331 01:19:03.992000 36157 torch/distributed/run.py:803] 
+W0331 01:19:03.992000 36157 torch/distributed/run.py:803] *****************************************
+W0331 01:19:03.992000 36157 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0331 01:19:03.992000 36157 torch/distributed/run.py:803] *****************************************
+logs/abl_random_ttt_8xh100.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=/parameter-golf/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:17059912
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:524288 train_seq_len:1024 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+train_adapter kind:none rank:8 targets:q,v,lm_head params:0 lr:0.02 dist:rademacher seed:20260331
+ttt_adapter kind:random_diag rank:8 lr:0.01 chunk:256 eval_seq:1024 batch:64
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9357 val_bpb:4.1077 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9370 train_time:24ms step_avg:23.82ms
+step:2/20000 train_loss:16.8367 train_time:63ms step_avg:31.59ms
+step:3/20000 train_loss:8.7609 train_time:107ms step_avg:35.61ms
+step:4/20000 train_loss:6.6384 train_time:151ms step_avg:37.63ms
+step:5/20000 train_loss:6.6120 train_time:194ms step_avg:38.85ms
+step:6/20000 train_loss:7.4223 train_time:238ms step_avg:39.73ms
+step:7/20000 train_loss:6.3503 train_time:291ms step_avg:41.51ms
+step:8/20000 train_loss:6.1576 train_time:336ms step_avg:42.03ms
+step:9/20000 train_loss:6.0676 train_time:380ms step_avg:42.21ms
+step:10/20000 train_loss:5.9743 train_time:424ms step_avg:42.38ms
+step:200/20000 train_loss:2.8515 train_time:8864ms step_avg:44.32ms
+step:400/20000 train_loss:2.3543 train_time:17844ms step_avg:44.61ms
+step:600/20000 train_loss:2.5473 train_time:26753ms step_avg:44.59ms
+step:800/20000 train_loss:2.2886 train_time:35672ms step_avg:44.59ms
+step:1000/20000 train_loss:2.3762 train_time:44609ms step_avg:44.61ms
+step:1000/20000 val_loss:2.3362 val_bpb:1.3836 train_time:44624ms step_avg:44.62ms
+step:1200/20000 train_loss:2.3913 train_time:53554ms step_avg:44.63ms
+step:1400/20000 train_loss:2.4318 train_time:62498ms step_avg:44.64ms
+step:1600/20000 train_loss:2.0997 train_time:71467ms step_avg:44.67ms
+step:1800/20000 train_loss:2.1991 train_time:80416ms step_avg:44.68ms
+step:2000/20000 train_loss:2.2503 train_time:89363ms step_avg:44.68ms
+step:2000/20000 val_loss:2.2370 val_bpb:1.3249 train_time:89378ms step_avg:44.69ms
+step:2200/20000 train_loss:2.0749 train_time:98311ms step_avg:44.69ms
+step:2400/20000 train_loss:2.2026 train_time:107251ms step_avg:44.69ms
+step:2600/20000 train_loss:2.4149 train_time:116187ms step_avg:44.69ms
+step:2800/20000 train_loss:2.2357 train_time:125117ms step_avg:44.68ms
+step:3000/20000 train_loss:2.2310 train_time:134046ms step_avg:44.68ms
+step:3000/20000 val_loss:2.1957 val_bpb:1.3004 train_time:134062ms step_avg:44.69ms
+step:3200/20000 train_loss:2.1893 train_time:142975ms step_avg:44.68ms
+step:3400/20000 train_loss:2.1586 train_time:151903ms step_avg:44.68ms
+step:3600/20000 train_loss:2.1135 train_time:160817ms step_avg:44.67ms
+step:3800/20000 train_loss:2.2211 train_time:169733ms step_avg:44.67ms
+step:4000/20000 train_loss:2.1631 train_time:178641ms step_avg:44.66ms
+step:4000/20000 val_loss:2.1706 val_bpb:1.2855 train_time:178656ms step_avg:44.66ms
+step:4200/20000 train_loss:2.1738 train_time:187620ms step_avg:44.67ms
+step:4400/20000 train_loss:2.1085 train_time:196529ms step_avg:44.67ms
+step:4600/20000 train_loss:1.9726 train_time:205439ms step_avg:44.66ms
+step:4800/20000 train_loss:2.2645 train_time:214341ms step_avg:44.65ms
+W0331 01:23:29.551000 36157 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 36225 closing signal SIGTERM
+W0331 01:23:29.553000 36157 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 36226 closing signal SIGTERM
+W0331 01:23:29.555000 36157 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 36227 closing signal SIGTERM
+W0331 01:23:29.558000 36157 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 36228 closing signal SIGTERM
+W0331 01:23:29.562000 36157 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 36229 closing signal SIGTERM
+W0331 01:23:29.565000 36157 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 36230 closing signal SIGTERM
+W0331 01:23:29.568000 36157 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 36231 closing signal SIGTERM
+W0331 01:23:29.570000 36157 torch/distributed/elastic/multiprocessing/api.py:908] Sending process 36232 closing signal SIGTERM
+Traceback (most recent call last):
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/elastic/agent/server/api.py", line 717, in run
+    result = self._invoke_run(role)
+             ^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/elastic/agent/server/api.py", line 881, in _invoke_run
+    time.sleep(monitor_interval)
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/elastic/multiprocessing/api.py", line 85, in _terminate_process_handler
+    raise SignalException(f"Process {os.getpid()} got signal: {sigval}", sigval=sigval)
+torch.distributed.elastic.multiprocessing.api.SignalException: Process 36157 got signal: 1
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "/usr/local/bin/torchrun", line 7, in <module>
+    sys.exit(main())
+             ^^^^^^
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 357, in wrapper
+    return f(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/run.py", line 936, in main
+    run(args)
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/run.py", line 927, in run
+    elastic_launch(
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/launcher/api.py", line 156, in __call__
+    return launch_agent(self._config, self._entrypoint, list(args))
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/launcher/api.py", line 284, in launch_agent
+    result = agent.run()
+             ^^^^^^^^^^^
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/elastic/metrics/api.py", line 138, in wrapper
+    result = f(*args, **kwargs)
+             ^^^^^^^^^^^^^^^^^^
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/elastic/agent/server/api.py", line 725, in run
+    logger.warning("Received %s death signal, shutting down workers", e.sigval)
+  File "/usr/lib/python3.12/logging/__init__.py", line 1551, in warning
+    self._log(WARNING, msg, args, **kwargs)
+  File "/usr/lib/python3.12/logging/__init__.py", line 1682, in _log
+    record = self.makeRecord(self.name, level, fn, lno, msg, args,
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/logging/__init__.py", line 1651, in makeRecord
+    rv = _logRecordFactory(name, level, fn, lno, msg, args, exc_info, func,
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3.12/logging/__init__.py", line 324, in __init__
+    if (args and len(args) == 1 and isinstance(args[0], collections.abc.Mapping)
+                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "<frozen abc>", line 119, in __instancecheck__
+  File "<frozen abc>", line 123, in __subclasscheck__
+  File "<frozen abc>", line 121, in __subclasscheck__
+  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/elastic/multiprocessing/api.py", line 85, in _terminate_process_handler
+    raise SignalException(f"Process {os.getpid()} got signal: {sigval}", sigval=sigval)
+torch.distributed.elastic.multiprocessing.api.SignalException: Process 36157 got signal: 1

--- a/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/plot_ablation_losses.py
+++ b/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/plot_ablation_losses.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import argparse
+import html
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+TRAIN_RE = re.compile(r"step:(\d+)/\d+\s+train_loss:([0-9.]+)")
+VAL_RE = re.compile(r"step:(\d+)/\d+\s+val_loss:([0-9.]+)\s+val_bpb:([0-9.]+)")
+FINAL_Q_RE = re.compile(r"final_int8_zlib_roundtrip(?:_exact)? val_loss:([0-9.]+) val_bpb:([0-9.]+)")
+FINAL_TTT_RE = re.compile(r"final_int8_ttt_adapter kind:([a-z_]+) val_loss:([0-9.]+) val_bpb:([0-9.]+)")
+COLOR_CYCLE = [
+    "#1f77b4",
+    "#d62728",
+    "#2ca02c",
+    "#9467bd",
+    "#ff7f0e",
+    "#17becf",
+    "#8c564b",
+    "#e377c2",
+]
+
+
+@dataclass
+class Series:
+    slug: str
+    description: str
+    log_path: Path
+    train_points: list[tuple[int, float]]
+    val_points: list[tuple[int, float]]
+    val_bpbs: list[tuple[int, float]]
+    final_roundtrip_bpb: float | None
+    final_ttt_kind: str | None
+    final_ttt_bpb: float | None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate an SVG loss graph from ablation logs.")
+    parser.add_argument("--log-dir", type=Path, default=Path("ablations") / "logs")
+    parser.add_argument("--output", type=Path, default=Path("ablations") / "ablations_loss.svg")
+    parser.add_argument("--summary", type=Path, default=Path("ablations") / "ablations_summary.tsv")
+    return parser.parse_args()
+
+
+def parse_log(log_path: Path) -> Series:
+    text = log_path.read_text(encoding="utf-8", errors="replace")
+    description = ""
+    for line in text.splitlines():
+        if line.startswith("# description="):
+            description = line.split("=", 1)[1]
+            break
+    train_points = [(int(step), float(loss)) for step, loss in TRAIN_RE.findall(text)]
+    val_points = [(int(step), float(loss)) for step, loss, _ in VAL_RE.findall(text)]
+    val_bpbs = [(int(step), float(bpb)) for step, _, bpb in VAL_RE.findall(text)]
+    roundtrip_matches = FINAL_Q_RE.findall(text)
+    ttt_matches = FINAL_TTT_RE.findall(text)
+    return Series(
+        slug=log_path.stem,
+        description=description or log_path.stem,
+        log_path=log_path,
+        train_points=train_points,
+        val_points=val_points,
+        val_bpbs=val_bpbs,
+        final_roundtrip_bpb=float(roundtrip_matches[-1][1]) if roundtrip_matches else None,
+        final_ttt_kind=ttt_matches[-1][0] if ttt_matches else None,
+        final_ttt_bpb=float(ttt_matches[-1][2]) if ttt_matches else None,
+    )
+
+
+def axis_bounds(series_list: list[Series], attr: str) -> tuple[float, float] | None:
+    values: list[float] = []
+    for series in series_list:
+        points = getattr(series, attr)
+        values.extend(value for _, value in points)
+    if not values:
+        return None
+    low = min(values)
+    high = max(values)
+    if low == high:
+        pad = max(abs(low) * 0.05, 0.1)
+        return low - pad, high + pad
+    pad = (high - low) * 0.08
+    return low - pad, high + pad
+
+
+def x_bounds(series_list: list[Series]) -> tuple[int, int]:
+    xs = [step for series in series_list for points in (series.train_points, series.val_points) for step, _ in points]
+    if not xs:
+        return 0, 1
+    return 0, max(xs)
+
+
+def scale_x(step: float, x_min: float, x_max: float, left: float, width: float) -> float:
+    span = max(x_max - x_min, 1.0)
+    return left + ((step - x_min) / span) * width
+
+
+def scale_y(value: float, y_min: float, y_max: float, top: float, height: float) -> float:
+    span = max(y_max - y_min, 1e-9)
+    return top + height - ((value - y_min) / span) * height
+
+
+def build_polyline(points: list[tuple[int, float]], x_min: float, x_max: float, y_min: float, y_max: float, left: float, top: float, width: float, height: float) -> str:
+    return " ".join(
+        f"{scale_x(step, x_min, x_max, left, width):.2f},{scale_y(value, y_min, y_max, top, height):.2f}"
+        for step, value in points
+    )
+
+
+def build_panel(series_list: list[Series], attr: str, title: str, left: float, top: float, width: float, height: float, x_min: float, x_max: float) -> str:
+    bounds = axis_bounds(series_list, attr)
+    if bounds is None:
+        return (
+            f"<g><rect x='{left}' y='{top}' width='{width}' height='{height}' fill='white' stroke='#cccccc'/>"
+            f"<text x='{left + 12}' y='{top + 24}' font-size='18' font-family='sans-serif'>{html.escape(title)}</text>"
+            f"<text x='{left + width / 2:.2f}' y='{top + height / 2:.2f}' text-anchor='middle' font-size='16' fill='#666'>No data yet</text></g>"
+        )
+
+    y_min, y_max = bounds
+    parts = [
+        f"<g><rect x='{left}' y='{top}' width='{width}' height='{height}' fill='white' stroke='#cccccc'/>",
+        f"<text x='{left + 12}' y='{top + 24}' font-size='18' font-family='sans-serif'>{html.escape(title)}</text>",
+    ]
+    for tick_idx in range(5):
+        frac = tick_idx / 4
+        y_value = y_min + frac * (y_max - y_min)
+        y = scale_y(y_value, y_min, y_max, top, height)
+        parts.append(f"<line x1='{left}' y1='{y:.2f}' x2='{left + width}' y2='{y:.2f}' stroke='#eeeeee'/>")
+        parts.append(f"<text x='{left - 10}' y='{y + 4:.2f}' text-anchor='end' font-size='12' fill='#555'>{y_value:.3f}</text>")
+    for tick_idx in range(6):
+        frac = tick_idx / 5
+        x_value = x_min + frac * (x_max - x_min)
+        x = scale_x(x_value, x_min, x_max, left, width)
+        parts.append(f"<line x1='{x:.2f}' y1='{top}' x2='{x:.2f}' y2='{top + height}' stroke='#f3f3f3'/>")
+        parts.append(f"<text x='{x:.2f}' y='{top + height + 18}' text-anchor='middle' font-size='12' fill='#555'>{int(round(x_value))}</text>")
+
+    for idx, series in enumerate(series_list):
+        points = getattr(series, attr)
+        if not points:
+            continue
+        color = COLOR_CYCLE[idx % len(COLOR_CYCLE)]
+        polyline = build_polyline(points, x_min, x_max, y_min, y_max, left, top, width, height)
+        parts.append(f"<polyline fill='none' stroke='{color}' stroke-width='2.25' points='{polyline}'/>")
+        end_x = scale_x(points[-1][0], x_min, x_max, left, width)
+        end_y = scale_y(points[-1][1], y_min, y_max, top, height)
+        parts.append(f"<circle cx='{end_x:.2f}' cy='{end_y:.2f}' r='3.5' fill='{color}'/>")
+    parts.append("</g>")
+    return "".join(parts)
+
+
+def legend(series_list: list[Series], left: float, top: float) -> str:
+    parts = [f"<g><text x='{left}' y='{top}' font-size='18' font-family='sans-serif'>Ablations</text>"]
+    y = top + 28
+    for idx, series in enumerate(series_list):
+        color = COLOR_CYCLE[idx % len(COLOR_CYCLE)]
+        bpb_bits: list[str] = []
+        if series.final_roundtrip_bpb is not None:
+            bpb_bits.append(f"roundtrip={series.final_roundtrip_bpb:.4f}")
+        if series.final_ttt_bpb is not None and series.final_ttt_kind is not None:
+            bpb_bits.append(f"ttt[{series.final_ttt_kind}]={series.final_ttt_bpb:.4f}")
+        metrics = " | ".join(bpb_bits) if bpb_bits else "pending"
+        parts.append(f"<line x1='{left}' y1='{y - 4}' x2='{left + 18}' y2='{y - 4}' stroke='{color}' stroke-width='3'/>")
+        parts.append(f"<text x='{left + 26}' y='{y}' font-size='13' font-family='sans-serif'>{html.escape(series.slug)} - {html.escape(metrics)}</text>")
+        y += 20
+    parts.append("</g>")
+    return "".join(parts)
+
+
+def build_svg(series_list: list[Series]) -> str:
+    width = 1500
+    height = 920
+    left = 85
+    panel_width = 980
+    panel_height = 300
+    x_min, x_max = x_bounds(series_list)
+    train_panel = build_panel(series_list, "train_points", "Train loss vs step", left, 70, panel_width, panel_height, x_min, x_max)
+    val_panel = build_panel(series_list, "val_points", "Validation loss vs step", left, 450, panel_width, panel_height, x_min, x_max)
+    return (
+        f"<svg xmlns='http://www.w3.org/2000/svg' width='{width}' height='{height}' viewBox='0 0 {width} {height}'>"
+        "<rect width='100%' height='100%' fill='#fafafa'/>"
+        "<text x='85' y='36' font-size='28' font-family='sans-serif'>Random-map adapter ablations</text>"
+        "<text x='85' y='780' font-size='13' fill='#555' font-family='sans-serif'>Step</text>"
+        f"{train_panel}{val_panel}{legend(series_list, 1110, 92)}"
+        "</svg>"
+    )
+
+
+def write_summary(series_list: list[Series], output_path: Path) -> None:
+    lines = ["slug\tdescription\ttrain_points\tval_points\tfinal_roundtrip_bpb\tfinal_ttt_kind\tfinal_ttt_bpb\tlog_path"]
+    for series in series_list:
+        lines.append(
+            "\t".join(
+                [
+                    series.slug,
+                    series.description.replace("\t", " "),
+                    str(len(series.train_points)),
+                    str(len(series.val_points)),
+                    f"{series.final_roundtrip_bpb:.8f}" if series.final_roundtrip_bpb is not None else "",
+                    series.final_ttt_kind or "",
+                    f"{series.final_ttt_bpb:.8f}" if series.final_ttt_bpb is not None else "",
+                    str(series.log_path),
+                ]
+            )
+        )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    args.log_dir.mkdir(parents=True, exist_ok=True)
+    series_list = [parse_log(path) for path in sorted(args.log_dir.glob("*.log"))]
+    svg = build_svg(series_list)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(svg, encoding="utf-8")
+    write_summary(series_list, args.summary)
+    print(f"Wrote {args.output}")
+    print(f"Wrote {args.summary}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/run_all_ablations.py
+++ b/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/run_all_ablations.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+REPO_ROOT = ROOT.parents[2]
+ABLATION_DIR = ROOT / "ablations"
+LOG_DIR = ABLATION_DIR / "logs"
+GRAPH_PATH = ABLATION_DIR / "ablations_loss.svg"
+SUMMARY_PATH = ABLATION_DIR / "ablations_summary.tsv"
+PLOT_SCRIPT = ROOT / "plot_ablation_losses.py"
+
+
+@dataclass(frozen=True)
+class Ablation:
+    slug: str
+    description: str
+    env: dict[str, str]
+
+
+ABLATIONS = [
+    Ablation(
+        "baseline",
+        "No train adapters and no TTT adapters",
+        {"TRAIN_ADAPTER_KIND": "none", "TTT_ADAPTER_KIND": "none"},
+    ),
+    Ablation(
+        "lora_ttt",
+        "LoRA TTT control",
+        {
+            "TRAIN_ADAPTER_KIND": "none",
+            "TTT_ADAPTER_KIND": "lora",
+            "TTT_ADAPTER_RANK": "8",
+            "TTT_ADAPTER_LR": "0.01",
+        },
+    ),
+    Ablation(
+        "random_ttt",
+        "Random-map TTT only",
+        {
+            "TRAIN_ADAPTER_KIND": "none",
+            "TTT_ADAPTER_KIND": "random_diag",
+            "TTT_ADAPTER_RANK": "8",
+            "TTT_ADAPTER_LR": "0.01",
+            "ADAPTER_RANDOM_DIST": "rademacher",
+            "ADAPTER_SEED": "20260331",
+        },
+    ),
+    Ablation(
+        "random_train",
+        "Random-map train only",
+        {
+            "TRAIN_ADAPTER_KIND": "random_diag",
+            "TRAIN_ADAPTER_RANK": "8",
+            "TRAIN_ADAPTER_LR": "0.02",
+            "TRAIN_ADAPTER_TARGETS": "q,v,lm_head",
+            "TTT_ADAPTER_KIND": "none",
+            "ADAPTER_RANDOM_DIST": "rademacher",
+            "ADAPTER_SEED": "20260331",
+        },
+    ),
+    Ablation(
+        "random_train_ttt",
+        "Random-map train + random-map TTT",
+        {
+            "TRAIN_ADAPTER_KIND": "random_diag",
+            "TRAIN_ADAPTER_RANK": "8",
+            "TRAIN_ADAPTER_LR": "0.02",
+            "TRAIN_ADAPTER_TARGETS": "q,v,lm_head",
+            "TTT_ADAPTER_KIND": "random_diag",
+            "TTT_ADAPTER_RANK": "8",
+            "TTT_ADAPTER_LR": "0.01",
+            "ADAPTER_RANDOM_DIST": "rademacher",
+            "ADAPTER_SEED": "20260331",
+        },
+    ),
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run all random-map ablations and update the loss graph.")
+    parser.add_argument("--nproc-per-node", type=int, default=8)
+    parser.add_argument("--max-wallclock-seconds", type=float, default=600.0)
+    parser.add_argument("--timeout-seconds", type=int, default=1800)
+    parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument("--val-loss-every", type=int, default=1000)
+    parser.add_argument("--only", type=str, default="")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--stop-on-error", action="store_true")
+    return parser.parse_args()
+
+
+def selected_ablations(only: str) -> list[Ablation]:
+    if not only.strip():
+        return ABLATIONS
+    wanted = {item.strip() for item in only.split(",") if item.strip()}
+    selected = [ablation for ablation in ABLATIONS if ablation.slug in wanted]
+    missing = sorted(wanted - {ablation.slug for ablation in selected})
+    if missing:
+        raise ValueError(f"Unknown ablations in --only: {missing}")
+    return selected
+
+
+def base_env(args: argparse.Namespace) -> dict[str, str]:
+    return {
+        "DATA_PATH": str(REPO_ROOT / "data" / "datasets" / "fineweb10B_sp1024"),
+        "TOKENIZER_PATH": str(REPO_ROOT / "data" / "tokenizers" / "fineweb_1024_bpe.model"),
+        "VOCAB_SIZE": "1024",
+        "SEED": str(args.seed),
+        "VAL_LOSS_EVERY": str(args.val_loss_every),
+        "MAX_WALLCLOCK_SECONDS": str(args.max_wallclock_seconds),
+        "PYTHONUNBUFFERED": "1",
+    }
+
+
+def validate_paths(env: dict[str, str]) -> None:
+    data_path = Path(env["DATA_PATH"])
+    tokenizer_path = Path(env["TOKENIZER_PATH"])
+    if not data_path.exists():
+        raise FileNotFoundError(f"Missing DATA_PATH: {data_path}")
+    if not tokenizer_path.exists():
+        raise FileNotFoundError(f"Missing TOKENIZER_PATH: {tokenizer_path}")
+
+
+def resolve_torchrun() -> str:
+    env_override = os.environ.get("TORCHRUN_BIN")
+    if env_override:
+        return env_override
+    path_hit = shutil.which("torchrun")
+    if path_hit is not None:
+        return path_hit
+    sibling = Path(sys.executable).with_name("torchrun")
+    if sibling.exists():
+        return str(sibling)
+    sibling_exe = Path(sys.executable).with_name("torchrun.exe")
+    if sibling_exe.exists():
+        return str(sibling_exe)
+    raise FileNotFoundError("Could not find `torchrun`; set TORCHRUN_BIN if needed")
+
+
+def plot_outputs() -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            str(PLOT_SCRIPT),
+            "--log-dir",
+            str(LOG_DIR),
+            "--output",
+            str(GRAPH_PATH),
+            "--summary",
+            str(SUMMARY_PATH),
+        ],
+        cwd=str(ROOT),
+        check=True,
+    )
+
+
+def run_one(ablation: Ablation, args: argparse.Namespace, common_env: dict[str, str], torchrun_bin: str) -> int:
+    env = os.environ.copy()
+    env.update(common_env)
+    env.update(ablation.env)
+    env["RUN_ID"] = f"abl_{ablation.slug}_8xh100"
+    command = [torchrun_bin, "--standalone", f"--nproc_per_node={args.nproc_per_node}", "train_gpt.py"]
+    log_path = LOG_DIR / f"{ablation.slug}.log"
+    started_at = time.strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{started_at}] starting {ablation.slug}: {ablation.description}", flush=True)
+    if args.dry_run:
+        print(f"DRY RUN {ablation.slug}: {' '.join(command)}", flush=True)
+        return 0
+
+    with log_path.open("w", encoding="utf-8") as handle:
+        handle.write(f"# slug={ablation.slug}\n")
+        handle.write(f"# description={ablation.description}\n")
+        handle.write(f"# started_at={started_at}\n")
+        handle.write(f"# command={' '.join(command)}\n")
+        for key in sorted(common_env.keys() | ablation.env.keys() | {'RUN_ID'}):
+            handle.write(f"# env.{key}={env[key]}\n")
+        handle.write("\n")
+        handle.flush()
+        try:
+            proc = subprocess.run(
+                command,
+                cwd=str(ROOT),
+                env=env,
+                stdout=handle,
+                stderr=subprocess.STDOUT,
+                timeout=args.timeout_seconds,
+                check=False,
+            )
+            return_code = proc.returncode
+        except subprocess.TimeoutExpired:
+            handle.write(f"\nTIMEOUT after {args.timeout_seconds} seconds\n")
+            return_code = 124
+    finished_at = time.strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{finished_at}] finished {ablation.slug} returncode={return_code} log={log_path}", flush=True)
+    plot_outputs()
+    return return_code
+
+
+def main() -> int:
+    args = parse_args()
+    chosen = selected_ablations(args.only)
+    common_env = base_env(args)
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    validate_paths(common_env)
+    torchrun_bin = resolve_torchrun()
+
+    if args.dry_run:
+        print(f"Record dir: {ROOT}")
+        print(f"Logs dir:   {LOG_DIR}")
+        print(f"Graph path: {GRAPH_PATH}")
+        print(f"Torchrun:   {torchrun_bin}")
+
+    exit_code = 0
+    for ablation in chosen:
+        return_code = run_one(ablation, args, common_env, torchrun_bin)
+        if return_code != 0:
+            exit_code = return_code
+            if args.stop_on_error:
+                break
+
+    if not args.dry_run:
+        plot_outputs()
+        print(f"Summary TSV: {SUMMARY_PATH}")
+        print(f"Loss graph:  {GRAPH_PATH}")
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/run_all_ablations.sh
+++ b/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/run_all_ablations.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+python3 run_all_ablations.py "$@"

--- a/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/submission.json
+++ b/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/submission.json
@@ -1,0 +1,18 @@
+{
+  "author": "",
+  "github_id": "",
+  "name": "Random-Map Adapter Train/Eval Ablations (best: LoRA TTT control)",
+  "blurb": "Non-record 8xH100 submission studying train-time random-map adapters and document-aware evaluation adapters. The best score in this ablation set came from the LoRA TTT control at 1.1917 val_bpb; the best random-map variant (train + random-map TTT) reached 1.2008. Final counted artifact size was 15,883,798 bytes.",
+  "date": "2026-03-31T00:00:00Z",
+  "track": "non-record-16mb",
+  "val_loss": 2.0122,
+  "val_bpb": 1.1917,
+  "pre_quant_val_loss": null,
+  "pre_quant_val_bpb": null,
+  "step_stop": 13507,
+  "wallclock_seconds": 600.012,
+  "bytes_total": 15883798,
+  "bytes_model_int8_zlib": 15817937,
+  "bytes_code": 65861,
+  "gpu": "8xH100"
+}

--- a/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py
+++ b/records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval/train_gpt.py
@@ -1,0 +1,1498 @@
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# HYPERPARAMETERS
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 2))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+
+    # Train-time / test-time adapter hyperparameters.
+    train_adapter_kind = os.environ.get("TRAIN_ADAPTER_KIND", "none").lower()
+    train_adapter_rank = int(os.environ.get("TRAIN_ADAPTER_RANK", 8))
+    train_adapter_lr = float(os.environ.get("TRAIN_ADAPTER_LR", 0.02))
+    train_adapter_targets = tuple(t.strip().lower() for t in os.environ.get("TRAIN_ADAPTER_TARGETS", "q,v,lm_head").split(",") if t.strip())
+    adapter_random_dist = os.environ.get("ADAPTER_RANDOM_DIST", "rademacher").lower()
+    adapter_seed = int(os.environ.get("ADAPTER_SEED", 20260331))
+    ttt_adapter_kind = os.environ.get("TTT_ADAPTER_KIND", "lora").lower()
+    ttt_adapter_rank = int(os.environ.get("TTT_ADAPTER_RANK", os.environ.get("TTT_LORA_RANK", 8)))
+    ttt_adapter_lr = float(os.environ.get("TTT_ADAPTER_LR", os.environ.get("TTT_LORA_LR", 0.01)))
+    ttt_chunk_size = int(os.environ.get("TTT_CHUNK_SIZE", 256))
+    ttt_eval_seq_len = int(os.environ.get("TTT_EVAL_SEQ_LEN", 1024))
+    ttt_batch_size = int(os.environ.get("TTT_BATCH_SIZE", 64))
+
+# MUON OPTIMIZER 
+# 
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# POST-TRAINING QUANTIZATION
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,train_q_adapter,train_v_adapter,train_lm_head_adapter",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+# DATA LOADING 
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# TRANSFORMER MODULES
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+class CastedLinear(nn.Linear):
+    # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, self.weight.to(x.dtype), bias)
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor, q_delta=None, v_delta=None) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x) + (q_delta if q_delta is not None else 0)
+        k = self.c_k(x)
+        v = self.c_v(x) + (v_delta if v_delta is not None else 0)
+        q = q.reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+class MLP(nn.Module):
+    # relu^2 MLP from the original modded-nanogpt setup
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+def _sum_optional(a: Tensor | None, b: Tensor | None) -> Tensor | None:
+    if a is None:
+        return b
+    if b is None:
+        return a
+    return a + b
+
+def _use_target(targets: tuple[str, ...], target: str) -> bool:
+    return target in targets
+
+def _make_random_map(rows: int, cols: int, seed: int, dist: str, scale: float) -> Tensor:
+    gen = torch.Generator(device="cpu")
+    gen.manual_seed(seed)
+    if dist == "gaussian":
+        mat = torch.randn((rows, cols), generator=gen, dtype=torch.float32)
+    elif dist == "rademacher":
+        mat = (torch.randint(0, 2, (rows, cols), generator=gen).to(torch.float32) * 2.0) - 1.0
+    else:
+        raise ValueError(f"Unsupported ADAPTER_RANDOM_DIST={dist}")
+    return mat * scale
+
+class LinearRandomMapAdapter(nn.Module):
+    def __init__(self, in_features: int, out_features: int, rank: int, seed: int, dist: str):
+        super().__init__()
+        self.register_buffer(
+            "random_in_map",
+            _make_random_map(rank, in_features, seed, dist, 1.0 / math.sqrt(in_features)),
+            persistent=False,
+        )
+        self.register_buffer(
+            "random_out_map",
+            _make_random_map(out_features, rank, seed + 1, dist, 1.0 / math.sqrt(max(rank, 1))),
+            persistent=False,
+        )
+        self.coeff = nn.Parameter(torch.zeros(rank, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        z = F.linear(x, self.random_in_map.to(dtype=x.dtype))
+        return F.linear(z * self.coeff.to(dtype=z.dtype), self.random_out_map.to(dtype=z.dtype))
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        train_adapter_kind: str,
+        train_adapter_rank: int,
+        train_adapter_targets: tuple[str, ...],
+        adapter_random_dist: str,
+        adapter_seed: int,
+        layer_idx: int,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        kv_dim = num_kv_heads * (dim // num_heads)
+        self.train_q_adapter = None
+        self.train_v_adapter = None
+        if train_adapter_kind == "random_diag":
+            if _use_target(train_adapter_targets, "q"):
+                self.train_q_adapter = LinearRandomMapAdapter(dim, dim, train_adapter_rank, adapter_seed + 17 * layer_idx, adapter_random_dist)
+            if _use_target(train_adapter_targets, "v"):
+                self.train_v_adapter = LinearRandomMapAdapter(dim, kv_dim, train_adapter_rank, adapter_seed + 17 * layer_idx + 2, adapter_random_dist)
+        elif train_adapter_kind != "none":
+            raise ValueError(f"Unsupported TRAIN_ADAPTER_KIND={train_adapter_kind}")
+
+    def forward(self, x: Tensor, x0: Tensor, q_adapter=None, v_adapter=None) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = self.attn_norm(x)
+        qd = _sum_optional(self.train_q_adapter(n) if self.train_q_adapter is not None else None, q_adapter(n) if q_adapter is not None else None)
+        vd = _sum_optional(self.train_v_adapter(n) if self.train_v_adapter is not None else None, v_adapter(n) if v_adapter is not None else None)
+        attn_out = self.attn(n, qd, vd)
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        train_adapter_kind: str,
+        train_adapter_rank: int,
+        train_adapter_targets: tuple[str, ...],
+        adapter_random_dist: str,
+        adapter_seed: int,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                    train_adapter_kind,
+                    train_adapter_rank,
+                    train_adapter_targets,
+                    adapter_random_dist,
+                    adapter_seed,
+                    i,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        self.train_lm_head_adapter = (
+            LinearRandomMapAdapter(model_dim, vocab_size, train_adapter_rank, adapter_seed + 10_000, adapter_random_dist)
+            if train_adapter_kind == "random_diag" and _use_target(train_adapter_targets, "lm_head")
+            else None
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor, adapter=None) -> Tensor:
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+
+        # First half stores skips; second half reuses them in reverse order.
+        for i in range(self.num_encoder_layers):
+            qd = adapter.q_adapters[i] if adapter else None
+            vd = adapter.v_adapters[i] if adapter else None
+            x = self.blocks[i](x, x0, qd, vd)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            qd = adapter.q_adapters[bi] if adapter else None
+            vd = adapter.v_adapters[bi] if adapter else None
+            x = self.blocks[bi](x, x0, qd, vd)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits = F.linear(x, self.tok_emb.weight)
+        else:
+            logits = self.lm_head(x)
+        logits = logits + (self.train_lm_head_adapter(x) if self.train_lm_head_adapter is not None else 0)
+        logits = logits + (adapter.lm_head_adapter(x) if adapter else 0)
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        if adapter:
+            bsz, sl, V = logits.shape
+            return F.cross_entropy(
+                logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none").reshape(bsz, sl)
+        return F.cross_entropy(logits.float().reshape(-1, logits.size(-1)), target_ids.reshape(-1), reduction="mean")
+
+# TEST-TIME TRAINING ADAPTERS
+#
+# At evaluation time, we adapt per-document adapters on the validation data.
+# Each document gets its own adapter, so there is no inter-document dependency.
+
+BOS_ID = 1
+
+class BatchedLinearLoRA(nn.Module):
+    """LoRA for a linear layer, with independent weights per batch element.
+    Computes x @ Aᵀ @ Bᵀ  =  x @ (BA)ᵀ,  i.e. the LoRA delta is ΔW = BA."""
+    def __init__(self, bsz: int, in_features: int, out_features: int, rank: int):
+        super().__init__()
+        self.in_features = in_features
+        self.A = nn.Parameter(torch.empty(bsz, rank, in_features))     # down-projection
+        self.B = nn.Parameter(torch.zeros(bsz, out_features, rank))    # up-projection
+        self.reset()
+
+    def forward(self, x: Tensor) -> Tensor:
+        return (x @ self.A.transpose(1, 2).to(dtype=x.dtype)) @ self.B.transpose(1, 2).to(dtype=x.dtype)
+
+    def reset(self) -> None:
+        bound = 1.0 / math.sqrt(self.in_features)
+        with torch.no_grad():
+            self.A.uniform_(-bound, bound)  # kaiming-uniform
+            self.B.zero_()
+
+class BatchedTTTLoRA(nn.Module):
+    """All LoRA adapters for one batch: LM head and Q/V per block."""
+    def __init__(self, bsz: int, model: GPT, rank: int):
+        super().__init__()
+        dim = model.tok_emb.embedding_dim
+        vocab = model.tok_emb.num_embeddings
+        self.lm_head_adapter = BatchedLinearLoRA(bsz, dim, vocab, rank)
+        self.q_adapters = nn.ModuleList()
+        self.v_adapters = nn.ModuleList()
+        for block in model.blocks:
+            self.q_adapters.append(BatchedLinearLoRA(bsz, dim, block.attn.c_q.weight.shape[0], rank))
+            self.v_adapters.append(BatchedLinearLoRA(bsz, dim, block.attn.c_v.weight.shape[0], rank))
+
+    def reset(self) -> None:
+        for m in self.modules():
+            if isinstance(m, BatchedLinearLoRA):
+                m.reset()
+
+class BatchedLinearRandomMapAdapter(nn.Module):
+    def __init__(self, bsz: int, in_features: int, out_features: int, rank: int, seed: int, dist: str):
+        super().__init__()
+        self.register_buffer(
+            "random_in_map",
+            _make_random_map(rank, in_features, seed, dist, 1.0 / math.sqrt(in_features)),
+            persistent=False,
+        )
+        self.register_buffer(
+            "random_out_map",
+            _make_random_map(out_features, rank, seed + 1, dist, 1.0 / math.sqrt(max(rank, 1))),
+            persistent=False,
+        )
+        self.coeff = nn.Parameter(torch.zeros(bsz, rank, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        z = F.linear(x, self.random_in_map.to(dtype=x.dtype))
+        return F.linear(z * self.coeff[:, None, :].to(dtype=z.dtype), self.random_out_map.to(dtype=z.dtype))
+
+    def reset(self) -> None:
+        with torch.no_grad():
+            self.coeff.zero_()
+
+class BatchedTTTRandomMap(nn.Module):
+    def __init__(self, bsz: int, model: GPT, rank: int, seed: int, dist: str):
+        super().__init__()
+        dim = model.tok_emb.embedding_dim
+        vocab = model.tok_emb.num_embeddings
+        self.lm_head_adapter = BatchedLinearRandomMapAdapter(bsz, dim, vocab, rank, seed + 10_000, dist)
+        self.q_adapters = nn.ModuleList()
+        self.v_adapters = nn.ModuleList()
+        for i, block in enumerate(model.blocks):
+            self.q_adapters.append(BatchedLinearRandomMapAdapter(bsz, dim, block.attn.c_q.weight.shape[0], rank, seed + 17 * i, dist))
+            self.v_adapters.append(BatchedLinearRandomMapAdapter(bsz, dim, block.attn.c_v.weight.shape[0], rank, seed + 17 * i + 2, dist))
+
+    def reset(self) -> None:
+        for m in self.modules():
+            if isinstance(m, BatchedLinearRandomMapAdapter):
+                m.reset()
+
+def _reset_ttt_optimizer(opt):
+    for group in opt.param_groups:
+        for p in group['params']:
+            s = opt.state.get(p)
+            if not s:   # Fresh state.
+                continue
+            s['exp_avg'].zero_()
+            s['exp_avg_sq'].zero_()
+            s['step'].fill_(0)
+
+def _build_ttt_adapter(kind: str, bsz: int, model: GPT, args: Hyperparameters):
+    if kind == "none":
+        return None
+    if kind == "lora":
+        return BatchedTTTLoRA(bsz, model, args.ttt_adapter_rank)
+    if kind == "random_diag":
+        return BatchedTTTRandomMap(bsz, model, args.ttt_adapter_rank, args.adapter_seed, args.adapter_random_dist)
+    raise ValueError(f"Unsupported TTT_ADAPTER_KIND={kind}")
+
+def _build_ttt_optimizer(adapter, args: Hyperparameters):
+    return torch.optim.Adam(adapter.parameters(), lr=args.ttt_adapter_lr, betas=(args.beta1, args.beta2), eps=1e-10)
+
+def _find_docs(all_tokens: Tensor, include_next_bos: bool = True) -> list[tuple[int, int]]:
+    """Return (start_offset, length) for each document, identified by BOS boundaries.
+
+    If include_next_bos is True, include next document's BOS (to match continuous-stream
+    eval token count exactly).
+    """
+    bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0].numpy()
+    docs = []
+    for i in range(len(bos_positions)):
+        start = int(bos_positions[i])
+        end = int(bos_positions[i + 1]) if i + 1 < len(bos_positions) else all_tokens.numel()
+        if include_next_bos and i + 1 < len(bos_positions):
+            end += 1
+        assert end - start >= 2
+        docs.append((start, end - start))
+    return docs
+
+def _compute_chunk_window(ci: int, pred_len: int, num_chunks: int, chunk_size: int, eval_seq_len: int):
+    """Return (win_start, win_len, chunk_offset, chunk_len) for chunk `ci` of a doc."""
+    chunk_start = ci * chunk_size
+    chunk_end = pred_len if ci == num_chunks - 1 else (ci + 1) * chunk_size
+    win_start = max(0, chunk_end - eval_seq_len)
+    win_len = chunk_end - win_start
+    chunk_offset = chunk_start - win_start
+    chunk_len = chunk_end - chunk_start
+    return win_start, win_len, chunk_offset, chunk_len
+
+def _accumulate_bpb(
+    ptl: Tensor, x: Tensor, y: Tensor,
+    batch_i: int, chunk_offset: int, chunk_len: int,
+    base_bytes_lut: Tensor, has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    loss_sum: Tensor, byte_sum: Tensor, token_count: Tensor,
+):
+    """Add one doc-chunk's contribution to the running BPB accumulators."""
+    lbl = ptl[batch_i, chunk_offset:chunk_offset + chunk_len].to(torch.float64)
+    prev = x[batch_i, chunk_offset:chunk_offset + chunk_len]
+    tgt = y[batch_i, chunk_offset:chunk_offset + chunk_len]
+    tok_bytes = base_bytes_lut[tgt].to(torch.float64)
+    tok_bytes += has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]
+    loss_sum += lbl.sum()
+    byte_sum += tok_bytes.sum()
+    token_count += chunk_len
+
+def eval_val_ttt_adapter(
+    args: Hyperparameters,
+    base_model: GPT,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    """Evaluate with document-aware adapters. Returns (val_loss, val_bpb)."""
+    # Load validation tokens and find document boundaries
+    files = sorted(glob.glob(args.val_files))
+    all_tokens = torch.cat([load_data_shard(Path(f)) for f in files])
+    docs = _find_docs(all_tokens)
+
+    # Each rank takes a contiguous slice of documents
+    rank_docs = docs[(len(docs) * rank) // world_size : (len(docs) * (rank + 1)) // world_size]
+    chunk_size = args.ttt_chunk_size
+    eval_seq_len = args.ttt_eval_seq_len
+    batch_size = args.ttt_batch_size
+    adapter_kind = args.ttt_adapter_kind
+
+    rank_docs.sort(key=lambda d: (d[1] - 2) // chunk_size)
+
+    base_model.eval()
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+
+    adapter = _build_ttt_adapter(adapter_kind, batch_size, base_model, args)
+    if adapter is not None:
+        adapter = adapter.to(device)
+        opt = _build_ttt_optimizer(adapter, args)
+    else:
+        opt = None
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    for bi in range(0, len(rank_docs), batch_size):
+        batch = rank_docs[bi:bi + batch_size]
+        bsz = len(batch)
+
+        if bsz == batch_size:
+            cur_adapter, cur_opt = adapter, opt
+            if cur_adapter is not None:
+                cur_adapter.reset()
+                _reset_ttt_optimizer(cur_opt)
+        else:
+            cur_adapter = _build_ttt_adapter(adapter_kind, bsz, base_model, args)
+            if cur_adapter is not None:
+                cur_adapter = cur_adapter.to(device)
+                cur_opt = _build_ttt_optimizer(cur_adapter, args)
+            else:
+                cur_opt = None
+
+        pred_lens = [doc_len - 1 for _, doc_len in batch]
+        num_chunks = [(pl + chunk_size - 1) // chunk_size for pl in pred_lens]
+        max_nc = max(num_chunks)
+
+        for ci in range(max_nc):
+            chunk_stats = _compute_chunk_window(ci, (ci + 1) * chunk_size, ci + 1, chunk_size, eval_seq_len)
+            context_size, chunk_offset = chunk_stats[1], chunk_stats[2]
+
+            active = [ci < nc for nc in num_chunks]
+            needs_train = cur_adapter is not None and any(ci < nc - 1 for nc in num_chunks)
+
+            x = torch.zeros(bsz, context_size, dtype=torch.int64, device=device)
+            y = torch.zeros(bsz, context_size, dtype=torch.int64, device=device)
+            doc_info = []  # (chunk_offset, chunk_len) per doc
+            for b in range(bsz):
+                if not active[b]:
+                    doc_info.append((0, 0))
+                    continue
+                ds, dl = batch[b]
+                ws, wl, co, cl = _compute_chunk_window(ci, pred_lens[b], num_chunks[b], chunk_size, eval_seq_len)
+                chunk = all_tokens[ds + ws: ds + ws + wl + 1]
+                toks = chunk.to(dtype=torch.int64, device=device)
+                x[b, :wl] = toks[:-1]
+                y[b, :wl] = toks[1:]
+                doc_info.append((co, cl))
+
+            # Forward pass (keep grad graph alive only when we need to train)
+            if needs_train:
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    ptl = base_model(x, y, adapter=cur_adapter)
+            else:
+                with torch.no_grad(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    ptl = base_model(x, y, adapter=cur_adapter)
+
+            # Score: accumulate loss and byte counts for BPB (before training on chunk)
+            with torch.no_grad():
+                for b in range(bsz):
+                    if not active[b]:
+                        continue
+                    co, cl = doc_info[b]
+                    _accumulate_bpb(
+                        ptl, x, y, b, co, cl, base_bytes_lut, has_leading_space_lut,
+                        is_boundary_token_lut, loss_sum, byte_sum, token_count)
+
+            # Train: one Adam step on the adapter params using this chunk's loss
+            if needs_train:
+                mask = torch.tensor([float(ci < num_chunks[b] - 1) for b in range(bsz)], device=device)
+                per_doc = ptl[:, chunk_offset:chunk_offset + chunk_size].mean(dim=-1)
+                cur_opt.zero_grad()
+                (per_doc * mask).sum().backward()
+                cur_opt.step()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+
+    val_loss = float(loss_sum.item() / token_count.item())
+    val_bpb = float((loss_sum.item() / math.log(2.0)) / byte_sum.item())
+    return val_loss, val_bpb
+
+# TRAINING
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    unknown_targets = set(args.train_adapter_targets) - {"q", "v", "lm_head"}
+    if unknown_targets:
+        raise ValueError(f"Unsupported TRAIN_ADAPTER_TARGETS={sorted(unknown_targets)}")
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # DISTRIBUTED + CUDA SETUP
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # TOKENIZER + VALIDATION METRIC SETUP
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # MODEL + OPTIMIZER SETUP
+
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        train_adapter_kind=args.train_adapter_kind,
+        train_adapter_rank=args.train_adapter_rank,
+        train_adapter_targets=args.train_adapter_targets,
+        adapter_random_dist=args.adapter_random_dist,
+        adapter_seed=args.adapter_seed,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+        if isinstance(module, Rotary):
+            module.inv_freq.data = module.inv_freq.data.float()
+    restore_low_dim_params_to_fp32(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    train_adapter_params = [
+        p for name, p in base_model.named_parameters()
+        if "train_" in name and "adapter" in name
+    ]
+    train_adapter_param_ids = {id(p) for p in train_adapter_params}
+    block_named_params = [
+        (name, p) for name, p in base_model.blocks.named_parameters()
+        if id(p) not in train_adapter_param_ids
+    ]
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+    if train_adapter_params:
+        optimizer_train_adapter = torch.optim.Adam(
+            [{"params": train_adapter_params, "lr": args.train_adapter_lr, "base_lr": args.train_adapter_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.append(optimizer_train_adapter)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    n_train_adapter = sum(p.numel() for p in train_adapter_params)
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(
+        f"train_adapter kind:{args.train_adapter_kind} rank:{args.train_adapter_rank} "
+        f"targets:{','.join(args.train_adapter_targets) or 'none'} params:{n_train_adapter} "
+        f"lr:{args.train_adapter_lr} dist:{args.adapter_random_dist} seed:{args.adapter_seed}"
+    )
+    log0(
+        f"ttt_adapter kind:{args.ttt_adapter_kind} rank:{args.ttt_adapter_rank} "
+        f"lr:{args.ttt_adapter_lr} chunk:{args.ttt_chunk_size} eval_seq:{args.ttt_eval_seq_len} "
+        f"batch:{args.ttt_batch_size}"
+    )
+    log0(f"seed:{args.seed}")
+    state_keys = tuple(base_model.state_dict().keys())
+    if any("random_" in key for key in state_keys):
+        raise RuntimeError("Random adapter maps must not be serialized in state_dict")
+
+    # DATA LOADER & MODEL WARMUP
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # MAIN TRAINING LOOP
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed int8+zlib artifact and validate the round-tripped weights.
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    # Document-aware adapter evaluation
+    torch._dynamo.reset()
+    torch.cuda.synchronize()
+    t_ttt = time.perf_counter()
+    ttt_val_loss, ttt_val_bpb = eval_val_ttt_adapter(
+        args, base_model, rank, world_size, device,
+        base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_ttt_adapter kind:{args.ttt_adapter_kind} val_loss:{ttt_val_loss:.4f} val_bpb:{ttt_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_ttt):.0f}ms"
+    )
+
+    if distributed:
+        dist.destroy_process_group()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a new non-record submission folder for an 8xH100 ablation study on train-time and evaluation-time adapters built on random linear maps:

     - `records/track_non_record_16mb/2026-03-31_RandomMapAdapters_TrainEval`

     The submission explores:
     - train-time `random_diag` adapters on `q`, `v`, and `lm_head`
     - document-aware evaluation adapters with both:
       - LoRA TTT
       - random-map TTT

     This is a non-record submission intended as an interesting signs-of-life result for the "learning
     adapters on random linear maps" direction requested in the repo README.

     ## Main results

     Best results from the ablation set:

     | Condition | Score |
     |---|---:|
     | baseline roundtrip | 1.2268 val_bpb |
     | LoRA TTT control | **1.1917 val_bpb** |
     | best random-map variant (`random_train_ttt`) | **1.2008 val_bpb** |

     Takeaway:
     - document-aware TTT is clearly helpful
     - LoRA remains stronger than the random-map parameterization in this implementation
     - random-map adapters show some promise, but are not yet competitive with the LoRA control

     ## What’s included

     This folder contains:

     - `train_gpt.py` — code snapshot for the ablation study
     - `run_all_ablations.py` / `run_all_ablations.sh` — reproducible launcher
     - `plot_ablation_losses.py` — log parsing / plotting utility
     - `ablations_summary.tsv` — compact summary of all runs
     - `logs/*.log` — raw run logs
     - `README.md` — writeup and interpretation
     - `submission.json` — submission metadata

     ## Notes

     - The best overall score in this folder is the LoRA TTT control (`1.1917`), which is why
     `submission.json` reflects that run.
     - The best pure random-map condition is `random_train_ttt` at `1.2008`.
     - The counted artifact for the best run is under the 16MB cap.
     - `baseline` and `random_train` emit clean final roundtrip validation lines, then crash in the final
      document-aware eval path because `TTT_ADAPTER_KIND=none` returns scalar loss instead of per-token
     loss. The counted roundtrip metrics are still present in the logs.