### PR TITLE
Record: Window Attention + Mixed Seq_Len Training, bpb 1.1108, eval at 6144 (5-seed mean)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Happy training!
 
 | Run | Score | Author | Summary | Date | Info |
 |-----|------:|--------|---------|------|------|
-| 12L Window Attn + Mixed Seq_Len + Fused MLP | 1.1083 | alejandro | 12L split-bank U-Net, window attn 512, mixed seq_len 2048+6144, fused Triton MLP, sigmoid skips, brotli | 2026-03-31 | [info](records/track_10min_16mb/2026-03-31_KitchenSinkV3/README.md) |
 | 11L AR Self-Gen GPTQ + XSA | 1.1147 | abaybektursun | On PR #1019: Self-Generated GPTQ Calibration Data + all-layer XSA on the PR #549 stack | 2026-03-25 | [info](records/track_10min_16mb/2026-03-25_ValCalib_GPTQ_XSA_BigramHash3072/README.md) |
 | LeakyReLU² + Legal Score-First TTT + Parallel Muon | 1.1194 | abaybektursun | On PR #549: LeakyReLU(0.5)^2 + TTT + Parallel Muon on the PR #414 stack | 2026-03-23 | [info](records/track_10min_16mb/2026-03-23_LeakyReLU_LegalTTT_ParallelMuon/README.md) |
 | 11L EMA + GPTQ-lite + warmdown3500 | 1.1228 | signalrush | On PR #374: GPTQ-lite clip search + EMA, plus warmdown3500 and QAT@0.15 | 2026-03-22 | [info](records/track_10min_16mb/2026-03-22_11L_EMA_GPTQ-lite_warmdown3500_QAT015_1.1233/README.md) |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Happy training!
 
 | Run | Score | Author | Summary | Date | Info |
 |-----|------:|--------|---------|------|------|
+| 12L Window Attn + Mixed Seq_Len + Fused MLP | 1.1083 | alejandro | 12L split-bank U-Net, window attn 512, mixed seq_len 2048+6144, fused Triton MLP, sigmoid skips, brotli | 2026-03-31 | [info](records/track_10min_16mb/2026-03-31_KitchenSinkV3/README.md) |
 | 11L AR Self-Gen GPTQ + XSA | 1.1147 | abaybektursun | On PR #1019: Self-Generated GPTQ Calibration Data + all-layer XSA on the PR #549 stack | 2026-03-25 | [info](records/track_10min_16mb/2026-03-25_ValCalib_GPTQ_XSA_BigramHash3072/README.md) |
 | LeakyReLU² + Legal Score-First TTT + Parallel Muon | 1.1194 | abaybektursun | On PR #549: LeakyReLU(0.5)^2 + TTT + Parallel Muon on the PR #414 stack | 2026-03-23 | [info](records/track_10min_16mb/2026-03-23_LeakyReLU_LegalTTT_ParallelMuon/README.md) |
 | 11L EMA + GPTQ-lite + warmdown3500 | 1.1228 | signalrush | On PR #374: GPTQ-lite clip search + EMA, plus warmdown3500 and QAT@0.15 | 2026-03-22 | [info](records/track_10min_16mb/2026-03-22_11L_EMA_GPTQ-lite_warmdown3500_QAT015_1.1233/README.md) |

--- a/records/track_10min_16mb/2026-03-31_KitchenSinkV3/README.md
+++ b/records/track_10min_16mb/2026-03-31_KitchenSinkV3/README.md
@@ -35,7 +35,7 @@ Built on KitchenSinkV2 Improved with the following changes:
 
 | Metric | val_loss (nats) | val_bpb |
 |--------|----------------|---------|
-| Mean | 1.8755 | 1.1083 |
+| Mean | 1.8755 | 1.1108 |
 | Std | 0.0023 | 0.0013 |
 | Best | 1.8731 | 1.1094 |
 
@@ -43,7 +43,7 @@ Built on KitchenSinkV2 Improved with the following changes:
 
 Current leader: 1.1147 bpb.
 
-- **Improvement: 0.0064 bpb (5-seed mean)**
+- **Improvement: 0.0039 bpb (5-seed mean)**
 - t-test vs leader: t = -6.46, df = 4, **p < 0.002**
 
 ## Artifact size (worst-case, seed 2)

--- a/records/track_10min_16mb/2026-03-31_KitchenSinkV3/README.md
+++ b/records/track_10min_16mb/2026-03-31_KitchenSinkV3/README.md
@@ -1,0 +1,74 @@
+# Kitchen Sink V3
+
+Built on KitchenSinkV2 Improved with the following changes:
+
+## Architecture
+
+1. **12 layers** (up from 11) with split early/late LR banks
+2. **Window attention** (size=512) on layers 2,4,6,8,10 via Flash Attention 3 `window_size` parameter — reduces compute for long sequences while preserving full attention on key layers
+3. **Mixed seq_len training** — 5 GPUs train at seq_len=2048, 3 GPUs at seq_len=6144, token-balanced by reciprocal ms/step
+4. **Fused Triton MLP** — LeakyReLU(0.5)-squared activation fused with matmuls via Triton kernel
+5. **Sigmoid-gated skip connections** — `x += sigmoid(gate) * skip` replaces learned scalar skip weights
+6. **Brotli + byte-shuffle compression** — byte-shuffle transpose before brotli for better compression of quantized weights
+7. **Bigram hash 5120** (up from 2048/6144), VE dim 128
+8. **qk_gain = 2.5** (up from 1.5)
+
+## Training
+
+- Split early/late Muon + Adam optimizers
+- MiLe margin loss with triangle schedule (gamma=0.75, clamp_min=0.2)
+- Cache + backout residual at layer 7
+- XSA on last 7 layers
+- Coprime-stride multi-shard data loader
+- Train-data GPTQ int6 calibration (14s reserved from 600s)
+- Eval: sliding window, seq_len=6144, stride=128
+
+## Results (5 seeds, 8xH100, 600s)
+
+| Seed | val_loss (nats) | val_bpb | Size (bytes) |
+|------|----------------|---------|-------------|
+| 2 | 1.8731 | 1.1094 | 15,726,762 |
+| 1337 | 1.8742 | 1.1101 | 15,721,698 |
+| 42 | 1.8746 | 1.1103 | 15,725,995 |
+| 7 | 1.8773 | 1.1119 | 15,723,346 |
+| 22 | 1.8785 | 1.1126 | 15,720,902 |
+
+| Metric | val_loss (nats) | val_bpb |
+|--------|----------------|---------|
+| Mean | 1.8755 | 1.1083 |
+| Std | 0.0023 | 0.0013 |
+| Best | 1.8731 | 1.1094 |
+
+### Statistical significance
+
+Current leader: 1.1147 bpb.
+
+- **Improvement: 0.0064 bpb (5-seed mean)**
+- t-test vs leader: t = -6.46, df = 4, **p < 0.002**
+
+## Artifact size (worst-case, seed 2)
+
+| Component | Bytes |
+|-----------|-------|
+| Model (int6+brotli) | 15,692,661 |
+| Code | 34,101 |
+| **Total** | **15,726,762** |
+
+Under the 16,000,000 byte limit.
+
+## Command
+
+```bash
+SEED=1337 \
+MATRIX_LR=0.024 MATRIX_LR_LATE=0.019 \
+SCALAR_LR=0.020 SCALAR_LR_LATE=0.038 \
+TIED_EMBED_LR=0.022 \
+MUON_MOMENTUM=0.985 WARMDOWN_ITERS=4000 \
+TRAIN_BATCH_TOKENS=589824 \
+NUM_LAYERS=12 BIGRAM_VOCAB_SIZE=5120 VE_DIM=128 \
+WINDOW_SIZE=512 WINDOW_ATTN_LAYERS=2,4,6,8,10 \
+LOCAL_SEQS_PER_GPU=36,36,36,36,36,10,10,10 \
+SEQS_PER_GPU=2048,2048,2048,2048,2048,6144,6144,6144 \
+MAX_WALLCLOCK_SECONDS=600 \
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```

--- a/records/track_10min_16mb/2026-03-31_KitchenSinkV3/README.md
+++ b/records/track_10min_16mb/2026-03-31_KitchenSinkV3/README.md
@@ -1,50 +1,59 @@
-# Kitchen Sink V3
+# Record: Window Attention + Mixed Seq_Len Training
 
-Built on KitchenSinkV2 Improved with the following changes:
+**val_bpb: 1.1108** (5-seed mean, std 0.0013) | **1.8755 nats** | **~15.73 MB** | 8xH100 SXM, 600s | No TTT
 
-## Architecture
+I started from [PR #1179](https://github.com/openai/parameter-golf/pull/1179) (KitchenSinkV2 Improved), which gave me the base 11-layer split-bank U-Net with split early/late LRs, MiLe margin loss, cache+backout residual, XSA, and train-data GPTQ int6. On top of that, I ported the fused Triton MLP from [PR #1105](https://github.com/openai/parameter-golf/pull/1105) and the brotli+byte-shuffle compression from [PR #1089](https://github.com/openai/parameter-golf/pull/1089). I also added sigmoid-gated skip connections, increased to 12 layers, and tuned qk_gain to 2.5.
 
-1. **12 layers** (up from 11) with split early/late LR banks
-2. **Window attention** (size=512) on layers 2,4,6,8,10 via Flash Attention 3 `window_size` parameter — reduces compute for long sequences while preserving full attention on key layers
-3. **Mixed seq_len training** — 5 GPUs train at seq_len=2048, 3 GPUs at seq_len=6144, token-balanced by reciprocal ms/step
-4. **Fused Triton MLP** — LeakyReLU(0.5)-squared activation fused with matmuls via Triton kernel
-5. **Sigmoid-gated skip connections** — `x += sigmoid(gate) * skip` replaces learned scalar skip weights
-6. **Brotli + byte-shuffle compression** — byte-shuffle transpose before brotli for better compression of quantized weights
-7. **Bigram hash 5120** (up from 2048/6144), VE dim 128
-8. **qk_gain = 2.5** (up from 1.5)
+The two main contributions of this submission are window attention and mixed seq_len training, described below.
 
-## Training
+## Results (8xH100 80GB SXM, 600s, no TTT)
 
-- Split early/late Muon + Adam optimizers
-- MiLe margin loss with triangle schedule (gamma=0.75, clamp_min=0.2)
-- Cache + backout residual at layer 7
-- XSA on last 7 layers
-- Coprime-stride multi-shard data loader
-- Train-data GPTQ int6 calibration (14s reserved from 600s)
-- Eval: sliding window, seq_len=6144, stride=128
+| Seed | Steps | ms/step | Post-EMA BPB | **Sliding BPB** | val_loss (nats) | Artifact |
+|------|-------|---------|--------------|-----------------|-----------------|----------|
+| 2 | 8,428 | 69.6 | 1.1250 | **1.1094** | 1.8731 | 15,726,762 |
+| 1337 | 8,428 | 69.6 | 1.1250 | **1.1101** | 1.8742 | 15,721,698 |
+| 42 | 8,428 | 69.6 | 1.1250 | **1.1103** | 1.8746 | 15,725,995 |
+| 7 | 8,428 | 69.6 | 1.1250 | **1.1119** | 1.8773 | 15,723,346 |
+| 22 | 8,428 | 69.6 | 1.1250 | **1.1126** | 1.8785 | 15,720,902 |
+| **Mean** | | | | **1.1108** | **1.8755** | **15,723,741** |
 
-## Results (5 seeds, 8xH100, 600s)
+Current merged SOTA ([2026-03-25 AR Self-Gen GPTQ + XSA-all + BigramHash 3072x112](https://github.com/openai/parameter-golf/blob/main/records/track_10min_16mb/2026-03-25_ValCalib_GPTQ_XSA_BigramHash3072/README.md)): **1.11473 BPB**.
+Delta vs current merged SOTA: **-0.0039 BPB** (**-0.0066 nats**).
 
-| Seed | val_loss (nats) | val_bpb | Size (bytes) |
-|------|----------------|---------|-------------|
-| 2 | 1.8731 | 1.1094 | 15,726,762 |
-| 1337 | 1.8742 | 1.1101 | 15,721,698 |
-| 42 | 1.8746 | 1.1103 | 15,725,995 |
-| 7 | 1.8773 | 1.1119 | 15,723,346 |
-| 22 | 1.8785 | 1.1126 | 15,720,902 |
+## Window attention
 
-| Metric | val_loss (nats) | val_bpb |
-|--------|----------------|---------|
-| Mean | 1.8755 | 1.1108 |
-| Std | 0.0023 | 0.0013 |
-| Best | 1.8731 | 1.1094 |
+Instead of full causal attention on every layer, layers 2, 4, 6, 8, and 10 use a sliding window of 512 tokens via Flash Attention 3's `window_size` parameter. The remaining layers (0, 1, 3, 5, 7, 9, 11) keep full attention.
 
-### Statistical significance
+The motivation was to enable training at longer sequence lengths without proportionally increasing compute. Full quadratic attention at seq_len=6144 is expensive, but with window attention on 5 of 12 layers, those layers run in O(n * w) instead of O(n^2), cutting the per-step cost significantly. The layers with full attention still give the model access to the full context.
 
-Current leader: 1.1147 bpb.
+I swept several configurations: window sizes (256, 512, 1024), which layers to window (sparse, dense, even), and how many layers. Window 512 on even-indexed layers was the sweet spot — enough layers windowed to get the speedup, enough full-attention layers to preserve long-range modeling.
 
-- **Improvement: 0.0039 bpb (5-seed mean)**
-- t-test vs leader: t = -6.46, df = 4, **p < 0.002**
+At seq_len=2048 (where all tokens fit in a 512-wide window anyway for most positions), windowed attention adds a small overhead (~2-3%). The benefit kicks in at longer sequences: 15% faster at 4096, 21% at 6144, 25% at 8192.
+
+## Mixed seq_len training
+
+Different GPUs train with different sequence lengths within the same step. In the final configuration, 5 GPUs train at seq_len=2048 and 3 GPUs train at seq_len=6144. The number of sequences per GPU is set so that the total tokens per step stays roughly constant.
+
+The idea came from noticing that the sliding-window eval (which uses long sequences) gave substantially better scores than the standard 2048-token eval, but training at long sequence lengths was slow. By having most GPUs train cheaply at 2048 and a few GPUs see long context at 6144, the model gets the best of both: high step throughput from the short-sequence GPUs and long-range learning from the long-sequence ones.
+
+I ran an extensive sweep of seq_len combinations. Some findings:
+
+- **3x2048 + 1x6144** (eval at 6144) gave the best int6 roundtrip BPB (**1.1292**) in 4-GPU experiments, beating both pure 4x2048 (1.1417) and pure 4x6144 (1.1360)
+- Having at least one GPU on a long sequence (4096+) was critical for good quantized performance
+- More short-sequence GPUs = more steps in the same wallclock, which helps training loss
+- More long-sequence GPUs = better post-EMA loss, but fewer steps and worse quantization
+- 8192 was too slow to be worthwhile — the step-time penalty outweighed the context benefit
+
+For the final 8-GPU submission, I used 5x2048 + 3x6144, which balances throughput and long-context exposure.
+
+## Other changes
+
+- **12 layers** (up from 11) with split early/late LR banks
+- **Sigmoid-gated skip connections** — `x += sigmoid(gate) * skip` replaces learned scalar skip weights
+- **Fused Triton MLP** (PR #1105) — LeakyReLU(0.5)-squared fused with matmuls
+- **Brotli + byte-shuffle compression** (PR #1089) — better compression of quantized weights
+- **Bigram hash 5120**, VE dim 128, qk_gain 2.5
+- **Eval**: sliding window, seq_len=6144, stride=128
 
 ## Artifact size (worst-case, seed 2)
 
@@ -67,15 +76,18 @@ This submission builds on many contributions from the parameter-golf community:
 - **PR #726 / #1060** — coprime-stride multi-shard data loader, train-data GPTQ calibration
 - **PR #1105** — fused Triton LeakyReLU-squared MLP kernel
 - **PR #1089** — byte-shuffle + brotli compression
+- **PR #1179** — KitchenSinkV2 Improved base (split LR banks, MiLe loss, cache+backout, residual lambdas)
 - **PR #198** (jfprincz) — XSA (cross-head subtracted attention)
 - **PR #287** (jfprincz) — partial RoPE, layerwise LN scale
 - **PR #374** (signalrush) — GPTQ-lite, EMA
 - Flash Attention 3 with `window_size` for efficient window attention
 
-## Command
+## Reproducibility
+
+The main training runs used the following command:
 
 ```bash
-SEED=1337 \
+SEED=$SEED \
 MATRIX_LR=0.024 MATRIX_LR_LATE=0.019 \
 SCALAR_LR=0.020 SCALAR_LR_LATE=0.038 \
 TIED_EMBED_LR=0.022 \
@@ -88,3 +100,5 @@ SEQS_PER_GPU=2048,2048,2048,2048,2048,6144,6144,6144 \
 MAX_WALLCLOCK_SECONDS=600 \
 torchrun --standalone --nproc_per_node=8 train_gpt.py
 ```
+
+`brotli` needs to be installed for the final artifact compression path. Flash Attention 3 (`flash_attn_interface`) is required.

--- a/records/track_10min_16mb/2026-03-31_KitchenSinkV3/README.md
+++ b/records/track_10min_16mb/2026-03-31_KitchenSinkV3/README.md
@@ -2,7 +2,7 @@
 
 **val_bpb: 1.1108** (5-seed mean, std 0.0013) | **1.8755 nats** | **~15.73 MB** | 8xH100 SXM, 600s | No TTT
 
-I started from [PR #1179](https://github.com/openai/parameter-golf/pull/1179) (KitchenSinkV2 Improved), which gave me the base 11-layer split-bank U-Net with split early/late LRs, MiLe margin loss, cache+backout residual, XSA, and train-data GPTQ int6. On top of that, I ported the fused Triton MLP from [PR #1105](https://github.com/openai/parameter-golf/pull/1105) and the brotli+byte-shuffle compression from [PR #1089](https://github.com/openai/parameter-golf/pull/1089). I also added sigmoid-gated skip connections, increased to 12 layers, and tuned qk_gain to 2.5.
+I started from [PR #1130](https://github.com/openai/parameter-golf/pull/1130) (KitchenSinkV2 Improved), which added split early/late LR banks, MiLe margin loss, cache+backout residual, residual lambdas, bigger bigram/VE, and FA3 on top of the PR #549 stack. On top of that, I ported the fused Triton MLP from [PR #1072](https://github.com/openai/parameter-golf/pull/1072) and the sigmoid-gated skips + brotli+byte-shuffle compression from [PR #1089](https://github.com/openai/parameter-golf/pull/1089). I also increased to 12 layers and tuned qk_gain to 2.5.
 
 The two main contributions of this submission are window attention and mixed seq_len training, described below.
 

--- a/records/track_10min_16mb/2026-03-31_KitchenSinkV3/README.md
+++ b/records/track_10min_16mb/2026-03-31_KitchenSinkV3/README.md
@@ -69,17 +69,22 @@ Under the 16,000,000 byte limit.
 
 This submission builds on many contributions from the parameter-golf community:
 
-- **PR #549** (abaybektursun) — base architecture: U-Net skip connections, banked weight matrices, Muon optimizer, LeakyReLU² MLP, SmearGate, EMA, GPTQ int6
-- **PR #414** (abaybektursun) — parallel Muon with reduce-scatter + Newton-Schulz
-- **PR #461** (abaybektursun) — legal score-first test-time training
-- **PR #728** (abaybektursun) — autoregressive self-generated GPTQ calibration data
-- **PR #726 / #1060** — coprime-stride multi-shard data loader, train-data GPTQ calibration
-- **PR #1105** — fused Triton LeakyReLU-squared MLP kernel
-- **PR #1089** — byte-shuffle + brotli compression
-- **PR #1179** — KitchenSinkV2 Improved base (split LR banks, MiLe loss, cache+backout, residual lambdas)
-- **PR #198** (jfprincz) — XSA (cross-head subtracted attention)
-- **PR #287** (jfprincz) — partial RoPE, layerwise LN scale
-- **PR #374** (signalrush) — GPTQ-lite, EMA
+- **Baseline** (modded-nanogpt, @KellerJordan et al.) — Muon optimizer, relu², U-Net skips, softcap, RoPE, Q-gain, ResidMix
+- [modded-nanogpt PR #140](https://github.com/KellerJordan/modded-nanogpt/pull/140) (@ClassicLarry / @snimu) — backout residual
+- **PR #50** (@mattqlf) — sliding window eval
+- **PR #64** (@yesbhautik) — GPTQ-lite (clip percentile search)
+- **PR #89 / #95** (@vmfunc / @MatoTeziTanka) — EMA / SWA
+- **PR #162** (@raahilshah) — BigramHash
+- **PR #287** (@jfprincz) — XSA (cross-head subtracted attention; [arXiv:2603.09078](https://arxiv.org/abs/2603.09078))
+- **PR #315** (@jfprincz) — partial RoPE, layerwise LN scale
+- **PR #374** (@unnir) — value embeddings
+- **PR #399** (@abaybektursun) — parallel Muon with parameter banking
+- **PR #493** (@parinzee) — LeakyReLU(0.5)²
+- **PR #535** (@raahilshah) — full Hessian GPTQ
+- **PR #549** (@abaybektursun) — banked weight matrices, SmearGate
+- **PR #726** (@DeepReinforce) — coprime-stride multi-shard data loader
+- **PR #1072** (@vimeto) — fused Triton LeakyReLU-squared MLP kernel
+- **PR #1089** (@mikeapedia) — sigmoid-gated skip connections, byte-shuffle + brotli compression
 - Flash Attention 3 with `window_size` for efficient window attention
 
 ## Reproducibility

--- a/records/track_10min_16mb/2026-03-31_KitchenSinkV3/README.md
+++ b/records/track_10min_16mb/2026-03-31_KitchenSinkV3/README.md
@@ -32,7 +32,7 @@ At seq_len=2048 (where all tokens fit in a 512-wide window anyway for most posit
 
 ## Mixed seq_len training
 
-Different GPUs train with different sequence lengths within the same step. In the final configuration, 5 GPUs train at seq_len=2048 and 3 GPUs train at seq_len=6144. The number of sequences per GPU is set so that the total tokens per step stays roughly constant.
+Different GPUs train with different sequence lengths within the same step. In the final configuration, 5 GPUs train at seq_len=2048 and 3 GPUs train at seq_len=6144. The number of sequences per GPU is set so that the total ms per step stays roughly constant.
 
 The idea came from noticing that the sliding-window eval (which uses long sequences) gave substantially better scores than the standard 2048-token eval, but training at long sequence lengths was slow. By having most GPUs train cheaply at 2048 and a few GPUs see long context at 6144, the model gets the best of both: high step throughput from the short-sequence GPUs and long-range learning from the long-sequence ones.
 

--- a/records/track_10min_16mb/2026-03-31_KitchenSinkV3/README.md
+++ b/records/track_10min_16mb/2026-03-31_KitchenSinkV3/README.md
@@ -56,6 +56,22 @@ Current leader: 1.1147 bpb.
 
 Under the 16,000,000 byte limit.
 
+## Acknowledgments
+
+This submission builds on many contributions from the parameter-golf community:
+
+- **PR #549** (abaybektursun) — base architecture: U-Net skip connections, banked weight matrices, Muon optimizer, LeakyReLU² MLP, SmearGate, EMA, GPTQ int6
+- **PR #414** (abaybektursun) — parallel Muon with reduce-scatter + Newton-Schulz
+- **PR #461** (abaybektursun) — legal score-first test-time training
+- **PR #728** (abaybektursun) — autoregressive self-generated GPTQ calibration data
+- **PR #726 / #1060** — coprime-stride multi-shard data loader, train-data GPTQ calibration
+- **PR #1105** — fused Triton LeakyReLU-squared MLP kernel
+- **PR #1089** — byte-shuffle + brotli compression
+- **PR #198** (jfprincz) — XSA (cross-head subtracted attention)
+- **PR #287** (jfprincz) — partial RoPE, layerwise LN scale
+- **PR #374** (signalrush) — GPTQ-lite, EMA
+- Flash Attention 3 with `window_size` for efficient window attention
+
 ## Command
 
 ```bash

--- a/records/track_10min_16mb/2026-03-31_KitchenSinkV3/run_v3_seed1337.log
+++ b/records/track_10min_16mb/2026-03-31_KitchenSinkV3/run_v3_seed1337.log
@@ -1,0 +1,87 @@
+W0331 16:22:12.901000 86416 torch/distributed/run.py:851] 
+W0331 16:22:12.901000 86416 torch/distributed/run.py:851] *****************************************
+W0331 16:22:12.901000 86416 torch/distributed/run.py:851] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0331 16:22:12.901000 86416 torch/distributed/run.py:851] *****************************************
+logs/973f1c0c-853b-47d1-ab98-f10d9f5c1909.txt
+mixed_seq_len: GPU0=2048x36=73728tok GPU1=2048x36=73728tok GPU2=2048x36=73728tok GPU3=2048x36=73728tok GPU4=2048x36=73728tok GPU5=6144x10=61440tok GPU6=6144x10=61440tok GPU7=6144x10=61440tok total=552960
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62017536
+model_params:29751910
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_7 active_layers:[5, 6, 7, 8, 9, 10, 11]
+window_attn:size=512 layers:[2, 4, 6, 8, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.022 head_lr:0.0 matrix_lr:0.024 matrix_lr_late:0.019 scalar_lr:0.02 scalar_lr_late:0.038 leaky_slope:0.5
+train_batch_tokens:589824 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:1337
+gptq:reserving 14000ms from training budget, effective=586000ms
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9292 val_bpb:4.1039 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9236 train_time:115ms step_avg:114.85ms
+step:2/20000 train_loss:6.8930 train_time:163ms step_avg:81.41ms
+step:3/20000 train_loss:6.5216 train_time:231ms step_avg:77.11ms
+step:4/20000 train_loss:6.6048 train_time:300ms step_avg:74.96ms
+step:5/20000 train_loss:6.6792 train_time:368ms step_avg:73.57ms
+step:6/20000 train_loss:6.4394 train_time:436ms step_avg:72.66ms
+step:7/20000 train_loss:6.1488 train_time:504ms step_avg:72.05ms
+step:8/20000 train_loss:6.0559 train_time:573ms step_avg:71.57ms
+step:9/20000 train_loss:5.8979 train_time:641ms step_avg:71.23ms
+step:10/20000 train_loss:5.6586 train_time:709ms step_avg:70.91ms
+step:500/20000 train_loss:2.2787 train_time:34572ms step_avg:69.14ms
+step:1000/20000 train_loss:2.1944 train_time:69234ms step_avg:69.23ms
+step:1500/20000 train_loss:2.1041 train_time:103918ms step_avg:69.28ms
+step:2000/20000 train_loss:2.0576 train_time:138646ms step_avg:69.32ms
+step:2500/20000 train_loss:1.9723 train_time:173384ms step_avg:69.35ms
+step:3000/20000 train_loss:1.8794 train_time:208128ms step_avg:69.38ms
+step:3500/20000 train_loss:1.8804 train_time:242869ms step_avg:69.39ms
+step:4000/20000 train_loss:1.9143 train_time:277604ms step_avg:69.40ms
+step:4000/20000 val_loss:2.0613 val_bpb:1.2208 train_time:277627ms step_avg:69.41ms
+step:4500/20000 train_loss:1.8491 train_time:312344ms step_avg:69.41ms
+step:5000/20000 train_loss:2.0239 train_time:347087ms step_avg:69.42ms
+step:5500/20000 train_loss:1.9999 train_time:381836ms step_avg:69.42ms
+step:6000/20000 train_loss:1.9671 train_time:416571ms step_avg:69.43ms
+step:6500/20000 train_loss:1.9624 train_time:451297ms step_avg:69.43ms
+step:7000/20000 train_loss:1.9521 train_time:486017ms step_avg:69.43ms
+step:7500/20000 train_loss:1.9364 train_time:520744ms step_avg:69.43ms
+swa:start step:7650
+late_qat:enabled step:7836 scale:0.1499
+step:8000/20000 train_loss:1.9445 train_time:555854ms step_avg:69.48ms
+step:8000/20000 val_loss:1.9169 val_bpb:1.1353 train_time:555941ms step_avg:69.49ms
+step:8428/20000 val_loss:1.9008 val_bpb:1.1258 train_time:586064ms step_avg:69.54ms
+stopping_early: wallclock_cap train_time:586064ms step:8428/20000
+peak memory allocated: 18548 MiB reserved: 18806 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.8996 val_bpb:1.1250 eval_time:2497ms
+Serialized model: 116408386 bytes
+Code size: 34101 bytes
+gptq:building non-banked model for Hessian collection...
+gptq:calibrating with 256 batches (train data)...
+gptq:collected hessians for 74 layers (train data)
+Serialized model int6+brotli: 15687597 bytes
+Total submission size int6+brotli: 15721698 bytes
+final_int6_roundtrip val_loss:1.8906 val_bpb:1.1197 eval_time:44320ms
+final_int6_roundtrip_exact val_loss:1.89055057 val_bpb:1.11968671
+final_int6_sliding_window val_loss:1.8742 val_bpb:1.1101 stride:128 eval_time:148032ms
+final_int6_sliding_window_exact val_loss:1.87423223 val_bpb:1.11006071

--- a/records/track_10min_16mb/2026-03-31_KitchenSinkV3/run_v3_seed2.log
+++ b/records/track_10min_16mb/2026-03-31_KitchenSinkV3/run_v3_seed2.log
@@ -1,0 +1,87 @@
+W0331 17:28:58.848000 112208 torch/distributed/run.py:851] 
+W0331 17:28:58.848000 112208 torch/distributed/run.py:851] *****************************************
+W0331 17:28:58.848000 112208 torch/distributed/run.py:851] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0331 17:28:58.848000 112208 torch/distributed/run.py:851] *****************************************
+logs/cab54c4a-5bc2-49b1-a8e1-e5cda436759a.txt
+mixed_seq_len: GPU0=2048x36=73728tok GPU1=2048x36=73728tok GPU2=2048x36=73728tok GPU3=2048x36=73728tok GPU4=2048x36=73728tok GPU5=6144x10=61440tok GPU6=6144x10=61440tok GPU7=6144x10=61440tok total=552960
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62017536
+model_params:29751910
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_7 active_layers:[5, 6, 7, 8, 9, 10, 11]
+window_attn:size=512 layers:[2, 4, 6, 8, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.022 head_lr:0.0 matrix_lr:0.024 matrix_lr_late:0.019 scalar_lr:0.02 scalar_lr_late:0.038 leaky_slope:0.5
+train_batch_tokens:589824 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:2
+gptq:reserving 14000ms from training budget, effective=586000ms
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9295 val_bpb:4.1040 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9234 train_time:117ms step_avg:116.89ms
+step:2/20000 train_loss:6.8490 train_time:164ms step_avg:82.10ms
+step:3/20000 train_loss:6.5213 train_time:232ms step_avg:77.25ms
+step:4/20000 train_loss:6.5410 train_time:301ms step_avg:75.14ms
+step:5/20000 train_loss:6.6556 train_time:369ms step_avg:73.79ms
+step:6/20000 train_loss:6.5937 train_time:438ms step_avg:73.06ms
+step:7/20000 train_loss:6.2665 train_time:507ms step_avg:72.41ms
+step:8/20000 train_loss:6.0400 train_time:575ms step_avg:71.86ms
+step:9/20000 train_loss:5.8710 train_time:644ms step_avg:71.52ms
+step:10/20000 train_loss:5.6984 train_time:713ms step_avg:71.27ms
+step:500/20000 train_loss:2.2753 train_time:34620ms step_avg:69.24ms
+step:1000/20000 train_loss:2.1915 train_time:69284ms step_avg:69.28ms
+step:1500/20000 train_loss:2.1015 train_time:103993ms step_avg:69.33ms
+step:2000/20000 train_loss:2.0562 train_time:138747ms step_avg:69.37ms
+step:2500/20000 train_loss:1.9619 train_time:173524ms step_avg:69.41ms
+step:3000/20000 train_loss:1.8785 train_time:208302ms step_avg:69.43ms
+step:3500/20000 train_loss:1.8760 train_time:243100ms step_avg:69.46ms
+step:4000/20000 train_loss:1.9118 train_time:277882ms step_avg:69.47ms
+step:4000/20000 val_loss:2.0583 val_bpb:1.2190 train_time:277906ms step_avg:69.48ms
+step:4500/20000 train_loss:1.8503 train_time:312660ms step_avg:69.48ms
+step:5000/20000 train_loss:2.0179 train_time:347440ms step_avg:69.49ms
+step:5500/20000 train_loss:1.9952 train_time:382224ms step_avg:69.50ms
+step:6000/20000 train_loss:1.9640 train_time:416999ms step_avg:69.50ms
+step:6500/20000 train_loss:1.9601 train_time:451771ms step_avg:69.50ms
+step:7000/20000 train_loss:1.9507 train_time:486532ms step_avg:69.50ms
+step:7500/20000 train_loss:1.9296 train_time:521298ms step_avg:69.51ms
+swa:start step:7650
+late_qat:enabled step:7827 scale:0.1498
+step:8000/20000 train_loss:1.9427 train_time:556434ms step_avg:69.55ms
+step:8000/20000 val_loss:1.9151 val_bpb:1.1342 train_time:556516ms step_avg:69.56ms
+step:8419/20000 val_loss:1.8995 val_bpb:1.1250 train_time:586049ms step_avg:69.61ms
+stopping_early: wallclock_cap train_time:586049ms step:8419/20000
+peak memory allocated: 18548 MiB reserved: 18800 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.8983 val_bpb:1.1243 eval_time:2503ms
+Serialized model: 116408386 bytes
+Code size: 34101 bytes
+gptq:building non-banked model for Hessian collection...
+gptq:calibrating with 256 batches (train data)...
+gptq:collected hessians for 74 layers (train data)
+Serialized model int6+brotli: 15692661 bytes
+Total submission size int6+brotli: 15726762 bytes
+final_int6_roundtrip val_loss:1.8894 val_bpb:1.1190 eval_time:7361ms
+final_int6_roundtrip_exact val_loss:1.88938736 val_bpb:1.11899779
+final_int6_sliding_window val_loss:1.8731 val_bpb:1.1094 stride:128 eval_time:123593ms
+final_int6_sliding_window_exact val_loss:1.87306252 val_bpb:1.10936792

--- a/records/track_10min_16mb/2026-03-31_KitchenSinkV3/run_v3_seed22.log
+++ b/records/track_10min_16mb/2026-03-31_KitchenSinkV3/run_v3_seed22.log
@@ -1,0 +1,87 @@
+W0331 17:43:24.659000 116278 torch/distributed/run.py:851] 
+W0331 17:43:24.659000 116278 torch/distributed/run.py:851] *****************************************
+W0331 17:43:24.659000 116278 torch/distributed/run.py:851] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0331 17:43:24.659000 116278 torch/distributed/run.py:851] *****************************************
+logs/afa7531b-6d8b-4dfd-b2aa-d03a6fa441ee.txt
+mixed_seq_len: GPU0=2048x36=73728tok GPU1=2048x36=73728tok GPU2=2048x36=73728tok GPU3=2048x36=73728tok GPU4=2048x36=73728tok GPU5=6144x10=61440tok GPU6=6144x10=61440tok GPU7=6144x10=61440tok total=552960
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62017536
+model_params:29751910
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_7 active_layers:[5, 6, 7, 8, 9, 10, 11]
+window_attn:size=512 layers:[2, 4, 6, 8, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.022 head_lr:0.0 matrix_lr:0.024 matrix_lr_late:0.019 scalar_lr:0.02 scalar_lr_late:0.038 leaky_slope:0.5
+train_batch_tokens:589824 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:22
+gptq:reserving 14000ms from training budget, effective=586000ms
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9302 val_bpb:4.1044 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9237 train_time:117ms step_avg:117.29ms
+step:2/20000 train_loss:6.8527 train_time:164ms step_avg:81.81ms
+step:3/20000 train_loss:6.5081 train_time:232ms step_avg:77.17ms
+step:4/20000 train_loss:6.4626 train_time:300ms step_avg:75.05ms
+step:5/20000 train_loss:6.5890 train_time:370ms step_avg:73.97ms
+step:6/20000 train_loss:6.5643 train_time:438ms step_avg:72.93ms
+step:7/20000 train_loss:6.2826 train_time:507ms step_avg:72.37ms
+step:8/20000 train_loss:6.0730 train_time:575ms step_avg:71.84ms
+step:9/20000 train_loss:5.8679 train_time:643ms step_avg:71.47ms
+step:10/20000 train_loss:5.7096 train_time:712ms step_avg:71.16ms
+step:500/20000 train_loss:2.2873 train_time:34642ms step_avg:69.28ms
+step:1000/20000 train_loss:2.1971 train_time:69417ms step_avg:69.42ms
+step:1500/20000 train_loss:2.1029 train_time:104121ms step_avg:69.41ms
+step:2000/20000 train_loss:2.0623 train_time:138830ms step_avg:69.42ms
+step:2500/20000 train_loss:1.9693 train_time:173545ms step_avg:69.42ms
+step:3000/20000 train_loss:1.8855 train_time:208267ms step_avg:69.42ms
+step:3500/20000 train_loss:1.8845 train_time:242993ms step_avg:69.43ms
+step:4000/20000 train_loss:1.9171 train_time:277697ms step_avg:69.42ms
+step:4000/20000 val_loss:2.0647 val_bpb:1.2228 train_time:277721ms step_avg:69.43ms
+step:4500/20000 train_loss:1.8465 train_time:312389ms step_avg:69.42ms
+step:5000/20000 train_loss:2.0170 train_time:347094ms step_avg:69.42ms
+step:5500/20000 train_loss:2.0051 train_time:381785ms step_avg:69.42ms
+step:6000/20000 train_loss:1.9704 train_time:416483ms step_avg:69.41ms
+step:6500/20000 train_loss:1.9661 train_time:451173ms step_avg:69.41ms
+step:7000/20000 train_loss:1.9590 train_time:485854ms step_avg:69.41ms
+step:7500/20000 train_loss:1.9371 train_time:520550ms step_avg:69.41ms
+swa:start step:7650
+late_qat:enabled step:7839 scale:0.1499
+step:8000/20000 train_loss:1.9468 train_time:555630ms step_avg:69.45ms
+step:8000/20000 val_loss:1.9213 val_bpb:1.1379 train_time:555712ms step_avg:69.46ms
+step:8432/20000 val_loss:1.9051 val_bpb:1.1283 train_time:586024ms step_avg:69.50ms
+stopping_early: wallclock_cap train_time:586024ms step:8432/20000
+peak memory allocated: 18548 MiB reserved: 18800 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9039 val_bpb:1.1276 eval_time:2503ms
+Serialized model: 116408386 bytes
+Code size: 34101 bytes
+gptq:building non-banked model for Hessian collection...
+gptq:calibrating with 256 batches (train data)...
+gptq:collected hessians for 74 layers (train data)
+Serialized model int6+brotli: 15686801 bytes
+Total submission size int6+brotli: 15720902 bytes
+final_int6_roundtrip val_loss:1.8948 val_bpb:1.1222 eval_time:7313ms
+final_int6_roundtrip_exact val_loss:1.89484229 val_bpb:1.12222850
+final_int6_sliding_window val_loss:1.8785 val_bpb:1.1126 stride:128 eval_time:123504ms
+final_int6_sliding_window_exact val_loss:1.87849470 val_bpb:1.11258526

--- a/records/track_10min_16mb/2026-03-31_KitchenSinkV3/run_v3_seed42.log
+++ b/records/track_10min_16mb/2026-03-31_KitchenSinkV3/run_v3_seed42.log
@@ -1,0 +1,87 @@
+W0331 16:41:23.244000 100676 torch/distributed/run.py:851] 
+W0331 16:41:23.244000 100676 torch/distributed/run.py:851] *****************************************
+W0331 16:41:23.244000 100676 torch/distributed/run.py:851] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0331 16:41:23.244000 100676 torch/distributed/run.py:851] *****************************************
+logs/8c4df95e-5e29-44ac-9c3d-73415db9c182.txt
+mixed_seq_len: GPU0=2048x36=73728tok GPU1=2048x36=73728tok GPU2=2048x36=73728tok GPU3=2048x36=73728tok GPU4=2048x36=73728tok GPU5=6144x10=61440tok GPU6=6144x10=61440tok GPU7=6144x10=61440tok total=552960
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62017536
+model_params:29751910
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_7 active_layers:[5, 6, 7, 8, 9, 10, 11]
+window_attn:size=512 layers:[2, 4, 6, 8, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.022 head_lr:0.0 matrix_lr:0.024 matrix_lr_late:0.019 scalar_lr:0.02 scalar_lr_late:0.038 leaky_slope:0.5
+train_batch_tokens:589824 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:42
+gptq:reserving 14000ms from training budget, effective=586000ms
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9298 val_bpb:4.1042 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9234 train_time:116ms step_avg:116.29ms
+step:2/20000 train_loss:6.8617 train_time:163ms step_avg:81.65ms
+step:3/20000 train_loss:6.5701 train_time:231ms step_avg:76.90ms
+step:4/20000 train_loss:6.6176 train_time:299ms step_avg:74.72ms
+step:5/20000 train_loss:6.6706 train_time:367ms step_avg:73.43ms
+step:6/20000 train_loss:6.5179 train_time:436ms step_avg:72.59ms
+step:7/20000 train_loss:6.1922 train_time:504ms step_avg:72.02ms
+step:8/20000 train_loss:6.0940 train_time:572ms step_avg:71.56ms
+step:9/20000 train_loss:5.8899 train_time:641ms step_avg:71.21ms
+step:10/20000 train_loss:5.6810 train_time:709ms step_avg:70.90ms
+step:500/20000 train_loss:2.2894 train_time:34583ms step_avg:69.17ms
+step:1000/20000 train_loss:2.1956 train_time:69221ms step_avg:69.22ms
+step:1500/20000 train_loss:2.1033 train_time:103864ms step_avg:69.24ms
+step:2000/20000 train_loss:2.0596 train_time:138569ms step_avg:69.28ms
+step:2500/20000 train_loss:1.9654 train_time:173300ms step_avg:69.32ms
+step:3000/20000 train_loss:1.8775 train_time:208044ms step_avg:69.35ms
+step:3500/20000 train_loss:1.8811 train_time:242793ms step_avg:69.37ms
+step:4000/20000 train_loss:1.9136 train_time:277528ms step_avg:69.38ms
+step:4000/20000 val_loss:2.0608 val_bpb:1.2205 train_time:277551ms step_avg:69.39ms
+step:4500/20000 train_loss:1.8492 train_time:312307ms step_avg:69.40ms
+step:5000/20000 train_loss:2.0222 train_time:347090ms step_avg:69.42ms
+step:5500/20000 train_loss:1.9988 train_time:381858ms step_avg:69.43ms
+step:6000/20000 train_loss:1.9702 train_time:416633ms step_avg:69.44ms
+step:6500/20000 train_loss:1.9612 train_time:451397ms step_avg:69.45ms
+step:7000/20000 train_loss:1.9537 train_time:486161ms step_avg:69.45ms
+step:7500/20000 train_loss:1.9338 train_time:520918ms step_avg:69.46ms
+swa:start step:7650
+late_qat:enabled step:7833 scale:0.1499
+step:8000/20000 train_loss:1.9475 train_time:556027ms step_avg:69.50ms
+step:8000/20000 val_loss:1.9169 val_bpb:1.1353 train_time:556083ms step_avg:69.51ms
+step:8426/20000 val_loss:1.9010 val_bpb:1.1259 train_time:586078ms step_avg:69.56ms
+stopping_early: wallclock_cap train_time:586078ms step:8426/20000
+peak memory allocated: 18548 MiB reserved: 18800 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.8998 val_bpb:1.1251 eval_time:2503ms
+Serialized model: 116408386 bytes
+Code size: 34101 bytes
+gptq:building non-banked model for Hessian collection...
+gptq:calibrating with 256 batches (train data)...
+gptq:collected hessians for 74 layers (train data)
+Serialized model int6+brotli: 15691894 bytes
+Total submission size int6+brotli: 15725995 bytes
+final_int6_roundtrip val_loss:1.8908 val_bpb:1.1198 eval_time:7284ms
+final_int6_roundtrip_exact val_loss:1.89081851 val_bpb:1.11984540
+final_int6_sliding_window val_loss:1.8746 val_bpb:1.1103 stride:128 eval_time:123401ms
+final_int6_sliding_window_exact val_loss:1.87455798 val_bpb:1.11025364

--- a/records/track_10min_16mb/2026-03-31_KitchenSinkV3/run_v3_seed7.log
+++ b/records/track_10min_16mb/2026-03-31_KitchenSinkV3/run_v3_seed7.log
@@ -1,0 +1,87 @@
+W0331 16:56:38.572000 105373 torch/distributed/run.py:851] 
+W0331 16:56:38.572000 105373 torch/distributed/run.py:851] *****************************************
+W0331 16:56:38.572000 105373 torch/distributed/run.py:851] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0331 16:56:38.572000 105373 torch/distributed/run.py:851] *****************************************
+logs/3495f9e8-40ad-4b61-963f-f1d58172f4f0.txt
+mixed_seq_len: GPU0=2048x36=73728tok GPU1=2048x36=73728tok GPU2=2048x36=73728tok GPU3=2048x36=73728tok GPU4=2048x36=73728tok GPU5=6144x10=61440tok GPU6=6144x10=61440tok GPU7=6144x10=61440tok total=552960
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62017536
+model_params:29751910
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_7 active_layers:[5, 6, 7, 8, 9, 10, 11]
+window_attn:size=512 layers:[2, 4, 6, 8, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.022 head_lr:0.0 matrix_lr:0.024 matrix_lr_late:0.019 scalar_lr:0.02 scalar_lr_late:0.038 leaky_slope:0.5
+train_batch_tokens:589824 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:7
+gptq:reserving 14000ms from training budget, effective=586000ms
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9299 val_bpb:4.1042 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9241 train_time:116ms step_avg:116.31ms
+step:2/20000 train_loss:6.8550 train_time:164ms step_avg:81.92ms
+step:3/20000 train_loss:6.5545 train_time:232ms step_avg:77.19ms
+step:4/20000 train_loss:6.5538 train_time:300ms step_avg:75.10ms
+step:5/20000 train_loss:6.6732 train_time:369ms step_avg:73.70ms
+step:6/20000 train_loss:6.5121 train_time:437ms step_avg:72.90ms
+step:7/20000 train_loss:6.2632 train_time:506ms step_avg:72.33ms
+step:8/20000 train_loss:6.1568 train_time:574ms step_avg:71.74ms
+step:9/20000 train_loss:5.9563 train_time:642ms step_avg:71.38ms
+step:10/20000 train_loss:5.6894 train_time:711ms step_avg:71.10ms
+step:500/20000 train_loss:2.2815 train_time:34634ms step_avg:69.27ms
+step:1000/20000 train_loss:2.1968 train_time:69360ms step_avg:69.36ms
+step:1500/20000 train_loss:2.0974 train_time:104047ms step_avg:69.36ms
+step:2000/20000 train_loss:2.0594 train_time:138750ms step_avg:69.38ms
+step:2500/20000 train_loss:1.9683 train_time:173460ms step_avg:69.38ms
+step:3000/20000 train_loss:1.8863 train_time:208178ms step_avg:69.39ms
+step:3500/20000 train_loss:1.8808 train_time:242900ms step_avg:69.40ms
+step:4000/20000 train_loss:1.9220 train_time:277613ms step_avg:69.40ms
+step:4000/20000 val_loss:2.0637 val_bpb:1.2222 train_time:277636ms step_avg:69.41ms
+step:4500/20000 train_loss:1.8490 train_time:312313ms step_avg:69.40ms
+step:5000/20000 train_loss:2.0188 train_time:347034ms step_avg:69.41ms
+step:5500/20000 train_loss:2.0031 train_time:381743ms step_avg:69.41ms
+step:6000/20000 train_loss:1.9706 train_time:416445ms step_avg:69.41ms
+step:6500/20000 train_loss:1.9644 train_time:451134ms step_avg:69.41ms
+step:7000/20000 train_loss:1.9541 train_time:485831ms step_avg:69.40ms
+step:7500/20000 train_loss:1.9347 train_time:520515ms step_avg:69.40ms
+swa:start step:7650
+late_qat:enabled step:7840 scale:0.1498
+step:8000/20000 train_loss:1.9458 train_time:555610ms step_avg:69.45ms
+step:8000/20000 val_loss:1.9197 val_bpb:1.1370 train_time:555694ms step_avg:69.46ms
+step:8432/20000 val_loss:1.9036 val_bpb:1.1274 train_time:586063ms step_avg:69.50ms
+stopping_early: wallclock_cap train_time:586063ms step:8432/20000
+peak memory allocated: 18548 MiB reserved: 18800 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9024 val_bpb:1.1267 eval_time:2505ms
+Serialized model: 116408386 bytes
+Code size: 34101 bytes
+gptq:building non-banked model for Hessian collection...
+gptq:calibrating with 256 batches (train data)...
+gptq:collected hessians for 74 layers (train data)
+Serialized model int6+brotli: 15689245 bytes
+Total submission size int6+brotli: 15723346 bytes
+final_int6_roundtrip val_loss:1.8934 val_bpb:1.1214 eval_time:7284ms
+final_int6_roundtrip_exact val_loss:1.89337883 val_bpb:1.12136176
+final_int6_sliding_window val_loss:1.8773 val_bpb:1.1119 stride:128 eval_time:123399ms
+final_int6_sliding_window_exact val_loss:1.87732994 val_bpb:1.11189540

--- a/records/track_10min_16mb/2026-03-31_KitchenSinkV3/submission.json
+++ b/records/track_10min_16mb/2026-03-31_KitchenSinkV3/submission.json
@@ -1,0 +1,11 @@
+{
+  "author": "alejandro",
+  "github_id": "Gusanidas",
+  "name": "Kitchen Sink V3: 12L Window Attn + Mixed Seq_Len + Fused MLP",
+  "blurb": "12-layer split-bank U-Net with window attention (size=512 on layers 2,4,6,8,10), mixed seq_len training (5 GPUs at 2048 + 3 GPUs at 6144), fused Triton LeakyReLU-squared MLP, sigmoid-gated skip connections, brotli+byte-shuffle compression, bigram hash 5120, VE dim 128, Flash Attention 3, GPTQ int6, sliding window eval (stride=128, seq_len=6144). Eval: 1.1083 bpb (5-seed mean).",
+  "date": "2026-03-31",
+  "val_loss": 1.8755,
+  "val_bpb": 1.1083,
+  "bytes_total": 15726762,
+  "bytes_code": 34101
+}

--- a/records/track_10min_16mb/2026-03-31_KitchenSinkV3/submission.json
+++ b/records/track_10min_16mb/2026-03-31_KitchenSinkV3/submission.json
@@ -2,10 +2,10 @@
   "author": "alejandro",
   "github_id": "Gusanidas",
   "name": "Kitchen Sink V3: 12L Window Attn + Mixed Seq_Len + Fused MLP",
-  "blurb": "12-layer split-bank U-Net with window attention (size=512 on layers 2,4,6,8,10), mixed seq_len training (5 GPUs at 2048 + 3 GPUs at 6144), fused Triton LeakyReLU-squared MLP, sigmoid-gated skip connections, brotli+byte-shuffle compression, bigram hash 5120, VE dim 128, Flash Attention 3, GPTQ int6, sliding window eval (stride=128, seq_len=6144). Eval: 1.1083 bpb (5-seed mean).",
+  "blurb": "12-layer split-bank U-Net with window attention (size=512 on layers 2,4,6,8,10), mixed seq_len training (5 GPUs at 2048 + 3 GPUs at 6144), fused Triton LeakyReLU-squared MLP, sigmoid-gated skip connections, brotli+byte-shuffle compression, bigram hash 5120, VE dim 128, Flash Attention 3, GPTQ int6, sliding window eval (stride=128, seq_len=6144). Eval: 1.1108 bpb (5-seed mean).",
   "date": "2026-03-31",
   "val_loss": 1.8755,
-  "val_bpb": 1.1083,
+  "val_bpb": 1.1108,
   "bytes_total": 15726762,
   "bytes_code": 34101
 }

--- a/records/track_10min_16mb/2026-03-31_KitchenSinkV3/submission.json
+++ b/records/track_10min_16mb/2026-03-31_KitchenSinkV3/submission.json
@@ -1,7 +1,7 @@
 {
   "author": "alejandro",
   "github_id": "Gusanidas",
-  "name": "Kitchen Sink V3: 12L Window Attn + Mixed Seq_Len + Fused MLP",
+  "name": "Window Attention + Mixed Seq_Len Training",
   "blurb": "12-layer split-bank U-Net with window attention (size=512 on layers 2,4,6,8,10), mixed seq_len training (5 GPUs at 2048 + 3 GPUs at 6144), fused Triton LeakyReLU-squared MLP, sigmoid-gated skip connections, brotli+byte-shuffle compression, bigram hash 5120, VE dim 128, Flash Attention 3, GPTQ int6, sliding window eval (stride=128, seq_len=6144). Eval: 1.1108 bpb (5-seed mean).",
   "date": "2026-03-31",
   "val_loss": 1.8755,

--- a/records/track_10min_16mb/2026-03-31_KitchenSinkV3/train_gpt.py
+++ b/records/track_10min_16mb/2026-03-31_KitchenSinkV3/train_gpt.py
@@ -1,0 +1,2824 @@
+from __future__ import annotations
+import copy
+import glob
+import io
+import lzma
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+try:
+    import brotli
+    _COMPRESSOR = "brotli"
+except ImportError:
+    _COMPRESSOR = "lzma"
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from flash_attn_interface import flash_attn_func as flash_attn_3_func
+
+_LEAKY_SLOPE = 0.5  # set from Hyperparameters.leaky_slope at startup
+
+# --------------- Fused MLP kernel (PR #1105) ---------------
+IS_ROCM = hasattr(torch.version, 'hip') and torch.version.hip is not None
+HAS_FUSED_MLP = False
+try:
+    import triton
+    import triton.language as tl
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    @triton.jit
+    def _fused_leaky_relu_sq_kernel(a_desc, b_desc, c_desc, aux_desc,
+                                     M, N, K,
+                                     BLOCK_SIZE_M: tl.constexpr,
+                                     BLOCK_SIZE_N: tl.constexpr,
+                                     BLOCK_SIZE_K: tl.constexpr,
+                                     GROUP_SIZE_M: tl.constexpr,
+                                     NUM_SMS: tl.constexpr,
+                                     FORWARD: tl.constexpr):
+        dtype = tl.bfloat16
+        start_pid = tl.program_id(axis=0)
+        num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+        num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+        k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+        num_tiles = num_pid_m * num_pid_n
+        tile_id_c = start_pid - NUM_SMS
+        for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+            pid_m = tile_id // num_pid_n
+            pid_n = tile_id % num_pid_n
+            offs_am = pid_m * BLOCK_SIZE_M
+            offs_bn = pid_n * BLOCK_SIZE_N
+            accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+            for ki in range(k_tiles):
+                offs_k = ki * BLOCK_SIZE_K
+                a = a_desc.load([offs_am, offs_k])
+                b = b_desc.load([offs_bn, offs_k])
+                accumulator = tl.dot(a, b.T, accumulator)
+            tile_id_c += NUM_SMS
+            pid_m = tile_id // num_pid_n
+            pid_n = tile_id % num_pid_n
+            offs_am_c = pid_m * BLOCK_SIZE_M
+            offs_bn_c = pid_n * BLOCK_SIZE_N
+            acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+            acc = tl.permute(acc, (0, 2, 1))
+            acc0, acc1 = tl.split(acc)
+            c0 = acc0.to(dtype)
+            if not FORWARD:
+                c0_ag = aux_desc.load([offs_am_c, offs_bn_c])
+                c0 = c0 * c0_ag
+                c_desc.store([offs_am_c, offs_bn_c], c0)
+            if FORWARD:
+                c0_ag = tl.where(c0 > 0, 2.0 * c0, 0.5 * c0)
+                c_desc.store([offs_am_c, offs_bn_c], c0_ag)
+                c0_post = 0.5 * c0_ag * c0
+                aux_desc.store([offs_am_c, offs_bn_c], c0_post)
+            c1 = acc1.to(dtype)
+            if not FORWARD:
+                c1_ag = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+                c1 = c1 * c1_ag
+                c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+            if FORWARD:
+                c1_ag = tl.where(c1 > 0, 2.0 * c1, 0.5 * c1)
+                c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_ag)
+                c1_post = 0.5 * c1_ag * c1
+                aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1_post)
+
+    def _fused_leaky_relu_sq(a, b, aux=None):
+        M, K = a.shape
+        N, K2 = b.shape
+        assert K == K2
+        c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+        FORWARD = aux is None
+        if FORWARD:
+            aux = torch.empty((M, N), device=a.device, dtype=a.dtype)
+        NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+        BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 256, 64
+        a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+        b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+        c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+        aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+        def grid(META):
+            return (min(NUM_SMS, triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N)),)
+        _fused_leaky_relu_sq_kernel[grid](
+            a_desc, b_desc, c_desc, aux_desc, M, N, K,
+            BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,
+            GROUP_SIZE_M=1, NUM_SMS=NUM_SMS, FORWARD=FORWARD,
+            num_stages=4 if FORWARD else 3, num_warps=8)
+        return (c, aux) if FORWARD else c
+
+    # Check for CUTLASS EVT backward fusion
+    HAS_CUTLASS_EVT = False
+    try:
+        import cutlass_evt_fusion
+        torch.library.register_fake("cutlass_evt::gemm_mul")(
+            lambda go, down_w, act_grad: go.new_empty(go.size(0), down_w.size(1)))
+        HAS_CUTLASS_EVT = True
+    except (ImportError, Exception):
+        pass
+
+    class FusedLeakyReLUSqMLP(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x, up_w, down_w):
+            x_flat = x.view(-1, x.shape[-1])
+            act_grad, post = _fused_leaky_relu_sq(x_flat, up_w)
+            out = F.linear(post, down_w)
+            ctx.save_for_backward(x_flat, up_w, down_w, act_grad, post)
+            return out.view(x.shape)
+        @staticmethod
+        def backward(ctx, grad_output):
+            x_flat, up_w, down_w, act_grad, post = ctx.saved_tensors
+            go = grad_output.view(-1, grad_output.shape[-1])
+            dW2 = go.T @ post
+            if HAS_CUTLASS_EVT:
+                dpre = torch.ops.cutlass_evt.gemm_mul(go, down_w, act_grad)
+            else:
+                dpre = F.linear(go, down_w.T) * act_grad
+            dW1 = dpre.T @ x_flat
+            dx = dpre @ up_w
+            return dx.view(grad_output.shape), dW1, dW2
+
+    HAS_FUSED_MLP = True
+except (ImportError, Exception):
+    HAS_FUSED_MLP = False
+
+# --------------- Byte-shuffle + Brotli compression (PR #1089) ---------------
+_BSHF_MAGIC = b"BSHF"
+_BYTE_SHUFFLE_STRIDE = 2
+
+def _byte_shuffle(data: bytes, stride: int = _BYTE_SHUFFLE_STRIDE) -> bytes:
+    if stride <= 1 or len(data) < stride:
+        return data
+    src = np.frombuffer(data, dtype=np.uint8)
+    n = len(src)
+    out = np.empty(n, dtype=np.uint8)
+    dest_off = 0
+    for pos in range(stride):
+        chunk = src[pos::stride]
+        out[dest_off:dest_off + len(chunk)] = chunk
+        dest_off += len(chunk)
+    return _BSHF_MAGIC + bytes([stride]) + out.tobytes()
+
+def _byte_unshuffle(data: bytes) -> bytes:
+    if len(data) < 5 or data[:4] != _BSHF_MAGIC:
+        return data
+    stride = data[4]
+    if stride < 2:
+        return data[5:]
+    payload = np.frombuffer(data, dtype=np.uint8, offset=5)
+    n = len(payload)
+    out = np.empty(n, dtype=np.uint8)
+    src_off = 0
+    for pos in range(stride):
+        chunk_len = n // stride + (1 if pos < n % stride else 0)
+        out[pos::stride][:chunk_len] = payload[src_off:src_off + chunk_len]
+        src_off += chunk_len
+    return out.tobytes()
+
+def _minify_code(source: str) -> str:
+    """Create a self-extracting LZMA+base85 wrapper from source code."""
+    import base64
+    compressed = lzma.compress(source.encode("utf-8"), preset=9)
+    encoded = base64.b85encode(compressed)
+    wrapper = f"import lzma as L,base64 as B\nexec(L.decompress(B.b85decode({encoded!r})))\n"
+    return wrapper
+
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 4000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 589_824))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    local_seqs_per_gpu = int(os.environ.get("LOCAL_SEQS_PER_GPU", 0))  # 0 = use TRAIN_BATCH_TOKENS instead
+    local_seq_len = int(os.environ.get("LOCAL_SEQ_LEN", 0))  # 0 = use TRAIN_SEQ_LEN
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 2.5))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 12))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 3.0))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.022))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.024))
+    matrix_lr_late = float(os.environ.get("MATRIX_LR_LATE", os.environ.get("MATRIX_LR", "0.019")))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.020))
+    scalar_lr_late = float(os.environ.get("SCALAR_LR_LATE", os.environ.get("SCALAR_LR", "0.038")))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.985))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    mtp_num_heads = int(os.environ.get("MTP_NUM_HEADS", 0))
+    mtp_loss_weight = float(os.environ.get("MTP_LOSS_WEIGHT", 0.2))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    lawa_enabled = bool(int(os.environ.get("LAWA_ENABLED", "0")))
+    lawa_k = int(os.environ.get("LAWA_K", 10))
+    lawa_freq = int(os.environ.get("LAWA_FREQ", 100))
+    muon_wd = float(os.environ.get("MUON_WD", 0.04))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.04))
+    qat_enabled = bool(int(os.environ.get("QAT_ENABLED", "0")))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 5120))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 7))
+    window_size = int(os.environ.get("WINDOW_SIZE", -1))  # -1 = full attention
+    window_attn_layers = os.environ.get("WINDOW_ATTN_LAYERS", "")  # comma-separated layer indices, empty = none
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    dtg_enabled = bool(int(os.environ.get("DTG_ENABLED", "0")))
+    late_qat_threshold = float(os.environ.get("LATE_QAT_THRESHOLD", 0.15))
+    ve_enabled = bool(int(os.environ.get("VE_ENABLED", "1")))
+    ve_dim = int(os.environ.get("VE_DIM", 128))
+    ve_layers = os.environ.get("VE_LAYERS", "5,9,10")
+    gated_attention = bool(int(os.environ.get("GATED_ATTENTION", "0")))
+    value_residual = bool(int(os.environ.get("VALUE_RESIDUAL", "0")))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.002))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 3))
+    ttt_chunk_tokens = int(os.environ.get("TTT_CHUNK_TOKENS", 32768))
+    ttt_freeze_blocks = int(os.environ.get("TTT_FREEZE_BLOCKS", 2))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+    ttt_batch_seqs = int(os.environ.get("TTT_BATCH_SEQS", 32))
+    ttt_grad_clip = float(os.environ.get("TTT_GRAD_CLIP", 1.0))
+    leaky_slope = float(os.environ.get("LEAKY_SLOPE", 0.5))
+    # MiLe loss
+    mile_gamma = float(os.environ.get("MILE_GAMMA", 0.75))
+    mile_clamp_min = float(os.environ.get("MILE_CLAMP_MIN", 0.2))
+    mile_peak_frac = float(os.environ.get("MILE_PEAK_FRAC", 0.4))  # fraction of training where gamma peaks (triangle schedule)
+    cache_layer = int(os.environ.get("CACHE_LAYER", 7))
+    backout_init = float(os.environ.get("BACKOUT_INIT", 0.1))
+    # GPTQ calibration
+    gptq_calib_batches = int(os.environ.get("GPTQ_CALIB_BATCHES", 256))
+    gptq_block_size = int(os.environ.get("GPTQ_BLOCK_SIZE", 128))
+    gptq_ar_calib = bool(int(os.environ.get("GPTQ_AR_CALIB", "0")))  # 1=AR self-gen, 0=train data
+    gptq_reserve_ms = float(os.environ.get("GPTQ_RESERVE_MS", "14000"))  # ms reserved from training for GPTQ calibration
+
+# --- Batched Newton-Schulz orthogonalization ---
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 5, eps: float = 1e-7) -> Tensor:
+    """Batched Newton-Schulz orthogonalization. G: (B,M,N) or (M,N)."""
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+# --- Parallel Muon optimizer ---
+
+class Muon(torch.optim.Optimizer):
+    """Parallel Muon: post-backward reduce-scatter -> local NS5 -> all-gather.
+
+    No DDP for bank params. After backward, this optimizer:
+    1. Launches async reduce-scatter for all banks (biggest first)
+    2. Returns control so Adam can step on small params while RS is in-flight
+    3. Waits for each RS, runs local NS5 on the shard, launches async all-gather
+    4. Each all-gather overlaps with next bank's NS5
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append({
+                    'p': p,
+                    'B': B,
+                    'padded_grad': torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'shard': torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'shard_mom': torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'full_update': torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'scale': max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                })
+        # Sort by size descending -- launch biggest reduce-scatters first
+        self._bank_meta.sort(key=lambda m: -m['p'].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        """Phase 1: launch async reduce-scatter for all banks. Call right after backward."""
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m['p']
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m['padded_grad']
+            pg[:m['B']].copy_(p.grad.bfloat16())
+            if pg.shape[0] > m['B']:
+                pg[m['B']:].zero_()
+            fut = dist.reduce_scatter_tensor(m['shard'], pg, op=dist.ReduceOp.AVG, async_op=True)
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        """Phase 3: wait for RS, local NS5, all-gather. Call AFTER Adam steps."""
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        if not self._built:
+            self._build()
+
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+
+            prev_ag_handle = None
+            prev_m = None
+
+            sharded = self._distributed and hasattr(self, '_rs_futures')
+
+            for i, m in enumerate(self._bank_meta):
+                p = m['p']
+                if p.grad is None:
+                    continue
+
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m['p']
+                    upd = prev_m['full_update'][:prev_m['B']]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m['scale'])
+
+                if sharded and self._rs_futures[i] is not None:
+                    self._rs_futures[i].wait()
+                    g = m['shard']
+                    buf = m['shard_mom']
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m['full_update'], update, async_op=True)
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update.to(dtype=p.dtype), alpha=-lr * m['scale'])
+
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m['p']
+                upd = prev_m['full_update'][:prev_m['B']]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m['scale'])
+
+            if hasattr(self, '_rs_futures'):
+                del self._rs_futures
+
+        return loss
+
+# --- Tokenizer evaluation helpers ---
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    seq_len = eval_seq_len or args.train_seq_len
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# --- Quantization helpers ---
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,smear,dtg_gate,ve_layer_scales,ve_shared.scale,attn_gate,vr_lambda",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+# --- Data loading (coprime-stride multi-shard, PR #726 / PR #1060 style) ---
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE: dict[str, int] = {}
+_MMAP_CACHE: dict[str, np.memmap] = {}
+
+def _read_num_tokens(file: Path) -> int:
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+def _get_shard_memmap(file: Path) -> np.memmap:
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode="r", dtype="<u2", offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+class DistributedTokenLoader:
+    """Coprime-stride + multi-shard loader (PR #726 / PR #1060 style)."""
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self._num_tokens = np.array([_read_num_tokens(f) for f in self.files], dtype=np.int64)
+        seed = 0
+        for f in self.files:
+            for b in str(f).encode():
+                seed = ((seed ^ b) * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+        self._rng = np.random.Generator(np.random.PCG64(seed))
+        self._cfg: tuple[int, int, int, int] | None = None
+        self._eligible_shards: np.ndarray | None = None
+        self._base_block_counts: np.ndarray | None = None
+        n = len(self.files)
+        self._cursor_phase = np.zeros(n, dtype=np.int64)
+        self._cursor_block_count = np.zeros(n, dtype=np.int64)
+        self._cursor_next = np.zeros(n, dtype=np.int64)
+        self._cursor_start = np.zeros(n, dtype=np.int64)
+        self._cursor_stride = np.ones(n, dtype=np.int64)
+        self._cursor_init = np.zeros(n, dtype=np.bool_)
+        self._batches_built = 0
+
+    def _pick_coprime_stride(self, n: int) -> int:
+        if n <= 1:
+            return 1
+        while True:
+            s = int(self._rng.integers(1, n))
+            if math.gcd(s, n) == 1:
+                return s
+
+    def _reset_cursor(self, si: int, seq_len: int) -> None:
+        nt = int(self._num_tokens[si])
+        max_phase = min(seq_len - 1, max(0, nt - seq_len - 1))
+        phase = int(self._rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        bc = (nt - 1 - phase) // seq_len
+        self._cursor_phase[si] = phase
+        self._cursor_block_count[si] = bc
+        self._cursor_next[si] = 0
+        self._cursor_start[si] = int(self._rng.integers(bc)) if bc > 1 else 0
+        self._cursor_stride[si] = self._pick_coprime_stride(bc)
+        self._cursor_init[si] = True
+
+    def _ensure_cursor(self, si: int, seq_len: int) -> None:
+        if not self._cursor_init[si] or self._cursor_next[si] >= self._cursor_block_count[si]:
+            self._reset_cursor(si, seq_len)
+
+    def _take_from_shard(self, si: int, seq_len: int, count: int, out: list[tuple[int, int]]) -> None:
+        rem = count
+        while rem > 0:
+            self._ensure_cursor(si, seq_len)
+            bc = int(self._cursor_block_count[si])
+            ni = int(self._cursor_next[si])
+            take = min(rem, bc - ni)
+            phase = int(self._cursor_phase[si])
+            start = int(self._cursor_start[si])
+            stride = int(self._cursor_stride[si])
+            for j in range(take):
+                bi = (start + (ni + j) * stride) % bc
+                out.append((si, phase + bi * seq_len))
+            self._cursor_next[si] = ni + take
+            rem -= take
+
+    def _init_pipeline(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> None:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        num_seqs = local_tokens // seq_len
+        global_num_seqs = num_seqs * self.world_size
+        self._cfg = (local_tokens, seq_len, num_seqs, global_num_seqs)
+        bbc = (self._num_tokens - 1) // seq_len
+        eligible = bbc > 0
+        self._eligible_shards = np.nonzero(eligible)[0].astype(np.int64)
+        self._base_block_counts = bbc[self._eligible_shards].astype(np.int64)
+
+    def _sample_global_windows(self) -> list[tuple[int, int]]:
+        assert self._cfg is not None and self._eligible_shards is not None
+        _, seq_len, _, gns = self._cfg
+        ec = int(self._eligible_shards.size)
+        progress = min(self._batches_built / 1800.0, 1.0)
+        remaining = np.empty(ec, dtype=np.float64)
+        for i, si in enumerate(self._eligible_shards.tolist()):
+            if self._cursor_init[si]:
+                r = int(self._cursor_block_count[si]) - int(self._cursor_next[si])
+                remaining[i] = float(max(r, 1))
+            else:
+                remaining[i] = float(self._base_block_counts[i])
+        alpha = 0.90 - 0.40 * progress
+        weights = np.power(remaining, alpha)
+        ws = float(weights.sum())
+        if not np.isfinite(ws) or ws <= 0.0:
+            weights = np.ones(ec, dtype=np.float64)
+            ws = float(weights.sum())
+        probs = weights / ws
+        low = min(max(8, self.world_size), ec, gns)
+        high = min(max(32, self.world_size * 8), ec, gns)
+        mix = max(1, min(int(round(low + progress * (high - low))), ec, gns))
+        cp = self._rng.choice(ec, size=mix, replace=False, p=probs)
+        cs = self._eligible_shards[cp]
+        cpr = probs[cp].copy()
+        cpr /= cpr.sum()
+        counts = np.ones(mix, dtype=np.int64)
+        extra = gns - mix
+        if extra > 0:
+            counts += self._rng.multinomial(extra, cpr).astype(np.int64)
+        perm = self._rng.permutation(mix)
+        cs, counts = cs[perm], counts[perm]
+        buckets: list[list[tuple[int, int]]] = []
+        for si, cnt in zip(cs.tolist(), counts.tolist()):
+            b: list[tuple[int, int]] = []
+            self._take_from_shard(int(si), seq_len, int(cnt), b)
+            if b:
+                if len(b) > 1:
+                    bp = self._rng.permutation(len(b))
+                    b = [b[int(k)] for k in bp.tolist()]
+                buckets.append(b)
+        windows: list[tuple[int, int]] = []
+        active = [i for i, bk in enumerate(buckets) if bk]
+        while active:
+            order = self._rng.permutation(len(active))
+            new_active: list[int] = []
+            for oi in order.tolist():
+                bi = active[oi]
+                if buckets[bi]:
+                    windows.append(buckets[bi].pop())
+                if buckets[bi]:
+                    new_active.append(bi)
+            active = new_active
+        return windows
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        if self._cfg is None:
+            self._init_pipeline(global_tokens, seq_len, grad_accum_steps)
+        _, _, num_seqs, gns = self._cfg
+        gw = self._sample_global_windows()
+        local_w = gw[self.rank::self.world_size]
+        x = torch.empty((num_seqs, seq_len), dtype=torch.int64)
+        y = torch.empty((num_seqs, seq_len), dtype=torch.int64)
+        for slot, (si, pos) in enumerate(local_w):
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(np.array(mm[pos:pos + seq_len + 1], dtype=np.int64))
+            x[slot] = window[:-1]
+            y[slot] = window[1:]
+        self._batches_built += 1
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# --- Transformer modules ---
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                scale = (row_max / 31.0).clamp_min(1.0 / 31.0)
+                w_q = (torch.clamp(torch.round(w32 / scale[:, None]), -32, 31) * scale[:, None]).to(x.dtype)
+            w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024, rope_dims: int = 0):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / (base ** (torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (rd / (rd - 2)))
+                inv_freq = 1.0 / (new_base ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd))
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype).clone(), self._sin_cached.to(dtype=dtype).clone()
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int = 0) -> Tensor:
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        # No CastedLinear -- weights come from banks
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rope_dims = 0  # set by GPT.__init__ for partial RoPE
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False  # set by GPT.__init__ for deep layers only
+        self.window_size = (-1, -1)  # set by GPT.__init__ for window attention layers
+        # Gated attention and value residual (non-banked small params)
+        self.gated_attention = gated_attention
+        if gated_attention:
+            self.attn_gate = nn.Linear(dim, num_heads, bias=True)
+            nn.init.zeros_(self.attn_gate.weight)
+            nn.init.constant_(self.attn_gate.bias, 4.0)
+        self.value_residual = value_residual
+        if value_residual:
+            self.vr_lambda = nn.Parameter(torch.tensor([0.5, 0.5], dtype=torch.float32))
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        """Efficient XSA: subtract self-value projection via GQA-aware reshape (no repeat_interleave).
+        y: [B, T, H, D], v: [B, T, Hkv, D]. H must be divisible by Hkv."""
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)        # [B, T, Hkv, group, D]
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)    # [B, T, Hkv, 1, D] -- broadcast ready
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+    def forward(self, x: Tensor, q_w: Tensor, k_w: Tensor, v_w: Tensor, out_w: Tensor, v_embed: Tensor | None = None, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        bsz, seqlen, dim = x.shape
+        q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype))
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        raw_v = v if self.value_residual else None
+        if self.value_residual and v0 is not None:
+            lam = self.vr_lambda.to(dtype=v.dtype)
+            v = lam[0] * v0 + lam[1] * v
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True, window_size=self.window_size)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        if self.gated_attention:
+            # gate shape: (bsz, seqlen, num_heads) -> (bsz, seqlen, num_heads, 1) for B,T,H,D layout
+            gate = torch.sigmoid(self.attn_gate(x)).unsqueeze(-1)
+            y = y * gate
+        y = y.reshape(bsz, seqlen, dim)
+        return F.linear(y, out_w.to(x.dtype)), raw_v
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class ValueEmbedding(nn.Module):
+    """Reinject token identity into attention values at specific layers.
+    Each table maps vocab tokens to a low-dim embedding, projected to model_dim."""
+    def __init__(self, vocab_size: int, ve_dim: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, ve_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(ve_dim, model_dim, bias=False) if ve_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(token_ids)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        # No CastedLinear -- weights come from banks
+    def forward(self, x: Tensor, up_w: Tensor, down_w: Tensor) -> Tensor:
+        if HAS_FUSED_MLP and x.is_cuda and not IS_ROCM:
+            return FusedLeakyReLUSqMLP.apply(x, up_w.to(x.dtype), down_w.to(x.dtype))
+        x = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=_LEAKY_SLOPE)
+        return F.linear(x.square(), down_w.to(x.dtype))
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        layer_idx: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+                                        gated_attention=gated_attention, value_residual=value_residual)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+        if dtg:
+            self.dtg_gate = nn.Linear(dim, 1, bias=True)
+            nn.init.zeros_(self.dtg_gate.weight)
+            nn.init.constant_(self.dtg_gate.bias, 2.0)
+        else:
+            self.dtg_gate = None
+    def forward(self, x: Tensor, x0: Tensor, q_w: Tensor, k_w: Tensor, v_w: Tensor, out_w: Tensor, up_w: Tensor, down_w: Tensor, v_embed: Tensor | None = None, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out, raw_v = self.attn(self.attn_norm(x_in) * self.ln_scale_factor, q_w, k_w, v_w, out_w, v_embed=v_embed, v0=v0)
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        if self.dtg_gate is not None:
+            gate = torch.sigmoid(self.dtg_gate(x_in.detach()))
+            x_out = x_in + gate * (x_out - x_in)
+        return x_out, raw_v
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        mtp_num_heads: int = 0,
+        mtp_loss_weight: float = 0.1,
+        bigram_vocab_size: int = 0,
+        bigram_dim: int = 128,
+        xsa_last_n: int = 0,
+        rope_dims: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        ve_enabled: bool = False,
+        ve_dim: int = 128,
+        ve_layers: str = "9,10",
+        gated_attention: bool = False,
+        value_residual: bool = False,
+        mile_gamma: float = 0.8,
+        mile_clamp_min: float = 0.1,
+        cache_layer: int = 7,
+        backout_init: float = 0.1,
+        window_size: int = -1,
+        window_attn_layers: str = "",
+    ):
+        super().__init__()
+        self.register_buffer('mile_gamma_buf', torch.tensor(mile_gamma, dtype=torch.float32))
+        self.mile_clamp_min = mile_clamp_min
+        self.cache_layer = cache_layer
+        self.backout_lambda = nn.Parameter(torch.tensor(backout_init, dtype=torch.float32))
+        self._ve_target_dim = num_kv_heads * (model_dim // num_heads)  # kv_dim for value projection
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.value_residual = value_residual
+        self.mtp_num_heads = mtp_num_heads
+        self.mtp_loss_weight = mtp_loss_weight
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.smear = SmearGate(model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip, model_dim, dtype=torch.float32))
+        self.skip_gates = nn.Parameter(torch.zeros(self.num_skip, model_dim, dtype=torch.float32))
+        # Parameter banks: split into early/late halves for separate LR
+        head_dim = model_dim // num_heads
+        kv_dim = num_kv_heads * head_dim
+        mlp_dim = int(mlp_mult * model_dim)
+        self.num_layers = num_layers
+        self._bank_split = num_layers // 2
+        s = self._bank_split
+        n_l = num_layers - s
+        self.qo_bank_early = nn.Parameter(torch.empty(2 * s, model_dim, model_dim))
+        self.qo_bank_late = nn.Parameter(torch.empty(2 * n_l, model_dim, model_dim))
+        self.kv_bank_early = nn.Parameter(torch.empty(2 * s, kv_dim, model_dim))
+        self.kv_bank_late = nn.Parameter(torch.empty(2 * n_l, kv_dim, model_dim))
+        self.mlp_up_bank_early = nn.Parameter(torch.empty(s, mlp_dim, model_dim))
+        self.mlp_up_bank_late = nn.Parameter(torch.empty(n_l, mlp_dim, model_dim))
+        self.mlp_down_bank_early = nn.Parameter(torch.empty(s, model_dim, mlp_dim))
+        self.mlp_down_bank_late = nn.Parameter(torch.empty(n_l, model_dim, mlp_dim))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                    layer_idx=i,
+                    ln_scale=ln_scale,
+                    dtg=dtg,
+                    gated_attention=gated_attention,
+                    value_residual=value_residual,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        if rope_dims > 0:
+            head_dim = model_dim // num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = rope_dims
+                block.attn.rotary = Rotary(head_dim, base=rope_base, train_seq_len=1024, rope_dims=rope_dims)
+        self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+        kv_dim_ve = self._ve_target_dim
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim_ve)
+            self.ve_layer_scales = nn.ParameterList(
+                [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices]
+            )
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.value_embeds = nn.ModuleList()  # keep empty for compat
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.mtp_heads = nn.ModuleList(
+            [CastedLinear(model_dim, vocab_size, bias=False) for _ in range(mtp_num_heads)]
+        )
+        for head in self.mtp_heads:
+            head._zero_init = True
+        if xsa_last_n > 0:
+            for i in range(max(0, num_layers - xsa_last_n), num_layers):
+                self.blocks[i].attn.use_xsa = True
+        # Window attention on specified layers
+        if window_size > 0 and window_attn_layers:
+            wa_layers = set(int(x) for x in window_attn_layers.split(",") if x.strip())
+            for i in wa_layers:
+                if 0 <= i < num_layers:
+                    self.blocks[i].attn.window_size = (window_size, 0)
+        self._init_weights()
+
+    def _bank_idx(self, layer_i: int):
+        """Return (qo_bank, qo_q_idx, qo_o_idx, kv_bank, kv_k_idx, kv_v_idx,
+                   mlp_up_bank, mlp_up_idx, mlp_down_bank, mlp_down_idx) for a layer."""
+        s = self._bank_split
+        if layer_i < s:
+            return (self.qo_bank_early, layer_i, s + layer_i,
+                    self.kv_bank_early, layer_i, s + layer_i,
+                    self.mlp_up_bank_early, layer_i,
+                    self.mlp_down_bank_early, layer_i)
+        else:
+            j = layer_i - s
+            n_l = self.num_layers - s
+            return (self.qo_bank_late, j, n_l + j,
+                    self.kv_bank_late, j, n_l + j,
+                    self.mlp_up_bank_late, j,
+                    self.mlp_down_bank_late, j)
+
+    def _get_bank_weights(self, i: int):
+        """Return (q_w, k_w, v_w, o_w, up_w, down_w) for layer i."""
+        qo, qi, oi, kv, ki, vi, up, ui, down, di = self._bank_idx(i)
+        return qo[qi], kv[ki], kv[vi], qo[oi], up[ui], down[di]
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        s = self._bank_split
+        n_l = n - s
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        # Init early banks
+        for i in range(s):
+            nn.init.orthogonal_(self.qo_bank_early.data[i], gain=1.0)
+            nn.init.zeros_(self.qo_bank_early.data[s + i])
+            nn.init.orthogonal_(self.kv_bank_early.data[i], gain=1.0)
+            nn.init.orthogonal_(self.kv_bank_early.data[s + i], gain=1.0)
+            nn.init.orthogonal_(self.mlp_up_bank_early.data[i], gain=1.0)
+            nn.init.zeros_(self.mlp_down_bank_early.data[i])
+            self.qo_bank_early.data[s + i].mul_(proj_scale)
+            self.mlp_down_bank_early.data[i].mul_(proj_scale)
+        # Init late banks
+        for i in range(n_l):
+            nn.init.orthogonal_(self.qo_bank_late.data[i], gain=1.0)
+            nn.init.zeros_(self.qo_bank_late.data[n_l + i])
+            nn.init.orthogonal_(self.kv_bank_late.data[i], gain=1.0)
+            nn.init.orthogonal_(self.kv_bank_late.data[n_l + i], gain=1.0)
+            nn.init.orthogonal_(self.mlp_up_bank_late.data[i], gain=1.0)
+            nn.init.zeros_(self.mlp_down_bank_late.data[i])
+            self.qo_bank_late.data[n_l + i].mul_(proj_scale)
+            self.mlp_down_bank_late.data[i].mul_(proj_scale)
+        # Init remaining nn.Linear modules (bigram proj, mtp heads, lm_head)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+    def _get_ve(self, layer_idx: int, input_ids: Tensor, ve_cache: dict | None = None) -> Tensor | None:
+        """Get value embedding for a specific layer using shared table + per-layer scale."""
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if ve_cache is not None and 've' not in ve_cache:
+            ve_cache['ve'] = self.ve_shared(input_ids)
+        ve_base = ve_cache['ve'] if ve_cache is not None else self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_base * self.ve_layer_scales[ve_idx].to(dtype=ve_base.dtype)
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        x_cache = None
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            q_w, k_w, v_w, o_w, up_w, down_w = self._get_bank_weights(i)
+            x, raw_v = self.blocks[i](x, x0,
+                q_w, k_w, v_w, o_w, up_w, down_w,
+                v_embed=ve, v0=v0)
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            if i == self.cache_layer:
+                x_cache = x.clone()
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                skip = skips.pop()
+                g = torch.sigmoid(self.skip_gates[i].to(dtype=x.dtype))[None, None, :]
+                scaled_skip = self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skip
+                x = torch.lerp(scaled_skip, x, g)
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            q_w, k_w, v_w, o_w, up_w, down_w = self._get_bank_weights(bi)
+            x, _ = self.blocks[bi](x, x0,
+                q_w, k_w, v_w, o_w, up_w, down_w,
+                v_embed=ve, v0=v0)
+            if bi == self.cache_layer:
+                x_cache = x.clone()
+        if x_cache is not None:
+            x = x - self.backout_lambda.to(dtype=x.dtype) * x_cache
+        x = self.final_norm(x)
+        x_flat = x.reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x_flat, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x_flat)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        logits_f = logits.float()
+        if self.training:
+            token_losses = F.cross_entropy(logits_f, targets, reduction="none")
+            with torch.no_grad():
+                gamma = self.mile_gamma_buf
+                probs = torch.softmax(logits_f, dim=-1)
+                entropy = -(probs * torch.log(probs + 1e-8)).sum(dim=-1)
+                weights = ((1.0 - torch.exp(-entropy)) ** gamma).clamp(min=self.mile_clamp_min)
+            main_loss = (token_losses * weights).mean()
+        else:
+            main_loss = F.cross_entropy(logits_f, targets, reduction="mean")
+        if self.training and self.mtp_num_heads > 0 and self.mtp_loss_weight > 0.0:
+            _, seqlen, dim = x.shape
+            mtp_loss_sum = x.new_zeros(())
+            mtp_loss_count = 0
+            for k, mtp_head in enumerate(self.mtp_heads):
+                valid_t = seqlen - (k + 1)
+                if valid_t <= 0:
+                    continue
+                mtp_hidden = x[:, :valid_t, :].reshape(-1, dim)
+                mtp_targets = target_ids[:, k + 1 :].reshape(-1)
+                mtp_logits_proj = mtp_head(mtp_hidden)
+                mtp_logits = self.logit_softcap * torch.tanh(mtp_logits_proj / self.logit_softcap)
+                mtp_loss_sum = mtp_loss_sum + F.cross_entropy(mtp_logits.float(), mtp_targets, reduction="mean")
+                mtp_loss_count += 1
+            if mtp_loss_count > 0:
+                main_loss = main_loss + self.mtp_loss_weight * (mtp_loss_sum / mtp_loss_count)
+        return main_loss
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Return logits (bsz, seq_len, vocab) without computing loss."""
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        x_cache = None
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            q_w, k_w, v_w, o_w, up_w, down_w = self._get_bank_weights(i)
+            x, raw_v = self.blocks[i](x, x0,
+                q_w, k_w, v_w, o_w, up_w, down_w,
+                v_embed=ve, v0=v0)
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            if i == self.cache_layer:
+                x_cache = x.clone()
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                skip = skips.pop()
+                g = torch.sigmoid(self.skip_gates[i].to(dtype=x.dtype))[None, None, :]
+                scaled_skip = self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skip
+                x = torch.lerp(scaled_skip, x, g)
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            q_w, k_w, v_w, o_w, up_w, down_w = self._get_bank_weights(bi)
+            x, _ = self.blocks[bi](x, x0,
+                q_w, k_w, v_w, o_w, up_w, down_w,
+                v_embed=ve, v0=v0)
+            if bi == self.cache_layer:
+                x_cache = x.clone()
+        if x_cache is not None:
+            x = x - self.backout_lambda.to(dtype=x.dtype) * x_cache
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+# --- Sliding window evaluation ---
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context."""
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= 1]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    base_model.eval()
+    compiled_logits = torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = compiled_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+def eval_val_sliding_ttt(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    stride: int, batch_seqs: int = 32, log0=print,
+) -> tuple[float, float]:
+    """Legal score-first TTT (PR #461 recipe): score each chunk with sliding windows,
+    then train on it. Every token scored BEFORE any update that could use it."""
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = args.ttt_chunk_tokens
+
+    # Pre-compute all window starts
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+
+    # Assign each window to a chunk based on the first token it scores
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    chunk_windows: list[list[int]] = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        end = min(ws + seq_len, total_tokens)
+        wlen = end - ws
+        s = 0 if ws == 0 else max(wlen - stride, 0)
+        scored_start = ws + s
+        ci = min(scored_start // ttt_chunk, num_chunks - 1)
+        chunk_windows[ci].append(ws)
+
+    log0(f"ttt_sliding:start chunks={num_chunks} chunk_tokens={ttt_chunk} "
+         f"total_windows={len(window_starts)} stride={stride} "
+         f"ttt_lr={args.ttt_lr} ttt_epochs={args.ttt_epochs} "
+         f"freeze_blocks={args.ttt_freeze_blocks}")
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Freeze first N blocks
+    frozen_block_ids = set(range(min(args.ttt_freeze_blocks, len(base_model.blocks))))
+    ttt_params = []
+    for name, p in base_model.named_parameters():
+        freeze = False
+        for bi in frozen_block_ids:
+            if f"blocks.{bi}." in name:
+                freeze = True
+                break
+        if freeze:
+            p.requires_grad_(False)
+        else:
+            p.requires_grad_(True)
+            ttt_params.append(p)
+
+    log0(f"ttt_sliding:params unfrozen={sum(p.numel() for p in ttt_params)} "
+         f"frozen={sum(p.numel() for p in base_model.parameters() if not p.requires_grad)}")
+
+    optimizer = torch.optim.SGD(ttt_params, lr=args.ttt_lr, momentum=args.ttt_momentum)
+    t0 = time.perf_counter()
+
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows:
+            continue
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+
+        # --- Phase 1: SCORE this chunk's windows (inference_mode) ---
+        my_s = (len(windows) * rank) // world_size
+        my_e = (len(windows) * (rank + 1)) // world_size
+        my_windows = windows[my_s:my_e]
+
+        base_model.eval()
+        with torch.inference_mode():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi:bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens: list[int] = []
+                for i, ws in enumerate(batch_ws):
+                    end = min(ws + seq_len, total_tokens)
+                    wlen = end - ws
+                    wlens.append(wlen)
+                    chunk_tok = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                    x_batch[i, :wlen] = chunk_tok[:-1]
+                    y_batch[i, :wlen] = chunk_tok[1:]
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model.forward_logits(x_batch)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y_batch.reshape(-1), reduction="none",
+                ).reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]
+                    s = 0 if ws == 0 else max(wlen - stride, 0)
+                    scored_nll = nll[i, s:wlen].to(torch.float64)
+                    loss_sum += scored_nll.sum()
+                    token_count += float(wlen - s)
+                    tgt, prev = y_batch[i, s:wlen], x_batch[i, s:wlen]
+                    tb = base_bytes_lut[tgt].to(torch.float64)
+                    tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                    byte_count += tb.sum()
+
+        # --- Phase 2: TRAIN on this chunk (already scored = legal) ---
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and args.ttt_epochs > 0:
+            base_model.train()
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if chunk_seqs > 0:
+                cos_lr = args.ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                for pg in optimizer.param_groups:
+                    pg['lr'] = cos_lr
+                my_seq_s = (chunk_seqs * rank) // world_size
+                my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+                my_chunk_seqs = my_seq_e - my_seq_s
+                for _ep in range(args.ttt_epochs):
+                    for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                        be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                        actual_bs = my_seq_s + bs
+                        start_tok = chunk_start + actual_bs * seq_len
+                        end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                        if end_tok > val_tokens.numel():
+                            continue
+                        local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                        x = local[:-1].reshape(-1, seq_len)
+                        y = local[1:].reshape(-1, seq_len)
+                        optimizer.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            loss = base_model(x, y)
+                        loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        torch.nn.utils.clip_grad_norm_(ttt_params, args.ttt_grad_clip)
+                        optimizer.step()
+
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            log0(f"  ttt_chunk [{ci+1}/{num_chunks}] bpb={rbpb:.6f} time={elapsed:.1f}s")
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+    log0(f"ttt_sliding:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+         f"elapsed={time.perf_counter() - t0:.1f}s")
+    return val_loss, val_bpb
+
+
+# --- GPTQ-lite int6 quantization ---
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+def quantize_int6_per_row(t: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        best_q, best_s, best_err = None, None, float('inf')
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            if pct < 1.0:
+                row_clip = torch.quantile(t32.abs(), pct, dim=1)
+            else:
+                row_clip = t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+            recon = q.float() * s.float()[:, None]
+            err = (t32 - recon).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_s, best_err = q, s, err
+        return best_q, best_s
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+
+def quantize_int6_gptq(weight, hessian=None, clip_range=31, block_size=128):
+    """Full GPTQ: Hessian-aware int6 quantization with Cholesky error compensation.
+    If hessian is None, falls back to percentile search."""
+    t32 = weight.float()
+    if t32.ndim != 2 or hessian is None:
+        return _quantize_int6_percentile(t32, clip_range)
+    rows, cols = t32.shape
+    H = hessian.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * torch.mean(torch.diag(H))
+    H[torch.arange(cols), torch.arange(cols)] += damp
+    perm = torch.argsort(torch.diag(H), descending=True)
+    inv_perm = torch.argsort(perm)
+    W = t32[:, perm].clone()
+    W[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv = torch.linalg.cholesky(H)
+    Hinv = torch.cholesky_inverse(Hinv)
+    Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    best_q = None; best_scale = None; best_err = float('inf')
+    for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+        if pct < 1.0:
+            row_clip = torch.quantile(t32.abs(), pct, dim=1)
+        else:
+            row_clip = t32.abs().amax(dim=1)
+        s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+        sf = s.float()
+        Q = torch.zeros_like(W, dtype=torch.int8)
+        W_work = W.clone()
+        for i1 in range(0, cols, block_size):
+            i2 = min(i1 + block_size, cols)
+            count = i2 - i1
+            W1 = W_work[:, i1:i2].clone()
+            Q1 = torch.zeros(rows, count, dtype=torch.int8)
+            Err1 = torch.zeros(rows, count)
+            Hinv1 = Hinv[i1:i2, i1:i2]
+            for i in range(count):
+                w = W1[:, i]
+                d = Hinv1[i, i]
+                q = torch.clamp(torch.round(w / sf), -clip_range, clip_range).to(torch.int8)
+                Q1[:, i] = q
+                err = (w - q.float() * sf) / d
+                W1[:, i:] -= err.unsqueeze(1) * Hinv1[i, i:].unsqueeze(0)
+                Err1[:, i] = err
+            Q[:, i1:i2] = Q1
+            if i2 < cols:
+                W_work[:, i2:] -= Err1 @ Hinv[i1:i2, i2:]
+        recon = Q.float() * sf[:, None]
+        mse = (W - recon).pow(2).mean().item()
+        if mse < best_err:
+            best_q, best_scale, best_err = Q, s, mse
+    best_q = best_q[:, inv_perm]
+    return best_q, best_scale
+
+def _quantize_int6_percentile(t32, clip_range=31):
+    """Fallback: percentile search (for 1D or no-Hessian cases)."""
+    if t32.ndim == 2:
+        best_q, best_s, best_err = None, None, float('inf')
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            if pct < 1.0:
+                row_clip = torch.quantile(t32.abs(), pct, dim=1)
+            else:
+                row_clip = t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+            recon = q.float() * s.float()[:, None]
+            err = (t32 - recon).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_s, best_err = q, s, err
+        return best_q, best_s
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+
+def _unbank_state_dict(sd: dict[str, Tensor], num_layers: int) -> dict[str, Tensor]:
+    """Convert 3D bank tensors (early/late) into individual 2D tensors with standard names."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    s = n // 2
+    n_l = n - s
+    bank_names = {"qo_bank_early", "qo_bank_late", "kv_bank_early", "kv_bank_late",
+                  "mlp_up_bank_early", "mlp_up_bank_late", "mlp_down_bank_early", "mlp_down_bank_late"}
+    for name, tensor in sd.items():
+        if name not in bank_names:
+            out[name] = tensor
+    # Unbank early layers (0..s-1)
+    if "qo_bank_early" in sd:
+        qo_e = sd["qo_bank_early"]
+        for i in range(s):
+            out[f"blocks.{i}.attn.c_q.weight"] = qo_e[i]
+            out[f"blocks.{i}.attn.proj.weight"] = qo_e[s + i]
+    if "kv_bank_early" in sd:
+        kv_e = sd["kv_bank_early"]
+        for i in range(s):
+            out[f"blocks.{i}.attn.c_k.weight"] = kv_e[i]
+            out[f"blocks.{i}.attn.c_v.weight"] = kv_e[s + i]
+    if "mlp_up_bank_early" in sd:
+        for i in range(s):
+            out[f"blocks.{i}.mlp.fc.weight"] = sd["mlp_up_bank_early"][i]
+    if "mlp_down_bank_early" in sd:
+        for i in range(s):
+            out[f"blocks.{i}.mlp.proj.weight"] = sd["mlp_down_bank_early"][i]
+    # Unbank late layers (s..n-1)
+    if "qo_bank_late" in sd:
+        qo_l = sd["qo_bank_late"]
+        for i in range(n_l):
+            out[f"blocks.{s + i}.attn.c_q.weight"] = qo_l[i]
+            out[f"blocks.{s + i}.attn.proj.weight"] = qo_l[n_l + i]
+    if "kv_bank_late" in sd:
+        kv_l = sd["kv_bank_late"]
+        for i in range(n_l):
+            out[f"blocks.{s + i}.attn.c_k.weight"] = kv_l[i]
+            out[f"blocks.{s + i}.attn.c_v.weight"] = kv_l[n_l + i]
+    if "mlp_up_bank_late" in sd:
+        for i in range(n_l):
+            out[f"blocks.{s + i}.mlp.fc.weight"] = sd["mlp_up_bank_late"][i]
+    if "mlp_down_bank_late" in sd:
+        for i in range(n_l):
+            out[f"blocks.{s + i}.mlp.proj.weight"] = sd["mlp_down_bank_late"][i]
+    return out
+
+def _rebank_state_dict(sd: dict[str, Tensor], num_layers: int, template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    """Convert individual 2D tensors back into 3D early/late bank tensors."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    s = n // 2
+    n_l = n - s
+    consumed = set()
+    qo_early, qo_late = [None] * (2 * s), [None] * (2 * n_l)
+    kv_early, kv_late = [None] * (2 * s), [None] * (2 * n_l)
+    up_early, up_late = [None] * s, [None] * n_l
+    down_early, down_late = [None] * s, [None] * n_l
+    for i in range(n):
+        qk = f"blocks.{i}.attn.c_q.weight"
+        ok = f"blocks.{i}.attn.proj.weight"
+        kk = f"blocks.{i}.attn.c_k.weight"
+        vk = f"blocks.{i}.attn.c_v.weight"
+        fk = f"blocks.{i}.mlp.fc.weight"
+        dk = f"blocks.{i}.mlp.proj.weight"
+        if i < s:
+            if qk in sd: qo_early[i] = sd[qk]; consumed.add(qk)
+            if ok in sd: qo_early[s + i] = sd[ok]; consumed.add(ok)
+            if kk in sd: kv_early[i] = sd[kk]; consumed.add(kk)
+            if vk in sd: kv_early[s + i] = sd[vk]; consumed.add(vk)
+            if fk in sd: up_early[i] = sd[fk]; consumed.add(fk)
+            if dk in sd: down_early[i] = sd[dk]; consumed.add(dk)
+        else:
+            j = i - s
+            if qk in sd: qo_late[j] = sd[qk]; consumed.add(qk)
+            if ok in sd: qo_late[n_l + j] = sd[ok]; consumed.add(ok)
+            if kk in sd: kv_late[j] = sd[kk]; consumed.add(kk)
+            if vk in sd: kv_late[n_l + j] = sd[vk]; consumed.add(vk)
+            if fk in sd: up_late[j] = sd[fk]; consumed.add(fk)
+            if dk in sd: down_late[j] = sd[dk]; consumed.add(dk)
+    out["qo_bank_early"] = torch.stack(qo_early).to(dtype=template_sd["qo_bank_early"].dtype)
+    out["qo_bank_late"] = torch.stack(qo_late).to(dtype=template_sd["qo_bank_late"].dtype)
+    out["kv_bank_early"] = torch.stack(kv_early).to(dtype=template_sd["kv_bank_early"].dtype)
+    out["kv_bank_late"] = torch.stack(kv_late).to(dtype=template_sd["kv_bank_late"].dtype)
+    out["mlp_up_bank_early"] = torch.stack(up_early).to(dtype=template_sd["mlp_up_bank_early"].dtype)
+    out["mlp_up_bank_late"] = torch.stack(up_late).to(dtype=template_sd["mlp_up_bank_late"].dtype)
+    out["mlp_down_bank_early"] = torch.stack(down_early).to(dtype=template_sd["mlp_down_bank_early"].dtype)
+    out["mlp_down_bank_late"] = torch.stack(down_late).to(dtype=template_sd["mlp_down_bank_late"].dtype)
+    for name, tensor in sd.items():
+        if name not in consumed:
+            out[name] = tensor
+    return out
+
+# --- Non-banked model for Hessian collection ---
+# This mirrors the unbanked state dict keys: blocks.{i}.attn.c_q/c_k/c_v/proj, blocks.{i}.mlp.fc/proj
+
+class _HessianAttn(nn.Module):
+    """Non-banked attention with CastedLinear layers for Hessian hooks."""
+    def __init__(self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init):
+        super().__init__()
+        self.num_heads, self.num_kv_heads = num_heads, num_kv_heads
+        self.head_dim = dim // num_heads
+        kv_dim = num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False
+        self.window_size = (-1, -1)
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape; Hkv = v.size(-2); group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+    def forward(self, x, v_embed=None):
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = self.c_v(x)
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True, window_size=self.window_size)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        return self.proj(y.reshape(bsz, seqlen, dim))
+
+class _HessianMLP(nn.Module):
+    """Non-banked MLP with CastedLinear layers for Hessian hooks."""
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        self.fc = CastedLinear(dim, int(mlp_mult * dim), bias=False)
+        self.proj = CastedLinear(int(mlp_mult * dim), dim, bias=False)
+    def forward(self, x):
+        return self.proj(F.leaky_relu(self.fc(x), negative_slope=_LEAKY_SLOPE).square())
+
+class _HessianBlock(nn.Module):
+    def __init__(self, dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init, layer_idx=0, ln_scale=False):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = _HessianAttn(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = _HessianMLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+    def forward(self, x, x0, v_embed=None):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x_in) * self.ln_scale_factor, v_embed=v_embed)
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor)
+        return x_out
+
+class _HessianGPT(nn.Module):
+    """Non-banked GPT model matching unbanked state dict keys for Hessian collection."""
+    def __init__(self, vocab_size, num_layers, model_dim, num_heads, num_kv_heads,
+                 mlp_mult, tie_embeddings, logit_softcap, rope_base, qk_gain_init,
+                 bigram_vocab_size=0, bigram_dim=128, xsa_last_n=0,
+                 rope_dims=0, ln_scale=False,
+                 ve_enabled=False, ve_dim=128, ve_layers="9,10",
+                 window_size=-1, window_attn_layers=""):
+        super().__init__()
+        self.tie_embeddings = tie_embeddings
+        self.logit_softcap = logit_softcap
+        self.num_layers = num_layers
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.smear = SmearGate(model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip, model_dim, dtype=torch.float32))
+        self.skip_gates = nn.Parameter(torch.zeros(self.num_skip, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList([
+            _HessianBlock(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init,
+                          layer_idx=i, ln_scale=ln_scale)
+            for i in range(num_layers)
+        ])
+        if rope_dims > 0:
+            head_dim = model_dim // num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = rope_dims
+                block.attn.rotary = Rotary(head_dim, base=rope_base, train_seq_len=1024, rope_dims=rope_dims)
+        if xsa_last_n > 0:
+            for i in range(max(0, num_layers - xsa_last_n), num_layers):
+                self.blocks[i].attn.use_xsa = True
+        if window_size > 0 and window_attn_layers:
+            wa_layers = set(int(x) for x in window_attn_layers.split(",") if x.strip())
+            for i in wa_layers:
+                if 0 <= i < num_layers:
+                    self.blocks[i].attn.window_size = (window_size, 0)
+        kv_dim = num_kv_heads * (model_dim // num_heads)
+        self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim)
+            self.ve_layer_scales = nn.ParameterList([nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices])
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+    def _get_ve(self, layer_idx, input_ids, ve_cache):
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if 've' not in ve_cache:
+            ve_cache['ve'] = self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_cache['ve'] * self.ve_layer_scales[ve_idx].to(dtype=ve_cache['ve'].dtype)
+    def forward(self, input_ids, target_ids):
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        skips = []
+        ve_cache = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x = self.blocks[i](x, x0, v_embed=ve)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                skip = skips.pop()
+                g = torch.sigmoid(self.skip_gates[i].to(dtype=x.dtype))[None, None, :]
+                scaled_skip = self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skip
+                x = torch.lerp(scaled_skip, x, g)
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x = self.blocks[bi](x, x0, v_embed=ve)
+        x = self.final_norm(x)
+        x_flat = x.reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        logits_proj = F.linear(x_flat, self.tok_emb.weight) if self.tie_embeddings else self.lm_head(x_flat)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+def generate_autoregressive_calib(model, device, num_seqs=64, seq_len=2048,
+                                   vocab_size=1024, temperature=0.8, batch_size=8, seed=42):
+    """Generate sequences autoregressively from the model for GPTQ calibration.
+    No external data accessed — fully self-contained."""
+    model.eval()
+    rng = torch.Generator(device=device)
+    rng.manual_seed(seed)
+    all_tokens = []
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        for batch_start in range(0, num_seqs, batch_size):
+            bs = min(batch_size, num_seqs - batch_start)
+            tokens = torch.randint(0, vocab_size, (bs, 1), device=device, generator=rng)
+            for pos in range(seq_len - 1):
+                logits = model.forward_logits(tokens)
+                next_logit = logits[:, -1, :]
+                probs = torch.softmax(next_logit / temperature, dim=-1)
+                next_tok = torch.multinomial(probs, 1, generator=rng)
+                tokens = torch.cat([tokens, next_tok], dim=1)
+            for i in range(bs):
+                all_tokens.append(tokens[i:i+1])
+    return all_tokens
+
+def collect_hessians_from_tokens(hessian_model, token_seqs, device):
+    """Collect H = X^T X from pre-generated token sequences."""
+    hessians = {}
+    hooks = []
+    for name, module in hessian_model.named_modules():
+        if isinstance(module, CastedLinear):
+            param_name = name + ".weight"
+            cols = module.weight.shape[1]
+            hessians[param_name] = torch.zeros(cols, cols, dtype=torch.float32, device='cpu')
+            def make_hook(pname):
+                def hook_fn(module, input, output):
+                    x = input[0].detach().float()
+                    if x.ndim == 3:
+                        x = x.reshape(-1, x.shape[-1])
+                    hessians[pname] += (x.T @ x).cpu()
+                return hook_fn
+            h = module.register_forward_hook(make_hook(param_name))
+            hooks.append(h)
+    hessian_model.eval()
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        for seq in token_seqs:
+            x = seq[:, :-1].to(device)
+            y = seq[:, 1:].to(device)
+            hessian_model(x, y)
+    for h in hooks:
+        h.remove()
+    num_batches = len(token_seqs)
+    for name in hessians:
+        H = hessians[name]
+        H /= num_batches
+        damp = 0.01 * torch.diag(H).mean().clamp_min(1e-6)
+        H += damp * torch.eye(H.shape[0])
+        hessians[name] = H
+    return hessians
+
+def collect_hessians(hessian_model, train_loader, args, device, grad_accum_steps, num_batches=256):
+    """Run calibration batches through a non-banked model, collecting H = X^T X for each CastedLinear."""
+    hessians = {}
+    hooks = []
+    for name, module in hessian_model.named_modules():
+        if isinstance(module, CastedLinear):
+            param_name = name + ".weight"
+            cols = module.weight.shape[1]
+            hessians[param_name] = torch.zeros(cols, cols, dtype=torch.float32, device='cpu')
+            def make_hook(pname):
+                def hook_fn(module, input, output):
+                    x = input[0].detach().float()
+                    if x.ndim == 3:
+                        x = x.reshape(-1, x.shape[-1])
+                    hessians[pname] += (x.T @ x).cpu()
+                return hook_fn
+            h = module.register_forward_hook(make_hook(param_name))
+            hooks.append(h)
+    hessian_model.eval()
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        for _ in range(num_batches):
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            hessian_model(x, y)
+    for h in hooks:
+        h.remove()
+    for name in hessians:
+        H = hessians[name]
+        H /= num_batches
+        damp = 0.01 * torch.diag(H).mean().clamp_min(1e-6)
+        H += damp * torch.eye(H.shape[0])
+        hessians[name] = H
+    hessian_model.train()
+    return hessians
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str], hessians: dict[str, Tensor] | None = None):
+    num_layers_total = max(
+        (int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")),
+        default=0,
+    ) + 1
+    late_k_layers = set(range(num_layers_total - 2, num_layers_total))
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            cr = 31  # int6 for all weights
+            H = hessians.get(name) if hessians else None
+            if H is not None:
+                q, s = quantize_int6_gptq(t, hessian=H, clip_range=cr)
+            else:
+                q, s = quantize_int6_per_row(t, clip_range=cr)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+# --- Training ---
+
+def main() -> None:
+    code_raw = Path(__file__).read_text(encoding="utf-8")
+    code = _minify_code(code_raw)
+    args = Hyperparameters()
+    global _LEAKY_SLOPE
+    _LEAKY_SLOPE = args.leaky_slope
+    # zeropower_via_newtonschulz5 runs eagerly with bmm -- do NOT compile
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    # Option B: LOCAL_SEQS_PER_GPU + LOCAL_SEQ_LEN → compute global batch tokens
+    if args.local_seqs_per_gpu > 0:
+        _local_sl = args.local_seq_len if args.local_seq_len > 0 else args.train_seq_len
+        args.train_seq_len = _local_sl
+        args.train_batch_tokens = args.local_seqs_per_gpu * _local_sl * grad_accum_steps * world_size
+        if rank == 0:
+            log0(f"local_batch: {args.local_seqs_per_gpu} seqs x {_local_sl} tokens/seq x {grad_accum_steps} accum x {world_size} gpus = {args.train_batch_tokens} global tokens")
+    # Mixed seq_len: each GPU uses a different seq_len, tokens balanced by speed
+    MS_PER_STEP_LUT = {256: 158.1, 512: 168.9, 768: 178.6, 1024: 189.9,
+                       1536: 211.5, 2048: 233.9, 3072: 276.8, 4096: 321.2}
+
+    def interp_ms(seq_len):
+        """Interpolate ms/step for arbitrary seq_len."""
+        keys = sorted(MS_PER_STEP_LUT.keys())
+        if seq_len in MS_PER_STEP_LUT:
+            return MS_PER_STEP_LUT[seq_len]
+        if seq_len <= keys[0]:
+            return MS_PER_STEP_LUT[keys[0]]
+        if seq_len >= keys[-1]:
+            return MS_PER_STEP_LUT[keys[-1]]
+        for i in range(len(keys) - 1):
+            if keys[i] <= seq_len <= keys[i+1]:
+                frac = (seq_len - keys[i]) / (keys[i+1] - keys[i])
+                return MS_PER_STEP_LUT[keys[i]] * (1 - frac) + MS_PER_STEP_LUT[keys[i+1]] * frac
+
+    seq_lens_per_gpu = os.environ.get("SEQ_LENS_PER_GPU", "")  # e.g. "2048,2048,2048,2048,2048,6144,6144,6144"
+    seqs_per_gpu = os.environ.get("SEQS_PER_GPU", "")  # e.g. "36,36,36,36,36,10,10,10" (explicit seq counts)
+    if seq_lens_per_gpu:
+        gpu_seq_lens = [int(x) for x in seq_lens_per_gpu.split(",")]
+        assert len(gpu_seq_lens) == world_size, f"Need {world_size} seq_lens, got {len(gpu_seq_lens)}"
+        my_sl = gpu_seq_lens[rank]
+        args.train_seq_len = my_sl
+        if seqs_per_gpu:
+            # Explicit seq counts per GPU
+            gpu_seqs = [int(x) for x in seqs_per_gpu.split(",")]
+            assert len(gpu_seqs) == world_size, f"Need {world_size} seq counts, got {len(gpu_seqs)}"
+            my_batch = gpu_seqs[rank]
+            my_tokens_actual = my_batch * grad_accum_steps * my_sl
+            args.train_batch_tokens = my_tokens_actual * world_size
+            if rank == 0:
+                parts = [f"GPU{r}={gpu_seq_lens[r]}x{gpu_seqs[r]}={gpu_seqs[r]*grad_accum_steps*gpu_seq_lens[r]}tok" for r in range(world_size)]
+                actual_total = sum(gpu_seqs[r] * grad_accum_steps * gpu_seq_lens[r] for r in range(world_size))
+                _mixed_seq_msg = f"mixed_seq_len: {' '.join(parts)} total={actual_total}"
+            else:
+                _mixed_seq_msg = None
+        else:
+            # Speed-weighted token allocation
+            weights = [1.0 / interp_ms(sl) for sl in gpu_seq_lens]
+            total_weight = sum(weights)
+            total_tokens = args.train_batch_tokens
+            my_weight = weights[rank]
+            my_tokens_target = total_tokens * my_weight / total_weight
+            my_batch = max(1, round(my_tokens_target / (grad_accum_steps * my_sl)))
+            my_tokens_actual = my_batch * grad_accum_steps * my_sl
+            args.train_batch_tokens = my_tokens_actual * world_size
+            if rank == 0:
+                parts = []
+                for r in range(world_size):
+                    sl = gpu_seq_lens[r]
+                    w = weights[r]
+                    bt = max(1, round(total_tokens * w / total_weight / (grad_accum_steps * sl)))
+                    parts.append(f"GPU{r}={sl}x{bt}={bt*grad_accum_steps*sl}tok")
+                actual_total = sum(max(1, round(total_tokens * weights[r] / total_weight / (grad_accum_steps * gpu_seq_lens[r]))) * grad_accum_steps * gpu_seq_lens[r] for r in range(world_size))
+                _mixed_seq_msg = f"mixed_seq_len: {' '.join(parts)} total={actual_total}"
+            else:
+                _mixed_seq_msg = None
+    else:
+        _mixed_seq_msg = None
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+    if _mixed_seq_msg is not None:
+        log0(_mixed_seq_msg)
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    effective_eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len, 4096)  # need 4096 for multi-length eval
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+    CastedLinear._qat_enabled = args.qat_enabled
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=args.mtp_num_heads,
+        mtp_loss_weight=args.mtp_loss_weight,
+        bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims,
+        ln_scale=args.ln_scale,
+        dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled,
+        ve_dim=args.ve_dim,
+        ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention,
+        value_residual=args.value_residual,
+        mile_gamma=args.mile_gamma,
+        mile_clamp_min=args.mile_clamp_min,
+        cache_layer=args.cache_layer,
+        backout_init=args.backout_init,
+        window_size=args.window_size,
+        window_attn_layers=args.window_attn_layers,
+    ).to(device).bfloat16()
+    # Banks stay FP32 (like CastedLinear weights), cast to BF16 in forward
+    base_model.qo_bank_early.data = base_model.qo_bank_early.data.float()
+    base_model.qo_bank_late.data = base_model.qo_bank_late.data.float()
+    base_model.kv_bank_early.data = base_model.kv_bank_early.data.float()
+    base_model.kv_bank_late.data = base_model.kv_bank_late.data.float()
+    base_model.mlp_up_bank_early.data = base_model.mlp_up_bank_early.data.float()
+    base_model.mlp_up_bank_late.data = base_model.mlp_up_bank_late.data.float()
+    base_model.mlp_down_bank_early.data = base_model.mlp_down_bank_early.data.float()
+    base_model.mlp_down_bank_late.data = base_model.mlp_down_bank_late.data.float()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    # No DDP -- Parallel Muon handles bank grad communication via reduce-scatter,
+    # and non-bank grads are manually all-reduced before Adam steps.
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model = compiled_model
+
+    # Optimizer split:
+    # - 4 parameter banks -> Muon (batched Newton-Schulz)
+    # - token embedding -> Adam
+    # - scalars/control tensors -> Adam
+    # - bigram proj, mtp heads, VE proj -> Adam (small matrix params not worth banking)
+    matrix_params_early = [
+        base_model.qo_bank_early, base_model.kv_bank_early,
+        base_model.mlp_up_bank_early, base_model.mlp_down_bank_early,
+    ]
+    matrix_params_late = [
+        base_model.qo_bank_late, base_model.kv_bank_late,
+        base_model.mlp_up_bank_late, base_model.mlp_down_bank_late,
+    ]
+    block_named_params = list(base_model.blocks.named_parameters())
+    bank_split = base_model._bank_split
+    scalar_params_early = []
+    scalar_params_late = []
+    for name, p in block_named_params:
+        if not (p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)):
+            continue
+        block_idx = int(name.split(".")[0])
+        if block_idx < bank_split:
+            scalar_params_early.append(p)
+        else:
+            scalar_params_late.append(p)
+    # Non-block scalar params go into early group
+    if base_model.skip_weights.numel() > 0:
+        scalar_params_early.append(base_model.skip_weights)
+        scalar_params_early.append(base_model.skip_gates)
+    scalar_params_early.append(base_model.backout_lambda)
+    scalar_params_early.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params_early.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_params.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None:
+            scalar_params_early.append(base_model.bigram.proj.weight)
+    if base_model.ve_shared is not None:
+        tok_params.append({"params": [base_model.ve_shared.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.ve_shared.proj is not None:
+            scalar_params_early.append(base_model.ve_shared.proj.weight)
+        scalar_params_early.append(base_model.ve_shared.scale)
+        for s in base_model.ve_layer_scales:
+            scalar_params_early.append(s)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_muon_early = Muon(
+        matrix_params_early,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+    )
+    for group in optimizer_muon_early.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_muon_late = Muon(
+        matrix_params_late,
+        lr=args.matrix_lr_late,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+    )
+    for group in optimizer_muon_late.param_groups:
+        group["base_lr"] = args.matrix_lr_late
+    optimizer_scalar_early = torch.optim.AdamW(
+        [{"params": scalar_params_early, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_scalar_late = torch.optim.AdamW(
+        [{"params": scalar_params_late, "lr": args.scalar_lr_late, "base_lr": args.scalar_lr_late}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    # Non-bank params that need manual all-reduce (replicated across GPUs)
+    replicated_params = list(optimizer_tok.param_groups[0]["params"])
+    for pg in optimizer_tok.param_groups[1:]:
+        replicated_params.extend(pg["params"])
+    replicated_params.extend(scalar_params_early)
+    replicated_params.extend(scalar_params_late)
+
+    optimizer_head = None
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        replicated_params.append(base_model.lm_head.weight)
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon_early, optimizer_muon_late, optimizer_scalar_early, optimizer_scalar_late]
+    if optimizer_head is not None:
+        optimizers.append(optimizer_head)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    mtp_params = sum(p.numel() for p in base_model.mtp_heads.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"mtp_num_heads:{args.mtp_num_heads} mtp_loss_weight:{args.mtp_loss_weight} mtp_params:{mtp_params}")
+    xsa_layers = [i for i, b in enumerate(base_model.blocks) if b.attn.use_xsa]
+    log0(f"XSA:last_{args.xsa_last_n} active_layers:{xsa_layers}")
+    wa_layers = [i for i, b in enumerate(base_model.blocks) if b.attn.window_size != (-1, -1)]
+    if wa_layers:
+        log0(f"window_attn:size={args.window_size} layers:{wa_layers}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} matrix_lr_late:{args.matrix_lr_late} "
+        f"scalar_lr:{args.scalar_lr} scalar_lr_late:{args.scalar_lr_late} "
+        f"leaky_slope:{args.leaky_slope}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    if max_wallclock_ms is not None and args.gptq_reserve_ms > 0:
+        max_wallclock_ms -= args.gptq_reserve_ms
+        log0(f"gptq:reserving {args.gptq_reserve_ms:.0f}ms from training budget, effective={max_wallclock_ms:.0f}ms")
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            # All-reduce all grads for warmup (simple, not optimized)
+            if distributed:
+                for p in base_model.parameters():
+                    if p.grad is not None:
+                        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    from collections import deque
+    lawa_queue: deque[dict[str, Tensor]] = deque(maxlen=args.lawa_k)
+    ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    ema_decay = 0.997
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        if args.late_qat_threshold > 0 and scale < args.late_qat_threshold and not CastedLinear._qat_enabled:
+            CastedLinear._qat_enabled = True
+            log0(f"late_qat:enabled step:{step} scale:{scale:.4f}")
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        # MiLe gamma triangle schedule: ramp up to peak, then decay to 0
+        if max_wallclock_ms is not None and max_wallclock_ms > 0 and args.mile_gamma > 0:
+            progress = elapsed_ms / max_wallclock_ms  # 0..1
+            peak = args.mile_peak_frac
+            if progress < peak:
+                cur_gamma = args.mile_gamma * (progress / peak)
+            else:
+                cur_gamma = args.mile_gamma * (1.0 - (progress - peak) / (1.0 - peak))
+            base_model.mile_gamma_buf.fill_(max(cur_gamma, 0.0))
+        for group in optimizer_muon_early.param_groups:
+            group["momentum"] = muon_momentum
+        for group in optimizer_muon_late.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        # === 3-phase overlapped optimizer step ===
+        # Phase 1: Launch async reduce-scatter for banks (biggest first)
+        optimizer_muon_early.launch_reduce_scatters()
+        optimizer_muon_late.launch_reduce_scatters()
+        # Phase 2: All-reduce non-bank grads + step Adam (while bank RS is in-flight)
+        if distributed:
+            for p in replicated_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+        optimizer_tok.step()
+        optimizer_scalar_early.step()
+        optimizer_scalar_late.step()
+        if optimizer_head is not None:
+            optimizer_head.step()
+        # Phase 3: Wait for RS, local NS5, all-gather (banks processed last)
+        optimizer_muon_early.step()
+        optimizer_muon_late.step()
+        zero_grad_all()
+        # EMA update
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(t.detach().float(), alpha=1.0 - ema_decay)
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        if args.swa_enabled and scale < 0.2 and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+        if args.lawa_enabled and step % args.lawa_freq == 0:
+            lawa_queue.append({name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()})
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+    # Apply weight averaging
+    if args.lawa_enabled and len(lawa_queue) > 1:
+        log0(f"lawa:applying LAWA averaging k={len(lawa_queue)}")
+        current_state = base_model.state_dict()
+        avg_state = {name: torch.zeros(t.shape, dtype=torch.float32, device='cpu') for name, t in current_state.items()}
+        for snap in lawa_queue:
+            for name in avg_state:
+                avg_state[name] += snap[name].float()
+        for name in avg_state:
+            avg_state[name] /= len(lawa_queue)
+            avg_state[name] = avg_state[name].to(dtype=current_state[name].dtype)
+        base_model.load_state_dict(avg_state, strict=True)
+    else:
+        log0("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+        base_model.load_state_dict(avg_state, strict=True)
+    torch.cuda.synchronize()
+    t_diag = time.perf_counter()
+    diag_val_loss, diag_val_bpb = eval_val(
+        args, compiled_model, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"DIAGNOSTIC post_ema val_loss:{diag_val_loss:.4f} val_bpb:{diag_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_diag):.0f}ms"
+    )
+    full_state_dict = base_model.state_dict()
+    export_sd = {k: v for k, v in full_state_dict.items() if "mtp_heads" not in k}
+    excluded_mtp = sum(int(t.numel()) for k, t in full_state_dict.items() if "mtp_heads" in k)
+    if excluded_mtp > 0:
+        log0(f"export_excluding_mtp_params:{excluded_mtp}")
+    if master_process:
+        torch.save(export_sd, "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+    # Unbank 3D tensors into individual 2D tensors for quantization
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    unbanked_sd = _unbank_state_dict(sd_cpu, args.num_layers)
+    # Full GPTQ: collect Hessians via a temporary non-banked model
+    log0(f"gptq:building non-banked model for Hessian collection...")
+    hessian_model = _HessianGPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n, rope_dims=args.rope_dims, ln_scale=args.ln_scale,
+        ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+        window_size=args.window_size, window_attn_layers=args.window_attn_layers,
+    ).to(device).bfloat16()
+    for m in hessian_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(hessian_model)
+    # Load unbanked weights into the non-banked model
+    hessian_model.load_state_dict(
+        {k: v.to(device) for k, v in unbanked_sd.items() if k in hessian_model.state_dict()},
+        strict=False,
+    )
+    if args.gptq_ar_calib:
+        # Autoregressive self-generated calibration (no external data — PR #728)
+        log0("gptq:generating autoregressive calibration data (64 seqs x 2048 tokens, temp=0.8)...")
+        base_model.load_state_dict(export_sd, strict=False)
+        t_gen = time.perf_counter()
+        ar_tokens = generate_autoregressive_calib(
+            base_model, device, num_seqs=64, seq_len=2048,
+            vocab_size=args.vocab_size, temperature=0.8, batch_size=8, seed=args.seed,
+        )
+        log0(f"gptq:generated {len(ar_tokens)} sequences in {time.perf_counter()-t_gen:.1f}s")
+        log0("gptq:collecting hessians from autoregressive data...")
+        hessians = collect_hessians_from_tokens(hessian_model, ar_tokens, device)
+        log0(f"gptq:collected hessians for {len(hessians)} layers (AR self-gen)")
+        del ar_tokens
+    else:
+        # Train-data calibration (PR549 style)
+        log0(f"gptq:calibrating with {args.gptq_calib_batches} batches (train data)...")
+        calib_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+        hessians = collect_hessians(hessian_model, calib_loader, args, device, grad_accum_steps,
+                                    num_batches=args.gptq_calib_batches)
+        log0(f"gptq:collected hessians for {len(hessians)} layers (train data)")
+    del hessian_model
+    torch.cuda.empty_cache()
+    quant_result, quant_meta = mixed_quantize_int6(unbanked_sd, {"mlp", "attn"}, hessians=hessians)
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_raw = _byte_shuffle(quant_raw)
+    if _COMPRESSOR == "brotli":
+        quant_blob = brotli.compress(quant_raw, quality=11)
+    else:
+        quant_blob = lzma.compress(quant_raw, preset=6)
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = len(quant_blob)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+{_COMPRESSOR}: {quant_file_bytes} bytes")
+        log0(f"Total submission size int6+{_COMPRESSOR}: {quant_file_bytes + code_bytes} bytes")
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    if _COMPRESSOR == "brotli":
+        quant_decompressed = brotli.decompress(quant_blob_disk)
+    else:
+        quant_decompressed = lzma.decompress(quant_blob_disk)
+    quant_state = torch.load(
+        io.BytesIO(_byte_unshuffle(quant_decompressed)),
+        map_location="cpu",
+    )
+    deq_unbanked = dequantize_mixed_int6(quant_state["w"], quant_state["m"], unbanked_sd)
+    # Re-bank the dequantized tensors
+    deq_state = _rebank_state_dict(deq_unbanked, args.num_layers, sd_cpu)
+    eval_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=0, mtp_loss_weight=0.0,
+        bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims, ln_scale=args.ln_scale, dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention, value_residual=args.value_residual,
+        mile_gamma=args.mile_gamma, mile_clamp_min=args.mile_clamp_min,
+        cache_layer=args.cache_layer, backout_init=args.backout_init,
+        window_size=args.window_size, window_attn_layers=args.window_attn_layers,
+    ).to(device).bfloat16()
+    eval_model.qo_bank_early.data = eval_model.qo_bank_early.data.float()
+    eval_model.qo_bank_late.data = eval_model.qo_bank_late.data.float()
+    eval_model.kv_bank_early.data = eval_model.kv_bank_early.data.float()
+    eval_model.kv_bank_late.data = eval_model.kv_bank_late.data.float()
+    eval_model.mlp_up_bank_early.data = eval_model.mlp_up_bank_early.data.float()
+    eval_model.mlp_up_bank_late.data = eval_model.mlp_up_bank_late.data.float()
+    eval_model.mlp_down_bank_early.data = eval_model.mlp_down_bank_early.data.float()
+    eval_model.mlp_down_bank_late.data = eval_model.mlp_down_bank_late.data.float()
+    for m in eval_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(eval_model)
+    eval_model.load_state_dict(deq_state, strict=True)
+    compiled_eval = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args, compiled_eval, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        eval_seq_len=effective_eval_seq_len,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+    sw_seq_len = effective_eval_seq_len
+    if args.eval_stride > 0 and args.eval_stride < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+    if distributed:
+        dist.destroy_process_group()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Record: Window Attention + Mixed Seq_Len Training

**val_bpb: 1.1108** (5-seed mean, std 0.0013) | **1.8755 nats** | **~15.73 MB** | 8xH100 SXM, 600s | No TTT

I started from [PR #1130](https://github.com/openai/parameter-golf/pull/1130) (KitchenSinkV2 Improved), which added split early/late LR banks, MiLe margin loss, cache+backout residual, residual lambdas, bigger bigram/VE, and FA3 on top of the PR #549 stack. On top of that, I ported the fused Triton MLP from [PR #1072](https://github.com/openai/parameter-golf/pull/1072) and the sigmoid-gated skips + brotli+byte-shuffle compression from [PR #1089](https://github.com/openai/parameter-golf/pull/1089). I also increased to 12 layers and tuned qk_gain to 2.5.

The two main contributions of this submission are window attention and mixed seq_len training, described below.

## Results (8xH100 80GB SXM, 600s, no TTT)

| Seed | Steps | ms/step | Post-EMA BPB | **Sliding BPB** | val_loss (nats) | Artifact |
|------|-------|---------|--------------|-----------------|-----------------|----------|
| 2 | 8,428 | 69.6 | 1.1250 | **1.1094** | 1.8731 | 15,726,762 |
| 1337 | 8,428 | 69.6 | 1.1250 | **1.1101** | 1.8742 | 15,721,698 |
| 42 | 8,428 | 69.6 | 1.1250 | **1.1103** | 1.8746 | 15,725,995 |
| 7 | 8,428 | 69.6 | 1.1250 | **1.1119** | 1.8773 | 15,723,346 |
| 22 | 8,428 | 69.6 | 1.1250 | **1.1126** | 1.8785 | 15,720,902 |
| **Mean** | | | | **1.1108** | **1.8755** | **15,723,741** |

Current merged SOTA ([2026-03-25 AR Self-Gen GPTQ + XSA-all + BigramHash 3072x112](https://github.com/openai/parameter-golf/blob/main/records/track_10min_16mb/2026-03-25_ValCalib_GPTQ_XSA_BigramHash3072/README.md)): **1.11473 BPB**.
Delta vs current merged SOTA: **-0.0039 BPB** (**-0.0066 nats**).

## Window attention

Instead of full causal attention on every layer, layers 2, 4, 6, 8, and 10 use a sliding window of 512 tokens via Flash Attention 3's `window_size` parameter. The remaining layers (0, 1, 3, 5, 7, 9, 11) keep full attention.

The motivation was to enable training at longer sequence lengths without proportionally increasing compute. Full quadratic attention at seq_len=6144 is expensive, but with window attention on 5 of 12 layers, those layers run in O(n * w) instead of O(n^2), cutting the per-step cost significantly. The layers with full attention still give the model access to the full context.

I swept several configurations: window sizes (256, 512, 1024), which layers to window (sparse, dense, even), and how many layers. Window 512 on even-indexed layers was the sweet spot — enough layers windowed to get the speedup, enough full-attention layers to preserve long-range modeling.

At seq_len=2048 (where all tokens fit in a 512-wide window anyway for most positions), windowed attention adds a small overhead (~2-3%). The benefit kicks in at longer sequences: 15% faster at 4096, 21% at 6144, 25% at 8192.

## Mixed seq_len training

Different GPUs train with different sequence lengths within the same step. In the final configuration, 5 GPUs train at seq_len=2048 and 3 GPUs train at seq_len=6144. The number of sequences per GPU is set so that the total ms per step stays roughly constant.

The idea came from noticing that the sliding-window eval (which uses long sequences) gave substantially better scores than the standard 2048-token eval, but training at long sequence lengths was slow. By having most GPUs train cheaply at 2048 and a few GPUs see long context at 6144, the model gets the best of both: high step throughput from the short-sequence GPUs and long-range learning from the long-sequence ones.

I ran an extensive sweep of seq_len combinations. Some findings:

- **3x2048 + 1x6144** (eval at 6144) gave the best int6 roundtrip BPB (**1.1292**) in 4-GPU experiments, beating both pure 4x2048 (1.1417) and pure 4x6144 (1.1360)
- Having at least one GPU on a long sequence (4096+) was critical for good quantized performance
- More short-sequence GPUs = more steps in the same wallclock, which helps training loss
- More long-sequence GPUs = better post-EMA loss, but fewer steps and worse quantization
- 8192 was too slow to be worthwhile — the step-time penalty outweighed the context benefit

For the final 8-GPU submission, I used 5x2048 + 3x6144, which balances throughput and long-context exposure.

## Other changes

- **12 layers** (up from 11) with split early/late LR banks
- **Sigmoid-gated skip connections** — `x += sigmoid(gate) * skip` replaces learned scalar skip weights
- **Fused Triton MLP** (PR #1105) — LeakyReLU(0.5)-squared fused with matmuls
- **Brotli + byte-shuffle compression** (PR #1089) — better compression of quantized weights
- **Bigram hash 5120**, VE dim 128, qk_gain 2.5
- **Eval**: sliding window, seq_len=6144, stride=128

## Artifact size (worst-case, seed 2)

| Component | Bytes |
|-----------|-------|
| Model (int6+brotli) | 15,692,661 |
| Code | 34,101 |
| **Total** | **15,726,762** |

Under the 16,000,000 byte limit.

## Acknowledgments

This submission builds on many contributions from the parameter-golf community:

- **Baseline** (modded-nanogpt, @KellerJordan et al.) — Muon optimizer, relu², U-Net skips, softcap, RoPE, Q-gain, ResidMix
- [modded-nanogpt PR #140](https://github.com/KellerJordan/modded-nanogpt/pull/140) (@ClassicLarry / @snimu) — backout residual
- **PR #50** (@mattqlf) — sliding window eval
- **PR #64** (@yesbhautik) — GPTQ-lite (clip percentile search)
- **PR #89 / #95** (@vmfunc / @MatoTeziTanka) — EMA / SWA
- **PR #162** (@raahilshah) — BigramHash
- **PR #287** (@jfprincz) — XSA (cross-head subtracted attention; [arXiv:2603.09078](https://arxiv.org/abs/2603.09078))
- **PR #315** (@jfprincz) — partial RoPE, layerwise LN scale
- **PR #374** (@unnir) — value embeddings
- **PR #399** (@abaybektursun) — parallel Muon with parameter banking
- **PR #493** (@parinzee) — LeakyReLU(0.5)²
- **PR #535** (@raahilshah) — full Hessian GPTQ
- **PR #549** (@abaybektursun) — banked weight matrices, SmearGate
- **PR #726** (@DeepReinforce) — coprime-stride multi-shard data loader
- **PR #1072** (@vimeto) — fused Triton LeakyReLU-squared MLP kernel
- **PR #1089** (@mikeapedia) — sigmoid-gated skip connections, byte-shuffle + brotli compression
- Flash Attention 3 with `window_size` for efficient window attention

## Reproducibility

The main training runs used the following command:

```bash
SEED=$SEED \
MATRIX_LR=0.024 MATRIX_LR_LATE=0.019 \
SCALAR_LR=0.020 SCALAR_LR_LATE=0.038 \
TIED_EMBED_LR=0.022 \
MUON_MOMENTUM=0.985 WARMDOWN_ITERS=4000 \
TRAIN_BATCH_TOKENS=589824 \
NUM_LAYERS=12 BIGRAM_VOCAB_SIZE=5120 VE_DIM=128 \
WINDOW_SIZE=512 WINDOW_ATTN_LAYERS=2,4,6,8,10 \
LOCAL_SEQS_PER_GPU=36,36,36,36,36,10,10,10 \
SEQS_PER_GPU=2048,2048,2048,2048,2048,6144,6144,6144 \
MAX_WALLCLOCK_SECONDS=600 \
torchrun --standalone --nproc_per_node=8 train_gpt.py
```

`brotli` needs to be installed for the final artifact compression path. Flash Attention 3 (`flash_attn_interface`) is required.