### PR TITLE
Non-record: Oscillatory Recurrence at Layer 0 (1.1915 BPB, 3-seed)

### DIFF
--- a/records/track_non_record_16mb/2026-04-01_Oscillatory_Recurrence_Layer0/README.md
+++ b/records/track_non_record_16mb/2026-04-01_Oscillatory_Recurrence_Layer0/README.md
@@ -1,0 +1,286 @@
+# Non-record: Oscillatory Recurrence at Layer 0 (1.1915 BPB, 3-seed)
+
+**val_bpb: 1.1915** (sliding window, 3-seed mean, std 0.0008) | **15.02 MB** dynamic quant | 8x H100 SXM, 600s | No TTT
+
+## Results
+
+| Seed | Steps | ms/step | int8 BPB | Sliding BPB | int5+zstd | dynamic+zstd |
+|------|-------|---------|----------|-------------|-----------|-------------|
+| 42   | ~8400 | ~72     | 1.2267   | 1.1924      | 1.2451/15.50MB | 1.2361/15.02MB |
+| 1337 | ~8400 | ~72     | 1.2255   | 1.1911      | 1.2422/-- | 1.2364/-- |
+| 2024 | ~8400 | ~72     | 1.2255   | 1.1910      | 1.2417/-- | 1.2377/-- |
+| **Mean** | | | **1.2259** | **1.1915** | **1.2430** | **1.2367** |
+| **Std** | | | **0.0007** | **0.0008** | **0.0018** | **0.0009** |
+
+## Ablation: TRN vs Pure Transformer
+
+Same config, TRN removed (all 11 layers = standard Transformer), single seed=42:
+
+| Metric | TRN@L0 (39d, seed=42) | ALL Transformer (39e) | Delta |
+|--------|----------------------|----------------------|-------|
+| Steps  | ~8400                | ~9439                | +12%  |
+| ms/step| 72                   | 59                   | -18%  |
+| int8   | 1.2267               | 1.2171               | -0.009 |
+| sliding| 1.1924               | 1.1830               | -0.009 |
+
+ALL Transformer wins on final BPP because it runs 18% faster and gets 12% more steps.
+But at equal step count (step 7000), TRN leads by 0.031 BPP. TRN loses because it
+is slower, not because it models worse.
+
+| Step | ALL Transformer | TRN@L0 | Delta |
+|------|-----------------|--------|-------|
+| 6000 | 1.2986          | 1.2800 | TRN -0.019 |
+| 7000 | 1.2881          | 1.2572 | TRN -0.031 |
+| 9000 | 1.2346          | --     | gap narrowing |
+| final| 1.2171          | 1.2259 | ALL -0.009 |
+
+---
+
+## Architecture
+
+11 layers: 1 ParallelTRNBlock (layer 0, attention disabled) + 10 Transformer Blocks.
+
+```
+[TRN+MLP] [Attn+MLP] [Attn+MLP] ... [Attn+MLP]
+   0          1          2              10
+```
+
+- Layer 0: SelectiveResonanceLayer (K=240 oscillators) + leaky_relu^2 MLP.
+  No attention -- raw embeddings go through oscillatory recurrence then MLP.
+- Layers 1-10: CausalSelfAttention + leaky_relu^2 MLP.
+
+### Config
+
+| Parameter | Value |
+|-----------|-------|
+| d_model | 512 |
+| num_layers | 11 |
+| num_heads / kv_heads | 8 / 4 |
+| mlp_mult | 2.5 (d_ff=1280) |
+| activation | leaky_relu(x, 0.5).square() |
+| TRN K | 240 oscillators |
+| vocab | 1024 (tied embeddings) |
+| params | 24,557,011 |
+
+### Other Techniques
+
+- **XSA-all-11 (Cross-Scale Attention)**: subtracts the value-direction projection from
+  attention output at all 11 layers, reducing head redundancy
+- **BigramHash(2816, 112)**: XOR hash of consecutive token pairs into a learned 112-dim
+  embedding table (2816 buckets), added to input embeddings
+- **Partial RoPE (Rotary Position Embedding, dims=16)**: only 16 of 64 head dimensions
+  rotate; remaining 48 pass through unchanged
+- **SWA (Stochastic Weight Averaging, every=50)**: averages model weights every 50 steps
+  during warmdown for smoother weight distribution and better quantization
+- **Sliding window eval (stride=64)**: each token scored with up to 1024 tokens of left
+  context by sliding the window 64 tokens at a time. Only the rightmost 64 tokens of each
+  window contribute to the score. ~0.030 BPP improvement over non-overlapping eval
+- **Dynamic quantization**: per-tensor bit allocation (int4 for low-sensitivity tensors,
+  int5 for high-sensitivity), fitting 24.56M params in 15.02MB compressed with zstd-22
+
+### Optimizer
+
+- Muon (Newton-Schulz, 5 backend steps) for 2D matrix params, lr=0.03
+- Adam (beta1=0.9, beta2=0.95) for scalar/1D params, lr=0.025
+- Muon weight decay=0.04, gradient clip=0.3
+- Warmdown: 3500 iterations, cosine decay
+- Batch: 524,288 tokens/step, seq_len=1024, grad_accum=1
+
+---
+
+## Temporal Resonance Network (TRN)
+
+### Overview
+
+TRN maintains a complex-valued hidden state per oscillator that rotates at a learned
+frequency and decays at a learned rate. K=240 oscillators give a 480-dimensional state
+(240 real + 240 imaginary) evolving causally across the sequence.
+
+Core recurrence:
+
+```
+r_t[k] = alpha_t[k] * r_{t-1}[k] + drive_t[k]
+```
+
+- `alpha_t[k] = sigmoid(alpha_proj(x_t)[k])` -- input-dependent decay gate (bias initialized to target centers 0.30/0.65/0.97)
+- `drive_t[k]` -- complex drive signal projected from input
+- State is complex: `r = r_real + i * r_imag`
+
+### SelectiveResonanceLayer (used here)
+
+Slim variant projecting input to 2K values (drive_r, drive_i). Alpha projected separately.
+Omega (frequency) and g_out (output gate) are per-channel constants, not token-dependent.
+No PCG, SCPM, delta-rule, or log-phase. ~1.2M params at K=240.
+
+We also developed TemporalResonanceLayer (6 projections, PCG, SCPM, delta-rule erase,
+~2.7M params) but the extra components didn't justify their cost at this scale.
+
+### Parallel Scan
+
+The recurrence runs as a Kogge-Stone parallel prefix scan in O(log n) steps:
+
+```python
+offset = 1
+while offset < n:
+    b[:, offset:] += a[:, offset:] * b[:, :-offset]
+    a[:, offset:] *= a[:, :-offset]
+    offset *= 2
+```
+
+10 stages for seq_len=1024. All in fp32 -- bf16 is unstable for alpha near 1.0 where
+the scan accumulates over hundreds of positions. A Triton kernel was written but gave
+<1% speedup (scan is a small fraction of total step time).
+
+### Frequency Initialization
+
+Omega is log-spaced from 1 cycle per full sequence to ~0.25 cycles/token:
+
+```python
+omega = linspace(log(2*pi/1024), log(pi*(1-1/K)), K).exp()
+```
+
+This covers periods from 1024 tokens (slow) to ~6 tokens (fast). Alpha is initialized
+in three groups: fast decay (center 0.30, half-life ~1 token), medium (0.65, ~4 tokens),
+slow (0.97, ~30 tokens).
+
+### Why Layer 0
+
+merge_gate analysis on full 11L TRN+Attention configs showed TRN contributing 37% at
+layer 0 but <3% at layers 1-10. Raw embeddings carry the strongest periodic/positional
+signal. After one attention layer, those patterns are absorbed into the residual and TRN
+becomes redundant.
+
+PR #1204 (1.1063 BPP, current SOTA candidate) independently found that attention at
+layer 0 is unnecessary (DISABLE_LAYER0_ATTN=1). We replace it with TRN.
+
+---
+
+## Why TRN Loses on Wall-Clock (But Wins Per-Step)
+
+TRN adds ~13ms to a 59ms pure-Transformer step (22% overhead from fp32 scan +
+projections). In 600s this costs ~1700 steps (8400 vs 9439). The ablation shows
+TRN leads by 0.031 BPP at step 7000, but the step deficit erases this by the end
+of training.
+
+Three reasons TRN converges faster per step:
+
+1. **Exponential decay memory**: TRN carries a recency-weighted state that tracks topic
+   drift, entity salience, and formatting mode. Attention with uniform 1024-token context
+   mixes recent and distant tokens equally -- TRN's decay gives this for free.
+
+2. **Frequency-selective filtering**: K=240 oscillators at different frequencies act as a
+   filter bank. Periodic text patterns (Q/A alternation, list items, code indentation) are
+   captured by resonant oscillators without attention having to dedicate heads to them.
+
+3. **Implicit position encoding**: Omega encodes position through phase (`angle = omega * log(1+t)`).
+   This supplements RoPE (Rotary Position Embedding) without using attention capacity.
+   Most visible at layer 0 on raw token embeddings.
+
+Three reasons the speed penalty outweighs the quality gain:
+
+1. **fp32 scan is bandwidth-bound**: B=64, K=240, T=1024 in fp32 = ~60MB per scan pass.
+   H100 HBM bandwidth is the bottleneck, not compute.
+
+2. **Muon optimizer benefits from more steps**: Newton-Schulz orthogonalization improves
+   with each update. 12% more steps is a large advantage.
+
+3. **26M params at 600s is update-limited**: the model needs ~8000+ steps to converge.
+   Every ms/step counts linearly.
+
+Reducing TRN overhead from 13ms to ~3ms (e.g. via fused CUDA kernel) would close the
+step-count gap enough for TRN to win on final BPP as well.
+
+---
+
+## Techniques Developed During Exploration
+
+### BRANCH_ORTHO (Branch Orthogonalization)
+
+Forces TRN output to be orthogonal to attention output via Gram-Schmidt:
+
+```python
+attn_n = F.normalize(attn_out.detach().float(), dim=-1, eps=1e-6)
+proj = (trn_out * attn_n).sum(dim=-1, keepdim=True) * attn_n
+trn_out = trn_out - proj
+```
+
+Prevents merge_gate collapse (attention dominating TRN to 97-99%). In Run 36 with full
+11L TRN, BRANCH_ORTHO improved fp from 1.2724 to 1.2452. However, in the final config
+(TRN@L0 with attention disabled), BRANCH_ORTHO is inactive -- there is no attention output
+to orthogonalize against at layer 0, and layers 1-10 have no TRN.
+
+### CausalEMA Input Filtering
+
+Causal EMA on TRN input via parallel prefix scan, focusing TRN on low-frequency patterns.
+Added ~0.004 BPP but cost 20-40ms/step. Not used in final config.
+
+---
+
+## Exploration History (39 Runs, 3 Days)
+
+| Phase | Runs | Architecture | Best BPP | Finding |
+|-------|------|-------------|----------|---------|
+| 1 | 25-31 | 11L full TRN+Attn | 1.2793 fp | TRN works but slow |
+| 2 | 32-33 | Zamba shared attn | 1.2920 int5 | QAT explosion with shared attn |
+| 3 | 34-35 | Progressive seq, Triton scan | -- | Compile retrace blocks progressive |
+| 4 | 36-37 | BRANCH_ORTHO + EMA + XSA11 | 1.2424 fp | Per-step quality improved |
+| 5 | 38 | TRN 3/11 layers | 1.2600 dyn | Below baseline. Params too low |
+| 6 | 39a-d | TRN@L0 + MLP2.5 + sliding | **1.1915** | Baseline exceeded |
+| 7 | 39e | ALL Transformer ablation | 1.1830 | TRN per-step +0.031, speed loses |
+
+## What We Learned
+
+1. **TRN improves per-step convergence.** At equal steps, TRN@L0 leads by 0.031 BPP.
+   The 566K param difference (2.3%) does not account for this.
+
+2. **Speed wins at 600s.** 13ms/step overhead costs ~1700 steps, enough to erase 0.031 BPP.
+   A faster TRN implementation would change the outcome.
+
+3. **Attention wins at content-addressable retrieval.** Copy, induction, entity routing --
+   softmax(QK^T)V handles these. TRN adds decay memory and periodic detection, but attention
+   picks up rough versions via positional biases. TRN becomes redundant at layers 1-10.
+
+4. **TRN converges slower.** Oscillator geometry needs many steps. Attention learns routing
+   in ~1000 steps. Swapping TRN for attention gives more loss reduction per step at layers 1-10.
+
+5. **merge_gate collapses.** All-TRN configs: sigmoid > 0.97 at layers 1-10. Gate suppresses
+   TRN because attention provides faster gradient signal.
+
+6. **Step count beats expressiveness at this scale.** Faster, simpler model gets more steps
+   and wins -- even if each step is individually worse.
+
+7. **Sliding eval has the best cost/benefit ratio.** -0.030 BPP for zero training cost.
+
+8. **Baseline leaves 11MB of budget unused.** 17M params / 4.6MB out of 16MB. Scaling to
+   11L/24.6M is the main structural gain.
+
+---
+
+## Related Work
+
+- **PR #1061**: Causal Oscillator LM (1.337 BPP) -- damped harmonic oscillator. Our TRN outperforms.
+- **PR #1204**: ParallelResiduals + MiniDepthRecurrence (1.1063 BPP). DISABLE_LAYER0_ATTN originated here.
+- **PR #852**: Hymba (1.119 BPP) -- Mamba + Attention hybrid.
+- **PR #1120**: Rascal (1.1099 BPP) -- pure Transformer SOTA.
+- This is the only oscillatory recurrence submission in Parameter Golf.
+
+---
+
+## Run Command
+
+```bash
+SELECTIVE_RESONATOR=1 PARALLEL_TRN=1 PARALLEL_TRN_K=240 \
+MODEL_TYPE=parallel NUM_LAYERS=11 MODEL_DIM=512 \
+NUM_HEADS=8 NUM_KV_HEADS=4 MLP_MULT=2.5 RELU2=1 \
+XSA_LAST_N=11 TRN_EMA=0 TRN_LAYERS=0 DISABLE_LAYER0_ATTN=1 \
+BIGRAM_VOCAB_SIZE=2816 BIGRAM_DIM=112 \
+PARTIAL_ROPE_DIMS=16 SWA_ENABLED=1 SWA_EVERY=50 \
+EVAL_STRIDE=64 COMPILE_MODE=default \
+GRAD_ACCUM_STEPS=1 SEED=$SEED \
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+Training script: `train_gpt.py` (included in this submission folder).
+
+Training logs were lost when the RunPod instance was terminated. Model checkpoints (.pt)
+for all 3 seeds are preserved. Results are reproducible with the above command.

--- a/records/track_non_record_16mb/2026-04-01_Oscillatory_Recurrence_Layer0/submission.json
+++ b/records/track_non_record_16mb/2026-04-01_Oscillatory_Recurrence_Layer0/submission.json
@@ -1,0 +1,39 @@
+{
+  "author": "amabito",
+  "github_id": "amabito",
+  "name": "Oscillatory Recurrence at Layer 0",
+  "blurb": "11L hybrid (1 TRN + 10 Transformer). TRN oscillatory recurrence at layer 0 gives +0.031 BPP per-step quality over pure Transformer, but 13ms/step overhead costs 0.009 BPP at 600s finish. Only oscillatory recurrence submission in Parameter Golf.",
+  "date": "2026-04-01",
+  "track": "non-record-16mb",
+  "val_bpb": 1.1915,
+  "val_loss": null,
+  "bytes_total": 15177260,
+  "bytes_code": 157260,
+  "gpu": "8x H100 SXM 80GB",
+  "technique_summary": "TRN oscillatory recurrence + sliding window eval + dynamic quantization + XSA-all + BigramHash + partial RoPE + SWA",
+  "metadata": {
+    "tags": ["trn", "hybrid", "oscillatory-recurrence", "sliding-eval", "ablation"],
+    "layers": 11,
+    "d_model": 512,
+    "mlp_mult": 2.5,
+    "params": "24,557,011",
+    "trn_layers": "0",
+    "quantization": "dynamic int4/int5 + zstd-22",
+    "eval_stride": 64,
+    "seeds": {
+      "42": {"sliding_bpb": 1.1924, "int8_bpb": 1.2267},
+      "1337": {"sliding_bpb": 1.1911, "int8_bpb": 1.2255},
+      "2024": {"sliding_bpb": 1.1910, "int8_bpb": 1.2255}
+    },
+    "mean_sliding_bpb": 1.1915,
+    "std_sliding_bpb": 0.0008,
+    "ablation": {
+      "all_transformer_sliding_bpb": 1.1830,
+      "all_transformer_int8_bpb": 1.2171,
+      "all_transformer_steps": 9439,
+      "trn_per_step_advantage_at_step7000": 0.031,
+      "trn_final_deficit": 0.009,
+      "conclusion": "TRN has genuine per-step quality but loses to speed penalty at 600s"
+    }
+  }
+}

--- a/records/track_non_record_16mb/2026-04-01_Oscillatory_Recurrence_Layer0/train_gpt.py
+++ b/records/track_non_record_16mb/2026-04-01_Oscillatory_Recurrence_Layer0/train_gpt.py
@@ -1,0 +1,3512 @@
+"""
+train_gpt_trn.py -- Hybrid TRN/Transformer experiment for parameter-golf.
+
+Supports 4 model variants via --model-type (or MODEL_TYPE env var):
+  transformer  -- baseline GPT (identical to train_gpt.py)
+  trn          -- all blocks replaced with TRN (no attention)
+  hybrid       -- first 2 blocks are CausalAttn, remaining blocks are TRN
+  parallel     -- each block runs TRN + attention in parallel, then merges
+
+TRN modules (oscillator, scan, resonance, block) are inlined here so this
+file has zero external dependencies beyond train_gpt.py requirements.
+
+Architecture match at default config (model_dim=512, 9 layers):
+  transformer  ~17.1M params
+  trn          ~17.5M params (K=model_dim//2=256, 1.116x per layer)
+  hybrid       ~17.3M params (2 attn + 7 trn)
+
+For ~same param budget, TRN uses K = model_dim // 2 by default.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import threading
+import uuid
+import zlib
+from math import pi
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# Optional Triton scan backend -- set TRITON_SCAN=1 to enable.
+# Falls back to Kogge-Stone scan when Triton is unavailable or env var is unset.
+_USE_TRITON_SCAN: bool = os.environ.get("TRITON_SCAN", "0") == "1"
+_triton_resonance_scan = None
+if _USE_TRITON_SCAN:
+    try:
+        from triton_scan import triton_resonance_scan as _triton_resonance_scan  # type: ignore[assignment]
+    except Exception as _triton_import_err:  # noqa: BLE001
+        import warnings
+        warnings.warn(
+            f"TRITON_SCAN=1 set but triton_scan import failed: {_triton_import_err}. "
+            "Falling back to Kogge-Stone scan.",
+            stacklevel=1,
+        )
+        _USE_TRITON_SCAN = False
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 2))
+    d_ff_override = int(os.environ.get("D_FF_HIDDEN", 0))  # override SwiGLU d_ff (0=auto from mlp_mult)
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # TRN-specific: K = number of oscillators per layer.
+    # Default 0 = auto-computed to approximately match transformer param count.
+    # At d_model=512: K=120 gives TRN ~+1.1% vs transformer (within 5% target).
+    trn_n_oscillators = int(os.environ.get("TRN_N_OSCILLATORS", 0))  # 0 = auto
+    # Hybrid: how many leading blocks are attention (rest are TRN).
+    hybrid_num_attn = int(os.environ.get("HYBRID_NUM_ATTN", 2))
+    # Parallel TRN: replace all blocks with ParallelTRNBlock.
+    parallel_trn = bool(int(os.environ.get("PARALLEL_TRN", 0)))
+    parallel_trn_k = int(os.environ.get("PARALLEL_TRN_K", 128))
+    gate_init = float(os.environ.get("GATE_INIT", 0.0))
+    # Staged hybrid: number of leading pure-TRN blocks before parallel blocks.
+    # e.g. PARALLEL_HEAD_TRN=3 means first 3 blocks are TRN, rest are ParallelTRNBlock.
+    parallel_head_trn = int(os.environ.get("PARALLEL_HEAD_TRN", 0))
+    if parallel_head_trn < 0:
+        raise ValueError(f"PARALLEL_HEAD_TRN must be >= 0, got {parallel_head_trn}")
+    # Interleaved: comma-separated 0-indexed positions for attention blocks.
+    # e.g. "2,5" means layers 2 and 5 are attention, rest TRN.
+    # Overrides hybrid_num_attn when set.
+    attn_positions_str = os.environ.get("ATTN_POSITIONS", "")
+    # TRN_LAYERS: comma-separated 0-indexed layer positions for ParallelTRNBlock.
+    # Other layers become pure attention (Block). Only used with model_type=parallel.
+    # e.g. TRN_LAYERS=0,5,10 means layers 0,5,10 are ParallelTRNBlock, rest are Block.
+    # Empty (default) = all layers are ParallelTRNBlock (original behavior).
+    trn_layers_str = os.environ.get("TRN_LAYERS", "")
+    # Model variant: "transformer", "trn", "hybrid", or "parallel".
+    # PARALLEL_TRN=1 forces "parallel" without changing MODEL_TYPE.
+    model_type = "parallel" if parallel_trn else os.environ.get("MODEL_TYPE", "hybrid")
+    # DISABLE_LAYER0_ATTN: skip attention in layer 0 (TRN/MLP only). Saves params + speed.
+    disable_layer0_attn = bool(int(os.environ.get("DISABLE_LAYER0_ATTN", 0)))
+    # Depth recurrence: how many times to run TRN blocks (attn blocks run once).
+    depth_recurrence = int(os.environ.get("DEPTH_RECURRENCE", 1))
+    # Token shift: RWKV-6 style x_t / x_{t-1} interpolation before resonance
+    use_token_shift = bool(int(os.environ.get("USE_TOKEN_SHIFT", 0)))
+    # BigramHash embedding: 0 = disabled, >0 = bucket count
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 0))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    # Sliding window eval: stride for overlapping windows (0 = disabled)
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 0))
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))
+    # SWA: stochastic weight averaging during warmdown
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", 0)))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.4))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    swa_decay = float(os.environ.get("SWA_DECAY", 0.997))
+    # EMA: exponential moving average, per-step, independent of LR schedule
+    ema_enabled = bool(int(os.environ.get("EMA_ENABLED", 0)))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+    ema_start_frac = float(os.environ.get("EMA_START_FRAC", 0.5))
+    # Int5 QAT: enable late quantization-aware training
+    int5_qat = bool(int(os.environ.get("INT5_QAT", 0)))
+    int5_qat_start_frac = float(os.environ.get("INT5_QAT_START_FRAC", 0.15))
+    int5_qat_start_step = int(os.environ.get("INT5_QAT_START_STEP", 0))  # 0 = use frac
+    # Orthogonal init: apply nn.init.orthogonal_ to transformer (attention/FFN) linear weights.
+    # TRN layer linears (OscillatorProjection.proj, W_res, W_phase) are excluded -- they have
+    # domain-specific custom init and must not be overwritten.
+    ortho_init = bool(int(os.environ.get("ORTHO_INIT", 0)))
+    # Strategy 1: bake EMA shadow weights into live model when QAT starts, then disable EMA.
+    # Requires EMA_ENABLED=1 and INT5_QAT=1.  EMA must have started before QAT trigger step.
+    # Final export uses live QAT weights (not EMA).  Best int5 checkpoint saved every 200 QAT steps.
+    strategy1 = bool(int(os.environ.get("STRATEGY1", 0)))
+    # Periodic checkpoint (0 = disabled)
+    ckpt_every = int(os.environ.get("CKPT_EVERY", 0))
+    # Compression: zstd (requires zstandard package), lzma (stdlib), or zlib
+    use_zstd = bool(int(os.environ.get("USE_ZSTD", 0)))
+    zstd_level = int(os.environ.get("ZSTD_LEVEL", 22))
+    use_lzma = bool(int(os.environ.get("USE_LZMA", 0)))
+
+    # CPU Pipeline: async quantization + mini-eval + snapshot SWA
+    cpu_async_export = bool(int(os.environ.get("CPU_ASYNC_EXPORT", 0)))
+    cpu_async_export_every = int(os.environ.get("CPU_ASYNC_EXPORT_EVERY", 200))
+    cpu_mini_eval_frac = float(os.environ.get("CPU_MINI_EVAL_FRAC", 1.0))  # 1.0 = full, 0.1 = 10%
+    cpu_snapshot_swa = bool(int(os.environ.get("CPU_SNAPSHOT_SWA", 0)))
+    cpu_snapshot_fracs = os.environ.get("CPU_SNAPSHOT_FRACS", "0.7,0.8,0.9")
+    cpu_mixed_quant = bool(int(os.environ.get("CPU_MIXED_QUANT", 0)))
+    cpu_mixed_quant_top_n = int(os.environ.get("CPU_MIXED_QUANT_TOP_N", 3))
+    # Dynamic mixed-bit quantization: per-tensor MSE-based bit allocation + int8 storage + zstd.
+    # DYNAMIC_QUANT=1 enables. Target size in bytes (default 16MB). Bit options: 3,4,5,6,8.
+    dynamic_quant = bool(int(os.environ.get("DYNAMIC_QUANT", 0)))
+    dynamic_quant_target_mb = float(os.environ.get("DYNAMIC_QUANT_TARGET_MB", 16.0))
+
+    # Optimizer hyperparameters (identical to train_gpt.py).
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    weight_decay = float(os.environ.get("WEIGHT_DECAY", 0.04))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+
+
+# -----------------------------
+# MUON OPTIMIZER
+# -----------------------------
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, weight_decay=weight_decay),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            wd = group["weight_decay"]
+            # Decoupled weight decay applied before the Newton-Schulz update.
+            if wd > 0:
+                for p in params:
+                    p.mul_(1.0 - wd * lr)
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION
+# -----------------------------
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+) -> tuple[float, float]:
+    """Sliding window evaluation -- overlapping windows for better context."""
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= 1]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = base_model.forward_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                # Only score the last `stride` tokens (except first window)
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+            if rank == 0 and (bi // batch_seqs) % 50 == 0:
+                done = min(bi + batch_seqs, len(my_windows))
+                pct = done / len(my_windows) * 100
+                running_bpb = 0.0
+                if token_count.item() > 0:
+                    rl = (loss_sum / token_count).item()
+                    running_bpb = rl / math.log(2.0) * (token_count.item() / byte_count.item())
+                print(f"  sliding_eval [{pct:5.1f}%] {done}/{len(my_windows)} windows running_bpb={running_bpb:.6f}", flush=True)
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,"
+        "merge_gate,res_scale,lambda_pcg,omega_base",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1e-4)  # fp16 min subnormal ~6e-5
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# INT5 QAT (QUANTIZATION-AWARE TRAINING)
+# -----------------------------
+
+_INT5_CLIP_Q = 0.9999984  # must match quantize_state_dict_int5 (used by QAT fake-quantize)
+
+# GPTQ-lite: per-row optimal clip percentile search (post-training only).
+# More aggressive candidates (0.99, 0.995) help heavy-tailed rows where one
+# outlier inflates the scale and wastes resolution on the other 99.9% of values.
+_GPTQ_LITE_CANDIDATES: list[float] = [0.99, 0.995, 0.999, 0.9995, 0.9999, _INT5_CLIP_Q]
+
+
+def _gptq_lite_int5(t32: Tensor) -> tuple[Tensor, Tensor]:
+    """Per-row int5 quantization with MSE-optimal clip percentile search.
+
+    Tries each candidate in _GPTQ_LITE_CANDIDATES and keeps the one that
+    minimizes reconstruction MSE per row. Zero size overhead.
+    """
+    R, C = t32.shape
+    candidates = torch.tensor(_GPTQ_LITE_CANDIDATES, dtype=torch.float32)
+    # (len(candidates), R) -- one quantile per candidate per row
+    all_clip = torch.quantile(t32.abs(), candidates, dim=1).clamp_min(1e-8)
+
+    best_mse = torch.full((R,), float("inf"))
+    best_q = torch.empty(R, C, dtype=torch.int8)
+    best_scale = torch.empty(R, dtype=torch.float32)
+
+    for i, _ in enumerate(_GPTQ_LITE_CANDIDATES):
+        clip_abs = all_clip[i]  # (R,)
+        scale = clip_abs / 15.0
+        clipped = t32.clamp(-clip_abs[:, None], clip_abs[:, None])
+        q = (clipped / scale[:, None]).round().clamp(-15, 15)
+        mse = ((t32 - q * scale[:, None]) ** 2).mean(dim=1)
+        improved = mse < best_mse
+        if improved.any():
+            best_mse[improved] = mse[improved]
+            best_scale[improved] = scale[improved]
+            best_q[improved] = q[improved].to(torch.int8)
+
+    return best_q, best_scale
+
+
+def _gptq_lite_int6(t32: Tensor) -> tuple[Tensor, Tensor]:
+    """Per-row int6 quantization with MSE-optimal clip percentile search.
+
+    Maps to [-31, 31] (6 bits, symmetric). Zero size overhead beyond int5.
+    """
+    R, C = t32.shape
+    candidates = torch.tensor(_GPTQ_LITE_CANDIDATES, dtype=torch.float32)
+    all_clip = torch.quantile(t32.abs(), candidates, dim=1).clamp_min(1e-8)
+
+    best_mse = torch.full((R,), float("inf"))
+    best_q = torch.empty(R, C, dtype=torch.int8)
+    best_scale = torch.empty(R, dtype=torch.float32)
+
+    for i, _ in enumerate(_GPTQ_LITE_CANDIDATES):
+        clip_abs = all_clip[i]
+        scale = clip_abs / 31.0
+        clipped = t32.clamp(-clip_abs[:, None], clip_abs[:, None])
+        q = (clipped / scale[:, None]).round().clamp(-31, 31)
+        mse = ((t32 - q * scale[:, None]) ** 2).mean(dim=1)
+        improved = mse < best_mse
+        if improved.any():
+            best_mse[improved] = mse[improved]
+            best_scale[improved] = scale[improved]
+            best_q[improved] = q[improved].to(torch.int8)
+
+    return best_q, best_scale
+
+
+def _gptq_lite_int8(t32: Tensor) -> tuple[Tensor, Tensor]:
+    """Per-row int8 quantization with MSE-optimal clip percentile search."""
+    R, C = t32.shape
+    candidates = torch.tensor(_GPTQ_LITE_CANDIDATES, dtype=torch.float32)
+    all_clip = torch.quantile(t32.abs(), candidates, dim=1).clamp_min(1e-8)
+
+    best_mse = torch.full((R,), float("inf"))
+    best_q = torch.empty(R, C, dtype=torch.int8)
+    best_scale = torch.empty(R, dtype=torch.float32)
+
+    for i, _ in enumerate(_GPTQ_LITE_CANDIDATES):
+        clip_abs = all_clip[i]
+        scale = clip_abs / 127.0
+        clipped = t32.clamp(-clip_abs[:, None], clip_abs[:, None])
+        q = (clipped / scale[:, None]).round().clamp(-127, 127)
+        mse = ((t32 - q * scale[:, None]) ** 2).mean(dim=1)
+        improved = mse < best_mse
+        if improved.any():
+            best_mse[improved] = mse[improved]
+            best_scale[improved] = scale[improved]
+            best_q[improved] = q[improved].to(torch.int8)
+
+    return best_q, best_scale
+
+# Layers to keep at int8 precision in the int5 submission format.
+# These have either high RMSE (tok_emb: 0.168, 25x worse than attention layers)
+# or high sensitivity to quantization error (alpha rows: scan amplification).
+# "proj.proj" entries get per-block mixed precision (alpha rows int8, rest int5).
+_INT8_MIXED_NAME_PATTERNS = ("tok_emb",)
+_INT8_MIXED_ALPHA_PATTERN = "proj.proj"  # OscillatorProjection -- alpha rows [3K:4K]
+
+
+def _int5_fake_quantize(w: Tensor) -> Tensor:
+    """Simulate int5 quantization: per-row percentile-clipped scale to [-15, 15]."""
+    if w.ndim < 2:
+        return w
+    w32 = w.float()
+    clip_abs = torch.quantile(w32.abs(), _INT5_CLIP_Q, dim=1).clamp_min(1e-8)
+    scale = (clip_abs / 15.0).unsqueeze(1)
+    clipped = w32.clamp(-clip_abs.unsqueeze(1), clip_abs.unsqueeze(1))
+    w_q = (clipped / scale).round().clamp(-15, 15)
+    return (w_q * scale).to(dtype=w.dtype)
+
+
+def _int6_fake_quantize(w: Tensor) -> Tensor:
+    """Simulate int6 quantization: per-row percentile-clipped scale to [-31, 31]."""
+    if w.ndim < 2:
+        return w
+    w32 = w.float()
+    clip_abs = torch.quantile(w32.abs(), _INT5_CLIP_Q, dim=1).clamp_min(1e-8)
+    scale = (clip_abs / 31.0).unsqueeze(1)
+    clipped = w32.clamp(-clip_abs.unsqueeze(1), clip_abs.unsqueeze(1))
+    w_q = (clipped / scale).round().clamp(-31, 31)
+    return (w_q * scale).to(dtype=w.dtype)
+
+
+def _int8_fake_quantize(w: Tensor) -> Tensor:
+    """Simulate int8 quantization: per-row percentile-clipped scale to [-127, 127]."""
+    if w.ndim < 2:
+        return w
+    w32 = w.float()
+    clip_abs = torch.quantile(w32.abs(), _INT5_CLIP_Q, dim=1).clamp_min(1e-8)
+    scale = (clip_abs / 127.0).unsqueeze(1)
+    clipped = w32.clamp(-clip_abs.unsqueeze(1), clip_abs.unsqueeze(1))
+    w_q = (clipped / scale).round().clamp(-127, 127)
+    return (w_q * scale).to(dtype=w.dtype)
+
+
+def _mixed_fake_quantize_osc(w: Tensor) -> Tensor:
+    """Simulate mixed int8/int6/int5 quantization for OscillatorProjection.proj.
+
+    Alpha rows [3K:4K] get int8 (127 levels) for scan sensitivity.
+    Omega rows [K:2K] get int6 (31 levels) -- second-highest RMSE contributor.
+    All other rows get int5 (15 levels).
+    """
+    if w.ndim < 2 or w.shape[0] % 6 != 0:
+        return _int5_fake_quantize(w)
+    K = w.shape[0] // 6
+    parts = []
+    for g in range(6):
+        block = w[g * K : (g + 1) * K]
+        if g == 3:  # alpha block
+            parts.append(_int8_fake_quantize(block))
+        elif g == 1:  # omega block
+            parts.append(_int6_fake_quantize(block))
+        else:
+            parts.append(_int5_fake_quantize(block))
+    return torch.cat(parts, dim=0)
+
+
+def _select_fake_quantize(name: str, weight: Tensor) -> callable:
+    """Select the appropriate fake-quantize function based on layer name.
+
+    Mixed precision: sensitive layers get int8 (127 levels), others int5 (15 levels).
+    OscillatorProjection.proj gets per-block mixed (alpha rows int8, rest int5).
+    """
+    if any(pat in name for pat in _INT8_MIXED_NAME_PATTERNS):
+        return _int8_fake_quantize
+    if _INT8_MIXED_ALPHA_PATTERN in name and weight.ndim == 2 and weight.shape[0] % 6 == 0:
+        return _mixed_fake_quantize_osc
+    return _int5_fake_quantize
+
+
+def apply_int5_ste_hooks(model: nn.Module) -> list:
+    """Register pre/post forward hooks for mixed-precision fake-quantization.
+
+    Pre-hook: save float weight, replace with quantized value.
+    Post-hook: restore float weight so optimizer steps on float values.
+    Gradient flows through the quantized forward via straight-through
+    (optimizer updates the float weight; next forward re-quantizes).
+
+    Mixed precision: tok_emb and alpha rows of OscillatorProjection use int8
+    fake-quantization; all other large layers use int5.
+    """
+    hooks: list = []
+    for name, module in model.named_modules():
+        if isinstance(module, (nn.Linear, CastedLinear)):
+            if module.weight.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+                continue
+
+            fq_fn = _select_fake_quantize(name, module.weight)
+
+            def _make_pre_hook(quantize_fn: callable) -> callable:
+                def hook(mod: nn.Module, args: tuple) -> None:
+                    mod._weight_float = mod.weight.data.clone()
+                    mod.weight.data = quantize_fn(mod.weight.data)
+                return hook
+
+            def _make_post_hook() -> callable:
+                def hook(mod: nn.Module, args: tuple, output: object) -> None:
+                    if hasattr(mod, "_weight_float"):
+                        mod.weight.data = mod._weight_float
+                        del mod._weight_float
+                return hook
+
+            hooks.append(module.register_forward_pre_hook(_make_pre_hook(fq_fn)))
+            hooks.append(module.register_forward_hook(_make_post_hook()))
+    return hooks
+
+
+def _quantize_int8_block(t32: Tensor) -> tuple[Tensor, Tensor]:
+    """Quantize a 2D tensor to int8 per-row. Returns (q_int8, scale)."""
+    clip_abs = torch.quantile(t32.abs(), _INT5_CLIP_Q, dim=1).clamp_min(1e-8)
+    scale = clip_abs / 127.0
+    clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+    q = (clipped / scale[:, None]).round().clamp(-127, 127).to(torch.int8)
+    return q, scale
+
+
+def _is_int8_mixed(name: str) -> bool:
+    """Check if a parameter should use int8 precision in the mixed format."""
+    return any(pat in name for pat in _INT8_MIXED_NAME_PATTERNS)
+
+
+def _is_osc_alpha_mixed(name: str, shape: list) -> bool:
+    """Check if a parameter is OscillatorProjection.proj needing alpha int8."""
+    return (_INT8_MIXED_ALPHA_PATTERN in name and len(shape) == 2 and shape[0] % 6 == 0)
+
+
+# --- CPU Pipeline: Async Quantization + Snapshot SWA + Mixed Quant ---
+
+
+class AsyncQuantizer:
+    """Background thread for int5+zstd quantization during GPU training."""
+
+    def __init__(self, zstd_level: int = 22) -> None:
+        from concurrent.futures import ThreadPoolExecutor
+        self._executor = ThreadPoolExecutor(max_workers=1)
+        self._future = None
+        self._latest_blob: bytes | None = None
+        self._latest_step: int = -1
+        self._lock = threading.Lock()
+        self._zstd_level = zstd_level
+
+    def submit(self, cpu_state: dict[str, Tensor], step: int) -> None:
+        """Submit a state_dict (already on CPU) for async quantization."""
+        if self._future is not None and not self._future.done():
+            return  # previous job still running, skip this checkpoint
+        self._future = self._executor.submit(self._quantize_and_compress, cpu_state, step)
+
+    def _quantize_and_compress(self, cpu_state: dict[str, Tensor], step: int) -> None:
+        packed = quantize_state_dict_int5(cpu_state)
+        try:
+            import zstandard
+            blob = zstandard.ZstdCompressor(level=self._zstd_level, threads=-1).compress(packed)
+        except ImportError:
+            blob = zlib.compress(packed, level=9)
+        with self._lock:
+            self._latest_blob = blob
+            self._latest_step = step
+
+    def get_latest(self) -> tuple[bytes | None, int]:
+        """Return the latest compressed blob and its step number."""
+        with self._lock:
+            return self._latest_blob, self._latest_step
+
+    def wait(self) -> None:
+        """Wait for any in-flight quantization to complete."""
+        if self._future is not None:
+            self._future.result()
+
+
+def _cpu_state_snapshot(base_model: nn.Module) -> dict[str, Tensor]:
+    """Non-blocking copy of model state_dict to CPU."""
+    return {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+
+
+def _compute_quant_sensitivity(cpu_state: dict[str, Tensor], top_n: int = 3) -> set[str]:
+    """Identify top_n most quantization-sensitive parameter names (by int5 SNR).
+
+    Returns set of parameter names that should use int6 instead of int5.
+    """
+    sensitivities: list[tuple[float, str]] = []
+    for name, tensor in cpu_state.items():
+        if tensor.ndim < 2 or tensor.numel() < 1024:
+            continue
+        t = tensor.float()
+        # Simulate int5 quantization per-row (symmetric signed, matches _gptq_lite_int5)
+        clip_abs = t.abs().amax(dim=-1, keepdim=True).clamp(min=1e-10)
+        scale = clip_abs / 15.0  # symmetric signed [-15, 15] = 31 levels
+        quantized = (t / scale).round().clamp(-15, 15)
+        dequantized = quantized * scale
+        error = (t - dequantized).norm()
+        signal = t.norm()
+        snr = signal / error.clamp(min=1e-10)
+        sensitivities.append((snr.item(), name))
+    # Lowest SNR = most sensitive
+    sensitivities.sort()
+    return {name for _, name in sensitivities[:top_n]}
+
+
+def _dynamic_bit_alloc(
+    state_dict: dict[str, Tensor],
+    target_bytes: int = 16_000_000,
+    bit_options: tuple[int, ...] = (3, 4, 5, 6, 8),
+) -> dict[str, int]:
+    """Per-tensor MSE-based bit allocation under a zstd-compressed size budget.
+
+    Measures actual quantization MSE at each bit-width per tensor,
+    then greedily allocates bits to minimize total weighted MSE.
+    Budget is estimated for int8-as-storage + zstd-22 compression.
+    """
+    min_bits = min(bit_options)
+    sorted_opts = sorted(bit_options)
+
+    # Measure MSE at each bit width
+    mse_table: dict[str, dict[int, float]] = {}
+    param_sizes: dict[str, int] = {}
+    for name, tensor in state_dict.items():
+        if not tensor.is_floating_point() or tensor.numel() < 64:
+            continue
+        t = tensor.float()
+        param_sizes[name] = tensor.numel()
+        mse_table[name] = {}
+        for bits in bit_options:
+            qmax = (1 << (bits - 1)) - 1
+            abs_max = t.abs().amax().clamp(min=1e-12)
+            scale = abs_max / qmax
+            q = (t / scale).round().clamp(-qmax, qmax)
+            dq = q * scale
+            mse_table[name][bits] = (t - dq).pow(2).mean().item()
+
+    # Estimate zstd-compressed size: int8 storage (1 byte/param) * compression ratio
+    # Lower bits -> fewer unique values -> better compression
+    # Empirical ratios from Run 36: int4=0.32x, int5=0.45x, int8=0.82x
+    ZSTD_RATIO = {3: 0.18, 4: 0.32, 5: 0.45, 6: 0.58, 8: 0.82}
+
+    # Estimate overhead for raw-passthrough tensors (non-float, numel<64)
+    raw_overhead = 0
+    for name, tensor in state_dict.items():
+        if not tensor.is_floating_point() or tensor.numel() < 64:
+            raw_overhead += tensor.numel() * tensor.element_size() + 256  # tensor bytes + pickle overhead
+    # 1D float tensors with numel>=64 are forced to int8 in export, override alloc
+    dim1_override: dict[str, int] = {}
+    for name, tensor in state_dict.items():
+        if tensor.is_floating_point() and tensor.numel() >= 64 and tensor.dim() <= 1:
+            dim1_override[name] = 8  # forced to int8 in _quantize_dynamic_int8_zstd
+
+    def estimate_compressed_size(alloc: dict[str, int]) -> float:
+        total = float(raw_overhead)
+        for name, bits in alloc.items():
+            n = param_sizes.get(name, 0)
+            effective_bits = dim1_override.get(name, bits)
+            ratio = ZSTD_RATIO.get(effective_bits, 0.55)
+            total += n * ratio
+        return total
+
+    # Start at min_bits
+    alloc = {n: min_bits for n in mse_table}
+
+    if estimate_compressed_size(alloc) > target_bytes:
+        return alloc  # even min_bits exceeds budget
+
+    # Greedy: upgrade tensor with best MSE-reduction per compressed-byte cost
+    while True:
+        best_name = None
+        best_eff = -1.0
+        best_new_bits = min_bits
+
+        for name in mse_table:
+            current = alloc[name]
+            idx = sorted_opts.index(current)
+            if idx >= len(sorted_opts) - 1:
+                continue
+            next_bits = sorted_opts[idx + 1]
+
+            # Estimate additional compressed bytes
+            n = param_sizes[name]
+            old_ratio = ZSTD_RATIO.get(current, 0.55)
+            new_ratio = ZSTD_RATIO.get(next_bits, 0.55)
+            extra_bytes = n * (new_ratio - old_ratio)
+
+            test_alloc = dict(alloc)
+            test_alloc[name] = next_bits
+            if estimate_compressed_size(test_alloc) > target_bytes:
+                continue
+
+            mse_reduction = mse_table[name].get(current, 0.0) - mse_table[name].get(next_bits, 0.0)
+            if mse_reduction <= 0:
+                continue
+
+            eff = mse_reduction / max(extra_bytes, 1.0)
+            if eff > best_eff:
+                best_eff = eff
+                best_name = name
+                best_new_bits = next_bits
+
+        if best_name is None:
+            break
+        alloc[best_name] = best_new_bits
+
+    return alloc
+
+
+def _quantize_dynamic_int8_zstd(
+    state_dict: dict[str, Tensor],
+    bit_alloc: dict[str, int],
+    zstd_level: int = 22,
+    default_bits: int = 5,
+) -> bytes:
+    """Quantize with per-tensor bit widths, store as int8, compress with zstd."""
+    packed: dict[str, dict] = {}
+    for name, tensor in state_dict.items():
+        bits = bit_alloc.get(name, default_bits)
+        # 1D tensors (norms, biases) keep int8
+        if tensor.dim() <= 1 and tensor.is_floating_point():
+            bits = 8
+        if not tensor.is_floating_point() or tensor.numel() < 64:
+            # Passthrough small/non-float tensors
+            packed[name] = {"raw": tensor.detach().cpu()}
+            continue
+        t = tensor.float()
+        qmax = (1 << (bits - 1)) - 1
+        abs_max = t.abs().amax().clamp(min=1e-12)
+        scale = abs_max / qmax
+        q = (t / scale).round().clamp(-qmax, qmax).to(torch.int8)
+        packed[name] = {"q": q, "s": scale.item(), "b": bits, "shape": list(tensor.shape)}
+
+    buf = io.BytesIO()
+    torch.save(packed, buf)
+    raw = buf.getvalue()
+    try:
+        import zstandard
+        compressed = zstandard.ZstdCompressor(level=zstd_level).compress(raw)
+    except ImportError:
+        compressed = zlib.compress(raw, level=9)
+    return compressed
+
+
+def _dequantize_dynamic_int8_zstd(blob: bytes) -> dict[str, Tensor]:
+    """Dequantize a dynamic mixed-bit model from zstd-compressed int8 storage."""
+    try:
+        import zstandard
+        raw = zstandard.ZstdDecompressor().decompress(blob)
+    except ImportError:
+        raw = zlib.decompress(blob)
+    except Exception:
+        # zstandard present but blob is zlib-compressed (saved without zstandard)
+        raw = zlib.decompress(blob)
+    packed = torch.load(io.BytesIO(raw), map_location="cpu", weights_only=False)
+    state = {}
+    for name, info in packed.items():
+        if "raw" in info:
+            state[name] = info["raw"]
+        else:
+            q = info["q"].float()
+            s = info["s"]
+            shape = info["shape"]
+            state[name] = (q * s).reshape(shape)
+    return state
+
+
+def quantize_state_dict_int5(state_dict: dict[str, Tensor]) -> bytes:
+    """Quantize to int5 per-row with mixed precision. Returns packed bytes.
+
+    Mixed precision: tok_emb and alpha rows of OscillatorProjection use int8
+    (127 levels) for higher precision. All other large tensors use int5 (15 levels).
+    """
+    packed_parts: list[bytes] = []
+    byte_offset: int = 0
+    meta: dict[str, object] = {"format": "int5_mixed_v3", "entries": {}}
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            # Keep as-is (passthrough)
+            buf = io.BytesIO()
+            torch.save({"t": t}, buf)
+            raw = buf.getvalue()
+            meta["entries"][name] = {"kind": "passthrough", "offset": byte_offset, "nbytes": len(raw)}
+            packed_parts.append(raw)
+            byte_offset += len(raw)
+            continue
+
+        t32 = t.float()
+        INT5_CLIP_Q = _INT5_CLIP_Q
+
+        # Full int8 for sensitive layers (tok_emb)
+        if _is_int8_mixed(name) and t32.ndim == 2:
+            q, scale = _gptq_lite_int8(t32)
+            q_bytes = q.numpy().tobytes()
+            scale_buf = io.BytesIO()
+            torch.save({"s": scale.to(torch.float32), "shape": list(t.shape),
+                         "dtype": str(t.dtype).removeprefix("torch.")}, scale_buf)
+            scale_raw = scale_buf.getvalue()
+            meta["entries"][name] = {
+                "kind": "int8_full",
+                "offset": byte_offset,
+                "data_nbytes": len(q_bytes),
+                "scale_nbytes": len(scale_raw),
+                "numel": t.numel(),
+            }
+            packed_parts.append(q_bytes)
+            packed_parts.append(scale_raw)
+            byte_offset += len(q_bytes) + len(scale_raw)
+            continue
+
+        # Mixed int8/int6/int5 for OscillatorProjection.proj
+        # alpha rows [3K:4K] at int8, omega rows [K:2K] at int6, rest at int5
+        if _is_osc_alpha_mixed(name, list(t.shape)):
+            K = t32.shape[0] // 6
+            # Quantize alpha rows [3K:4K] at int8
+            alpha_block = t32[3 * K : 4 * K]
+            alpha_q, alpha_scale = _gptq_lite_int8(alpha_block)
+            alpha_bytes = alpha_q.numpy().tobytes()
+            alpha_scale_buf = io.BytesIO()
+            torch.save({"s": alpha_scale.to(torch.float32)}, alpha_scale_buf)
+            alpha_scale_raw = alpha_scale_buf.getvalue()
+
+            # Quantize omega rows [K:2K] at int6
+            omega_block = t32[K : 2 * K]
+            omega_q, omega_scale = _gptq_lite_int6(omega_block)
+            omega_shifted = (omega_q.flatten() + 31).to(torch.uint8)
+            packed_int6 = _pack_int6(omega_shifted.numpy())
+            omega_scale_buf = io.BytesIO()
+            torch.save({"s": omega_scale.to(torch.float32)}, omega_scale_buf)
+            omega_scale_raw = omega_scale_buf.getvalue()
+
+            # Quantize remaining rows at int5 (GPTQ-lite per-row clip search)
+            # Remaining: A=[0:K], phi=[2K:3K], g_out=[4K:5K], beta=[5K:6K] -- 4K rows total
+            other_rows = torch.cat([t32[:K], t32[2 * K : 3 * K], t32[4 * K :]], dim=0)  # (4K, d_model)
+            q, scale = _gptq_lite_int5(other_rows)
+            shifted = (q.flatten() + 15).to(torch.uint8)
+            packed_int5 = _pack_int5(shifted.numpy())
+            scale_buf = io.BytesIO()
+            torch.save({"s": scale.to(torch.float32), "shape": list(t.shape),
+                         "dtype": str(t.dtype).removeprefix("torch."), "K": K}, scale_buf)
+            scale_raw = scale_buf.getvalue()
+
+            meta["entries"][name] = {
+                "kind": "int5_alpha8_omega6",
+                "offset": byte_offset,
+                "alpha_data_nbytes": len(alpha_bytes),
+                "alpha_scale_nbytes": len(alpha_scale_raw),
+                "omega_int6_packed_nbytes": len(packed_int6),
+                "omega_scale_nbytes": len(omega_scale_raw),
+                "int5_packed_nbytes": len(packed_int5),
+                "int5_scale_nbytes": len(scale_raw),
+                "numel": t.numel(),
+            }
+            packed_parts.extend([alpha_bytes, alpha_scale_raw, packed_int6, omega_scale_raw, packed_int5, scale_raw])
+            byte_offset += (len(alpha_bytes) + len(alpha_scale_raw)
+                            + len(packed_int6) + len(omega_scale_raw)
+                            + len(packed_int5) + len(scale_raw))
+            continue
+
+        # Standard int5 quantize with GPTQ-lite per-row clip search
+        if t32.ndim == 2:
+            q, scale = _gptq_lite_int5(t32)
+        else:
+            scale_val = t32.abs().max().clamp_min(1e-8).item() / 15.0
+            scale = torch.tensor([scale_val], dtype=torch.float32)
+            q = (t32 / scale_val).round().clamp(-15, 15).to(torch.int8)
+
+        shifted = (q.flatten() + 15).to(torch.uint8)
+        packed = _pack_int5(shifted.numpy())
+
+        scale_buf = io.BytesIO()
+        torch.save({"s": scale.to(torch.float32), "shape": list(t.shape),
+                     "dtype": str(t.dtype).removeprefix("torch.")}, scale_buf)
+        scale_raw = scale_buf.getvalue()
+
+        meta["entries"][name] = {
+            "kind": "int5",
+            "offset": byte_offset,
+            "packed_nbytes": len(packed),
+            "scale_nbytes": len(scale_raw),
+            "numel": t.numel(),
+        }
+        packed_parts.append(packed)
+        packed_parts.append(scale_raw)
+        byte_offset += len(packed) + len(scale_raw)
+
+    payload = b"".join(packed_parts)
+    meta_buf = io.BytesIO()
+    torch.save(meta, meta_buf)
+    meta_raw = meta_buf.getvalue()
+    # Format: [4-byte meta_len][meta][payload]
+    import struct
+    result = struct.pack("<I", len(meta_raw)) + meta_raw + payload
+    return result
+
+
+def _pack_int5(values: np.ndarray) -> bytes:
+    """Pack uint8 values (0-30, 5 bits each) into bytes. 8 values -> 5 bytes."""
+    n = len(values)
+    # Pad to multiple of 8
+    pad = (8 - n % 8) % 8
+    if pad > 0:
+        values = np.concatenate([values, np.zeros(pad, dtype=np.uint8)])
+    values = values.reshape(-1, 8).astype(np.uint64)
+    # Pack 8 x 5-bit values into 40 bits (5 bytes)
+    packed_u64 = np.zeros(values.shape[0], dtype=np.uint64)
+    for i in range(8):
+        packed_u64 |= values[:, i].astype(np.uint64) << (i * 5)
+    # Extract 5 bytes from each uint64
+    result = np.zeros((values.shape[0], 5), dtype=np.uint8)
+    for i in range(5):
+        result[:, i] = ((packed_u64 >> (i * 8)) & 0xFF).astype(np.uint8)
+    return result.tobytes()
+
+
+def _unpack_int5(data: bytes, numel: int) -> np.ndarray:
+    """Unpack bytes into uint8 values (0-30, 5 bits each). Inverse of _pack_int5."""
+    # Calculate padded length (multiple of 8)
+    padded = numel + (8 - numel % 8) % 8
+    n_groups = padded // 8
+    raw = np.frombuffer(data, dtype=np.uint8).reshape(n_groups, 5)
+    # Reconstruct uint64 from 5 bytes
+    packed_u64 = np.zeros(n_groups, dtype=np.uint64)
+    for i in range(5):
+        packed_u64 |= raw[:, i].astype(np.uint64) << (i * 8)
+    # Extract 8 x 5-bit values from each uint64
+    result = np.zeros((n_groups, 8), dtype=np.uint8)
+    for i in range(8):
+        result[:, i] = ((packed_u64 >> (i * 5)) & 0x1F).astype(np.uint8)
+    return result.flatten()[:numel]
+
+
+def _pack_int6(values: np.ndarray) -> bytes:
+    """Pack uint8 values (0-62, 6 bits each) into bytes. 4 values -> 3 bytes."""
+    n = len(values)
+    # Pad to multiple of 4
+    pad = (4 - n % 4) % 4
+    if pad > 0:
+        values = np.concatenate([values, np.zeros(pad, dtype=np.uint8)])
+    values = values.reshape(-1, 4).astype(np.uint32)
+    # Pack 4 x 6-bit values into 24 bits (3 bytes)
+    packed_u32 = np.zeros(values.shape[0], dtype=np.uint32)
+    for i in range(4):
+        packed_u32 |= values[:, i].astype(np.uint32) << (i * 6)
+    # Extract 3 bytes from each uint32
+    result = np.zeros((values.shape[0], 3), dtype=np.uint8)
+    for i in range(3):
+        result[:, i] = ((packed_u32 >> (i * 8)) & 0xFF).astype(np.uint8)
+    return result.tobytes()
+
+
+def _unpack_int6(data: bytes, numel: int) -> np.ndarray:
+    """Unpack bytes into uint8 values (0-62, 6 bits each). Inverse of _pack_int6."""
+    # Calculate padded length (multiple of 4)
+    padded = numel + (4 - numel % 4) % 4
+    n_groups = padded // 4
+    raw = np.frombuffer(data, dtype=np.uint8).reshape(n_groups, 3)
+    # Reconstruct uint32 from 3 bytes
+    packed_u32 = np.zeros(n_groups, dtype=np.uint32)
+    for i in range(3):
+        packed_u32 |= raw[:, i].astype(np.uint32) << (i * 8)
+    # Extract 4 x 6-bit values from each uint32
+    result = np.zeros((n_groups, 4), dtype=np.uint8)
+    for i in range(4):
+        result[:, i] = ((packed_u32 >> (i * 6)) & 0x3F).astype(np.uint8)
+    return result.flatten()[:numel]
+
+
+def dequantize_state_dict_int5(data: bytes) -> dict[str, Tensor]:
+    """Dequantize int5/int8/int6 mixed-precision packed state dict back to float tensors.
+
+    Supports format "int5_mixed_v3" (alpha int8 + omega int6 + rest int5),
+    "int5_mixed_v2" (alpha int8 + rest int5), and "int5_packed_v1" (legacy int5-only).
+    """
+    import struct
+    meta_len = struct.unpack("<I", data[:4])[0]
+    meta = torch.load(io.BytesIO(data[4 : 4 + meta_len]), map_location="cpu")
+    payload = data[4 + meta_len :]
+
+    state_dict: dict[str, Tensor] = {}
+    for name, info in meta["entries"].items():
+        if info["kind"] == "passthrough":
+            offset = info["offset"]
+            nbytes = info["nbytes"]
+            obj = torch.load(io.BytesIO(payload[offset : offset + nbytes]), map_location="cpu")
+            state_dict[name] = obj["t"]
+        elif info["kind"] == "int8_full":
+            offset = info["offset"]
+            data_nbytes = info["data_nbytes"]
+            scale_nbytes = info["scale_nbytes"]
+            q_raw = np.frombuffer(payload[offset : offset + data_nbytes], dtype=np.int8)
+            scale_data = payload[offset + data_nbytes : offset + data_nbytes + scale_nbytes]
+            scale_obj = torch.load(io.BytesIO(scale_data), map_location="cpu")
+            scale = scale_obj["s"].float()
+            shape = scale_obj["shape"]
+            target_dtype = getattr(torch, scale_obj["dtype"])
+            q_float = torch.from_numpy(q_raw.copy()).float().reshape(shape)
+            result = q_float * scale[:, None]
+            state_dict[name] = result.to(dtype=target_dtype)
+
+        elif info["kind"] == "int5_alpha8":
+            # Legacy path: alpha rows int8, all others int5 (5 other groups)
+            offset = info["offset"]
+            alpha_data_nb = info["alpha_data_nbytes"]
+            alpha_scale_nb = info["alpha_scale_nbytes"]
+            int5_packed_nb = info["int5_packed_nbytes"]
+            int5_scale_nb = info["int5_scale_nbytes"]
+            numel = info["numel"]
+            # Dequantize alpha block (int8)
+            pos = offset
+            alpha_raw = np.frombuffer(payload[pos : pos + alpha_data_nb], dtype=np.int8)
+            pos += alpha_data_nb
+            alpha_scale_obj = torch.load(io.BytesIO(payload[pos : pos + alpha_scale_nb]), map_location="cpu")
+            alpha_scale = alpha_scale_obj["s"].float()
+            pos += alpha_scale_nb
+            # Dequantize other rows (int5)
+            int5_data = payload[pos : pos + int5_packed_nb]
+            pos += int5_packed_nb
+            int5_scale_obj = torch.load(io.BytesIO(payload[pos : pos + int5_scale_nb]), map_location="cpu")
+            int5_scale = int5_scale_obj["s"].float()
+            shape = int5_scale_obj["shape"]
+            target_dtype = getattr(torch, int5_scale_obj["dtype"])
+            K = int5_scale_obj["K"]
+            # Reconstruct alpha
+            alpha_q = torch.from_numpy(alpha_raw.copy()).float().reshape(K, shape[1])
+            alpha_deq = alpha_q * alpha_scale[:, None]
+            # Reconstruct other rows (5K rows)
+            other_numel = numel - K * shape[1]
+            shifted = _unpack_int5(int5_data, other_numel)
+            q = shifted.astype(np.int8) - 15
+            other_q = torch.from_numpy(q.copy()).float().reshape(5 * K, shape[1])
+            other_deq = other_q * int5_scale[:, None]
+            # Reassemble: [A, omega, phi] + [alpha] + [g_out, beta]
+            result = torch.cat([other_deq[:3 * K], alpha_deq, other_deq[3 * K:]], dim=0)
+            state_dict[name] = result.to(dtype=target_dtype)
+
+        elif info["kind"] == "int5_alpha8_omega6":
+            # alpha rows [3K:4K] at int8, omega rows [K:2K] at int6, rest (4 groups) at int5
+            offset = info["offset"]
+            alpha_data_nb = info["alpha_data_nbytes"]
+            alpha_scale_nb = info["alpha_scale_nbytes"]
+            omega_int6_packed_nb = info["omega_int6_packed_nbytes"]
+            omega_scale_nb = info["omega_scale_nbytes"]
+            int5_packed_nb = info["int5_packed_nbytes"]
+            int5_scale_nb = info["int5_scale_nbytes"]
+            numel = info["numel"]
+            # Dequantize alpha block (int8)
+            pos = offset
+            alpha_raw = np.frombuffer(payload[pos : pos + alpha_data_nb], dtype=np.int8)
+            pos += alpha_data_nb
+            alpha_scale_obj = torch.load(io.BytesIO(payload[pos : pos + alpha_scale_nb]), map_location="cpu")
+            alpha_scale = alpha_scale_obj["s"].float()
+            pos += alpha_scale_nb
+            # Dequantize omega block (int6)
+            omega_int6_data = payload[pos : pos + omega_int6_packed_nb]
+            pos += omega_int6_packed_nb
+            omega_scale_obj = torch.load(io.BytesIO(payload[pos : pos + omega_scale_nb]), map_location="cpu")
+            omega_scale = omega_scale_obj["s"].float()
+            pos += omega_scale_nb
+            # Dequantize remaining rows (int5): A, phi, g_out, beta -- 4K rows
+            int5_data = payload[pos : pos + int5_packed_nb]
+            pos += int5_packed_nb
+            int5_scale_obj = torch.load(io.BytesIO(payload[pos : pos + int5_scale_nb]), map_location="cpu")
+            int5_scale = int5_scale_obj["s"].float()
+            shape = int5_scale_obj["shape"]
+            target_dtype = getattr(torch, int5_scale_obj["dtype"])
+            K = int5_scale_obj["K"]
+            # Reconstruct alpha (K rows)
+            alpha_q = torch.from_numpy(alpha_raw.copy()).float().reshape(K, shape[1])
+            alpha_deq = alpha_q * alpha_scale[:, None]
+            # Reconstruct omega (K rows)
+            omega_numel = K * shape[1]
+            omega_shifted = _unpack_int6(omega_int6_data, omega_numel)
+            omega_q = omega_shifted.astype(np.int8) - 31
+            omega_q_t = torch.from_numpy(omega_q.copy()).float().reshape(K, shape[1])
+            omega_deq = omega_q_t * omega_scale[:, None]
+            # Reconstruct other rows (4K rows): A, phi, g_out, beta
+            other_numel = 4 * K * shape[1]
+            shifted = _unpack_int5(int5_data, other_numel)
+            q = shifted.astype(np.int8) - 15
+            other_q = torch.from_numpy(q.copy()).float().reshape(4 * K, shape[1])
+            other_deq = other_q * int5_scale[:, None]
+            # Reassemble in original order: A[0:K] + omega[K:2K] + phi[2K:3K] + alpha[3K:4K] + g_out[4K:5K] + beta[5K:6K]
+            # other_deq order: A(K), phi(K), g_out(K), beta(K) -- matches packing order
+            result = torch.cat([
+                other_deq[:K],       # A rows [0:K]
+                omega_deq,           # omega rows [K:2K]
+                other_deq[K:2 * K],  # phi rows [2K:3K]
+                alpha_deq,           # alpha rows [3K:4K]
+                other_deq[2 * K:3 * K],  # g_out rows [4K:5K]
+                other_deq[3 * K:],   # beta rows [5K:6K]
+            ], dim=0)
+            state_dict[name] = result.to(dtype=target_dtype)
+
+        elif info["kind"] == "int5":
+            offset = info["offset"]
+            packed_nbytes = info["packed_nbytes"]
+            scale_nbytes = info["scale_nbytes"]
+            numel = info["numel"]
+            packed_data = payload[offset : offset + packed_nbytes]
+            shifted = _unpack_int5(packed_data, numel)
+            q = shifted.astype(np.int8) - 15
+            q_tensor = torch.from_numpy(q.copy()).to(torch.int8)
+            scale_data = payload[offset + packed_nbytes : offset + packed_nbytes + scale_nbytes]
+            scale_obj = torch.load(io.BytesIO(scale_data), map_location="cpu")
+            scale = scale_obj["s"].float()
+            shape = scale_obj["shape"]
+            dtype_str = scale_obj["dtype"]
+            target_dtype = getattr(torch, dtype_str)
+            q_float = q_tensor.float().reshape(shape)
+            if q_float.ndim == 2:
+                result = q_float * scale[:, None] if scale.ndim == 1 else q_float * scale
+            else:
+                result = q_float * scale
+            state_dict[name] = result.to(dtype=target_dtype)
+        else:
+            raise ValueError(f"Unknown quantization kind {info['kind']!r} for {name!r}")
+    return state_dict
+
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+
+# -----------------------------
+# BASELINE TRANSFORMER MODULES
+# (identical to train_gpt.py)
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, self.weight.to(x.dtype), bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+# PARTIAL_ROPE_DIMS: 64 = full RoPE (default), 16 = partial. No if-branch to avoid dynamo break.
+_PARTIAL_ROPE_DIMS: int = int(os.environ.get("PARTIAL_ROPE_DIMS", 64))
+
+# XSA_LAST_N: apply Cross-Scale Attention (value-direction subtraction) to the last N layers.
+# 0 = disabled (default). E.g. XSA_LAST_N=4 enables XSA on the last 4 attention-bearing layers.
+_XSA_LAST_N: int = int(os.environ.get("XSA_LAST_N", "0"))
+
+# RELU2: replace SwiGLU FFN in ParallelTRNBlock with leaky_relu^2 (same as Block's MLP).
+# 0 = SwiGLU (default), 1 = leaky_relu(x, 0.5)^2.
+_USE_RELU2: bool = os.environ.get("RELU2", "0") == "1"
+
+# SLIM_TRN: reduce OscillatorProjection from 6K to 4K (fix omega+beta, keep phi).
+# Saves ~33% OscProj params/FLOPs. omega uses omega_base only, beta fixed at sigmoid(-2).
+_SLIM_TRN: bool = os.environ.get("SLIM_TRN", "0") == "1"
+
+# BRANCH_ORTHO: orthogonalize TRN output against attention direction before merge.
+# Forces TRN to carry only information complementary to attention.
+# Without this, merge_gate collapses to ~0.99 (attention dominates, TRN dies).
+_BRANCH_ORTHO: bool = os.environ.get("BRANCH_ORTHO", "0") == "1"
+
+# TRN_EMA: filter TRN input with causal EMA to focus on low-frequency patterns.
+# Attention sees full input (unchanged). Only TRN input is filtered.
+_TRN_EMA: bool = os.environ.get("TRN_EMA", "0") == "1"
+
+# ZAMBA_LORA_RANK: enable Zamba-style shared attention with per-layer LoRA.
+# 0 = disabled (per-layer attention, default). >0 = shared attn + LoRA on q+v.
+_ZAMBA_LORA_RANK: int = int(os.environ.get("ZAMBA_LORA_RANK", "0"))
+
+
+def apply_partial_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int) -> Tensor:
+    """Apply RoPE to first rope_dims dims only; leave rest unchanged."""
+    x_rot = x[..., :rope_dims]
+    x_pass = x[..., rope_dims:]
+    cos_r = cos[..., : rope_dims // 2]
+    sin_r = sin[..., : rope_dims // 2]
+    half = rope_dims // 2
+    x1, x2 = x_rot[..., :half], x_rot[..., half:]
+    x_rotated = torch.cat((x1 * cos_r + x2 * sin_r, x1 * (-sin_r) + x2 * cos_r), dim=-1)
+    return torch.cat((x_rotated, x_pass), dim=-1)
+
+
+class AttentionLoRA(nn.Module):
+    """Per-layer LoRA delta for shared CausalSelfAttention (q + v only)."""
+
+    def __init__(self, dim: int, kv_dim: int, rank: int = 8) -> None:
+        super().__init__()
+        self.lora_A_q = nn.Linear(dim, rank, bias=False)
+        self.lora_B_q = nn.Linear(rank, dim, bias=False)
+        self.lora_A_v = nn.Linear(dim, rank, bias=False)
+        self.lora_B_v = nn.Linear(rank, kv_dim, bias=False)
+        nn.init.normal_(self.lora_A_q.weight, std=dim ** -0.5)
+        nn.init.zeros_(self.lora_B_q.weight)
+        nn.init.normal_(self.lora_A_v.weight, std=dim ** -0.5)
+        nn.init.zeros_(self.lora_B_v.weight)
+
+    def apply_q(self, x: Tensor) -> Tensor:
+        return self.lora_B_q(self.lora_A_q(x))
+
+    def apply_v(self, x: Tensor) -> Tensor:
+        return self.lora_B_v(self.lora_A_v(x))
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self._gqa = num_kv_heads != num_heads
+        self._gqa_repeat = num_heads // num_kv_heads
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor, lora: AttentionLoRA | None = None, apply_xsa: bool = False) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q_flat = self.c_q(x)
+        v_flat = self.c_v(x)
+        if lora is not None:
+            q_flat = q_flat + lora.apply_q(x)
+            v_flat = v_flat + lora.apply_v(x)
+        q = q_flat.reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = v_flat.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_partial_rotary_emb(q, cos, sin, _PARTIAL_ROPE_DIMS)
+        k = apply_partial_rotary_emb(k, cos, sin, _PARTIAL_ROPE_DIMS)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            is_causal=True,
+            enable_gqa=self._gqa,
+        )
+        # XSA: per-call flag (supports per-layer control with shared attention).
+        # apply_xsa is a Python bool, constant-folded by dynamo.
+        if apply_xsa:
+            v_xsa = v.repeat_interleave(self._gqa_repeat, dim=1) if self._gqa else v
+            vn = F.normalize(v_xsa, dim=-1)
+            y = y - (y * vn).sum(dim=-1, keepdim=True) * vn
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: float):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = F.leaky_relu(self.fc(x), 0.5)
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        use_xsa: bool = False,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.use_xsa = use_xsa
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x), apply_xsa=self.use_xsa)
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+# -----------------------------
+# TRN MODULES (inlined from Tri-Memory)
+# -----------------------------
+
+# --- scan.py ---
+
+class _SafeCumprod(torch.autograd.Function):
+    """torch.cumprod with NaN/Inf-safe backward."""
+
+    @staticmethod
+    def forward(ctx, alpha: Tensor, dim: int = 1) -> Tensor:
+        result = torch.cumprod(alpha, dim=dim)
+        ctx.save_for_backward(alpha, result)
+        ctx.dim = dim
+        return result
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor) -> tuple[Tensor, None]:
+        alpha, result = ctx.saved_tensors
+        dim = ctx.dim
+        grad_weighted = grad_output * result
+        grad_sum = torch.flip(
+            torch.cumsum(torch.flip(grad_weighted, [dim]), dim=dim), [dim],
+        )
+        grad_input = grad_sum / alpha.clamp(min=1e-6)
+        nonfinite_mask = ~torch.isfinite(grad_input)
+        grad_input = torch.where(nonfinite_mask, torch.zeros_like(grad_input), grad_input)
+        return grad_input, None
+
+
+def _kogge_stone_scan(alpha: Tensor, drive: Tensor) -> Tensor:
+    """O(log n) parallel prefix scan for r_t = a_t * r_{t-1} + d_t."""
+    B, n, K = alpha.shape
+    a = alpha
+    b = drive
+    offset = 1
+    while offset < n:
+        # F.pad avoids new tensor alloc from torch.cat: pad left with identity values
+        a_left = F.pad(a[:, : n - offset], (0, 0, offset, 0), value=1.0)
+        b_left = F.pad(b[:, : n - offset], (0, 0, offset, 0), value=0.0)
+        b = b + a * b_left
+        a = a * a_left
+        offset *= 2
+    return b
+
+
+def _parallel_resonance_scan(
+    alpha: Tensor,
+    drive_r: Tensor,
+    drive_i: Tensor,
+) -> tuple[Tensor, Tensor]:
+    """O(log n) parallel Kogge-Stone scan. No Triton/FLA dependency."""
+    alpha = alpha.float()
+    drive_r = drive_r.float()
+    drive_i = drive_i.float()
+    return _kogge_stone_scan(alpha, drive_r), _kogge_stone_scan(alpha, drive_i)
+
+
+def _triton_resonance_scan_fused(
+    alpha: Tensor,
+    drive_r: Tensor,
+    drive_i: Tensor,
+) -> tuple[Tensor, Tensor]:
+    """Triton-backed fused scan for r_t = alpha_t * r_{t-1} + d_t.
+
+    Fuses drive_r and drive_i into a single (B, n, 2K) call so that both
+    channels share the same alpha broadcast, halving kernel launch overhead.
+
+    Requires TRITON_SCAN=1 and triton_scan module on PYTHONPATH.
+    """
+    assert _triton_resonance_scan is not None, "Triton scan not available"
+    B, n, K = alpha.shape
+    alpha_f = alpha.float().contiguous()
+    # Stack real and imaginary drive along the K dimension: (B, n, 2K)
+    drive_fused = torch.cat([drive_r.float(), drive_i.float()], dim=-1)
+    # alpha: interleave K values for real+imag (avoids full repeat copy)
+    alpha_fused = torch.cat([alpha_f, alpha_f], dim=-1)
+    out_fused = _triton_resonance_scan(alpha_fused, drive_fused)  # (B, n, 2K)
+    return out_fused[..., :K], out_fused[..., K:]
+
+
+def _scan_chunk(
+    alpha_chunk: Tensor,
+    drive_chunk: Tensor,
+    r_prev: Tensor,
+) -> tuple[Tensor, Tensor]:
+    alpha_cum = _SafeCumprod.apply(alpha_chunk, 1)
+    prev_contrib = alpha_cum * r_prev.unsqueeze(1)
+    safe_alpha_cum = alpha_cum.clamp(min=1e-6)
+    scaled_drive = drive_chunk / safe_alpha_cum
+    drive_contrib = torch.cumsum(scaled_drive, dim=1) * alpha_cum
+    small_alpha = alpha_cum < 1e-6
+    drive_contrib = torch.where(small_alpha, drive_chunk * alpha_cum, drive_contrib)
+    chunk_out = prev_contrib + drive_contrib
+    return chunk_out, chunk_out[:, -1]
+
+
+def _chunked_resonance_scan(
+    alpha: Tensor,
+    drive_r: Tensor,
+    drive_i: Tensor,
+    chunk_size: int = 64,
+) -> tuple[Tensor, Tensor]:
+    """CPU-compatible fallback scan."""
+    B, n, K = alpha.shape
+    r_r = alpha.new_zeros(B, K)
+    r_i = alpha.new_zeros(B, K)
+    out_r_chunks: list[Tensor] = []
+    out_i_chunks: list[Tensor] = []
+    for start in range(0, n, chunk_size):
+        end = min(start + chunk_size, n)
+        chunk_r, r_r = _scan_chunk(alpha[:, start:end], drive_r[:, start:end], r_r)
+        chunk_i, r_i = _scan_chunk(alpha[:, start:end], drive_i[:, start:end], r_i)
+        out_r_chunks.append(chunk_r)
+        out_i_chunks.append(chunk_i)
+    return torch.cat(out_r_chunks, dim=1), torch.cat(out_i_chunks, dim=1)
+
+
+# --- oscillator.py ---
+
+class OscillatorProjection(nn.Module):
+    """Projects token embeddings to oscillator params (A, omega, phi, alpha, g_out, beta)."""
+
+    def __init__(
+        self,
+        d_model: int,
+        K: int,
+        amplitude_max: float = 3.0,
+        gate_bias_init: float = 0.65,
+        max_seq_len: int = 2048,
+    ) -> None:
+        super().__init__()
+        self.K = K
+        self.register_buffer("amplitude_max", torch.tensor(amplitude_max))
+        self.register_buffer("_pi", torch.tensor(pi))
+        self._slim = _SLIM_TRN
+        proj_dim = 4 * K if self._slim else 6 * K
+        self.proj = nn.Linear(d_model, proj_dim, bias=True)
+        self.proj._no_ortho_init = True  # custom domain-specific init in _init_weights
+
+        omega_init = torch.linspace(
+            math.log(2.0 * pi / max_seq_len),
+            math.log(pi * (1.0 - 1.0 / max(K, 2))),
+            K,
+        ).exp()
+        self.omega_base = nn.Parameter(omega_init)
+
+        if self._slim:
+            # Fixed beta (per-channel, not token-dependent). Init sigmoid(-2)=0.119.
+            self.beta_fixed = nn.Parameter(torch.full((K,), -2.0))
+
+        self._init_weights(gate_bias_init)
+
+    def _init_weights(self, gate_bias_init: float = 0.65) -> None:
+        nn.init.normal_(self.proj.weight, std=self.proj.in_features ** -0.5)
+        nn.init.zeros_(self.proj.bias)
+        K = self.K
+        group_sizes = [K // 4, K // 2, K - K // 4 - K // 2]
+        alpha_centers = [0.30, 0.65, 0.97]
+        if self._slim:
+            # 4K layout: A_r[0:K], Ph_r[K:2K], Ga_r[2K:3K], Go_r[3K:4K]
+            offset = 2 * K  # alpha starts at 2K
+        else:
+            # 6K layout: A_r[0:K], Om_r[K:2K], Ph_r[2K:3K], Ga_r[3K:4K], Go_r[4K:5K], Be_r[5K:6K]
+            offset = 3 * K
+        for n_k, alpha_c in zip(group_sizes, alpha_centers):
+            alpha_c_clamped = max(0.01, min(0.99, alpha_c))
+            bias_val = math.log(alpha_c_clamped / (1.0 - alpha_c_clamped))
+            self.proj.bias.data[offset : offset + n_k].fill_(bias_val)
+            offset += n_k
+        gate_bias_init_clamped = max(0.01, min(0.99, gate_bias_init))
+        g_out_bias = math.log(gate_bias_init_clamped / (1.0 - gate_bias_init_clamped))
+        if self._slim:
+            self.proj.bias.data[3 * K : 4 * K].fill_(g_out_bias)
+        else:
+            self.proj.bias.data[4 * K : 5 * K].fill_(g_out_bias)
+            self.proj.bias.data[5 * K :].fill_(-2.0)
+
+    def forward(self, x: Tensor) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor]:
+        out = self.proj(x)
+        if self._slim:
+            A_r, Ph_r, Ga_r, Go_r = out.chunk(4, dim=-1)
+            A = F.softplus(A_r).clamp(max=self.amplitude_max)
+            omega = self.omega_base.clamp(min=1e-4, max=self._pi - 1e-4)
+            phi = torch.tanh(Ph_r) * self._pi
+            alpha = torch.sigmoid(Ga_r)
+            g_out = torch.sigmoid(Go_r)
+            beta = torch.sigmoid(self.beta_fixed)
+            return A, omega, phi, alpha, g_out, beta
+        A_r, Om_r, Ph_r, Ga_r, Go_r, Be_r = out.chunk(6, dim=-1)
+        A = F.softplus(A_r).clamp(max=self.amplitude_max)
+        omega = (torch.sigmoid(Om_r) * self._pi + self.omega_base).clamp(min=1e-4, max=self._pi - 1e-4)
+        phi = torch.tanh(Ph_r) * self._pi
+        alpha = torch.sigmoid(Ga_r)
+        g_out = torch.sigmoid(Go_r)
+        beta = torch.sigmoid(Be_r)
+        return A, omega, phi, alpha, g_out, beta
+
+
+# --- resonance.py (simplified: log phase_mode, SCPM on, no ATDR, no token_shift) ---
+
+class TemporalResonanceLayer(nn.Module):
+    """Core TRN layer with oscillatory recurrence.
+
+    Uses log phase mode and SCPM (Spectral Cross-Product Mixing).
+    ATDR regularization is disabled for parameter-golf simplicity.
+    """
+
+    def __init__(
+        self,
+        d_model: int,
+        K: int,
+        amplitude_max: float = 3.0,
+        gate_bias_init: float = 0.65,
+        res_scale_init: float = 0.05,
+        state_norm: bool = True,
+        max_seq_len: int = 2048,
+        scan_chunk_size: int = 64,
+    ) -> None:
+        super().__init__()
+        self.K = K
+        self.state_norm_enabled = state_norm
+        self.scan_chunk_size = scan_chunk_size
+
+        self.proj = OscillatorProjection(
+            d_model, K,
+            amplitude_max=amplitude_max,
+            gate_bias_init=gate_bias_init,
+            max_seq_len=max_seq_len,
+        )
+
+        # W_res: readout projection. SLIM_TRN uses 2K (no SCPM), else 4K-2 (with SCPM).
+        self._slim = _SLIM_TRN
+        w_res_in = 2 * K if self._slim else 4 * K - 2
+        self.W_res = nn.Linear(w_res_in, d_model, bias=False)
+        nn.init.normal_(self.W_res.weight, std=2e-3)
+        self.W_res._no_ortho_init = True  # custom small-std init for stable TRN output scale
+
+        # PCG: phase-coupled gating
+        self.W_phase = nn.Linear(d_model, K, bias=True)
+        nn.init.normal_(self.W_phase.weight, std=1e-3)
+        nn.init.zeros_(self.W_phase.bias)
+        self.W_phase._no_ortho_init = True  # custom small-std init for phase sensitivity
+        self.lambda_pcg = nn.Parameter(torch.tensor(0.5))
+
+        # Learnable output scale (small init for stable training start)
+        self.res_scale = nn.Parameter(torch.tensor(res_scale_init))
+        self.register_buffer("_forward_count", torch.tensor(0, dtype=torch.long))
+        # Cache for log-phase positions (invalidated on sequence length change)
+        self._cached_positions: torch.Tensor | None = None
+        self._cached_positions_n: int = -1
+
+    def _apply_state_norm(self, r_r: Tensor, r_i: Tensor) -> tuple[Tensor, Tensor]:
+        modulus = (r_r.pow(2) + r_i.pow(2) + 1e-8).sqrt()
+        scale = modulus.clamp(min=1.0)
+        return r_r / scale, r_i / scale
+
+    def forward(self, x: Tensor) -> Tensor:
+        B, n, _ = x.shape
+        device = x.device
+
+        A, omega, phi, alpha, g_out, beta = self.proj(x)
+
+        # Log-phase time encoding (positions cached across calls for same n)
+        if self._cached_positions_n != n or self._cached_positions is None or self._cached_positions.device != device:
+            self._cached_positions = torch.log1p(
+                torch.arange(n, device=device, dtype=torch.float32)
+            ).view(1, n, 1)
+            self._cached_positions_n = n
+        positions = self._cached_positions
+        angle = omega * positions + phi
+        alpha_f = alpha.float()
+        drive_scale = 1.0 - alpha_f
+        cos_angle = torch.cos(angle).float()
+        sin_angle = torch.sin(angle).float()
+        A_f = A.float()
+        drive_r = drive_scale * A_f * cos_angle
+        drive_i = drive_scale * A_f * sin_angle
+
+        device_type = "cuda" if x.is_cuda else "cpu"
+        with torch.amp.autocast(device_type, enabled=False):
+            if x.is_cuda and _USE_TRITON_SCAN:
+                r_r, r_i = _triton_resonance_scan_fused(alpha_f, drive_r, drive_i)
+            elif x.is_cuda:
+                r_r, r_i = _parallel_resonance_scan(alpha_f, drive_r, drive_i)
+            else:
+                r_r, r_i = _chunked_resonance_scan(alpha_f, drive_r, drive_i, self.scan_chunk_size)
+
+        # Delta rule erase
+        beta_f = beta.float()
+        readout = r_r * cos_angle + r_i * sin_angle
+        r_r = r_r - beta_f * readout * cos_angle
+        r_i = r_i - beta_f * readout * sin_angle
+
+        if self.state_norm_enabled:
+            r_r, r_i = self._apply_state_norm(r_r, r_i)
+
+        r_r = r_r.to(x.dtype)
+        r_i = r_i.to(x.dtype)
+        cos_a = cos_angle.to(r_r.dtype)
+        sin_a = sin_angle.to(r_r.dtype)
+        rho_re = r_r * cos_a + r_i * sin_a
+        rho_im = -r_r * sin_a + r_i * cos_a
+
+        # PCG: phase-coupled gate
+        rho_norm = (rho_re.pow(2) + rho_im.pow(2) + 1e-6).sqrt()
+        rho_re_n = rho_re / rho_norm
+        rho_im_n = rho_im / rho_norm
+        phase_query = self.W_phase(x)
+        cos_pq = torch.cos(phase_query)
+        sin_pq = torch.sin(phase_query)
+        phase_alignment = rho_re_n * cos_pq + rho_im_n * sin_pq
+        phase_gate = torch.sigmoid(self.lambda_pcg * phase_alignment)
+        rho_re = phase_gate * rho_re
+        rho_im = phase_gate * rho_im
+
+        g = g_out.to(rho_re.dtype)
+        if self._slim:
+            # SLIM_TRN: no SCPM, 2K readout
+            rho = torch.cat([g * rho_re, g * rho_im], dim=-1)  # (B, n, 2K)
+        else:
+            # SCPM: spectral cross-product mixing
+            xcross_re = rho_re[:, :, :-1] * rho_re[:, :, 1:] - rho_im[:, :, :-1] * rho_im[:, :, 1:]
+            xcross_im = rho_re[:, :, :-1] * rho_im[:, :, 1:] + rho_im[:, :, :-1] * rho_re[:, :, 1:]
+            rho_base = torch.cat([rho_re, rho_im], dim=-1)
+            g_base = g.repeat(1, 1, 2)
+            g_cross = (g[:, :, :-1] + g[:, :, 1:]) / 2.0
+            xcross = torch.cat([xcross_re, xcross_im], dim=-1)
+            g_cross_full = g_cross.repeat(1, 1, 2)
+            rho = torch.cat([g_base * rho_base, g_cross_full * xcross], dim=-1)  # (B, n, 4K-2)
+
+        # Smoothstep warmup for res_scale during training
+        # Note: with depth_recurrence>1, this increments multiple times per step.
+        # Use 2000 base steps to accommodate up to 2x recurrence.
+        if self.training:
+            self._forward_count += 1
+            warmup_steps = 2000
+            warmup_t = (self._forward_count.float() / warmup_steps).clamp(max=1.0)
+            warmup_factor: float | Tensor = warmup_t * warmup_t * (3.0 - 2.0 * warmup_t)
+        else:
+            warmup_factor = 1.0
+
+        return (self.res_scale * warmup_factor) * self.W_res(rho)
+
+
+# --- TRNBlock ---
+
+class TRNBlock(nn.Module):
+    """TRN layer: pre-norm resonance + pre-norm SwiGLU FFN.
+
+    Compatible with the GPT U-Net forward (takes x and x0).
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        K: int,
+        mlp_mult: int,
+        max_seq_len: int = 2048,
+        use_token_shift: bool = False,
+    ) -> None:
+        super().__init__()
+        self.norm1 = RMSNorm()
+        self.norm2 = RMSNorm()
+        # Token shift: RWKV-6 style lerp between x_t and x_{t-1}
+        self.token_shift_mu = nn.Parameter(torch.zeros(dim)) if use_token_shift else None
+        self.resonance = TemporalResonanceLayer(
+            d_model=dim,
+            K=K,
+            max_seq_len=max_seq_len,
+        )
+        # SwiGLU FFN (LLaMA-style, matches param count of relu^2 MLP at mlp_mult=2)
+        _d_ff_env = int(os.environ.get("D_FF_HIDDEN", 0))
+        if _d_ff_env > 0:
+            d_ff_hidden = _d_ff_env
+        else:
+            raw_hidden = int(2 / 3 * mlp_mult * dim)
+            d_ff_hidden = (raw_hidden + 255) // 256 * 256
+        self.gate_up = nn.Linear(dim, d_ff_hidden * 2, bias=False)
+        self.down = nn.Linear(d_ff_hidden, dim, bias=False)
+        self.d_ff_hidden = d_ff_hidden
+
+        # Control tensors (kept in fp32, matched to Block API)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+        nn.init.normal_(self.gate_up.weight, std=dim ** -0.5)
+        nn.init.normal_(self.down.weight, std=d_ff_hidden ** -0.5)
+
+    def _swiglu(self, x: Tensor) -> Tensor:
+        y = self.gate_up(x)
+        gate, up = y.split(self.d_ff_hidden, dim=-1)
+        return self.down(F.silu(gate) * up)
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        h = self.norm1(x)
+        if self.token_shift_mu is not None:
+            mu = torch.sigmoid(self.token_shift_mu.to(dtype=h.dtype))
+            h_shifted = torch.empty_like(h)
+            h_shifted[:, 0, :] = h[:, 0, :]
+            h_shifted[:, 1:, :] = mu * h[:, 1:, :] + (1.0 - mu) * h[:, :-1, :]
+            h = h_shifted
+        res_out = self.resonance(h)
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * res_out
+        ffn_out = self._swiglu(self.norm2(x))
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * ffn_out
+        return x
+
+
+class CausalEMA(nn.Module):
+    """Causal exponential moving average via parallel prefix scan.
+
+    Learnable alpha (1 scalar per block). Uses Kogge-Stone style O(log T)
+    parallel scan for constant-alpha EMA: y_t = alpha * y_{t-1} + (1-alpha) * x_t.
+    """
+
+    def __init__(self, alpha_init: float = 0.9) -> None:
+        super().__init__()
+        logit = math.log(alpha_init / (1.0 - alpha_init))
+        self.alpha_logit = nn.Parameter(torch.tensor(logit))
+        self.alpha_logit._no_ortho_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        alpha = torch.sigmoid(self.alpha_logit).to(dtype=x.dtype)
+        # drive = (1 - alpha) * x
+        b = (1.0 - alpha) * x
+        # Kogge-Stone parallel prefix scan for constant alpha:
+        # b_t += alpha^offset * b_{t-offset}, doubling offset each stage
+        offset = 1
+        alpha_pow = alpha
+        while offset < x.shape[1]:
+            b = torch.cat([
+                b[:, :offset],
+                b[:, offset:] + alpha_pow * b[:, :-offset],
+            ], dim=1)
+            alpha_pow = alpha_pow * alpha_pow
+            offset *= 2
+        return b
+
+
+class ParallelTRNBlock(nn.Module):
+    """Parallel TRN + attention block with shared FFN (SwiGLU or leaky_relu^2)."""
+
+    def __init__(
+        self,
+        dim: int,
+        K: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        max_seq_len: int = 2048,
+        use_token_shift: bool = False,
+        gate_init: float = 0.0,
+        use_xsa: bool = False,
+        shared_attn: CausalSelfAttention | None = None,
+        lora: AttentionLoRA | None = None,
+        disable_attn: bool = False,
+    ) -> None:
+        super().__init__()
+        self.disable_attn = disable_attn
+        self.norm1 = RMSNorm()
+        self.norm2 = None if disable_attn else RMSNorm()
+        self.norm3 = RMSNorm()
+        self.use_xsa = use_xsa
+        self._gqa = num_kv_heads != num_heads
+        self._gqa_repeat = num_heads // num_kv_heads
+        # Token shift is applied only on the TRN branch input.
+        self.token_shift_mu = nn.Parameter(torch.zeros(dim)) if use_token_shift else None
+
+        # TRN_EMA: causal EMA filter on TRN input for low-frequency focus.
+        self.trn_ema = CausalEMA(alpha_init=0.9) if _TRN_EMA else None
+
+        self.resonance = TemporalResonanceLayer(
+            d_model=dim,
+            K=K,
+            max_seq_len=max_seq_len,
+        )
+        if disable_attn:
+            # Layer 0 optimization: skip attention entirely, TRN+MLP only.
+            self._use_shared = False
+            object.__setattr__(self, "_lora", None)
+        elif shared_attn is not None:
+            # Zamba mode: store shared attention AND lora outside _modules to avoid
+            # state_dict duplication and optimizer param duplication.
+            # Params are managed at HybridGPT level (shared_attn, layer_loras).
+            object.__setattr__(self, "_shared_attn", shared_attn)
+            object.__setattr__(self, "_lora", lora)
+            self._use_shared = True
+        else:
+            self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+            object.__setattr__(self, "_lora", None)
+            self._use_shared = False
+
+        _d_ff_env = int(os.environ.get("D_FF_HIDDEN", 0))
+        self.use_relu2 = _USE_RELU2
+        if self.use_relu2:
+            # leaky_relu^2 FFN: param-matched to SwiGLU via 3/2 hidden expansion.
+            # SwiGLU uses gate_up(2*d) + down(d) = 3*d*dim. relu^2 uses fc(h) + proj(h) = 2*h*dim.
+            # Match: h = 3*d/2. No 256-alignment on override to preserve exact param match.
+            if _d_ff_env > 0:
+                d_ff_hidden = _d_ff_env * 3 // 2
+            else:
+                raw_hidden = int(mlp_mult * dim)
+                d_ff_hidden = (raw_hidden + 255) // 256 * 256
+            self.fc = nn.Linear(dim, d_ff_hidden, bias=False)
+            self.proj_down = nn.Linear(d_ff_hidden, dim, bias=False)
+            self.d_ff_hidden = d_ff_hidden
+            nn.init.normal_(self.fc.weight, std=dim ** -0.5)
+            nn.init.normal_(self.proj_down.weight, std=d_ff_hidden ** -0.5)
+        else:
+            # SwiGLU FFN
+            if _d_ff_env > 0:
+                d_ff_hidden = _d_ff_env
+            else:
+                raw_hidden = int(2 / 3 * mlp_mult * dim)
+                d_ff_hidden = (raw_hidden + 255) // 256 * 256
+            self.gate_up = nn.Linear(dim, d_ff_hidden * 2, bias=False)
+            self.down = nn.Linear(d_ff_hidden, dim, bias=False)
+            self.d_ff_hidden = d_ff_hidden
+            nn.init.normal_(self.gate_up.weight, std=dim ** -0.5)
+            nn.init.normal_(self.down.weight, std=d_ff_hidden ** -0.5)
+
+        self.merge_gate = None if disable_attn else nn.Parameter(torch.full((dim,), gate_init, dtype=torch.float32))
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def _apply_token_shift(self, x: Tensor) -> Tensor:
+        if self.token_shift_mu is None:
+            return x
+        mu = torch.sigmoid(self.token_shift_mu.to(dtype=x.dtype))
+        x_shifted = torch.empty_like(x)
+        x_shifted[:, 0, :] = x[:, 0, :]
+        x_shifted[:, 1:, :] = mu * x[:, 1:, :] + (1.0 - mu) * x[:, :-1, :]
+        return x_shifted
+
+    def _ffn(self, x: Tensor) -> Tensor:
+        if self.use_relu2:
+            return self.proj_down(F.leaky_relu(self.fc(x), 0.5).square())
+        y = self.gate_up(x)
+        gate, up = y.split(self.d_ff_hidden, dim=-1)
+        return self.down(F.silu(gate) * up)
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        trn_in = self._apply_token_shift(self.norm1(x))
+        if self.trn_ema is not None:
+            trn_in = self.trn_ema(trn_in)
+        trn_out = self.resonance(trn_in)
+
+        # Attention: skip when disable_attn (layer 0 TRN-only mode).
+        if self.disable_attn:
+            # TRN output only -- no attention, no merge gate, no branch ortho.
+            x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * trn_out
+            x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self._ffn(self.norm3(x))
+            return x
+
+        # Attention: shared (Zamba) or per-layer. XSA via apply_xsa arg (per-layer control).
+        attn_input = self.norm2(x)
+        if self._use_shared:
+            attn_out = self._shared_attn(attn_input, lora=self._lora, apply_xsa=self.use_xsa)
+        else:
+            attn_out = self.attn(attn_input, apply_xsa=self.use_xsa)
+
+        # Branch orthogonalization: remove attention-direction component from TRN output.
+        # Forces TRN to contribute only information complementary to attention.
+        # attn_n is detached so gradients don't flow back through the projection
+        # (avoids double gradient path into attention weights).
+        if _BRANCH_ORTHO:
+            attn_n = F.normalize(attn_out.detach().float(), dim=-1, eps=1e-6)
+            trn_f = trn_out.float()
+            proj = (trn_f * attn_n).sum(dim=-1, keepdim=True) * attn_n
+            trn_out = (trn_f - proj).to(dtype=trn_out.dtype)
+
+        gate = torch.sigmoid(self.merge_gate).to(dtype=x.dtype)[None, None, :]
+        merged = gate * attn_out + (1.0 - gate) * trn_out
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * merged
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self._ffn(self.norm3(x))
+        return x
+
+
+# -----------------------------
+# BIGRAM HASH EMBEDDING
+# -----------------------------
+
+class BigramHashEmbedding(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int) -> None:
+        super().__init__()
+        if bigram_vocab_size < 2:
+            raise ValueError(f"bigram_vocab_size must be >= 2, got {bigram_vocab_size}")
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+# -----------------------------
+# HYBRID GPT MODEL
+# -----------------------------
+
+class HybridGPT(nn.Module):
+    """GPT model supporting transformer, TRN-only, and hybrid block layouts.
+
+    U-Net skip connections and resid_mix are preserved from the baseline.
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        model_type: str,
+        trn_K: int,
+        hybrid_num_attn: int,
+        gate_init: float = 0.0,
+        attn_positions: set[int] | None = None,
+        depth_recurrence: int = 1,
+        bigram_vocab_size: int = 0,
+        bigram_dim: int = 128,
+        use_token_shift: bool = False,
+        max_seq_len: int = 2048,
+        ortho_init: bool = False,
+        parallel_head_trn: int = 0,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        if model_type not in ("transformer", "trn", "hybrid", "parallel"):
+            raise ValueError(
+                f"model_type must be 'transformer', 'trn', 'hybrid', or 'parallel', got {model_type!r}"
+            )
+
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.model_type = model_type
+        self.ortho_init = ortho_init
+        self.parallel_head_trn = parallel_head_trn
+        if model_type == "parallel" and parallel_head_trn >= num_layers:
+            raise ValueError(
+                f"PARALLEL_HEAD_TRN={parallel_head_trn} >= num_layers={num_layers}. "
+                "Staged Hybrid requires at least one ParallelTRNBlock."
+            )
+        if parallel_head_trn > 0 and model_type != "parallel":
+            print(f"[WARN] PARALLEL_HEAD_TRN={parallel_head_trn} set but MODEL_TYPE={model_type!r} -- ignored.", flush=True)
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+
+        attn_pos_set = attn_positions or set()
+
+        # XSA_LAST_N: enable XSA on the last N attention-bearing layers.
+        # For "parallel" mode, all ParallelTRNBlocks have attention.
+        # For "transformer"/"hybrid", count only attention blocks.
+        xsa_last_n = _XSA_LAST_N
+
+        # Pre-compute which layer indices get XSA (attention-bearing layers from the tail).
+        _xsa_layer_set: set[int] = set()
+        if xsa_last_n > 0:
+            attn_layer_indices: list[int] = []
+            for idx in range(num_layers):
+                if model_type == "transformer":
+                    attn_layer_indices.append(idx)
+                elif model_type == "trn":
+                    pass  # TRN-only has no attention
+                elif model_type == "parallel":
+                    if not (parallel_head_trn > 0 and idx < parallel_head_trn):
+                        attn_layer_indices.append(idx)
+                else:  # hybrid
+                    if attn_pos_set:
+                        if idx in attn_pos_set:
+                            attn_layer_indices.append(idx)
+                    elif idx < hybrid_num_attn:
+                        attn_layer_indices.append(idx)
+            _xsa_layer_set = set(attn_layer_indices[-xsa_last_n:])
+            if _xsa_layer_set:
+                print(f"[XSA] Enabled on layers: {sorted(_xsa_layer_set)} (last {xsa_last_n})", flush=True)
+
+        # Zamba shared attention: create single CausalSelfAttention + per-layer LoRA.
+        _use_zamba = _ZAMBA_LORA_RANK > 0 and model_type == "parallel"
+        _shared_attn: CausalSelfAttention | None = None
+        _layer_loras: nn.ModuleList | None = None
+        if _use_zamba:
+            kv_dim = num_kv_heads * (model_dim // num_heads)
+            _shared_attn = CausalSelfAttention(
+                model_dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+            )
+            n_parallel_blocks = num_layers - parallel_head_trn
+            _layer_loras = nn.ModuleList([
+                AttentionLoRA(model_dim, kv_dim, rank=_ZAMBA_LORA_RANK)
+                for _ in range(n_parallel_blocks)
+            ])
+            self.shared_attn = _shared_attn
+            self.layer_loras = _layer_loras
+            print(f"[ZAMBA] Shared attention + LoRA rank={_ZAMBA_LORA_RANK} for {n_parallel_blocks} blocks", flush=True)
+
+        # TRN_LAYERS: parse layer indices for selective ParallelTRNBlock placement.
+        _trn_layers_str = os.environ.get("TRN_LAYERS", "")
+        _trn_layer_set: set[int] = set()
+        if _trn_layers_str.strip():
+            _trn_layer_set = {int(x.strip()) for x in _trn_layers_str.split(",") if x.strip()}
+            print(f"[TRN_LAYERS] ParallelTRNBlock on layers: {sorted(_trn_layer_set)}, "
+                  f"pure Attention on others", flush=True)
+
+        _disable_layer0_attn = os.environ.get("DISABLE_LAYER0_ATTN", "0") == "1"
+        if _disable_layer0_attn:
+            print("[DISABLE_LAYER0_ATTN] Layer 0 attention skipped (TRN+MLP only)", flush=True)
+
+        def _make_block(i: int) -> nn.Module:
+            _xsa = i in _xsa_layer_set
+            if model_type == "transformer":
+                return Block(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init, use_xsa=_xsa)
+            if model_type == "trn":
+                return TRNBlock(model_dim, trn_K, mlp_mult, max_seq_len, use_token_shift=use_token_shift)
+            if model_type == "parallel":
+                if parallel_head_trn > 0 and i < parallel_head_trn:
+                    # Pure TRN block at the head of the staged hybrid.
+                    return TRNBlock(model_dim, trn_K, mlp_mult, max_seq_len, use_token_shift=use_token_shift)
+                # TRN_LAYERS: if set, only specified layers get ParallelTRNBlock.
+                # Other layers become pure attention (Block).
+                if _trn_layer_set and i not in _trn_layer_set:
+                    return Block(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init, use_xsa=_xsa)
+                # Gate init: if GATE_INIT env var is explicitly set (!= 0.0), use uniform.
+                # Otherwise, generate Schedule C (Attn-first gradient) for any num_layers.
+                parallel_idx = i - parallel_head_trn
+                n_parallel = num_layers - parallel_head_trn
+                if gate_init != 0.0:
+                    block_gate_init = gate_init
+                else:
+                    block_gate_init = 1.5 - 3.0 * parallel_idx / max(n_parallel - 1, 1)
+                # Zamba: pass shared attn + per-layer LoRA
+                _sa = _shared_attn if _use_zamba else None
+                _lo = _layer_loras[parallel_idx] if _use_zamba else None
+                return ParallelTRNBlock(
+                    model_dim,
+                    trn_K,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                    max_seq_len=max_seq_len,
+                    use_token_shift=use_token_shift,
+                    gate_init=block_gate_init,
+                    use_xsa=_xsa,
+                    shared_attn=_sa,
+                    lora=_lo,
+                    disable_attn=(_disable_layer0_attn and i == 0),
+                )
+            # hybrid: use attn_positions if set, else front-loaded
+            if attn_pos_set:
+                is_attn = i in attn_pos_set
+            else:
+                is_attn = i < hybrid_num_attn
+            if is_attn:
+                return Block(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init, use_xsa=_xsa)
+            return TRNBlock(model_dim, trn_K, mlp_mult, max_seq_len, use_token_shift=use_token_shift)
+
+        self.blocks = nn.ModuleList([_make_block(i) for i in range(num_layers)])
+        # Track TRN-only blocks for depth recurrence.
+        # ParallelTRNBlock is excluded so pass 2+ does not re-run attention.
+        self.is_trn_block = [isinstance(b, TRNBlock) for b in self.blocks]
+        self.depth_recurrence = depth_recurrence
+        # Learnable pass embeddings for depth recurrence (pass 1+)
+        if depth_recurrence > 1:
+            self.pass_embeds = nn.ParameterList([
+                nn.Parameter(torch.zeros(1, 1, model_dim))
+                for _ in range(depth_recurrence - 1)
+            ])
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if not isinstance(module, nn.Linear):
+                continue
+            if getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+            elif self.ortho_init and not getattr(module, "_no_ortho_init", False):
+                # Apply orthogonal init to transformer (attention/FFN) linears.
+                # TRN linears marked _no_ortho_init are skipped -- they have
+                # domain-specific custom init (OscillatorProjection.proj,
+                # TemporalResonanceLayer.W_res, W_phase).
+                nn.init.orthogonal_(module.weight)
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+
+        # Pass 1: full U-Net (all blocks)
+        # LN Scale removed -- dynamo incompatible + residual compound bug
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+
+        # Pass 2..N: re-run TRN blocks only (skip attn blocks)
+        for pass_idx in range(1, self.depth_recurrence):
+            x1 = x + self.pass_embeds[pass_idx - 1].to(dtype=x.dtype)
+            for i, block in enumerate(self.blocks):
+                if self.is_trn_block[i]:
+                    x1 = block(x1, x)
+            x = x1
+
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return logits
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        logits = self.forward_logits(input_ids)
+        return F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            target_ids.reshape(-1),
+            reduction="mean",
+        )
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    import torch._inductor.config as _inductor_cfg
+    # Disable cpp codegen on Windows to avoid MSVC CP932/UTF-8 conflict
+    if os.name == "nt":
+        _inductor_cfg.disable_cpp_codegen = True
+    # H100 optimizations: kernel param sweep + best GEMM algorithm selection
+    # COMPILE_MODE=default disables autotune (saves 30-60min compile time)
+    _compile_mode = os.environ.get("COMPILE_MODE", "max-autotune-no-cudagraphs")
+    if _compile_mode == "default":
+        _inductor_cfg.coordinate_descent_tuning = False
+        _inductor_cfg.max_autotune_gemm = False
+    else:
+        _inductor_cfg.coordinate_descent_tuning = True
+        _inductor_cfg.max_autotune_gemm = True
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    if not bool(int(os.environ.get("SKIP_COMPILE", "0"))):
+        zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    default_accum = 8 // world_size if 8 % world_size == 0 else 8
+    grad_accum_steps = int(os.environ.get("GRAD_ACCUM_STEPS", default_accum))
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(True)
+    enable_math_sdp(True)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # Resolve TRN K (number of oscillators).
+    # TRN_N_OSCILLATORS=256 gives ~1.44M params/layer vs 0.79M for attention.
+    # To match ~17M budget: 9*0.79M = 7.1M attn; 7*1.44M = 10.1M TRN.
+    # With MLP + embedding, 7-layer TRN is ~15.6M and 7-layer hybrid ~16.1M.
+    if args.trn_n_oscillators > 0:
+        trn_K = args.trn_n_oscillators
+    elif args.model_type == "parallel":
+        trn_K = args.parallel_trn_k
+    else:
+        trn_K = 256  # default K per instructions
+
+    # Auto-select layer count by model_type to match ~17M param budget:
+    #   transformer: 9L (baseline)
+    #   trn:         7L (~15.6M with K=256)
+    #   hybrid:      7L (2 attn + 5 TRN, ~16.1M)
+    num_layers = args.num_layers  # override by NUM_LAYERS env if set explicitly
+    if os.environ.get("NUM_LAYERS") is None:
+        if args.model_type == "trn":
+            num_layers = 7
+        elif args.model_type == "hybrid":
+            num_layers = args.hybrid_num_attn + 5  # 2+5=7 by default
+
+    base_model = HybridGPT(
+        vocab_size=args.vocab_size,
+        num_layers=num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        model_type=args.model_type,
+        trn_K=trn_K,
+        hybrid_num_attn=args.hybrid_num_attn,
+        gate_init=args.gate_init,
+        attn_positions={int(x.strip()) for x in args.attn_positions_str.split(",")} if args.attn_positions_str else None,
+        depth_recurrence=args.depth_recurrence,
+        bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim,
+        use_token_shift=args.use_token_shift,
+        max_seq_len=args.train_seq_len,
+        ortho_init=args.ortho_init,
+        parallel_head_trn=args.parallel_head_trn,
+    ).to(device).bfloat16()
+
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    skip_compile = bool(int(os.environ.get("SKIP_COMPILE", "0")))
+    if skip_compile:
+        compiled_model = base_model
+    elif args.model_type == "transformer":
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True, mode=_compile_mode)
+    else:
+        # dynamic=False: T=1024 fixed at competition time, avoids recompilation overhead.
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=False, mode=_compile_mode)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False, gradient_as_bucket_view=True, bucket_cap_mb=64) if distributed else compiled_model
+
+    # Optimizer split matching train_gpt.py:
+    # matrix_params (2D, not control) -> Muon
+    # scalar_params (1D or control)  -> Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    if hasattr(base_model, "pass_embeds"):
+        for pe in base_model.pass_embeds:
+            scalar_params.append(pe)
+
+    # Zamba shared attention + LoRA params (registered at model level, not in blocks)
+    _shared_attn_matrix: list[Tensor] = []
+    if hasattr(base_model, "shared_attn"):
+        for name, p in base_model.shared_attn.named_parameters():
+            if p.ndim == 2:
+                _shared_attn_matrix.append(p)
+            else:
+                scalar_params.append(p)
+    if hasattr(base_model, "layer_loras"):
+        for name, p in base_model.layer_loras.named_parameters():
+            if p.ndim == 2:
+                matrix_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    # BigramHash params: scale -> scalar, proj -> matrix, embed -> token optimizer
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+        if base_model.bigram.proj is not None:
+            matrix_params.append(base_model.bigram.proj.weight)
+
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_param_list: list[dict] = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_param_list.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+    optimizer_tok = torch.optim.Adam(
+        tok_param_list,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    # Shared attn weights get scaled LR (called N times per step -> gradient N times larger)
+    muon_param_groups: list[dict] = [{"params": matrix_params, "lr": args.matrix_lr}]
+    if _shared_attn_matrix:
+        n_shared_calls = len(base_model.layer_loras) if hasattr(base_model, "layer_loras") else 1
+        shared_lr = args.matrix_lr / max(n_shared_calls, 1)
+        muon_param_groups.append({"params": _shared_attn_matrix, "lr": shared_lr})
+        print(f"[ZAMBA] Shared attn LR = {shared_lr:.6f} (base/{n_shared_calls})", flush=True)
+    optimizer_muon = Muon(
+        muon_param_groups,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.weight_decay,
+    )
+    for group in optimizer_muon.param_groups:
+        group.setdefault("base_lr", group["lr"])
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=0.0,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            weight_decay=0.0,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_type:{args.model_type} num_layers:{num_layers} trn_K:{trn_K} hybrid_num_attn:{args.hybrid_num_attn} ortho_init:{args.ortho_init}")
+    if args.model_type == "parallel" and args.parallel_head_trn > 0:
+        log0(f"staged_hybrid: parallel_head_trn:{args.parallel_head_trn} pure_trn_head:{args.parallel_head_trn} parallel_tail:{num_layers - args.parallel_head_trn}")
+    if args.attn_positions_str:
+        log0(f"attn_positions:{args.attn_positions_str}")
+    # Log layout
+    layout = []
+    for blk in base_model.blocks:
+        if isinstance(blk, ParallelTRNBlock):
+            layout.append("Parallel")
+        elif isinstance(blk, Block):
+            layout.append("Attn")
+        else:
+            layout.append("TRN")
+    log0(f"layout:[{'|'.join(layout)}]")
+    if args.depth_recurrence > 1:
+        log0(f"depth_recurrence:{args.depth_recurrence} effective_trn_depth:{sum(1 for t in base_model.is_trn_block if t) * args.depth_recurrence}")
+    log0(f"model_params:{n_params}")
+    if base_model.bigram is not None:
+        bigram_params = sum(p.numel() for p in base_model.bigram.parameters())
+        log0(f"bigram:vocab={args.bigram_vocab_size} dim={args.bigram_dim} params={bigram_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"weight_decay:{args.weight_decay} (muon only) ema_enabled:{args.ema_enabled} ema_decay:{args.ema_decay} ema_start_frac:{args.ema_start_frac}")
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    ema_state: dict[str, Tensor] | None = None
+    ema_start_step = int(args.ema_start_frac * args.iterations)
+
+    # CPU Pipeline setup
+    _async_quantizer: AsyncQuantizer | None = None
+    if args.cpu_async_export and master_process:
+        _async_quantizer = AsyncQuantizer(zstd_level=args.zstd_level)
+        log0(f"cpu_pipeline:async_export enabled every {args.cpu_async_export_every} steps")
+    _snapshot_swa_states: list[dict[str, Tensor]] = []
+    _snapshot_swa_fracs = [float(f) for f in args.cpu_snapshot_fracs.split(",") if f.strip()]
+    _snapshot_swa_steps = {int(f * args.iterations) for f in _snapshot_swa_fracs} if args.cpu_snapshot_swa else set()
+    if _snapshot_swa_steps:
+        log0(f"cpu_pipeline:snapshot_swa at steps {sorted(_snapshot_swa_steps)}")
+    _ema_executor = None
+    _ema_future = None
+    if args.ema_enabled:
+        from concurrent.futures import ThreadPoolExecutor
+        _ema_executor = ThreadPoolExecutor(max_workers=1)
+    if args.ema_enabled and args.swa_enabled:
+        log0("ema:warning both EMA_ENABLED and SWA_ENABLED set -- EMA takes priority at apply time")
+    qat_hooks: list | None = None
+    qat_active = False
+    strategy1_qat_active = False
+    best_qat_int5_bpb = float("inf")
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            # CPU Pipeline: mini-eval uses reduced val tokens for intermediate evals.
+            # Final eval (last_step) always uses full val set.
+            _mini_frac = args.cpu_mini_eval_frac
+            if not last_step and _mini_frac < 1.0:
+                _mini_n = max(args.train_seq_len * 2, int(len(val_tokens) * _mini_frac))
+                _val_tokens_sub = val_tokens[:_mini_n]
+            else:
+                _val_tokens_sub = val_tokens
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                _val_tokens_sub,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            _mini_label = f" (mini:{_mini_frac:.0%})" if not last_step and _mini_frac < 1.0 else ""
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f}{_mini_label} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+
+        # Late QAT: activate int5 STE (step-based or frac-based)
+        qat_trigger = (
+            (args.int5_qat_start_step > 0 and step >= args.int5_qat_start_step)
+            or (args.int5_qat_start_step == 0 and scale < args.int5_qat_start_frac)
+        )
+        if args.int5_qat and not qat_active and qat_trigger:
+            if args.strategy1:
+                # Strategy 1: bake EMA shadow weights into live model, reset optimizer moments.
+                # This makes live weights equal to EMA's smoothed distribution before QAT starts.
+                # EMA updates are stopped from this point (strategy1_qat_active flag below).
+                if not args.ema_enabled:
+                    raise RuntimeError("STRATEGY1=1 requires EMA_ENABLED=1")
+                if ema_state is None:
+                    raise RuntimeError(
+                        f"STRATEGY1=1: EMA shadow is empty at QAT start (step:{step}). "
+                        f"EMA must begin before QAT trigger. "
+                        f"Set EMA_START_FRAC lower than QAT trigger or use INT5_QAT_START_STEP."
+                    )
+                current_state = base_model.state_dict()
+                baked_state = {
+                    name: tensor.to(dtype=current_state[name].dtype, device=current_state[name].device)
+                    for name, tensor in ema_state.items()
+                }
+                base_model.load_state_dict(baked_state, strict=True)
+                # Reset first/second moments only -- keep param values and lr schedule intact.
+                for opt in optimizers:
+                    for state in opt.state.values():
+                        if "exp_avg" in state:
+                            state["exp_avg"].zero_()
+                        if "exp_avg_sq" in state:
+                            state["exp_avg_sq"].zero_()
+                        if "max_exp_avg_sq" in state:
+                            state["max_exp_avg_sq"].zero_()
+                        if "momentum_buffer" in state:
+                            state["momentum_buffer"].zero_()
+                # Disable weight decay during QAT -- WD shrinks weights toward zero,
+                # conflicting with QAT's quantization bin optimization.
+                for opt in optimizers:
+                    for group in opt.param_groups:
+                        if group.get("weight_decay", 0) > 0:
+                            group["_orig_weight_decay"] = group["weight_decay"]
+                            group["weight_decay"] = 0.0
+                strategy1_qat_active = True
+                # Save pre-QAT checkpoint for rollback.
+                if master_process:
+                    torch.save(base_model.state_dict(), "strategy1_baked_step{}.pt".format(step))
+                log0(f"strategy1:bake_in step:{step} ema_shadow_applied:1 optimizer_moments_reset:1 weight_decay:0.0")
+            # Forward hooks mutate weight.data, which causes graph breaks.
+            # fullgraph=True does not allow graph breaks, so recompile with
+            # fullgraph=False before registering hooks.
+            if not skip_compile:
+                compiled_model = torch.compile(base_model, dynamic=False, fullgraph=False, mode=_compile_mode)
+                model = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False, gradient_as_bucket_view=True, bucket_cap_mb=64) if distributed else compiled_model
+            qat_hooks = apply_int5_ste_hooks(base_model)
+            qat_active = True
+            log0(f"int5_qat:start step:{step} scale:{scale:.4f}")
+
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                lr_scale = scale
+                # Strategy 1: reduce LR to 0.3x during QAT phase for stable bin adaptation.
+                if strategy1_qat_active:
+                    lr_scale = scale * 0.3
+                group["lr"] = group["base_lr"] * lr_scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        # SWA/EMA: update every step during warmdown (decay is per-step)
+        if args.swa_enabled and scale < args.swa_start_frac:
+            decay = args.swa_decay
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"ema:start step:{step} decay:{decay}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    if swa_state[name].is_floating_point():
+                        swa_state[name] = decay * swa_state[name] + (1.0 - decay) * t.detach().cpu()
+                    else:
+                        swa_state[name] = t.detach().cpu()
+                swa_count += 1
+
+        # EMA: per-step update (async CPU when executor available).
+        # Strategy 1: stop EMA once QAT has started (live weights are already baked-in EMA).
+        if args.ema_enabled and step >= ema_start_step and not strategy1_qat_active:
+            ema_decay_val = args.ema_decay
+            if ema_state is None:
+                ema_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                log0(f"ema:start step:{step} decay:{ema_decay_val}")
+            elif _ema_executor is not None:
+                # Async EMA: wait for previous update, then launch new one during next forward
+                if _ema_future is not None:
+                    _ema_future.result()
+                cpu_snap = {name: t.detach().cpu() for name, t in base_model.state_dict().items()}
+                def _ema_update(snap: dict, state: dict, decay: float) -> None:
+                    for name, t in snap.items():
+                        if state[name].is_floating_point():
+                            state[name] = decay * state[name] + (1.0 - decay) * t
+                        else:
+                            state[name] = t
+                _ema_future = _ema_executor.submit(_ema_update, cpu_snap, ema_state, ema_decay_val)
+            else:
+                for name, t in base_model.state_dict().items():
+                    if ema_state[name].is_floating_point():
+                        ema_state[name] = ema_decay_val * ema_state[name] + (1.0 - ema_decay_val) * t.detach().cpu()
+                    else:
+                        ema_state[name] = t.detach().cpu()
+
+        step += 1
+
+        # CPU Pipeline: async export (background int5+zstd quantization)
+        if _async_quantizer is not None and step % args.cpu_async_export_every == 0:
+            cpu_snap = _cpu_state_snapshot(base_model)
+            _async_quantizer.submit(cpu_snap, step)
+
+        # CPU Pipeline: snapshot SWA (save checkpoints at specified fractions)
+        if step in _snapshot_swa_steps:
+            _snapshot_swa_states.append(_cpu_state_snapshot(base_model))
+            log0(f"cpu_pipeline:snapshot_swa saved at step {step} ({len(_snapshot_swa_states)} total)")
+
+        # Strategy 1: every 200 QAT steps, do actual int5 roundtrip eval and save best checkpoint.
+        # Temporarily remove hooks, quantize/dequantize, eval, restore live weights, re-attach hooks.
+        if strategy1_qat_active and step % 200 == 0:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            # Save live fp32 weights before quantizing.
+            live_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+            # Detach QAT hooks so eval uses clean quantized weights (no double-quantization).
+            if qat_hooks is None:
+                raise RuntimeError("strategy1_qat_active but qat_hooks is None -- internal error")
+            for h in qat_hooks:
+                h.remove()
+            qat_hooks.clear()
+            # Full int5 roundtrip: quantize -> dequantize -> load.
+            int5_packed = quantize_state_dict_int5(live_state)
+            int5_state = dequantize_state_dict_int5(int5_packed)
+            base_model.load_state_dict(int5_state, strict=True)
+            torch.cuda.synchronize()
+            t_int5eval = time.perf_counter()
+            int5_val_loss, int5_val_bpb = eval_val(
+                args,
+                base_model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            torch.cuda.synchronize()
+            log0(
+                f"step:{step}/{args.iterations} strategy1_int5_roundtrip "
+                f"val_loss:{int5_val_loss:.4f} val_bpb:{int5_val_bpb:.4f} "
+                f"eval_time:{1000.0 * (time.perf_counter() - t_int5eval):.0f}ms"
+            )
+            if int5_val_bpb < best_qat_int5_bpb:
+                best_qat_int5_bpb = int5_val_bpb
+                if master_process:
+                    torch.save(live_state, "best_qat_int5.pt")
+                log0(f"strategy1_int5_best step:{step} val_bpb:{int5_val_bpb:.4f} path:best_qat_int5.pt")
+            # Restore live fp32 weights and re-attach QAT hooks.
+            base_model.load_state_dict(live_state, strict=True)
+            qat_hooks = apply_int5_ste_hooks(base_model)
+            # Reset timing reference after eval.
+            t0 = time.perf_counter()
+
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Periodic checkpoint
+        if args.ckpt_every > 0 and step > 0 and step % args.ckpt_every == 0 and master_process:
+            ckpt_path = f"ckpt_step{step}.pt"
+            torch.save(base_model.state_dict(), ckpt_path)
+            log0(f"checkpoint:{ckpt_path}")
+
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # Apply EMA if collected (takes priority over SWA).
+    # Strategy 1: skip -- live model already carries baked-in EMA weights adapted by QAT.
+    if strategy1_qat_active:
+        log0(
+            f"strategy1:skip_ema_apply final export uses live QAT weights "
+            f"best_int5_bpb:{best_qat_int5_bpb:.4f}"
+        )
+    elif qat_active and args.ema_enabled and ema_state is not None:
+        # QAT was active but strategy1 was not used -- EMA shadow weights
+        # were never fake-quantized during training, so applying them would
+        # destroy the quantization-friendly distribution learned by STE.
+        # Use the live QAT-trained weights instead.
+        log0("qat:skip_ema_apply -- live QAT weights used (EMA not quantization-aware)")
+    elif args.ema_enabled and ema_state is not None:
+        log0(f"ema:applying decay={args.ema_decay}")
+        current_state = base_model.state_dict()
+        avg_state = {}
+        for name, tensor in ema_state.items():
+            avg_state[name] = tensor.to(dtype=current_state[name].dtype, device=current_state[name].device)
+        base_model.load_state_dict(avg_state)
+    # Apply SWA if collected (skip when QAT was active -- same reason as EMA above)
+    elif args.swa_enabled and swa_state is not None and swa_count > 1 and not qat_active:
+        log0(f"swa:applying decay={args.swa_decay} from {swa_count} updates")
+        current_state = base_model.state_dict()
+        avg_state = {}
+        for name, tensor in swa_state.items():
+            avg_state[name] = tensor.to(dtype=current_state[name].dtype)
+        base_model.load_state_dict(avg_state)
+
+    # CPU Pipeline: wait for async EMA to finish
+    if _ema_future is not None:
+        _ema_future.result()
+
+    # CPU Pipeline: 3-Snapshot Polyak SWA (applied only if EMA/SWA not already applied).
+    # Mutually exclusive with EMA and standard SWA to avoid double-averaging.
+    _ema_or_swa_applied = (
+        (args.ema_enabled and ema_state is not None and not strategy1_qat_active and not qat_active)
+        or (args.swa_enabled and swa_state is not None and swa_count > 1 and not qat_active)
+    )
+    if _snapshot_swa_states and not strategy1_qat_active and not qat_active and not _ema_or_swa_applied:
+        log0(f"cpu_pipeline:snapshot_swa applying Polyak average of {len(_snapshot_swa_states)} snapshots")
+        current_state = base_model.state_dict()
+        n = len(_snapshot_swa_states)
+        avg_state = {}
+        for name in current_state:
+            tensors = [s[name].float() for s in _snapshot_swa_states]
+            avg = sum(tensors) / n
+            avg_state[name] = avg.to(dtype=current_state[name].dtype, device=current_state[name].device)
+        base_model.load_state_dict(avg_state)
+        log0(f"cpu_pipeline:snapshot_swa applied from {n} snapshots")
+
+    # CPU Pipeline: wait for async quantizer and save latest blob
+    if _async_quantizer is not None:
+        _async_quantizer.wait()
+        blob, blob_step = _async_quantizer.get_latest()
+        if blob is not None and master_process:
+            with open("async_best.int5.ptz", "wb") as f:
+                f.write(blob)
+            log0(f"cpu_pipeline:async_export saved {len(blob)} bytes from step {blob_step}")
+
+    # CPU Pipeline: mixed int5/int6 sensitivity analysis (diagnostic only).
+    # TODO: integrate _int6_sensitive_params into quantize_state_dict_int5 for mixed precision.
+    # Currently logs the most quantization-sensitive layers for manual analysis.
+    _int6_sensitive_params: set[str] = set()
+    if args.cpu_mixed_quant and master_process:
+        log0("cpu_pipeline:mixed_quant analyzing quantization sensitivity...")
+        cpu_snap = _cpu_state_snapshot(base_model)
+        _int6_sensitive_params = _compute_quant_sensitivity(cpu_snap, top_n=args.cpu_mixed_quant_top_n)
+        log0(f"cpu_pipeline:mixed_quant int6 candidates (diagnostic): {sorted(_int6_sensitive_params)}")
+
+    # Remove QAT hooks before eval to avoid double-quantization
+    if qat_active:
+        for h in qat_hooks:
+            h.remove()
+        qat_hooks.clear()
+        log0("int5_qat:hooks_removed before final eval")
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    if args.use_zstd:
+        try:
+            import zstandard
+        except ImportError:
+            raise ImportError("USE_ZSTD=1 requires: pip install zstandard")
+        quant_blob = zstandard.ZstdCompressor(level=args.zstd_level).compress(quant_raw)
+        compress_label = f"zstd-{args.zstd_level}"
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+        compress_label = "zlib-9"
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int8+{compress_label}: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    if args.use_zstd:
+        try:
+            import zstandard
+        except ImportError:
+            raise ImportError("USE_ZSTD=1 requires: pip install zstandard")
+        decompressed = zstandard.ZstdDecompressor().decompress(quant_blob_disk)
+    else:
+        decompressed = zlib.decompress(quant_blob_disk)
+    quant_state = torch.load(io.BytesIO(decompressed), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    # Sliding window eval on quantized model
+    if args.eval_stride > 0 and args.eval_stride < args.train_seq_len:
+        log0(f"final_eval_mode:sliding_window stride:{args.eval_stride} batch_seqs:{args.eval_batch_seqs}")
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args, base_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, batch_seqs=args.eval_batch_seqs,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"final_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+
+    # Int5 roundtrip eval (if QAT was used or for size comparison)
+    if args.int5_qat or os.environ.get("INT5_EVAL", "0") == "1":
+        log0("int5_roundtrip: quantizing to int5...")
+        # Reload fresh fp32 weights (int8 roundtrip may have overwritten)
+        base_model.load_state_dict(torch.load("final_model.pt", map_location="cpu"))
+        int5_data = quantize_state_dict_int5(base_model.state_dict())
+        if args.use_lzma:
+            import lzma
+            int5_blob = lzma.compress(int5_data, preset=9)
+            int5_compress_label = "lzma-9"
+        elif args.use_zstd:
+            import zstandard
+            int5_blob = zstandard.ZstdCompressor(level=args.zstd_level).compress(int5_data)
+            int5_compress_label = f"zstd-{args.zstd_level}"
+        else:
+            int5_blob = zlib.compress(int5_data, level=9)
+            int5_compress_label = "zlib-9"
+        if master_process:
+            with open("final_model.int5.ptz", "wb") as f:
+                f.write(int5_blob)
+            int5_file_bytes = os.path.getsize("final_model.int5.ptz")
+            log0(
+                f"Serialized model int5+{int5_compress_label}: {int5_file_bytes} bytes "
+                f"({int5_file_bytes / 1_000_000:.2f} MB)"
+            )
+            log0(f"Total submission size int5: {int5_file_bytes + code_bytes} bytes")
+
+        # Barrier so non-master ranks wait for file write
+        if distributed:
+            dist.barrier()
+
+        # Dequantize and eval
+        with open("final_model.int5.ptz", "rb") as f:
+            int5_blob_disk = f.read()
+        if args.use_lzma:
+            import lzma
+            int5_decompressed = lzma.decompress(int5_blob_disk)
+        elif args.use_zstd:
+            import zstandard
+            int5_decompressed = zstandard.ZstdDecompressor().decompress(int5_blob_disk)
+        else:
+            int5_decompressed = zlib.decompress(int5_blob_disk)
+        int5_state = dequantize_state_dict_int5(int5_decompressed)
+        base_model.load_state_dict(int5_state, strict=True)
+        base_model.to(device)
+        torch.cuda.synchronize()
+        t_int5eval = time.perf_counter()
+        int5_val_loss, int5_val_bpb = eval_val(
+            args, base_model, rank, world_size, device, grad_accum_steps,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int5_roundtrip val_loss:{int5_val_loss:.4f} val_bpb:{int5_val_bpb:.4f} "
+            f"eval_time:{1000.0 * (time.perf_counter() - t_int5eval):.0f}ms"
+        )
+        log0(f"final_int5_roundtrip_exact val_loss:{int5_val_loss:.8f} val_bpb:{int5_val_bpb:.8f}")
+
+    # Dynamic mixed-bit quantization: per-tensor MSE allocation + int8 storage + zstd
+    if args.dynamic_quant:
+        log0("dynamic_quant: computing per-tensor bit allocation...")
+        base_model.load_state_dict(torch.load("final_model.pt", map_location="cpu"))
+        dq_state = base_model.state_dict()
+        target_bytes = int(args.dynamic_quant_target_mb * 1_000_000)
+        bit_alloc = _dynamic_bit_alloc(dq_state, target_bytes=target_bytes)
+
+        # Log allocation summary
+        alloc_counts: dict[int, int] = {}
+        alloc_params: dict[int, int] = {}
+        for name, bits in bit_alloc.items():
+            alloc_counts[bits] = alloc_counts.get(bits, 0) + 1
+            alloc_params[bits] = alloc_params.get(bits, 0) + dq_state[name].numel()
+        for bits in sorted(alloc_counts.keys()):
+            log0(f"  int{bits}: {alloc_counts[bits]} tensors, {alloc_params[bits]:,} params")
+
+        dq_blob = _quantize_dynamic_int8_zstd(dq_state, bit_alloc, zstd_level=args.zstd_level)
+        dq_file_bytes = len(dq_blob)
+
+        # Hard check: if exceeds budget, selectively downgrade lowest-sensitivity tensors
+        if dq_file_bytes > target_bytes:
+            excess = dq_file_bytes - target_bytes
+            log0(f"dynamic_quant: {dq_file_bytes} bytes EXCEEDS {target_bytes} by {excess}. Selective downgrade...")
+            # Rank tensors by sensitivity (MSE at current bits): lowest sensitivity = cheapest to downgrade
+            sorted_opts = sorted({3, 4, 5, 6, 8})
+            downgrade_candidates: list[tuple[float, str]] = []
+            for name in bit_alloc:
+                cur = bit_alloc[name]
+                idx = sorted_opts.index(cur) if cur in sorted_opts else -1
+                if idx <= 0:
+                    continue  # already at min_bits
+                # Sensitivity = MSE increase from downgrading 1 level
+                prev_bits = sorted_opts[idx - 1]
+                t = dq_state[name].float()
+                qmax_cur = (1 << (cur - 1)) - 1
+                qmax_prev = (1 << (prev_bits - 1)) - 1
+                abs_max = t.abs().amax().clamp(min=1e-12)
+                mse_cur = (t - (t / (abs_max / qmax_cur)).round().clamp(-qmax_cur, qmax_cur) * (abs_max / qmax_cur)).pow(2).mean().item()
+                mse_prev = (t - (t / (abs_max / qmax_prev)).round().clamp(-qmax_prev, qmax_prev) * (abs_max / qmax_prev)).pow(2).mean().item()
+                mse_increase = mse_prev - mse_cur  # quality cost of downgrading
+                downgrade_candidates.append((mse_increase, name))
+            # Sort by MSE increase (ascending): downgrade cheapest first
+            downgrade_candidates.sort()
+            for _mse_cost, name in downgrade_candidates:
+                cur = bit_alloc[name]
+                if cur not in sorted_opts:
+                    continue
+                idx = sorted_opts.index(cur)
+                if idx <= 0:
+                    continue
+                bit_alloc[name] = sorted_opts[idx - 1]
+                # Re-quantize and check size
+                dq_blob = _quantize_dynamic_int8_zstd(dq_state, bit_alloc, zstd_level=args.zstd_level)
+                dq_file_bytes = len(dq_blob)
+                if dq_file_bytes <= target_bytes:
+                    log0(f"dynamic_quant: fits after downgrading {name} to int{sorted_opts[idx-1]}: {dq_file_bytes} bytes")
+                    break
+            else:
+                log0(f"dynamic_quant: after full selective downgrade: {dq_file_bytes} bytes ({dq_file_bytes / 1e6:.2f} MB)")
+
+        if master_process:
+            with open("final_model.dynamic.ptz", "wb") as f:
+                f.write(dq_blob)
+            log0(
+                f"Serialized model dynamic+zstd-{args.zstd_level}: {dq_file_bytes} bytes "
+                f"({dq_file_bytes / 1_000_000:.2f} MB) "
+                f"[{'FITS' if dq_file_bytes <= target_bytes else 'EXCEEDS'} {args.dynamic_quant_target_mb}MB]"
+            )
+            if dq_file_bytes > target_bytes:
+                log0(f"[ERROR] dynamic_quant: STILL exceeds {args.dynamic_quant_target_mb}MB after downgrade!")
+
+        if distributed:
+            dist.barrier()
+
+        # Roundtrip eval
+        with open("final_model.dynamic.ptz", "rb") as f:
+            dq_blob_disk = f.read()
+        dq_state_rt = _dequantize_dynamic_int8_zstd(dq_blob_disk)
+        base_model.load_state_dict(dq_state_rt, strict=True)
+        base_model.to(device)
+        torch.cuda.synchronize()
+        t_dqeval = time.perf_counter()
+        dq_val_loss, dq_val_bpb = eval_val(
+            args, base_model, rank, world_size, device, grad_accum_steps,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_dynamic_roundtrip val_loss:{dq_val_loss:.4f} val_bpb:{dq_val_bpb:.4f} "
+            f"eval_time:{1000.0 * (time.perf_counter() - t_dqeval):.0f}ms"
+        )
+        log0(f"final_dynamic_roundtrip_exact val_loss:{dq_val_loss:.8f} val_bpb:{dq_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- 11L hybrid: 1 TRN (oscillatory recurrence) layer at position 0 + 10 standard Transformer layers
- **val_bpb: 1.1915** (sliding window, 3-seed mean, std 0.0008)
- 24.56M params, 15.02 MB dynamic quant, 8x H100 SXM, 600s
- Only oscillatory recurrence submission in Parameter Golf

## Ablation (TRN vs Pure Transformer)

At equal step count (step 7000), TRN leads by 0.031 BPP. But TRN adds 13ms/step (22% overhead), costing ~1700 steps in 600s. Pure Transformer overtakes on final BPP by 0.009 due to more steps.

TRN loses because it is slower, not because it models worse.

## Test plan

- [x] 3 seeds completed (42, 1337, 2024), std 0.0008
- [x] Ablation: pure Transformer comparison (single seed)
- [x] 16MB size compliance (15.02 MB dynamic quant)
- [ ] Training logs lost due to pod termination (results reproducible with provided script + seeds)