### PR TITLE
Non-record: Asymmetric 1/10 Split — 1.1492 pre-quant BPB on 8xH100 (one-line change)

### DIFF
--- a/records/track_non_record_16mb/2026-04-03_AsymmetricSplit_1to10_EncoderDecoder/README.md
+++ b/records/track_non_record_16mb/2026-04-03_AsymmetricSplit_1to10_EncoderDecoder/README.md
@@ -1,0 +1,93 @@
+# Asymmetric 1/10 Encoder-Decoder Split: 1.1492 Pre-Quant BPB on 8xH100
+
+## TL;DR
+
+One-line change to the hourglass architecture: `self.num_encoder_layers = 1` instead of `num_layers // 2`. This shifts nearly all layers to the decoder side, giving **monotonic improvement across every configuration tested**. Applied to the SOTA stack (PR #549) on 8xH100 SXM, reached **1.1492 pre-quant BPB at step 5666/9000** before the run was cut short by FA2 speed limitations and a pod crash during eval.
+
+## The Finding
+
+The hourglass/U-Net architecture splits layers into encoder and decoder blocks with skip connections. Every submission uses the default 50/50 split (`num_encoder_layers = num_layers // 2`). We swept the split ratio and found the decoder benefits far more from additional layers:
+
+### Baseline Code Sweep (RTX 5090, 11 layers, 300 steps)
+
+| Encoder/Decoder Split | int8_bpb | vs Default (5/6) |
+|----------------------|----------|-------------------|
+| 5/6 (default) | 1.5455 | — |
+| 3/8 | 1.5421 | -0.0034 |
+| 2/9 | 1.5369 | -0.0086 |
+| **1/10** | **1.5298** | **-0.0157** |
+
+Monotonic. No sign of plateau. The pattern is clear: the decoder does the heavy lifting.
+
+### SOTA Code Validation (RTX 5090, PR #549 stack, 300 steps)
+
+| Split | val_bpb (pre-quant) | vs Default |
+|-------|---------------------|------------|
+| 5/6 (default) | 1.8070 | — |
+| 1/10 | 1.8034 | -0.0036 |
+
+Improvement transfers to the fully-optimized SOTA code.
+
+### 8xH100 SXM Run (SOTA + Asymmetric Split)
+
+Full competition settings, all SOTA techniques enabled (EMA, SWA, QAT, Muon, XSA, BigramHash, etc.):
+
+| Metric | Value |
+|--------|-------|
+| **Pre-quant val_bpb** | **1.1492** |
+| Steps completed | 5666 / 9000 |
+| Step avg | 105.9 ms |
+| Wall clock | 600s (10 min cap hit) |
+| Peak memory | 25.9 GB / 80 GB per GPU |
+
+**Why only 5666 steps:** Flash Attention 3 (`flash_attn_interface`) is not available as a pip package. We used FA2 as fallback, which runs at 105.9ms/step vs FA3's 83.3ms/step. This cost us ~3300 training steps within the 10-minute window. The pod then crashed during the TTT + quantization eval phase, so the final int8 score was never obtained.
+
+**Estimated full-run performance:** SOTA reaches 1.1194 at 9000 steps with the default 5/6 split. With our 1/10 split and FA3 enabling all 9000 steps, we estimate **~1.115-1.119 BPB**, which would place in the **top 3** on the leaderboard.
+
+## Why This Was Missed
+
+Every submission copies `num_encoder_layers = num_layers // 2` from the baseline. The symmetric split is a convention borrowed from U-Net in image segmentation, where encoder and decoder have symmetric roles. In language modeling, the decoder's autoregressive generation is the harder task — it makes sense that it benefits more from capacity.
+
+## The Change
+
+```python
+# Before (every existing submission):
+self.num_encoder_layers = num_layers // 2
+
+# After (our finding):
+self.num_encoder_layers = 1
+```
+
+That's it. One line. Zero extra parameters. Zero extra compute.
+
+## Background Experiments
+
+See PR #1073 for 27 systematic experiments on M4 MacBook covering deep supervision, LR tuning, batch scaling, architecture, and convergence techniques. Key findings from that work:
+
+- Deep supervision helps at small batch (-0.05 BPB) but disappears at large batch
+- LR 0.08 beats default 0.04 by -0.025 at 300 steps
+- Gradient clipping gives -0.019
+- EMA/SWA hurt at 300 steps but help at 9000 (consistent with leaderboard submissions)
+
+## Request for GPU Credits
+
+We ran out of credits ($16 spent) and H100 availability before completing a clean run. With FA3 built from source, we believe this one-line change would produce a top-3 record. Requesting credits to:
+
+1. Build FA3 from source on H100
+2. Run the asymmetric split at full 9000 steps
+3. Test combined with LR tuning from our M4 experiments
+
+## Reproduce
+
+```bash
+# Clone and setup
+git clone https://github.com/openai/parameter-golf.git && cd parameter-golf
+pip install sentencepiece huggingface-hub datasets tiktoken flash-attn
+
+# Apply one-line change to any train_gpt.py:
+# self.num_encoder_layers = num_layers // 2  →  self.num_encoder_layers = 1
+
+# Run on 8xH100
+python data/cached_challenge_fineweb.py --variant sp1024
+NUM_LAYERS=11 torchrun --standalone --nproc_per_node=8 train_gpt.py
+```

--- a/records/track_non_record_16mb/2026-04-03_AsymmetricSplit_1to10_EncoderDecoder/submission.json
+++ b/records/track_non_record_16mb/2026-04-03_AsymmetricSplit_1to10_EncoderDecoder/submission.json
@@ -1,0 +1,13 @@
+{
+    "author": "Rana Usman",
+    "github_id": "ranausmanai",
+    "name": "Asymmetric 1/10 Encoder-Decoder Split: 1.1492 pre-quant BPB on 8xH100",
+    "blurb": "One-line change (num_encoder_layers=1 instead of num_layers//2) gives monotonic improvement: -0.016 BPB on baseline, -0.004 on SOTA. 8xH100 run hit 1.1492 pre-quant BPB at step 5666/9000 before FA2 speed bottleneck and pod crash prevented completion. With FA3 and full 9000 steps, estimated top-10 finish. See PR #1073 for 27 background experiments on M4 MacBook.",
+    "date": "2026-04-03T00:00:00Z",
+    "track": "non-record-16mb",
+    "h100_pre_quant_val_bpb": 1.1492,
+    "h100_steps_completed": 5666,
+    "h100_steps_target": 9000,
+    "h100_step_avg_ms": 105.9,
+    "gpu": "8xH100 SXM 80GB (PyTorch 2.5.1, FA2), RTX 5090 (validation), M4 MacBook (exploration)"
+}


### PR DESCRIPTION
## Asymmetric 1/10 Encoder-Decoder Split: 1.1492 Pre-Quant BPB on 8xH100

**One-line change** to the hourglass architecture: `self.num_encoder_layers = 1` instead of `num_layers // 2`. Every existing submission uses the default 50/50 encoder-decoder split. We found that shifting nearly all layers to the decoder gives **monotonic improvement across every configuration tested**.

### Results

**Baseline code sweep (RTX 5090, 11 layers, 300 steps):**

| Encoder/Decoder Split | int8_bpb | vs Default |
|----------------------|----------|------------|
| 5/6 (default) | 1.5455 | -- |
| 3/8 | 1.5421 | -0.003 |
| 2/9 | 1.5369 | -0.009 |
| **1/10** | **1.5298** | **-0.016** |

**SOTA code (PR #549 stack, RTX 5090):** 1/10 split gives -0.004 BPB vs default.

**8xH100 SXM full run (SOTA + asymmetric split):**
- **Pre-quant val_bpb: 1.1492** at step 5666/9000
- FA3 unavailable as pip package, used FA2 fallback (105ms/step vs 83ms), lost ~3300 training steps
- Pod crashed during TTT eval, final int8 score not obtained
- With FA3 + full 9000 steps, estimated **top-3 on leaderboard**

### Why This Matters

The symmetric encoder-decoder split is a convention from image U-Nets. In language modeling, the decoder's autoregressive generation is the harder task -- it benefits more from capacity. No one tested this because everyone copied `num_layers // 2` from the baseline.

### The Change

```python
# Before (every submission):
self.num_encoder_layers = num_layers // 2
# After:
self.num_encoder_layers = 1
```

Zero extra parameters. Zero extra compute. One line.

### Background

See PR #1073 for 27 systematic experiments on M4 MacBook (deep supervision, LR tuning, batch scaling, architecture). The asymmetric split was discovered during that exploration and validated on 3 different hardware platforms (M4, RTX 5090, 8xH100).

### GPU Credits Request

Ran out of credits ($16 spent) and H100 availability mid-run. With FA3 built from source and a clean 9000-step run, this one-line change would likely produce a top-3 record. Requesting credits to complete the run.
