### PR TITLE
[Non-record] Scaled Byte-level H-Net matches 4-hour subword-level baseline (H-Net val_bpb = 1.2070)

### DIFF
--- a/records/track_non_record_16mb/2026-04-01_Scaled_HNet_Byte260_and_Sp1024/README.md
+++ b/records/track_non_record_16mb/2026-04-01_Scaled_HNet_Byte260_and_Sp1024/README.md
@@ -1,0 +1,230 @@
+# [Non-record] Scaled Byte-level H-Net matches 4-hour subword-level baseline (H-Net val_bpb = 1.2070)
+
+>**12L H-Net (3 Encoder + 6 Main + 3 Decoder) + byte260 + GQA KV4 + INT6 GPTQ + QAT + zstd-22 + Stride-64 Sliding Eval; val_bpb: 1.2070**
+
+Follow-up to [PR #1104](https://github.com/openai/parameter-golf/pull/1104), which introduced a byte-level H-Net that learns whitespace-aligned, word-like boundaries from raw bytes but reached only 1.36 BPB on a 4 hours run, significantly worse than the competition's 4 hours baseline of 1.20.
+
+This submission closes that gap. By scaling the architecture from 9 layers (2 outer layers x2; Encoder + Decoder) to 12 layers (3 outer layers x2; Encoder + Decoder), adding INT6 GPTQ quantization, quantization-aware training (QAT), sliding window eval, and a `torch.compile` compatible chunking strategy, the H-Net `byte260` model now reaches **1.2070 BPB** in a 4-hour set-up, matching the 4-hour baseline (1.2074) and a comparable `sp1024` H-Net (1.2107).
+
+We also include a detailed comparison of `byte260` vs `sp1024` H-Net, analysis of how the fixed chunking strategy impacts sliding window eval, and results on dynamic chunking at inference.
+
+## Key Results
+
+#### 4 hour runs
+
+| Config | BPB | Steps | Artifact size |
+|--------|-----|------:|--------:|
+| **H-Net `byte260` 12L (3 OLs, KV=4)** | **1.2070** | 153,381 | 15.8 MB |
+| H-Net `sp1024` 11L (3 OLs, KV=4, div=2) | 1.2107 | 84,278 | 14.6 MB |
+|**Baselines**||
+| 4-hour baseline | 1.2074 | 329,430 | 15.8 MB |
+| H-Net `byte260` 9L ([PR #1104](https://github.com/openai/parameter-golf/pull/1104)) | 1.3595 | 85,242 | 16.0 MB |
+
+
+#### 10 min runs
+
+| Config | BPB | Steps | Artifact size |
+|--------|-----|------:|--------:|
+| H-Net `byte260` 12L (3 OLs, KV=4) chunk_size=6 | 1.3123 | 5,957 | 15.2 MB |
+| H-Net `sp1024` 11L (3 OLs, KV=4) chunk_size=6 | 1.2754 | 6,161 | 14.1 MB |
+|**Baselines**||
+| Naive baseline (9L 512dim `sp1024` KV4) | 1.2244 | 13,780 | 15.9 MB |
+| H-Net `byte260` 9L OL2 chunk_size=9 ([PR #1104](https://github.com/openai/parameter-golf/pull/1104)) | 1.4116 | 4,520 | 15.8 MB |
+| H-Net `sp1024` 9L OL2 chunk_size=12 ([PR #1104](https://github.com/openai/parameter-golf/pull/1104)) | 1.3734 | 4,466 | 16.0 MB |
+
+(*OL = Outer Layers, used for H-Net Encoders and Decoders*)
+
+
+- At 10 minutes, `byte260` still has a significant gap compared to `sp1024` (+0.037 BPB). With a 4-hour budget, `byte260` closes the gap entirely, matching both the `sp1024` H-Net (1.2070 `byte260` vs 1.2107 `sp1024`) and the 4-hour baseline (1.2074).
+- The byte H-Net still has clear optimization headroom as val BPB is still decreasing at the 4 hours cutoff. This suggests that part of the remaining gap is due to optimization budget rather than a hard limit of byte-level H-Net.
+
+## Changes compared to [PR #1104](https://github.com/openai/parameter-golf/pull/1104)
+
+| | PR #1104 | This submission (`byte260`) |
+|--|---------|-----------------|
+| **Architecture** | 9L, OL2 (2 encoder + 5 main + 2 decoder) | 12L, OL3 (3 encoder + 6 main + 3 decoder) |
+| **Parameters** | 17.5M | 23.0M |
+| **Quantization** | int8+zlib (no GPTQ) | int6 GPTQ + zstd-22 |
+| **QAT** | None | 85% of warmdown (~21k steps) |
+| **Evaluation** | Full-sequence roundtrip | Sliding window (stride 64) |
+| **Best 4hr BPB** | 1.3595 | **1.2070** |
+
+## Architecture
+
+Same 1-stage H-Net layout as [PR #1104](https://github.com/openai/parameter-golf/pull/1104), scaled up:
+
+```
+Input -> Embedding -> Encoder (3 blocks) -> Routing -> ChunkLayer (L -> C)
+      -> Main Transformer (6 blocks) -> DeChunkLayer (C -> L)
+      -> + Residual Skip -> Decoder (3 blocks) -> LM Head
+```
+
+- **12 layers total**: 3 encoder + 6 main + 3 decoder (OL3)
+- **512 model dim**, 8 heads, 4 KV heads (GQA)
+- **22.97M parameters**, `byte260` tokenizer (vocab=260)
+- **Chunk target size**: 6
+
+## Trade-off: Compile-Chunking
+
+- **Issue**: To take full advantage of `torch.compile`'s speed efficiency, this requires tensor shapes to be fixed at trace time. In the H-Net dynamic chunking variant, the number of chunks varies for every batch, depending on how many boundaries the router predicts. This results in a graph break that prevents compilation, making training 2.6x slower (previously 245ms - in [PR #1104](https://github.com/openai/parameter-golf/pull/1104) - vs the current 93ms per step).
+
+- **One solution**: `torch.compile` requires fixed-size tensors, so we decide to chunk the sequence at `L // CHUNK_DIVISOR` positions, where *L* = sequence length.
+
+  This simple solution comes with some issues:
+
+  -   *Issue 1 - Boundary truncation*: When the router predicts more boundaries than the limit, the first `L // CHUNK_DIVISOR` boundaries are kept and everything past the cap gets merged into one large final chunk. In early training (~first 1k steps), truncation can happen. Since truncated boundaries receive no useful gradient, the router learns to simply predict fewer boundaries rather than learning where to place them. Empirically, we didn't find this to affect the quality of the learned boundaries.
+
+  -   *Issue 2 - Some wasted compute*: When the actual boundary count is below the cap (i.e., later in training), the main transformer processes padded positions. In practice, we found this overhead to be negligible.
+
+  - *Potential improvements*: The truncation issue could be mitigated by (a) setting the cap to `L` (no truncation), though this negates much of the compile speedup due to wasted compute on padded positions (i.e., issue 2), or (b) starting with a larger cap (e.g., `L` or `L // 2`) in early training and reducing it to `L // 4` as the router converges, e.g., by tracking boundary count statistics. Approach (b) requires recompilation of the traced graph at each cap change (which is expensive), so it could only be practical for long runs where the recompilation cost is amortized. Given our compute constraints and the competitive results from the fixed-cap approach, we haven't explored alternatives.
+
+- **Choosing CHUNK_DIVISOR**: In [PR #1104](https://github.com/openai/parameter-golf/pull/1104), we observed that after training, the byte-level model converges to an average chunk size of 4-5 bytes (when chunk_target_size=6).
+
+   > For `L=2048` bytes, that's roughly 410-512 chunks. With `CHUNK_DIVISOR=4` the cap is 2048 // 4 = `512`, which should be enough to capture most of the boundaries. Issue 1 only affects early training: the router produces more boundaries in the beginning, and then converges to a lower average chunk size (after ~1k steps).
+
+
+### 10 min runs
+
+#### `byte260` - `CHUNK_DIVISOR` sweep
+
+All runs: 12L, OL3, 512dim, `byte260`, 8xH100, 10 minutes.
+
+| CHUNK_DIVISOR | Steps | ms/step | Float BPB | Sliding INT6 BPB |
+|-----|------:|--------:|----------:|-----------------:|
+| 2 | 3,155 | 175.9 | 1.3714 | 1.3348 |
+| **4** | **5,957** | **93.2** | **1.3465** | **1.3123** |
+| 6 | 7,219 | 76.9 | 1.3494 | 1.3435 |
+| 8 | 7,957 | 69.8 | 1.3480 | 1.3273 |
+
+As explained above, given our observation from [PR #1104](https://github.com/openai/parameter-golf/pull/1104) that chunks converge to an average of 4-5 bytes, we choose `CHUNK_DIVISOR=4` during training.
+
+## `byte260` vs `sp1024`
+
+### 10 min runs
+
+Comparing the `byte260` H-Net (this submission) against `sp1024` H-Net runs.
+
+| Config | Tokenizer | Params | BPB (sliding INT6) | Steps | ms/step | Artifact size |
+|--------|-----------|-------:|-------------------:|------:|--------:|--------------:|
+| 12L OL3 DIV=4 KV4 | `byte260` | 23.0M | **1.3123** | 5,957 | 93.2 | 15.2 MB |
+| 11L OL3 DIV=4 KV4* | `sp1024` | 21.5M | 1.2754 | 6,161 | 90.0 | 14.1 MB |
+| 11L OL3 DIV=2 KV4* | `sp1024` | 21.5M | 1.2820 | 3,219 | 172.4 | 14.2 MB |
+
+\* For the `sp1024` run, we use 11 layers (11L) instead of 12, as otherwise the `sp1024` model doesn't fit within the 16MB budget.
+
+\* DIV refers to the CHUNK_DIVISOR
+
+> At 10 minutes, `byte260` (1.3123) still has a significant gap compared to `sp1024` (1.2754) - i.e., +0.0369 BPB.
+
+
+### 4 hours runs
+
+| | `byte260` (12L OL3 KV4) | `sp1024` (div=2, 11L OL3 KV4) | `sp1024` (div=4, 11L OL3 KV4) |
+|--|------:|------:|------:|
+| CHUNK_DIVISOR | 4 | 2 | 4 |
+| Params | 23.0M | 21.5M | 21.5M |
+| Pre-QAT BPB | 1.2125 | 1.2120 | 1.1904 |
+| Float Roundtrip BPB | 1.2302 | 1.2163 | 1.2118 |
+| Float Sliding BPB | 1.1980 (−0.032) | 1.1940 (−0.022) | 1.2295 (+0.018) |
+| INT6 Roundtrip BPB | 1.2444 | 1.2338 | 1.2385 |
+| INT6 Sliding BPB | **1.2070** (−0.037) | **1.2107** (−0.023) | 1.2533 (+0.015) |
+| Quant gap (roundtrip) | +0.014 | +0.017 | +0.027 |
+| Steps | 153,381 | 84,278 | 161,364 |
+| ms/step | 93.1 | 169.4 | 88.5 |
+| Artifact size | 15.8 MB | 14.6 MB | 14.8 MB |
+
+> **The `byte260` H-Net is closing the gap to `sp1024`.** At 4 hours, `byte260` reaches 1.2070 vs `sp1024`'s 1.2107 (INT6 sliding), effectively closing the gap with `sp1024` and the baseline (1.2074). Note that these are single runs with shared hyperparameters rather than individually tuned configurations. The key takeaway is that byte-level H-Net can match subword-level performance given sufficient compute.
+
+Some remarks: After pre-QAT, two post-training effects impact the val_bpb:
+
+1. **QAT needs per-model tuning.** We use the same QAT settings for both models (85% threshold, 25k warmdown, ~21k QAT steps). Both spike at QAT onset and only partially recover. Per-model tuning would likely help, but due to compute constraints, we haven't explored this further.
+
+2. **`sp1024` chunk truncation hurts sliding window eval.**
+
+   **The problem:** In the 4-hour table above, sliding window eval helps `byte260` (INT6 sliding 1.2070 vs roundtrip 1.2444, Δ=−0.037) but *hurts* `sp1024` div=4 (INT6 sliding 1.2533 vs roundtrip 1.2385, Δ=+0.015). The question is why?
+
+   **Hypothesis:** With `CHUNK_DIVISOR=4`, boundaries are capped at `seq_len // 4 = 512`. The `sp1024` router predicts ~525 boundaries per sequence - 13 over the cap (based on our collected statistics). These excess boundaries sit at the tail and are effectively silently dropped. Sliding eval (stride=64) only scores the last 64 positions, which is exactly where truncation occurs. Roundtrip eval scores all 2048 positions, so the ~13 'impacted' positions are <1% of the total and barely affect the result.
+
+   We confirmed this hypothesis with boundary stability measurements across 2000 windows, using `CHUNK_DIVISOR=2` and `CHUNK_DIVISOR=4`:
+
+   | | `byte260` (div=4) | `sp1024` (div=2) | `sp1024` (div=4) |
+   |--|------:|------:|------:|
+   | Raw boundaries / seq | 461 | 465 | 525 |
+   | Cap | 512 | 1024 | 512 |
+   | **Truncated** | **No** | **No** | **Yes** |
+   | Boundary flips per window shift | 1.7 | 1.8 | 2.9 |
+   | Float→INT6 boundary flips | 2.6 | 2.5 | 5.4 |
+
+   *Boundary flips =* how many positions change their boundary decision (boundary vs non-boundary) between two overlapping windows (window shift) or between the float and INT6 model on the same input (quant). Some flips are expected since shifting the window changes context, but fewer flips indicate more stable boundaries.
+
+   > Another result that confirms this hypothesis is the switch to dynamic boundaries during inference (see results below).
+
+   **Fix:** With `CHUNK_DIVISOR=2` (cap=1024), `sp1024` is no longer truncated (465 < 1024). Boundary stability matches `byte260` (1.8 vs 1.7 flips), and more importantly, sliding window now helps instead of hurting (INT6 sliding 1.2107 vs roundtrip 1.2338, Δ=−0.023), and the quantization gap drops from +0.027 to +0.017. However, using `CHUNK_DIVISOR=2` will result in wasted compute later in training since the cap is much higher than the average number of boundaries (1024 vs ~465).
+
+
+### Dynamic chunking at inference
+
+During training, we use a fixed boundary cap (`max_chunks = L // CHUNK_DIVISOR`), as explained above.
+
+> **Does switching to a dynamic cap (set per-batch to the actual boundary count) at inference improve results, or has the router adapted to the fixed cap during training?**
+
+To get a sense of this, we evaluate the 4-hour models with dynamic chunking at inference, where `max_chunks` is set per-batch to the actual maximum boundary count, rather than the fixed `L // CHUNK_DIVISOR` used during training.
+
+**Results** for 4 hours runs:
+
+| | `byte260` (div=4) | `sp1024` (div=2) | `sp1024` (div=4) |
+|--|------:|------:|------:|
+| Float Sliding (fixed cap) | 1.1980 | 1.1940 | 1.2295 |
+| Float Sliding (dynamic) | 1.1912 | 1.1940 | 1.1960 |
+| Δ float | −0.007 | 0.000 | −0.034 |
+| INT6 Sliding (fixed cap) | **1.2070** | 1.2107 | 1.2533 |
+| INT6 Sliding (dynamic) | **1.2049** | 1.2107 | 1.2201 |
+| Δ INT6 | −0.002 | 0.000 | −0.033 |
+
+- Dynamic inference improves or matches all models. The biggest gain is `sp1024` div=4 (INT6 sliding: 1.2533 → 1.2201), which also supports the truncation analysis above: the router was predicting correct boundaries, they were just being silently dropped by the fixed cap.
+
+- For `byte260`, the effect is negligible since it wasn't truncated or very rarely truncated. `sp1024` div=2 shows exactly `Δ=0.000`: since it was never truncated (465 < 1024 cap), there's nothing to recover. However, this comes at the cost of wasted compute during training on ~559 padded positions per sequence.
+
+*Note* that `sp1024` div=4 with dynamic inference (1.2201) still trails `sp1024` div=2 (1.2107). Removing the cap at inference restores the dropped boundaries, but can't undo the training-time 'damage' from 161k steps of truncation. This shows that choosing `CHUNK_DIVISOR` carefully is very important.
+
+## Reproduction
+
+```bash
+# Best `byte260` 4-hour run (1.2070 BPB)
+COMPILE_MODEL=1 OUTER_LAYERS=3 NUM_LAYERS=12 MODEL_DIM=512 \
+    TRAIN_SEQ_LEN=2048 MAX_WALLCLOCK_SECONDS=14400 ITERATIONS=500000 \
+    RATIO_LOSS_WEIGHT=0.05 LATE_QAT_THRESHOLD=0.85 WARMDOWN_ITERS=25000 \
+    EMA_DECAY=0 EVAL_STRIDE=64 EVAL_BATCH_SEQS=16 \
+    GPTQ_RESERVE_SECONDS=120 GPTQ_CALIB_BATCHES=512 PRUNE_PCT=0.03 \
+    CHUNK_DIVISOR=4 CHECKPOINT_EVERY=50000 \
+    MODEL_SAVE_PATH=models/byte260_compile_12L_OL3_4hr_qat85.pt \
+    RUN_ID=byte260_compile_12L_OL3_4hr_qat85 \
+    torchrun --standalone --nproc_per_node=8 hnet/train_gpt_hnet_compile_gptq.py
+
+# 10 min equivalent
+COMPILE_MODEL=1 OUTER_LAYERS=3 NUM_LAYERS=12 MODEL_DIM=512 \
+    TRAIN_SEQ_LEN=2048 MAX_WALLCLOCK_SECONDS=600 ITERATIONS=20000 \
+    RATIO_LOSS_WEIGHT=0.05 LATE_QAT_THRESHOLD=0.15 EMA_DECAY=0 \
+    EVAL_STRIDE=64 EVAL_BATCH_SEQS=16 \
+    GPTQ_RESERVE_SECONDS=45 GPTQ_CALIB_BATCHES=256 PRUNE_PCT=0.03 \
+    CHUNK_DIVISOR=4 \
+    MODEL_SAVE_PATH=models/sweep_div4_compile_10min.pt \
+    RUN_ID=sweep_div4_compile_10min \
+    torchrun --standalone --nproc_per_node=8 hnet/train_gpt_hnet_compile_gptq.py
+```
+
+> *Note*: All experiments use `seed=1337`
+
+## Compliance
+
+- [x] Artifact ≤16,000,000 bytes
+- [x] 8×H100 training
+- [x] No training on validation data
+- [x] No network calls during evaluation
+- [x] Non-record: extended run exceeds 10 min wallclock (**153k steps / 4h**)
+
+
+## Credits
+
+- **Paper**: Hwang et al. (2025), [*Dynamic Chunking for End-to-End Hierarchical Sequence Modeling*](https://arxiv.org/abs/2507.07955) - the H-Net architecture this submission implements. Official code: [github.com/goombalab/hnet](https://github.com/goombalab/hnet)
+- PRs including QAT / GPTQ / INT6 quantization / sliding window eval.

--- a/records/track_non_record_16mb/2026-04-01_Scaled_HNet_Byte260_and_Sp1024/logs/byte260_4hrs.log
+++ b/records/track_non_record_16mb/2026-04-01_Scaled_HNet_Byte260_and_Sp1024/logs/byte260_4hrs.log
@@ -1,0 +1,2001 @@
+W0402 02:01:48.361000 235139 torch/distributed/run.py:851]
+W0402 02:01:48.361000 235139 torch/distributed/run.py:851] *****************************************
+W0402 02:01:48.361000 235139 torch/distributed/run.py:851] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed.
+W0402 02:01:48.361000 235139 torch/distributed/run.py:851] *****************************************
+[W402 02:02:04.728974892 Utils.hpp:137] Warning: Environment variable TORCH_NCCL_TRACE_BUFFER_SIZE is deprecated; use TORCH_FR_BUFFER_SIZE instead (function operator())
+[W402 02:02:04.729977931 Utils.hpp:137] Warning: Environment variable TORCH_NCCL_TRACE_BUFFER_SIZE is deprecated; use TORCH_FR_BUFFER_SIZE instead (function operator())
+[W402 02:02:04.730006559 Utils.hpp:137] Warning: Environment variable TORCH_NCCL_TRACE_BUFFER_SIZE is deprecated; use TORCH_FR_BUFFER_SIZE instead (function operator())
+[W402 02:02:04.730341628 Utils.hpp:137] Warning: Environment variable TORCH_NCCL_TRACE_BUFFER_SIZE is deprecated; use TORCH_FR_BUFFER_SIZE instead (function operator())
+[W402 02:02:04.730441030 Utils.hpp:137] Warning: Environment variable TORCH_NCCL_TRACE_BUFFER_SIZE is deprecated; use TORCH_FR_BUFFER_SIZE instead (function operator())
+[W402 02:02:04.730635047 Utils.hpp:137] Warning: Environment variable TORCH_NCCL_TRACE_BUFFER_SIZE is deprecated; use TORCH_FR_BUFFER_SIZE instead (function operator())
+[W402 02:02:04.731340976 Utils.hpp:137] Warning: Environment variable TORCH_NCCL_TRACE_BUFFER_SIZE is deprecated; use TORCH_FR_BUFFER_SIZE instead (function operator())
+[W402 02:02:04.731753234 Utils.hpp:137] Warning: Environment variable TORCH_NCCL_TRACE_BUFFER_SIZE is deprecated; use TORCH_FR_BUFFER_SIZE instead (function operator())
+logs/byte260_compile_12L_OL3_4hr_qat85_gptq_120_2april.txt
+val_bpb:enabled tokenizer_kind=byte vocab_size=260
+train_loader:dataset:fineweb10B_byte260 train_shards:476
+val_loader:shards pattern=./data/datasets/fineweb10B_byte260/fineweb_val_*.bin tokens:151130112
+model_params:22966880
+world_size:8 grad_accum_steps:1
+outer_layers:3 main_layers:6 chunk_divisor:4
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:524288 train_seq_len:2048 iterations:500000 warmup_steps:20 max_wallclock_seconds:14400.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+ema:disabled
+late_qat:will enable when lr_scale < 0.85
+step:0/500000 val_loss:5.3950 val_bpb:7.7859 train_time:0ms step_avg:0.02ms
+step:1/500000 train_loss:5.4707 train_time:91ms step_avg:91.00ms
+step:2/500000 train_loss:5.8382 train_time:175ms step_avg:87.70ms
+step:3/500000 train_loss:6.1293 train_time:269ms step_avg:89.56ms
+step:4/500000 train_loss:6.4580 train_time:360ms step_avg:90.02ms
+step:5/500000 train_loss:4.7920 train_time:454ms step_avg:90.78ms
+step:6/500000 train_loss:4.1938 train_time:546ms step_avg:91.00ms
+step:7/500000 train_loss:4.1064 train_time:640ms step_avg:91.41ms
+step:8/500000 train_loss:3.7861 train_time:734ms step_avg:91.78ms
+step:9/500000 train_loss:3.7311 train_time:826ms step_avg:91.76ms
+step:10/500000 train_loss:3.6588 train_time:919ms step_avg:91.94ms
+step:200/500000 train_loss:1.4921 train_time:18430ms step_avg:92.15ms
+step:400/500000 train_loss:1.2370 train_time:37541ms step_avg:93.85ms
+step:600/500000 train_loss:1.1194 train_time:56654ms step_avg:94.42ms
+step:800/500000 train_loss:1.1945 train_time:74970ms step_avg:93.71ms
+step:1000/500000 train_loss:1.1277 train_time:94267ms step_avg:94.27ms
+step:1200/500000 train_loss:1.1358 train_time:113332ms step_avg:94.44ms
+step:1400/500000 train_loss:1.3242 train_time:132670ms step_avg:94.76ms
+step:1600/500000 train_loss:1.1334 train_time:151711ms step_avg:94.82ms
+step:1800/500000 train_loss:1.1243 train_time:170983ms step_avg:94.99ms
+step:2000/500000 train_loss:1.0456 train_time:189306ms step_avg:94.65ms
+step:2200/500000 train_loss:1.0760 train_time:207850ms step_avg:94.48ms
+step:2400/500000 train_loss:1.1106 train_time:226051ms step_avg:94.19ms
+step:2600/500000 train_loss:0.9904 train_time:244715ms step_avg:94.12ms
+step:2800/500000 train_loss:0.9154 train_time:263139ms step_avg:93.98ms
+step:3000/500000 train_loss:1.0085 train_time:281311ms step_avg:93.77ms
+step:3200/500000 train_loss:1.0539 train_time:299812ms step_avg:93.69ms
+step:3400/500000 train_loss:1.0669 train_time:318655ms step_avg:93.72ms
+step:3600/500000 train_loss:1.0359 train_time:338673ms step_avg:94.08ms
+step:3800/500000 train_loss:1.0171 train_time:357493ms step_avg:94.08ms
+step:4000/500000 train_loss:0.9759 train_time:376173ms step_avg:94.04ms
+step:4200/500000 train_loss:0.9933 train_time:394939ms step_avg:94.03ms
+step:4400/500000 train_loss:1.0347 train_time:413371ms step_avg:93.95ms
+step:4600/500000 train_loss:1.0798 train_time:431598ms step_avg:93.83ms
+step:4800/500000 train_loss:0.9499 train_time:450101ms step_avg:93.77ms
+step:5000/500000 train_loss:0.9857 train_time:468456ms step_avg:93.69ms
+step:5200/500000 train_loss:1.0122 train_time:486841ms step_avg:93.62ms
+step:5400/500000 train_loss:0.9728 train_time:505428ms step_avg:93.60ms
+step:5600/500000 train_loss:0.9388 train_time:524479ms step_avg:93.66ms
+step:5800/500000 train_loss:0.9144 train_time:543833ms step_avg:93.76ms
+step:6000/500000 train_loss:0.9484 train_time:563056ms step_avg:93.84ms
+step:6200/500000 train_loss:0.9774 train_time:581207ms step_avg:93.74ms
+step:6400/500000 train_loss:0.9632 train_time:599648ms step_avg:93.69ms
+step:6600/500000 train_loss:0.9728 train_time:618030ms step_avg:93.64ms
+step:6800/500000 train_loss:0.9824 train_time:636521ms step_avg:93.61ms
+step:7000/500000 train_loss:0.9796 train_time:655043ms step_avg:93.58ms
+step:7200/500000 train_loss:0.9957 train_time:673255ms step_avg:93.51ms
+step:7400/500000 train_loss:1.0254 train_time:691712ms step_avg:93.47ms
+step:7600/500000 train_loss:0.9952 train_time:710173ms step_avg:93.44ms
+step:7800/500000 train_loss:1.0016 train_time:729181ms step_avg:93.48ms
+step:8000/500000 train_loss:0.9596 train_time:748881ms step_avg:93.61ms
+step:8200/500000 train_loss:1.0012 train_time:767957ms step_avg:93.65ms
+step:8400/500000 train_loss:1.0072 train_time:786481ms step_avg:93.63ms
+step:8600/500000 train_loss:0.9784 train_time:805003ms step_avg:93.61ms
+step:8800/500000 train_loss:0.9740 train_time:823135ms step_avg:93.54ms
+step:9000/500000 train_loss:0.9880 train_time:841563ms step_avg:93.51ms
+step:9200/500000 train_loss:0.9055 train_time:859925ms step_avg:93.47ms
+step:9400/500000 train_loss:0.9104 train_time:878144ms step_avg:93.42ms
+step:9600/500000 train_loss:0.9229 train_time:896614ms step_avg:93.40ms
+step:9800/500000 train_loss:0.9617 train_time:915318ms step_avg:93.40ms
+step:10000/500000 train_loss:0.9764 train_time:935283ms step_avg:93.53ms
+step:10000/500000 val_loss:0.9149 val_bpb:1.3204 train_time:935304ms step_avg:93.53ms
+step:10200/500000 train_loss:1.0136 train_time:954349ms step_avg:93.56ms
+step:10400/500000 train_loss:1.0051 train_time:972600ms step_avg:93.52ms
+step:10600/500000 train_loss:0.9058 train_time:990975ms step_avg:93.49ms
+step:10800/500000 train_loss:0.9501 train_time:1009330ms step_avg:93.46ms
+step:11000/500000 train_loss:0.9092 train_time:1027506ms step_avg:93.41ms
+step:11200/500000 train_loss:0.8851 train_time:1045957ms step_avg:93.39ms
+step:11400/500000 train_loss:1.0447 train_time:1064324ms step_avg:93.36ms
+step:11600/500000 train_loss:0.9509 train_time:1082603ms step_avg:93.33ms
+step:11800/500000 train_loss:0.9382 train_time:1100953ms step_avg:93.30ms
+step:12000/500000 train_loss:1.0288 train_time:1119509ms step_avg:93.29ms
+step:12200/500000 train_loss:1.0590 train_time:1139601ms step_avg:93.41ms
+step:12400/500000 train_loss:0.8633 train_time:1158644ms step_avg:93.44ms
+step:12600/500000 train_loss:1.0033 train_time:1176858ms step_avg:93.40ms
+step:12800/500000 train_loss:0.9474 train_time:1195187ms step_avg:93.37ms
+step:13000/500000 train_loss:0.9017 train_time:1213487ms step_avg:93.35ms
+step:13200/500000 train_loss:0.9307 train_time:1231924ms step_avg:93.33ms
+step:13400/500000 train_loss:0.9635 train_time:1250259ms step_avg:93.30ms
+step:13600/500000 train_loss:0.8734 train_time:1268427ms step_avg:93.27ms
+step:13800/500000 train_loss:0.9056 train_time:1286893ms step_avg:93.25ms
+step:14000/500000 train_loss:0.9059 train_time:1305261ms step_avg:93.23ms
+step:14200/500000 train_loss:0.9214 train_time:1324409ms step_avg:93.27ms
+step:14400/500000 train_loss:0.9664 train_time:1344179ms step_avg:93.35ms
+step:14600/500000 train_loss:0.9193 train_time:1363056ms step_avg:93.36ms
+step:14800/500000 train_loss:0.9604 train_time:1381609ms step_avg:93.35ms
+step:15000/500000 train_loss:0.9525 train_time:1400064ms step_avg:93.34ms
+step:15200/500000 train_loss:0.9748 train_time:1418202ms step_avg:93.30ms
+step:15400/500000 train_loss:0.9722 train_time:1436661ms step_avg:93.29ms
+step:15600/500000 train_loss:0.8736 train_time:1455116ms step_avg:93.28ms
+step:15800/500000 train_loss:0.9184 train_time:1473233ms step_avg:93.24ms
+step:16000/500000 train_loss:0.9539 train_time:1491659ms step_avg:93.23ms
+step:16200/500000 train_loss:0.9397 train_time:1509821ms step_avg:93.20ms
+step:16400/500000 train_loss:0.8480 train_time:1529920ms step_avg:93.29ms
+step:16600/500000 train_loss:0.9577 train_time:1549759ms step_avg:93.36ms
+step:16800/500000 train_loss:0.9524 train_time:1568022ms step_avg:93.33ms
+step:17000/500000 train_loss:0.9144 train_time:1586546ms step_avg:93.33ms
+step:17200/500000 train_loss:0.9754 train_time:1604947ms step_avg:93.31ms
+step:17400/500000 train_loss:0.8571 train_time:1623127ms step_avg:93.28ms
+step:17600/500000 train_loss:0.9715 train_time:1641848ms step_avg:93.29ms
+step:17800/500000 train_loss:0.8696 train_time:1660054ms step_avg:93.26ms
+step:18000/500000 train_loss:0.8578 train_time:1678453ms step_avg:93.25ms
+step:18200/500000 train_loss:0.9395 train_time:1696868ms step_avg:93.23ms
+step:18400/500000 train_loss:0.9019 train_time:1715472ms step_avg:93.23ms
+step:18600/500000 train_loss:0.9321 train_time:1735612ms step_avg:93.31ms
+step:18800/500000 train_loss:0.9363 train_time:1754922ms step_avg:93.35ms
+step:19000/500000 train_loss:0.9410 train_time:1773134ms step_avg:93.32ms
+step:19200/500000 train_loss:0.9673 train_time:1791624ms step_avg:93.31ms
+step:19400/500000 train_loss:0.9940 train_time:1809896ms step_avg:93.29ms
+step:19600/500000 train_loss:0.9792 train_time:1828271ms step_avg:93.28ms
+step:19800/500000 train_loss:0.9786 train_time:1846800ms step_avg:93.27ms
+step:20000/500000 train_loss:0.9101 train_time:1864981ms step_avg:93.25ms
+step:20000/500000 val_loss:0.8884 val_bpb:1.2821 train_time:1865003ms step_avg:93.25ms
+step:20200/500000 train_loss:0.9637 train_time:1883522ms step_avg:93.24ms
+step:20400/500000 train_loss:0.9564 train_time:1902052ms step_avg:93.24ms
+step:20600/500000 train_loss:0.9488 train_time:1921239ms step_avg:93.26ms
+step:20800/500000 train_loss:1.0018 train_time:1940859ms step_avg:93.31ms
+step:21000/500000 train_loss:0.9240 train_time:1960120ms step_avg:93.34ms
+step:21200/500000 train_loss:1.0104 train_time:1978443ms step_avg:93.32ms
+step:21400/500000 train_loss:0.8407 train_time:1996802ms step_avg:93.31ms
+step:21600/500000 train_loss:0.9112 train_time:2014945ms step_avg:93.28ms
+step:21800/500000 train_loss:0.8916 train_time:2033344ms step_avg:93.27ms
+step:22000/500000 train_loss:0.9796 train_time:2051694ms step_avg:93.26ms
+step:22200/500000 train_loss:0.9063 train_time:2069851ms step_avg:93.24ms
+step:22400/500000 train_loss:0.8800 train_time:2088265ms step_avg:93.23ms
+step:22600/500000 train_loss:1.0029 train_time:2106440ms step_avg:93.21ms
+step:22800/500000 train_loss:0.9401 train_time:2126509ms step_avg:93.27ms
+step:23000/500000 train_loss:0.8991 train_time:2146147ms step_avg:93.31ms
+step:23200/500000 train_loss:0.9744 train_time:2164396ms step_avg:93.29ms
+step:23400/500000 train_loss:0.8975 train_time:2182858ms step_avg:93.28ms
+step:23600/500000 train_loss:0.9171 train_time:2201605ms step_avg:93.29ms
+step:23800/500000 train_loss:0.9855 train_time:2219813ms step_avg:93.27ms
+step:24000/500000 train_loss:0.9585 train_time:2238247ms step_avg:93.26ms
+step:24200/500000 train_loss:0.8978 train_time:2256380ms step_avg:93.24ms
+step:24400/500000 train_loss:0.9325 train_time:2275075ms step_avg:93.24ms
+step:24600/500000 train_loss:0.8656 train_time:2293510ms step_avg:93.23ms
+step:24800/500000 train_loss:0.9574 train_time:2311819ms step_avg:93.22ms
+step:25000/500000 train_loss:0.8974 train_time:2331675ms step_avg:93.27ms
+step:25200/500000 train_loss:0.9013 train_time:2351463ms step_avg:93.31ms
+step:25400/500000 train_loss:0.9650 train_time:2369680ms step_avg:93.29ms
+step:25600/500000 train_loss:0.9204 train_time:2388154ms step_avg:93.29ms
+step:25800/500000 train_loss:0.8882 train_time:2406366ms step_avg:93.27ms
+step:26000/500000 train_loss:0.9185 train_time:2424727ms step_avg:93.26ms
+step:26200/500000 train_loss:0.8974 train_time:2443178ms step_avg:93.25ms
+step:26400/500000 train_loss:0.7991 train_time:2461356ms step_avg:93.23ms
+step:26600/500000 train_loss:0.8827 train_time:2479766ms step_avg:93.22ms
+step:26800/500000 train_loss:0.9009 train_time:2497922ms step_avg:93.21ms
+step:27000/500000 train_loss:0.8016 train_time:2517205ms step_avg:93.23ms
+step:27200/500000 train_loss:0.9653 train_time:2536988ms step_avg:93.27ms
+step:27400/500000 train_loss:0.9326 train_time:2555666ms step_avg:93.27ms
+step:27600/500000 train_loss:0.8790 train_time:2574132ms step_avg:93.27ms
+step:27800/500000 train_loss:0.9185 train_time:2592473ms step_avg:93.25ms
+step:28000/500000 train_loss:0.9588 train_time:2610664ms step_avg:93.24ms
+step:28200/500000 train_loss:0.9743 train_time:2629079ms step_avg:93.23ms
+step:28400/500000 train_loss:0.8707 train_time:2647361ms step_avg:93.22ms
+step:28600/500000 train_loss:0.8897 train_time:2665728ms step_avg:93.21ms
+step:28800/500000 train_loss:0.9231 train_time:2684113ms step_avg:93.20ms
+step:29000/500000 train_loss:0.8537 train_time:2702484ms step_avg:93.19ms
+step:29200/500000 train_loss:0.9602 train_time:2721665ms step_avg:93.21ms
+step:29400/500000 train_loss:0.9245 train_time:2741343ms step_avg:93.24ms
+step:29600/500000 train_loss:0.9644 train_time:2759938ms step_avg:93.24ms
+step:29800/500000 train_loss:0.9169 train_time:2778371ms step_avg:93.23ms
+step:30000/500000 train_loss:0.8512 train_time:2796511ms step_avg:93.22ms
+step:30000/500000 val_loss:0.8750 val_bpb:1.2628 train_time:2796532ms step_avg:93.22ms
+step:30200/500000 train_loss:0.8902 train_time:2814762ms step_avg:93.20ms
+step:30400/500000 train_loss:1.0666 train_time:2833140ms step_avg:93.20ms
+step:30600/500000 train_loss:0.7969 train_time:2851271ms step_avg:93.18ms
+step:30800/500000 train_loss:0.9510 train_time:2869652ms step_avg:93.17ms
+step:31000/500000 train_loss:0.8856 train_time:2888270ms step_avg:93.17ms
+step:31200/500000 train_loss:0.9226 train_time:2906492ms step_avg:93.16ms
+step:31400/500000 train_loss:0.9228 train_time:2926630ms step_avg:93.20ms
+step:31600/500000 train_loss:0.8921 train_time:2946337ms step_avg:93.24ms
+step:31800/500000 train_loss:0.8541 train_time:2964565ms step_avg:93.23ms
+step:32000/500000 train_loss:1.1194 train_time:2983115ms step_avg:93.22ms
+step:32200/500000 train_loss:0.9257 train_time:3001349ms step_avg:93.21ms
+step:32400/500000 train_loss:0.9001 train_time:3019749ms step_avg:93.20ms
+step:32600/500000 train_loss:0.9370 train_time:3038168ms step_avg:93.20ms
+step:32800/500000 train_loss:0.9268 train_time:3056316ms step_avg:93.18ms
+step:33000/500000 train_loss:0.9494 train_time:3074987ms step_avg:93.18ms
+step:33200/500000 train_loss:0.9265 train_time:3093141ms step_avg:93.17ms
+step:33400/500000 train_loss:0.9153 train_time:3112081ms step_avg:93.18ms
+step:33600/500000 train_loss:0.9069 train_time:3132181ms step_avg:93.22ms
+step:33800/500000 train_loss:0.8995 train_time:3151241ms step_avg:93.23ms
+step:34000/500000 train_loss:0.9207 train_time:3169673ms step_avg:93.23ms
+step:34200/500000 train_loss:0.8763 train_time:3188101ms step_avg:93.22ms
+step:34400/500000 train_loss:0.8484 train_time:3206200ms step_avg:93.20ms
+step:34600/500000 train_loss:0.9550 train_time:3224702ms step_avg:93.20ms
+step:34800/500000 train_loss:0.9618 train_time:3242859ms step_avg:93.19ms
+step:35000/500000 train_loss:0.9317 train_time:3261310ms step_avg:93.18ms
+step:35200/500000 train_loss:0.9289 train_time:3279684ms step_avg:93.17ms
+step:35400/500000 train_loss:0.8875 train_time:3297932ms step_avg:93.16ms
+step:35600/500000 train_loss:0.9080 train_time:3317637ms step_avg:93.19ms
+step:35800/500000 train_loss:0.8772 train_time:3337142ms step_avg:93.22ms
+step:36000/500000 train_loss:1.0079 train_time:3355793ms step_avg:93.22ms
+step:36200/500000 train_loss:0.9476 train_time:3374185ms step_avg:93.21ms
+step:36400/500000 train_loss:0.9459 train_time:3392345ms step_avg:93.20ms
+step:36600/500000 train_loss:0.9560 train_time:3410710ms step_avg:93.19ms
+step:36800/500000 train_loss:0.9798 train_time:3429114ms step_avg:93.18ms
+step:37000/500000 train_loss:0.9516 train_time:3447282ms step_avg:93.17ms
+step:37200/500000 train_loss:0.9333 train_time:3465914ms step_avg:93.17ms
+step:37400/500000 train_loss:0.9434 train_time:3484109ms step_avg:93.16ms
+step:37600/500000 train_loss:0.9991 train_time:3502415ms step_avg:93.15ms
+step:37800/500000 train_loss:0.9050 train_time:3522445ms step_avg:93.19ms
+step:38000/500000 train_loss:0.9059 train_time:3541926ms step_avg:93.21ms
+step:38200/500000 train_loss:0.9826 train_time:3560554ms step_avg:93.21ms
+step:38400/500000 train_loss:0.8973 train_time:3578917ms step_avg:93.20ms
+step:38600/500000 train_loss:0.8890 train_time:3597159ms step_avg:93.19ms
+step:38800/500000 train_loss:0.9621 train_time:3615593ms step_avg:93.19ms
+step:39000/500000 train_loss:0.9516 train_time:3633864ms step_avg:93.18ms
+step:39200/500000 train_loss:0.9720 train_time:3652337ms step_avg:93.17ms
+step:39400/500000 train_loss:0.8962 train_time:3670966ms step_avg:93.17ms
+step:39600/500000 train_loss:0.9070 train_time:3689111ms step_avg:93.16ms
+step:39800/500000 train_loss:0.9131 train_time:3707882ms step_avg:93.16ms
+step:40000/500000 train_loss:0.9677 train_time:3727929ms step_avg:93.20ms
+step:40000/500000 val_loss:0.8656 val_bpb:1.2492 train_time:3727950ms step_avg:93.20ms
+step:40200/500000 train_loss:0.9292 train_time:3746943ms step_avg:93.21ms
+step:40400/500000 train_loss:0.9182 train_time:3765394ms step_avg:93.20ms
+step:40600/500000 train_loss:1.0334 train_time:3783795ms step_avg:93.20ms
+step:40800/500000 train_loss:0.8485 train_time:3801963ms step_avg:93.19ms
+step:41000/500000 train_loss:0.8960 train_time:3820354ms step_avg:93.18ms
+step:41200/500000 train_loss:0.9149 train_time:3838695ms step_avg:93.17ms
+step:41400/500000 train_loss:0.8809 train_time:3857072ms step_avg:93.17ms
+step:41600/500000 train_loss:0.8015 train_time:3875408ms step_avg:93.16ms
+step:41800/500000 train_loss:0.8549 train_time:3893589ms step_avg:93.15ms
+step:42000/500000 train_loss:0.9770 train_time:3912476ms step_avg:93.15ms
+step:42200/500000 train_loss:0.8809 train_time:3932092ms step_avg:93.18ms
+step:42400/500000 train_loss:0.9155 train_time:3950748ms step_avg:93.18ms
+step:42600/500000 train_loss:0.9942 train_time:3969233ms step_avg:93.17ms
+step:42800/500000 train_loss:1.2681 train_time:3987377ms step_avg:93.16ms
+step:43000/500000 train_loss:0.9522 train_time:4005730ms step_avg:93.16ms
+step:43200/500000 train_loss:0.9392 train_time:4024305ms step_avg:93.16ms
+step:43400/500000 train_loss:0.8458 train_time:4042486ms step_avg:93.14ms
+step:43600/500000 train_loss:0.8995 train_time:4060914ms step_avg:93.14ms
+step:43800/500000 train_loss:0.8148 train_time:4079174ms step_avg:93.13ms
+step:44000/500000 train_loss:0.9790 train_time:4097750ms step_avg:93.13ms
+step:44200/500000 train_loss:0.9189 train_time:4118255ms step_avg:93.17ms
+step:44400/500000 train_loss:0.8832 train_time:4137388ms step_avg:93.18ms
+step:44600/500000 train_loss:0.8687 train_time:4155903ms step_avg:93.18ms
+step:44800/500000 train_loss:0.9476 train_time:4174285ms step_avg:93.18ms
+step:45000/500000 train_loss:0.8941 train_time:4192573ms step_avg:93.17ms
+step:45200/500000 train_loss:0.8711 train_time:4211061ms step_avg:93.17ms
+step:45400/500000 train_loss:0.9292 train_time:4229374ms step_avg:93.16ms
+step:45600/500000 train_loss:0.9008 train_time:4247760ms step_avg:93.15ms
+step:45800/500000 train_loss:0.9762 train_time:4266177ms step_avg:93.15ms
+step:46000/500000 train_loss:0.7978 train_time:4284354ms step_avg:93.14ms
+step:46200/500000 train_loss:0.8854 train_time:4302792ms step_avg:93.13ms
+step:46400/500000 train_loss:0.9072 train_time:4322462ms step_avg:93.16ms
+step:46600/500000 train_loss:0.9444 train_time:4341604ms step_avg:93.17ms
+step:46800/500000 train_loss:0.7754 train_time:4360107ms step_avg:93.16ms
+step:47000/500000 train_loss:0.9090 train_time:4378357ms step_avg:93.16ms
+step:47200/500000 train_loss:1.3480 train_time:4396847ms step_avg:93.15ms
+step:47400/500000 train_loss:0.9517 train_time:4415283ms step_avg:93.15ms
+step:47600/500000 train_loss:0.9439 train_time:4433495ms step_avg:93.14ms
+step:47800/500000 train_loss:0.9820 train_time:4451817ms step_avg:93.13ms
+step:48000/500000 train_loss:0.8999 train_time:4470000ms step_avg:93.12ms
+step:48200/500000 train_loss:0.9453 train_time:4488419ms step_avg:93.12ms
+step:48400/500000 train_loss:0.9758 train_time:4507184ms step_avg:93.12ms
+step:48600/500000 train_loss:0.9096 train_time:4527038ms step_avg:93.15ms
+step:48800/500000 train_loss:1.0319 train_time:4546237ms step_avg:93.16ms
+step:49000/500000 train_loss:0.8900 train_time:4564693ms step_avg:93.16ms
+step:49200/500000 train_loss:0.8963 train_time:4582807ms step_avg:93.15ms
+step:49400/500000 train_loss:0.9086 train_time:4601583ms step_avg:93.15ms
+step:49600/500000 train_loss:0.9163 train_time:4619784ms step_avg:93.14ms
+step:49800/500000 train_loss:0.8849 train_time:4638111ms step_avg:93.13ms
+step:50000/500000 train_loss:0.9125 train_time:4656445ms step_avg:93.13ms
+step:50000/500000 val_loss:0.8598 val_bpb:1.2408 train_time:4656469ms step_avg:93.13ms
+step:50200/500000 train_loss:0.9371 train_time:4674639ms step_avg:93.12ms
+step:50400/500000 train_loss:0.9027 train_time:4693104ms step_avg:93.12ms
+step:50600/500000 train_loss:1.0174 train_time:4712616ms step_avg:93.13ms
+step:50800/500000 train_loss:0.9137 train_time:4731672ms step_avg:93.14ms
+step:51000/500000 train_loss:0.8843 train_time:4750643ms step_avg:93.15ms
+step:51200/500000 train_loss:0.9057 train_time:4768968ms step_avg:93.14ms
+step:51400/500000 train_loss:0.8713 train_time:4787154ms step_avg:93.14ms
+step:51600/500000 train_loss:0.8741 train_time:4805495ms step_avg:93.13ms
+step:51800/500000 train_loss:0.8957 train_time:4823665ms step_avg:93.12ms
+step:52000/500000 train_loss:0.9577 train_time:4842099ms step_avg:93.12ms
+step:52200/500000 train_loss:0.9239 train_time:4860456ms step_avg:93.11ms
+step:52400/500000 train_loss:0.9532 train_time:4878644ms step_avg:93.10ms
+step:52600/500000 train_loss:0.8867 train_time:4897032ms step_avg:93.10ms
+step:52800/500000 train_loss:0.8645 train_time:4917431ms step_avg:93.13ms
+step:53000/500000 train_loss:0.8890 train_time:4936470ms step_avg:93.14ms
+step:53200/500000 train_loss:0.9593 train_time:4954923ms step_avg:93.14ms
+step:53400/500000 train_loss:0.8703 train_time:4973232ms step_avg:93.13ms
+step:53600/500000 train_loss:0.9052 train_time:4992030ms step_avg:93.13ms
+step:53800/500000 train_loss:0.8517 train_time:5010469ms step_avg:93.13ms
+step:54000/500000 train_loss:0.8612 train_time:5028700ms step_avg:93.12ms
+step:54200/500000 train_loss:0.9275 train_time:5047052ms step_avg:93.12ms
+step:54400/500000 train_loss:0.8667 train_time:5065271ms step_avg:93.11ms
+step:54600/500000 train_loss:1.0107 train_time:5083745ms step_avg:93.11ms
+step:54800/500000 train_loss:0.9132 train_time:5102741ms step_avg:93.12ms
+step:55000/500000 train_loss:0.9186 train_time:5122606ms step_avg:93.14ms
+step:55200/500000 train_loss:0.8188 train_time:5141857ms step_avg:93.15ms
+step:55400/500000 train_loss:0.9143 train_time:5160330ms step_avg:93.15ms
+step:55600/500000 train_loss:0.8622 train_time:5178450ms step_avg:93.14ms
+step:55800/500000 train_loss:0.8314 train_time:5196831ms step_avg:93.13ms
+step:56000/500000 train_loss:0.8815 train_time:5215110ms step_avg:93.13ms
+step:56200/500000 train_loss:0.8657 train_time:5233472ms step_avg:93.12ms
+step:56400/500000 train_loss:0.8938 train_time:5251933ms step_avg:93.12ms
+step:56600/500000 train_loss:0.8761 train_time:5270149ms step_avg:93.11ms
+step:56800/500000 train_loss:0.9170 train_time:5288541ms step_avg:93.11ms
+step:57000/500000 train_loss:0.8858 train_time:5308627ms step_avg:93.13ms
+step:57200/500000 train_loss:0.8311 train_time:5327716ms step_avg:93.14ms
+step:57400/500000 train_loss:1.0337 train_time:5346617ms step_avg:93.15ms
+step:57600/500000 train_loss:0.9143 train_time:5364789ms step_avg:93.14ms
+step:57800/500000 train_loss:0.8459 train_time:5383492ms step_avg:93.14ms
+step:58000/500000 train_loss:0.8830 train_time:5401932ms step_avg:93.14ms
+step:58200/500000 train_loss:0.8057 train_time:5420099ms step_avg:93.13ms
+step:58400/500000 train_loss:0.9057 train_time:5438494ms step_avg:93.12ms
+step:58600/500000 train_loss:1.0758 train_time:5456965ms step_avg:93.12ms
+step:58800/500000 train_loss:0.8391 train_time:5475092ms step_avg:93.11ms
+step:59000/500000 train_loss:1.0262 train_time:5493492ms step_avg:93.11ms
+step:59200/500000 train_loss:0.9234 train_time:5513306ms step_avg:93.13ms
+step:59400/500000 train_loss:0.8761 train_time:5532459ms step_avg:93.14ms
+step:59600/500000 train_loss:0.8939 train_time:5551534ms step_avg:93.15ms
+step:59800/500000 train_loss:0.8940 train_time:5569750ms step_avg:93.14ms
+step:60000/500000 train_loss:1.0463 train_time:5588205ms step_avg:93.14ms
+step:60000/500000 val_loss:0.8567 val_bpb:1.2364 train_time:5588226ms step_avg:93.14ms
+step:60200/500000 train_loss:0.8508 train_time:5606649ms step_avg:93.13ms
+step:60400/500000 train_loss:0.8837 train_time:5624805ms step_avg:93.13ms
+step:60600/500000 train_loss:1.2200 train_time:5643462ms step_avg:93.13ms
+step:60800/500000 train_loss:0.9086 train_time:5661613ms step_avg:93.12ms
+step:61000/500000 train_loss:0.8484 train_time:5680061ms step_avg:93.12ms
+step:61200/500000 train_loss:0.9358 train_time:5699595ms step_avg:93.13ms
+step:61400/500000 train_loss:1.0205 train_time:5718951ms step_avg:93.14ms
+step:61600/500000 train_loss:0.9139 train_time:5738624ms step_avg:93.16ms
+step:61800/500000 train_loss:0.8326 train_time:5757430ms step_avg:93.16ms
+step:62000/500000 train_loss:0.9129 train_time:5775559ms step_avg:93.15ms
+step:62200/500000 train_loss:0.8683 train_time:5793917ms step_avg:93.15ms
+step:62400/500000 train_loss:0.8965 train_time:5812328ms step_avg:93.15ms
+step:62600/500000 train_loss:1.0742 train_time:5830538ms step_avg:93.14ms
+step:62800/500000 train_loss:0.8567 train_time:5849005ms step_avg:93.14ms
+step:63000/500000 train_loss:0.8317 train_time:5867248ms step_avg:93.13ms
+step:63200/500000 train_loss:0.8495 train_time:5885756ms step_avg:93.13ms
+step:63400/500000 train_loss:0.8585 train_time:5905093ms step_avg:93.14ms
+step:63600/500000 train_loss:0.8741 train_time:5924690ms step_avg:93.16ms
+step:63800/500000 train_loss:0.8623 train_time:5943588ms step_avg:93.16ms
+step:64000/500000 train_loss:0.9306 train_time:5961781ms step_avg:93.15ms
+step:64200/500000 train_loss:0.9809 train_time:5980208ms step_avg:93.15ms
+step:64400/500000 train_loss:0.9477 train_time:5998676ms step_avg:93.15ms
+step:64600/500000 train_loss:0.9216 train_time:6016846ms step_avg:93.14ms
+step:64800/500000 train_loss:1.0239 train_time:6035239ms step_avg:93.14ms
+step:65000/500000 train_loss:0.9138 train_time:6053665ms step_avg:93.13ms
+step:65200/500000 train_loss:0.9199 train_time:6071824ms step_avg:93.13ms
+step:65400/500000 train_loss:0.9260 train_time:6090254ms step_avg:93.12ms
+step:65600/500000 train_loss:1.0365 train_time:6110058ms step_avg:93.14ms
+step:65800/500000 train_loss:1.1548 train_time:6129212ms step_avg:93.15ms
+step:66000/500000 train_loss:0.8494 train_time:6148317ms step_avg:93.16ms
+step:66200/500000 train_loss:0.9065 train_time:6166560ms step_avg:93.15ms
+step:66400/500000 train_loss:0.8210 train_time:6184944ms step_avg:93.15ms
+step:66600/500000 train_loss:0.8431 train_time:6203439ms step_avg:93.14ms
+step:66800/500000 train_loss:0.9818 train_time:6221629ms step_avg:93.14ms
+step:67000/500000 train_loss:0.9239 train_time:6240010ms step_avg:93.13ms
+step:67200/500000 train_loss:0.8302 train_time:6258150ms step_avg:93.13ms
+step:67400/500000 train_loss:0.9006 train_time:6276589ms step_avg:93.12ms
+step:67600/500000 train_loss:0.8887 train_time:6295825ms step_avg:93.13ms
+step:67800/500000 train_loss:0.9085 train_time:6315241ms step_avg:93.15ms
+step:68000/500000 train_loss:0.8968 train_time:6334090ms step_avg:93.15ms
+step:68200/500000 train_loss:0.9130 train_time:6353039ms step_avg:93.15ms
+step:68400/500000 train_loss:0.8554 train_time:6371218ms step_avg:93.15ms
+step:68600/500000 train_loss:0.8544 train_time:6389528ms step_avg:93.14ms
+step:68800/500000 train_loss:0.8774 train_time:6407742ms step_avg:93.14ms
+step:69000/500000 train_loss:0.9123 train_time:6426124ms step_avg:93.13ms
+step:69200/500000 train_loss:0.8960 train_time:6444453ms step_avg:93.13ms
+step:69400/500000 train_loss:0.9253 train_time:6462599ms step_avg:93.12ms
+step:69600/500000 train_loss:0.8809 train_time:6481020ms step_avg:93.12ms
+step:69800/500000 train_loss:0.9420 train_time:6500367ms step_avg:93.13ms
+step:70000/500000 train_loss:0.9124 train_time:6519666ms step_avg:93.14ms
+step:70000/500000 val_loss:0.8526 val_bpb:1.2304 train_time:6519688ms step_avg:93.14ms
+step:70200/500000 train_loss:0.9098 train_time:6539023ms step_avg:93.15ms
+step:70400/500000 train_loss:0.8804 train_time:6557220ms step_avg:93.14ms
+step:70600/500000 train_loss:0.8464 train_time:6575609ms step_avg:93.14ms
+step:70800/500000 train_loss:0.8994 train_time:6594010ms step_avg:93.14ms
+step:71000/500000 train_loss:0.9021 train_time:6612266ms step_avg:93.13ms
+step:71200/500000 train_loss:0.9345 train_time:6630724ms step_avg:93.13ms
+step:71400/500000 train_loss:0.8523 train_time:6649132ms step_avg:93.13ms
+step:71600/500000 train_loss:0.8466 train_time:6667307ms step_avg:93.12ms
+step:71800/500000 train_loss:0.8758 train_time:6685612ms step_avg:93.11ms
+step:72000/500000 train_loss:0.8549 train_time:6705535ms step_avg:93.13ms
+step:72200/500000 train_loss:0.8120 train_time:6724740ms step_avg:93.14ms
+step:72400/500000 train_loss:0.9164 train_time:6743841ms step_avg:93.15ms
+step:72600/500000 train_loss:0.9204 train_time:6762116ms step_avg:93.14ms
+step:72800/500000 train_loss:0.8253 train_time:6780458ms step_avg:93.14ms
+step:73000/500000 train_loss:0.8968 train_time:6798940ms step_avg:93.14ms
+step:73200/500000 train_loss:0.8657 train_time:6817154ms step_avg:93.13ms
+step:73400/500000 train_loss:0.9168 train_time:6835516ms step_avg:93.13ms
+step:73600/500000 train_loss:0.9449 train_time:6853711ms step_avg:93.12ms
+step:73800/500000 train_loss:0.8315 train_time:6872116ms step_avg:93.12ms
+step:74000/500000 train_loss:0.9208 train_time:6891471ms step_avg:93.13ms
+step:74200/500000 train_loss:0.8539 train_time:6910597ms step_avg:93.13ms
+step:74400/500000 train_loss:0.9307 train_time:6930034ms step_avg:93.15ms
+step:74600/500000 train_loss:0.9225 train_time:6949123ms step_avg:93.15ms
+step:74800/500000 train_loss:0.9780 train_time:6967260ms step_avg:93.15ms
+step:75000/500000 train_loss:0.9534 train_time:6985635ms step_avg:93.14ms
+step:75200/500000 train_loss:0.9287 train_time:7003818ms step_avg:93.14ms
+step:75400/500000 train_loss:0.8665 train_time:7022288ms step_avg:93.13ms
+step:75600/500000 train_loss:0.9988 train_time:7040770ms step_avg:93.13ms
+step:75800/500000 train_loss:0.9770 train_time:7058972ms step_avg:93.13ms
+step:76000/500000 train_loss:0.9629 train_time:7077366ms step_avg:93.12ms
+step:76200/500000 train_loss:0.9386 train_time:7096776ms step_avg:93.13ms
+step:76400/500000 train_loss:0.8257 train_time:7116142ms step_avg:93.14ms
+step:76600/500000 train_loss:0.8693 train_time:7134936ms step_avg:93.15ms
+step:76800/500000 train_loss:1.0731 train_time:7153636ms step_avg:93.15ms
+step:77000/500000 train_loss:1.0028 train_time:7172084ms step_avg:93.14ms
+step:77200/500000 train_loss:0.9502 train_time:7190721ms step_avg:93.14ms
+step:77400/500000 train_loss:0.8657 train_time:7208859ms step_avg:93.14ms
+step:77600/500000 train_loss:0.9391 train_time:7227251ms step_avg:93.13ms
+step:77800/500000 train_loss:0.9324 train_time:7245468ms step_avg:93.13ms
+step:78000/500000 train_loss:0.9193 train_time:7263806ms step_avg:93.13ms
+step:78200/500000 train_loss:0.8315 train_time:7282745ms step_avg:93.13ms
+step:78400/500000 train_loss:0.9203 train_time:7302308ms step_avg:93.14ms
+step:78600/500000 train_loss:0.8814 train_time:7321622ms step_avg:93.15ms
+step:78800/500000 train_loss:0.9117 train_time:7340597ms step_avg:93.15ms
+step:79000/500000 train_loss:0.9635 train_time:7358791ms step_avg:93.15ms
+step:79200/500000 train_loss:0.9501 train_time:7377247ms step_avg:93.15ms
+step:79400/500000 train_loss:0.9118 train_time:7395337ms step_avg:93.14ms
+step:79600/500000 train_loss:0.9322 train_time:7413852ms step_avg:93.14ms
+step:79800/500000 train_loss:0.9071 train_time:7432293ms step_avg:93.14ms
+step:80000/500000 train_loss:0.9132 train_time:7450452ms step_avg:93.13ms
+step:80000/500000 val_loss:0.8490 val_bpb:1.2252 train_time:7450473ms step_avg:93.13ms
+step:80200/500000 train_loss:0.9114 train_time:7468880ms step_avg:93.13ms
+step:80400/500000 train_loss:0.8950 train_time:7487706ms step_avg:93.13ms
+step:80600/500000 train_loss:0.8931 train_time:7507077ms step_avg:93.14ms
+step:80800/500000 train_loss:0.9463 train_time:7525865ms step_avg:93.14ms
+step:81000/500000 train_loss:0.8915 train_time:7544910ms step_avg:93.15ms
+step:81200/500000 train_loss:0.9432 train_time:7563078ms step_avg:93.14ms
+step:81400/500000 train_loss:0.8800 train_time:7581565ms step_avg:93.14ms
+step:81600/500000 train_loss:0.7996 train_time:7599790ms step_avg:93.13ms
+step:81800/500000 train_loss:0.8262 train_time:7618154ms step_avg:93.13ms
+step:82000/500000 train_loss:0.8652 train_time:7636501ms step_avg:93.13ms
+step:82200/500000 train_loss:0.9617 train_time:7654723ms step_avg:93.12ms
+step:82400/500000 train_loss:0.8405 train_time:7673335ms step_avg:93.12ms
+step:82600/500000 train_loss:0.9045 train_time:7692251ms step_avg:93.13ms
+step:82800/500000 train_loss:0.8767 train_time:7711509ms step_avg:93.13ms
+step:83000/500000 train_loss:0.9188 train_time:7730676ms step_avg:93.14ms
+step:83200/500000 train_loss:0.9337 train_time:7749385ms step_avg:93.14ms
+step:83400/500000 train_loss:0.8735 train_time:7767733ms step_avg:93.14ms
+step:83600/500000 train_loss:0.8184 train_time:7786225ms step_avg:93.14ms
+step:83800/500000 train_loss:0.9180 train_time:7804400ms step_avg:93.13ms
+step:84000/500000 train_loss:0.9060 train_time:7822831ms step_avg:93.13ms
+step:84200/500000 train_loss:0.9972 train_time:7840987ms step_avg:93.12ms
+step:84400/500000 train_loss:1.0239 train_time:7859396ms step_avg:93.12ms
+step:84600/500000 train_loss:0.8671 train_time:7878173ms step_avg:93.12ms
+step:84800/500000 train_loss:0.9093 train_time:7897561ms step_avg:93.13ms
+step:85000/500000 train_loss:0.9727 train_time:7916789ms step_avg:93.14ms
+step:85200/500000 train_loss:0.8674 train_time:7935265ms step_avg:93.14ms
+step:85400/500000 train_loss:0.8379 train_time:7953860ms step_avg:93.14ms
+step:85600/500000 train_loss:0.8477 train_time:7972253ms step_avg:93.13ms
+step:85800/500000 train_loss:0.8729 train_time:7990441ms step_avg:93.13ms
+step:86000/500000 train_loss:0.9136 train_time:8008755ms step_avg:93.13ms
+step:86200/500000 train_loss:0.8884 train_time:8027168ms step_avg:93.12ms
+step:86400/500000 train_loss:0.8971 train_time:8045319ms step_avg:93.12ms
+step:86600/500000 train_loss:0.8792 train_time:8063877ms step_avg:93.12ms
+step:86800/500000 train_loss:0.9327 train_time:8082508ms step_avg:93.12ms
+step:87000/500000 train_loss:0.9450 train_time:8102049ms step_avg:93.13ms
+step:87200/500000 train_loss:0.8781 train_time:8121212ms step_avg:93.13ms
+step:87400/500000 train_loss:0.9249 train_time:8139921ms step_avg:93.13ms
+step:87600/500000 train_loss:0.8834 train_time:8158288ms step_avg:93.13ms
+step:87800/500000 train_loss:0.8902 train_time:8176681ms step_avg:93.13ms
+step:88000/500000 train_loss:0.9238 train_time:8194863ms step_avg:93.12ms
+step:88200/500000 train_loss:0.8509 train_time:8213252ms step_avg:93.12ms
+step:88400/500000 train_loss:0.8646 train_time:8231436ms step_avg:93.12ms
+step:88600/500000 train_loss:0.8785 train_time:8250049ms step_avg:93.12ms
+step:88800/500000 train_loss:0.8639 train_time:8268447ms step_avg:93.11ms
+step:89000/500000 train_loss:0.9267 train_time:8287404ms step_avg:93.12ms
+step:89200/500000 train_loss:0.8439 train_time:8306602ms step_avg:93.12ms
+step:89400/500000 train_loss:0.8801 train_time:8325815ms step_avg:93.13ms
+step:89600/500000 train_loss:0.8575 train_time:8344395ms step_avg:93.13ms
+step:89800/500000 train_loss:0.8809 train_time:8362761ms step_avg:93.13ms
+step:90000/500000 train_loss:0.8878 train_time:8381028ms step_avg:93.12ms
+step:90000/500000 val_loss:0.8460 val_bpb:1.2209 train_time:8381049ms step_avg:93.12ms
+step:90200/500000 train_loss:0.9068 train_time:8399256ms step_avg:93.12ms
+step:90400/500000 train_loss:0.8162 train_time:8417906ms step_avg:93.12ms
+step:90600/500000 train_loss:0.9347 train_time:8436212ms step_avg:93.11ms
+step:90800/500000 train_loss:0.9195 train_time:8454520ms step_avg:93.11ms
+step:91000/500000 train_loss:0.9405 train_time:8473143ms step_avg:93.11ms
+step:91200/500000 train_loss:0.9029 train_time:8492513ms step_avg:93.12ms
+step:91400/500000 train_loss:0.9069 train_time:8511471ms step_avg:93.12ms
+step:91600/500000 train_loss:0.9354 train_time:8530331ms step_avg:93.13ms
+step:91800/500000 train_loss:0.8768 train_time:8548947ms step_avg:93.13ms
+step:92000/500000 train_loss:0.8941 train_time:8567504ms step_avg:93.13ms
+step:92200/500000 train_loss:0.8863 train_time:8585721ms step_avg:93.12ms
+step:92400/500000 train_loss:0.8996 train_time:8604049ms step_avg:93.12ms
+step:92600/500000 train_loss:0.9083 train_time:8622771ms step_avg:93.12ms
+step:92800/500000 train_loss:0.8202 train_time:8640897ms step_avg:93.11ms
+step:93000/500000 train_loss:0.8782 train_time:8659538ms step_avg:93.11ms
+step:93200/500000 train_loss:0.9395 train_time:8677990ms step_avg:93.11ms
+step:93400/500000 train_loss:0.9190 train_time:8697721ms step_avg:93.12ms
+step:93600/500000 train_loss:0.8757 train_time:8716807ms step_avg:93.13ms
+step:93800/500000 train_loss:0.8670 train_time:8734943ms step_avg:93.12ms
+step:94000/500000 train_loss:0.8666 train_time:8753749ms step_avg:93.12ms
+step:94200/500000 train_loss:0.9263 train_time:8772041ms step_avg:93.12ms
+step:94400/500000 train_loss:0.9090 train_time:8790181ms step_avg:93.12ms
+step:94600/500000 train_loss:0.9117 train_time:8808494ms step_avg:93.11ms
+step:94800/500000 train_loss:0.8963 train_time:8826545ms step_avg:93.11ms
+step:95000/500000 train_loss:0.8533 train_time:8844861ms step_avg:93.10ms
+step:95200/500000 train_loss:0.9194 train_time:8863635ms step_avg:93.11ms
+step:95400/500000 train_loss:0.8899 train_time:8882223ms step_avg:93.11ms
+step:95600/500000 train_loss:0.8753 train_time:8901297ms step_avg:93.11ms
+step:95800/500000 train_loss:0.8653 train_time:8920462ms step_avg:93.12ms
+step:96000/500000 train_loss:0.9190 train_time:8939044ms step_avg:93.12ms
+step:96200/500000 train_loss:0.8267 train_time:8957449ms step_avg:93.11ms
+step:96400/500000 train_loss:0.7358 train_time:8975548ms step_avg:93.11ms
+step:96600/500000 train_loss:0.8065 train_time:8993899ms step_avg:93.10ms
+step:96800/500000 train_loss:0.8875 train_time:9012233ms step_avg:93.10ms
+step:97000/500000 train_loss:0.8662 train_time:9030504ms step_avg:93.10ms
+step:97200/500000 train_loss:0.9109 train_time:9048907ms step_avg:93.10ms
+step:97400/500000 train_loss:0.8804 train_time:9067396ms step_avg:93.09ms
+step:97600/500000 train_loss:0.9476 train_time:9086836ms step_avg:93.10ms
+step:97800/500000 train_loss:0.8609 train_time:9105629ms step_avg:93.10ms
+step:98000/500000 train_loss:0.8611 train_time:9124191ms step_avg:93.10ms
+step:98200/500000 train_loss:0.9998 train_time:9143135ms step_avg:93.11ms
+step:98400/500000 train_loss:0.8971 train_time:9161438ms step_avg:93.10ms
+step:98600/500000 train_loss:0.8802 train_time:9179516ms step_avg:93.10ms
+step:98800/500000 train_loss:0.8739 train_time:9197858ms step_avg:93.10ms
+step:99000/500000 train_loss:0.8465 train_time:9216061ms step_avg:93.09ms
+step:99200/500000 train_loss:0.9280 train_time:9234411ms step_avg:93.09ms
+step:99400/500000 train_loss:0.8723 train_time:9252702ms step_avg:93.09ms
+step:99600/500000 train_loss:0.8544 train_time:9271234ms step_avg:93.08ms
+step:99800/500000 train_loss:1.0714 train_time:9290726ms step_avg:93.09ms
+step:100000/500000 train_loss:0.8744 train_time:9309410ms step_avg:93.09ms
+step:100000/500000 val_loss:0.8451 val_bpb:1.2197 train_time:9309430ms step_avg:93.09ms
+step:100200/500000 train_loss:0.9083 train_time:9327901ms step_avg:93.09ms
+step:100400/500000 train_loss:0.8725 train_time:9346611ms step_avg:93.09ms
+step:100600/500000 train_loss:0.9066 train_time:9364830ms step_avg:93.09ms
+step:100800/500000 train_loss:0.8643 train_time:9382900ms step_avg:93.08ms
+step:101000/500000 train_loss:0.9570 train_time:9401240ms step_avg:93.08ms
+step:101200/500000 train_loss:0.9434 train_time:9419331ms step_avg:93.08ms
+step:101400/500000 train_loss:0.9140 train_time:9437653ms step_avg:93.07ms
+step:101600/500000 train_loss:0.8880 train_time:9456508ms step_avg:93.08ms
+step:101800/500000 train_loss:1.2701 train_time:9475109ms step_avg:93.08ms
+step:102000/500000 train_loss:0.8532 train_time:9494293ms step_avg:93.08ms
+step:102200/500000 train_loss:0.8909 train_time:9513201ms step_avg:93.08ms
+step:102400/500000 train_loss:0.8874 train_time:9532039ms step_avg:93.09ms
+step:102600/500000 train_loss:0.9350 train_time:9550286ms step_avg:93.08ms
+step:102800/500000 train_loss:0.9506 train_time:9568473ms step_avg:93.08ms
+step:103000/500000 train_loss:0.8991 train_time:9586847ms step_avg:93.08ms
+step:103200/500000 train_loss:0.8385 train_time:9605192ms step_avg:93.07ms
+step:103400/500000 train_loss:0.8671 train_time:9623236ms step_avg:93.07ms
+step:103600/500000 train_loss:0.8962 train_time:9641498ms step_avg:93.06ms
+step:103800/500000 train_loss:0.8183 train_time:9659958ms step_avg:93.06ms
+step:104000/500000 train_loss:0.9274 train_time:9679066ms step_avg:93.07ms
+step:104200/500000 train_loss:0.9323 train_time:9698598ms step_avg:93.08ms
+step:104400/500000 train_loss:0.9007 train_time:9717130ms step_avg:93.08ms
+step:104600/500000 train_loss:0.8562 train_time:9736173ms step_avg:93.08ms
+step:104800/500000 train_loss:0.8985 train_time:9754402ms step_avg:93.08ms
+step:105000/500000 train_loss:0.8763 train_time:9772610ms step_avg:93.07ms
+step:105200/500000 train_loss:0.8325 train_time:9790928ms step_avg:93.07ms
+step:105400/500000 train_loss:0.8911 train_time:9809066ms step_avg:93.07ms
+step:105600/500000 train_loss:0.9726 train_time:9827355ms step_avg:93.06ms
+step:105800/500000 train_loss:0.8329 train_time:9845619ms step_avg:93.06ms
+step:106000/500000 train_loss:0.7651 train_time:9864200ms step_avg:93.06ms
+step:106200/500000 train_loss:0.9194 train_time:9883801ms step_avg:93.07ms
+step:106400/500000 train_loss:0.8794 train_time:9902292ms step_avg:93.07ms
+step:106600/500000 train_loss:0.9250 train_time:9920994ms step_avg:93.07ms
+step:106800/500000 train_loss:1.0348 train_time:9939768ms step_avg:93.07ms
+step:107000/500000 train_loss:0.8450 train_time:9957938ms step_avg:93.06ms
+step:107200/500000 train_loss:0.9058 train_time:9976178ms step_avg:93.06ms
+step:107400/500000 train_loss:0.8889 train_time:9994417ms step_avg:93.06ms
+step:107600/500000 train_loss:0.9046 train_time:10032914ms step_avg:93.24ms
+step:107800/500000 train_loss:0.8516 train_time:10051046ms step_avg:93.24ms
+step:108000/500000 train_loss:1.3196 train_time:10069787ms step_avg:93.24ms
+step:108200/500000 train_loss:0.8707 train_time:10088490ms step_avg:93.24ms
+step:108400/500000 train_loss:0.9037 train_time:10107405ms step_avg:93.24ms
+step:108600/500000 train_loss:0.8563 train_time:10126043ms step_avg:93.24ms
+step:108800/500000 train_loss:0.8549 train_time:10144718ms step_avg:93.24ms
+step:109000/500000 train_loss:0.8589 train_time:10163236ms step_avg:93.24ms
+step:109200/500000 train_loss:0.9023 train_time:10181793ms step_avg:93.24ms
+step:109400/500000 train_loss:0.8962 train_time:10199867ms step_avg:93.23ms
+step:109600/500000 train_loss:0.8403 train_time:10218312ms step_avg:93.23ms
+step:109800/500000 train_loss:0.9102 train_time:10236746ms step_avg:93.23ms
+step:110000/500000 train_loss:0.9439 train_time:10254886ms step_avg:93.23ms
+step:110000/500000 val_loss:0.8434 val_bpb:1.2172 train_time:10254907ms step_avg:93.23ms
+step:110200/500000 train_loss:0.9160 train_time:10273398ms step_avg:93.23ms
+step:110400/500000 train_loss:0.8705 train_time:10292570ms step_avg:93.23ms
+step:110600/500000 train_loss:0.9198 train_time:10311088ms step_avg:93.23ms
+step:110800/500000 train_loss:0.9278 train_time:10330236ms step_avg:93.23ms
+step:111000/500000 train_loss:0.8443 train_time:10348887ms step_avg:93.23ms
+step:111200/500000 train_loss:0.9047 train_time:10367209ms step_avg:93.23ms
+step:111400/500000 train_loss:0.8325 train_time:10385468ms step_avg:93.23ms
+step:111600/500000 train_loss:0.8964 train_time:10403595ms step_avg:93.22ms
+step:111800/500000 train_loss:0.9269 train_time:10421888ms step_avg:93.22ms
+step:112000/500000 train_loss:0.9103 train_time:10440141ms step_avg:93.22ms
+step:112200/500000 train_loss:0.8615 train_time:10458671ms step_avg:93.21ms
+step:112400/500000 train_loss:0.8787 train_time:10476969ms step_avg:93.21ms
+step:112600/500000 train_loss:0.9577 train_time:10496343ms step_avg:93.22ms
+step:112800/500000 train_loss:0.9020 train_time:10515081ms step_avg:93.22ms
+step:113000/500000 train_loss:0.8883 train_time:10533775ms step_avg:93.22ms
+step:113200/500000 train_loss:0.9038 train_time:10552347ms step_avg:93.22ms
+step:113400/500000 train_loss:0.8666 train_time:10570730ms step_avg:93.22ms
+step:113600/500000 train_loss:0.9325 train_time:10588829ms step_avg:93.21ms
+step:113800/500000 train_loss:0.8595 train_time:10607364ms step_avg:93.21ms
+step:114000/500000 train_loss:0.8486 train_time:10625571ms step_avg:93.21ms
+step:114200/500000 train_loss:0.9409 train_time:10643857ms step_avg:93.20ms
+step:114400/500000 train_loss:0.9117 train_time:10662483ms step_avg:93.20ms
+step:114600/500000 train_loss:0.9368 train_time:10681089ms step_avg:93.20ms
+step:114800/500000 train_loss:0.8733 train_time:10700113ms step_avg:93.21ms
+step:115000/500000 train_loss:0.9636 train_time:10718851ms step_avg:93.21ms
+step:115200/500000 train_loss:0.8467 train_time:10737334ms step_avg:93.21ms
+step:115400/500000 train_loss:0.8935 train_time:10756286ms step_avg:93.21ms
+step:115600/500000 train_loss:0.8498 train_time:10774597ms step_avg:93.21ms
+step:115800/500000 train_loss:0.9470 train_time:10792734ms step_avg:93.20ms
+step:116000/500000 train_loss:0.8852 train_time:10811126ms step_avg:93.20ms
+step:116200/500000 train_loss:0.9227 train_time:10829225ms step_avg:93.19ms
+step:116400/500000 train_loss:0.9175 train_time:10847486ms step_avg:93.19ms
+step:116600/500000 train_loss:0.8862 train_time:10866397ms step_avg:93.19ms
+step:116800/500000 train_loss:0.8455 train_time:10884943ms step_avg:93.19ms
+step:117000/500000 train_loss:0.8910 train_time:10903995ms step_avg:93.20ms
+step:117200/500000 train_loss:0.8799 train_time:10922641ms step_avg:93.20ms
+step:117400/500000 train_loss:0.8988 train_time:10941185ms step_avg:93.20ms
+step:117600/500000 train_loss:0.8448 train_time:10959920ms step_avg:93.20ms
+step:117800/500000 train_loss:0.9093 train_time:10978045ms step_avg:93.19ms
+step:118000/500000 train_loss:0.8548 train_time:10996320ms step_avg:93.19ms
+step:118200/500000 train_loss:0.7910 train_time:11014701ms step_avg:93.19ms
+step:118400/500000 train_loss:0.9902 train_time:11032766ms step_avg:93.18ms
+step:118600/500000 train_loss:0.7885 train_time:11051517ms step_avg:93.18ms
+step:118800/500000 train_loss:0.8849 train_time:11069664ms step_avg:93.18ms
+step:119000/500000 train_loss:0.8968 train_time:11089108ms step_avg:93.19ms
+step:119200/500000 train_loss:0.8444 train_time:11108080ms step_avg:93.19ms
+step:119400/500000 train_loss:0.9127 train_time:11126531ms step_avg:93.19ms
+step:119600/500000 train_loss:0.9083 train_time:11145244ms step_avg:93.19ms
+step:119800/500000 train_loss:0.8190 train_time:11163523ms step_avg:93.18ms
+step:120000/500000 train_loss:0.8309 train_time:11181595ms step_avg:93.18ms
+step:120000/500000 val_loss:0.8422 val_bpb:1.2154 train_time:11181617ms step_avg:93.18ms
+step:120200/500000 train_loss:0.8949 train_time:11199926ms step_avg:93.18ms
+step:120400/500000 train_loss:0.9346 train_time:11218429ms step_avg:93.18ms
+step:120600/500000 train_loss:0.9340 train_time:11236563ms step_avg:93.17ms
+step:120800/500000 train_loss:0.8871 train_time:11255325ms step_avg:93.17ms
+step:121000/500000 train_loss:0.8495 train_time:11273442ms step_avg:93.17ms
+step:121200/500000 train_loss:0.8854 train_time:11292862ms step_avg:93.18ms
+step:121400/500000 train_loss:0.8891 train_time:11311617ms step_avg:93.18ms
+step:121600/500000 train_loss:0.7929 train_time:11330105ms step_avg:93.18ms
+step:121800/500000 train_loss:0.8270 train_time:11348907ms step_avg:93.18ms
+step:122000/500000 train_loss:0.8795 train_time:11367213ms step_avg:93.17ms
+step:122200/500000 train_loss:0.8881 train_time:11385430ms step_avg:93.17ms
+step:122400/500000 train_loss:0.9193 train_time:11403748ms step_avg:93.17ms
+step:122600/500000 train_loss:0.8806 train_time:11421836ms step_avg:93.16ms
+step:122800/500000 train_loss:0.8919 train_time:11440116ms step_avg:93.16ms
+step:123000/500000 train_loss:0.9022 train_time:11458748ms step_avg:93.16ms
+step:123200/500000 train_loss:0.8538 train_time:11477286ms step_avg:93.16ms
+step:123400/500000 train_loss:0.9367 train_time:11496423ms step_avg:93.16ms
+step:123600/500000 train_loss:0.9333 train_time:11514926ms step_avg:93.16ms
+step:123800/500000 train_loss:0.8664 train_time:11533801ms step_avg:93.16ms
+step:124000/500000 train_loss:0.9384 train_time:11552595ms step_avg:93.17ms
+step:124200/500000 train_loss:0.8203 train_time:11570705ms step_avg:93.16ms
+step:124400/500000 train_loss:0.8643 train_time:11588965ms step_avg:93.16ms
+step:124600/500000 train_loss:0.8745 train_time:11607449ms step_avg:93.16ms
+step:124800/500000 train_loss:0.8872 train_time:11625513ms step_avg:93.15ms
+step:125000/500000 train_loss:0.9247 train_time:11644156ms step_avg:93.15ms
+step:125200/500000 train_loss:0.9327 train_time:11662256ms step_avg:93.15ms
+step:125400/500000 train_loss:0.8169 train_time:11681740ms step_avg:93.16ms
+step:125600/500000 train_loss:0.8931 train_time:11700375ms step_avg:93.16ms
+step:125800/500000 train_loss:0.8949 train_time:11718523ms step_avg:93.15ms
+step:126000/500000 train_loss:0.8690 train_time:11737187ms step_avg:93.15ms
+step:126200/500000 train_loss:0.8504 train_time:11755841ms step_avg:93.15ms
+step:126400/500000 train_loss:0.8395 train_time:11774027ms step_avg:93.15ms
+step:126600/500000 train_loss:0.9073 train_time:11792412ms step_avg:93.15ms
+step:126800/500000 train_loss:0.8746 train_time:11810515ms step_avg:93.14ms
+step:127000/500000 train_loss:0.8750 train_time:11828787ms step_avg:93.14ms
+step:127200/500000 train_loss:0.8296 train_time:11847574ms step_avg:93.14ms
+step:127400/500000 train_loss:0.8798 train_time:11865692ms step_avg:93.14ms
+step:127600/500000 train_loss:0.8898 train_time:11885260ms step_avg:93.14ms
+step:127800/500000 train_loss:0.9616 train_time:11903854ms step_avg:93.14ms
+step:128000/500000 train_loss:0.8671 train_time:11922609ms step_avg:93.15ms
+step:128200/500000 train_loss:0.9181 train_time:11941439ms step_avg:93.15ms
+step:128400/500000 train_loss:0.9380 train_time:11959578ms step_avg:93.14ms
+step:128600/500000 train_loss:0.8942 train_time:11977845ms step_avg:93.14ms
+step:128800/500000 train_loss:0.9493 train_time:11996170ms step_avg:93.14ms
+step:129000/500000 train_loss:0.8889 train_time:12014287ms step_avg:93.13ms
+step:129200/500000 train_loss:0.8263 train_time:12033145ms step_avg:93.14ms
+step:129400/500000 train_loss:0.9978 train_time:12051263ms step_avg:93.13ms
+step:129600/500000 train_loss:0.8364 train_time:12070071ms step_avg:93.13ms
+step:129800/500000 train_loss:0.9053 train_time:12089196ms step_avg:93.14ms
+step:130000/500000 train_loss:1.0166 train_time:12107732ms step_avg:93.14ms
+step:130000/500000 val_loss:0.8402 val_bpb:1.2125 train_time:12107753ms step_avg:93.14ms
+step:130200/500000 train_loss:0.8632 train_time:12126590ms step_avg:93.14ms
+step:130400/500000 train_loss:0.8902 train_time:12145773ms step_avg:93.14ms
+step:130600/500000 train_loss:0.8452 train_time:12163974ms step_avg:93.14ms
+step:130800/500000 train_loss:0.8814 train_time:12182405ms step_avg:93.14ms
+step:131000/500000 train_loss:0.8366 train_time:12200710ms step_avg:93.14ms
+step:131200/500000 train_loss:0.7830 train_time:12219154ms step_avg:93.13ms
+step:131400/500000 train_loss:0.8733 train_time:12237833ms step_avg:93.13ms
+step:131600/500000 train_loss:0.9006 train_time:12255926ms step_avg:93.13ms
+step:131800/500000 train_loss:0.8631 train_time:12275411ms step_avg:93.14ms
+step:132000/500000 train_loss:0.9362 train_time:12294107ms step_avg:93.14ms
+late_qat:enabled step:132075 scale:0.8500
+step:132200/500000 train_loss:1.0573 train_time:12312401ms step_avg:93.13ms
+step:132400/500000 train_loss:0.9566 train_time:12331194ms step_avg:93.14ms
+step:132600/500000 train_loss:0.8265 train_time:12349753ms step_avg:93.14ms
+step:132800/500000 train_loss:0.8961 train_time:12368056ms step_avg:93.13ms
+step:133000/500000 train_loss:0.9467 train_time:12386421ms step_avg:93.13ms
+step:133200/500000 train_loss:0.9768 train_time:12404442ms step_avg:93.13ms
+step:133400/500000 train_loss:0.8925 train_time:12422761ms step_avg:93.12ms
+step:133600/500000 train_loss:0.9167 train_time:12441582ms step_avg:93.13ms
+step:133800/500000 train_loss:0.9667 train_time:12459705ms step_avg:93.12ms
+step:134000/500000 train_loss:0.9430 train_time:12479542ms step_avg:93.13ms
+step:134200/500000 train_loss:0.9326 train_time:12498139ms step_avg:93.13ms
+step:134400/500000 train_loss:0.8825 train_time:12516582ms step_avg:93.13ms
+step:134600/500000 train_loss:0.9443 train_time:12535291ms step_avg:93.13ms
+step:134800/500000 train_loss:0.8333 train_time:12554032ms step_avg:93.13ms
+step:135000/500000 train_loss:0.9502 train_time:12572605ms step_avg:93.13ms
+step:135200/500000 train_loss:0.9392 train_time:12590728ms step_avg:93.13ms
+step:135400/500000 train_loss:0.9754 train_time:12609067ms step_avg:93.12ms
+step:135600/500000 train_loss:0.9397 train_time:12627931ms step_avg:93.13ms
+step:135800/500000 train_loss:0.9662 train_time:12646043ms step_avg:93.12ms
+step:136000/500000 train_loss:1.1170 train_time:12664958ms step_avg:93.12ms
+step:136200/500000 train_loss:0.9342 train_time:12684145ms step_avg:93.13ms
+step:136400/500000 train_loss:0.9926 train_time:12702650ms step_avg:93.13ms
+step:136600/500000 train_loss:0.9526 train_time:12721386ms step_avg:93.13ms
+step:136800/500000 train_loss:0.9317 train_time:12739944ms step_avg:93.13ms
+step:137000/500000 train_loss:0.9052 train_time:12758229ms step_avg:93.13ms
+step:137200/500000 train_loss:0.9044 train_time:12776506ms step_avg:93.12ms
+step:137400/500000 train_loss:0.9793 train_time:12795027ms step_avg:93.12ms
+step:137600/500000 train_loss:0.9037 train_time:12813350ms step_avg:93.12ms
+step:137800/500000 train_loss:0.8626 train_time:12832182ms step_avg:93.12ms
+step:138000/500000 train_loss:0.9240 train_time:12850263ms step_avg:93.12ms
+step:138200/500000 train_loss:0.8724 train_time:12869844ms step_avg:93.12ms
+step:138400/500000 train_loss:0.8780 train_time:12888309ms step_avg:93.12ms
+step:138600/500000 train_loss:0.9672 train_time:12906740ms step_avg:93.12ms
+step:138800/500000 train_loss:0.9803 train_time:12925593ms step_avg:93.12ms
+step:139000/500000 train_loss:1.0194 train_time:12944173ms step_avg:93.12ms
+step:139200/500000 train_loss:0.8961 train_time:12962417ms step_avg:93.12ms
+step:139400/500000 train_loss:0.8936 train_time:12980537ms step_avg:93.12ms
+step:139600/500000 train_loss:0.8748 train_time:12999050ms step_avg:93.12ms
+step:139800/500000 train_loss:0.8752 train_time:13017392ms step_avg:93.11ms
+step:140000/500000 train_loss:0.9011 train_time:13035918ms step_avg:93.11ms
+step:140000/500000 val_loss:0.8637 val_bpb:1.2465 train_time:13035921ms step_avg:93.11ms
+step:140200/500000 train_loss:0.8033 train_time:13054493ms step_avg:93.11ms
+step:140400/500000 train_loss:0.9034 train_time:13074288ms step_avg:93.12ms
+step:140600/500000 train_loss:0.7248 train_time:13092831ms step_avg:93.12ms
+step:140800/500000 train_loss:0.9066 train_time:13111383ms step_avg:93.12ms
+step:141000/500000 train_loss:0.9065 train_time:13130195ms step_avg:93.12ms
+step:141200/500000 train_loss:0.9280 train_time:13149048ms step_avg:93.12ms
+step:141400/500000 train_loss:0.9119 train_time:13167402ms step_avg:93.12ms
+step:141600/500000 train_loss:0.9180 train_time:13185482ms step_avg:93.12ms
+step:141800/500000 train_loss:0.9553 train_time:13203962ms step_avg:93.12ms
+step:142000/500000 train_loss:0.8340 train_time:13222929ms step_avg:93.12ms
+step:142200/500000 train_loss:0.8951 train_time:13241042ms step_avg:93.12ms
+step:142400/500000 train_loss:0.9086 train_time:13259711ms step_avg:93.12ms
+step:142600/500000 train_loss:0.9028 train_time:13279036ms step_avg:93.12ms
+step:142800/500000 train_loss:1.0509 train_time:13297567ms step_avg:93.12ms
+step:143000/500000 train_loss:0.9483 train_time:13316021ms step_avg:93.12ms
+step:143200/500000 train_loss:0.8903 train_time:13334551ms step_avg:93.12ms
+step:143400/500000 train_loss:0.8314 train_time:13353318ms step_avg:93.12ms
+step:143600/500000 train_loss:0.8552 train_time:13371834ms step_avg:93.12ms
+step:143800/500000 train_loss:0.8351 train_time:13390015ms step_avg:93.12ms
+step:144000/500000 train_loss:0.9297 train_time:13408638ms step_avg:93.12ms
+step:144200/500000 train_loss:0.9698 train_time:13427379ms step_avg:93.12ms
+step:144400/500000 train_loss:0.9134 train_time:13445518ms step_avg:93.11ms
+step:144600/500000 train_loss:0.9023 train_time:13464900ms step_avg:93.12ms
+step:144800/500000 train_loss:0.9239 train_time:13483778ms step_avg:93.12ms
+step:145000/500000 train_loss:0.9301 train_time:13502264ms step_avg:93.12ms
+step:145200/500000 train_loss:0.8776 train_time:13521150ms step_avg:93.12ms
+step:145400/500000 train_loss:0.9259 train_time:13539688ms step_avg:93.12ms
+step:145600/500000 train_loss:0.8930 train_time:13558197ms step_avg:93.12ms
+step:145800/500000 train_loss:0.8825 train_time:13576376ms step_avg:93.12ms
+step:146000/500000 train_loss:0.9235 train_time:13594678ms step_avg:93.11ms
+step:146200/500000 train_loss:0.9322 train_time:13613343ms step_avg:93.11ms
+step:146400/500000 train_loss:0.9304 train_time:13631441ms step_avg:93.11ms
+step:146600/500000 train_loss:0.8734 train_time:13649783ms step_avg:93.11ms
+step:146800/500000 train_loss:0.9564 train_time:13669565ms step_avg:93.12ms
+step:147000/500000 train_loss:0.8547 train_time:13688084ms step_avg:93.12ms
+step:147200/500000 train_loss:0.9105 train_time:13706483ms step_avg:93.11ms
+step:147400/500000 train_loss:0.9218 train_time:13725060ms step_avg:93.11ms
+step:147600/500000 train_loss:0.9570 train_time:13743840ms step_avg:93.12ms
+step:147800/500000 train_loss:0.8876 train_time:13762211ms step_avg:93.11ms
+step:148000/500000 train_loss:0.8984 train_time:13780300ms step_avg:93.11ms
+step:148200/500000 train_loss:0.8387 train_time:13798615ms step_avg:93.11ms
+step:148400/500000 train_loss:0.8684 train_time:13817447ms step_avg:93.11ms
+step:148600/500000 train_loss:0.8961 train_time:13835487ms step_avg:93.11ms
+step:148800/500000 train_loss:0.8929 train_time:13854291ms step_avg:93.11ms
+step:149000/500000 train_loss:0.8994 train_time:13873188ms step_avg:93.11ms
+step:149200/500000 train_loss:0.9032 train_time:13892046ms step_avg:93.11ms
+step:149400/500000 train_loss:0.9412 train_time:13910459ms step_avg:93.11ms
+step:149600/500000 train_loss:0.9359 train_time:13929010ms step_avg:93.11ms
+step:149800/500000 train_loss:0.9125 train_time:13947874ms step_avg:93.11ms
+step:150000/500000 train_loss:0.9140 train_time:13965922ms step_avg:93.11ms
+step:150000/500000 val_loss:0.8528 val_bpb:1.2307 train_time:13965925ms step_avg:93.11ms
+step:150200/500000 train_loss:0.8668 train_time:13984044ms step_avg:93.10ms
+step:150400/500000 train_loss:0.9186 train_time:14002423ms step_avg:93.10ms
+step:150600/500000 train_loss:0.9345 train_time:14020895ms step_avg:93.10ms
+step:150800/500000 train_loss:0.8613 train_time:14039429ms step_avg:93.10ms
+step:151000/500000 train_loss:0.9197 train_time:14058662ms step_avg:93.10ms
+step:151200/500000 train_loss:0.8892 train_time:14077345ms step_avg:93.10ms
+step:151400/500000 train_loss:0.9329 train_time:14096120ms step_avg:93.11ms
+step:151600/500000 train_loss:0.8629 train_time:14114466ms step_avg:93.10ms
+step:151800/500000 train_loss:0.8865 train_time:14132995ms step_avg:93.10ms
+step:152000/500000 train_loss:0.8903 train_time:14151780ms step_avg:93.10ms
+step:152200/500000 train_loss:0.8625 train_time:14169873ms step_avg:93.10ms
+step:152400/500000 train_loss:0.7995 train_time:14188249ms step_avg:93.10ms
+step:152600/500000 train_loss:0.8970 train_time:14207122ms step_avg:93.10ms
+step:152800/500000 train_loss:0.9028 train_time:14225226ms step_avg:93.10ms
+step:153000/500000 train_loss:0.9238 train_time:14243765ms step_avg:93.10ms
+step:153200/500000 train_loss:0.9279 train_time:14263209ms step_avg:93.10ms
+step:153381/500000 val_loss:0.8524 val_bpb:1.2302 train_time:14280042ms step_avg:93.10ms
+stopping_early: wallclock_cap train_time:14280042ms step:153381/500000 (reserving 120.0s for GPTQ)
+peak memory allocated: 10054 MiB reserved: 10290 MiB
+gptq:calibrating with 512 batches...
+gptq:collected hessians for 75 layers in 46678ms
+Serialized model: 91657491 bytes
+Code size: 83709 bytes
+Total submission size: 91741200 bytes
+prune:zeroed 1840730 int6 weights (threshold=0)
+gptq:quantized 75 layers with GPTQ, 0 naive, 1 INT8 embeds
+artifact int6+gptq+zstd-22: 15697770 bytes + 83709 code = 15781479 total (payload:23125896 payload_ratio:3.96x)
+artifact headroom: 218521 bytes (0.219MB)
+artifact int8+zlib: 20691531 bytes (for comparison)
+final_int6_gptq_roundtrip val_loss:0.8623 val_bpb:1.2444 eval_time:4553ms
+final_int6_gptq_roundtrip_exact val_loss:0.86225433 val_bpb:1.24438173
+sliding_eval: stride=64 batch_seqs=16 seq_len=2048
+  sliding_eval [  0.0%] 16/295176 windows running_bpb=1.175649
+  sliding_eval [  0.3%] 816/295176 windows running_bpb=1.279901
+  sliding_eval [  0.5%] 1616/295176 windows running_bpb=1.296070
+  sliding_eval [  0.8%] 2416/295176 windows running_bpb=1.252167
+  sliding_eval [  1.1%] 3216/295176 windows running_bpb=1.205401
+  sliding_eval [  1.4%] 4016/295176 windows running_bpb=1.204793
+  sliding_eval [  1.6%] 4816/295176 windows running_bpb=1.220195
+  sliding_eval [  1.9%] 5616/295176 windows running_bpb=1.213799
+  sliding_eval [  2.2%] 6416/295176 windows running_bpb=1.208766
+  sliding_eval [  2.4%] 7216/295176 windows running_bpb=1.201405
+  sliding_eval [  2.7%] 8016/295176 windows running_bpb=1.203634
+  sliding_eval [  3.0%] 8816/295176 windows running_bpb=1.207179
+  sliding_eval [  3.3%] 9616/295176 windows running_bpb=1.203789
+  sliding_eval [  3.5%] 10416/295176 windows running_bpb=1.199312
+  sliding_eval [  3.8%] 11216/295176 windows running_bpb=1.199441
+  sliding_eval [  4.1%] 12016/295176 windows running_bpb=1.198537
+  sliding_eval [  4.3%] 12816/295176 windows running_bpb=1.200096
+  sliding_eval [  4.6%] 13616/295176 windows running_bpb=1.199367
+  sliding_eval [  4.9%] 14416/295176 windows running_bpb=1.215119
+  sliding_eval [  5.2%] 15216/295176 windows running_bpb=1.219746
+  sliding_eval [  5.4%] 16016/295176 windows running_bpb=1.216142
+  sliding_eval [  5.7%] 16816/295176 windows running_bpb=1.217130
+  sliding_eval [  6.0%] 17616/295176 windows running_bpb=1.218024
+  sliding_eval [  6.2%] 18416/295176 windows running_bpb=1.217911
+  sliding_eval [  6.5%] 19216/295176 windows running_bpb=1.218306
+  sliding_eval [  6.8%] 20016/295176 windows running_bpb=1.219973
+  sliding_eval [  7.1%] 20816/295176 windows running_bpb=1.221663
+  sliding_eval [  7.3%] 21616/295176 windows running_bpb=1.222590
+  sliding_eval [  7.6%] 22416/295176 windows running_bpb=1.222397
+  sliding_eval [  7.9%] 23216/295176 windows running_bpb=1.218808
+  sliding_eval [  8.1%] 24016/295176 windows running_bpb=1.218393
+  sliding_eval [  8.4%] 24816/295176 windows running_bpb=1.215692
+  sliding_eval [  8.7%] 25616/295176 windows running_bpb=1.216616
+  sliding_eval [  8.9%] 26416/295176 windows running_bpb=1.214458
+  sliding_eval [  9.2%] 27216/295176 windows running_bpb=1.211799
+  sliding_eval [  9.5%] 28016/295176 windows running_bpb=1.210485
+  sliding_eval [  9.8%] 28816/295176 windows running_bpb=1.211278
+  sliding_eval [ 10.0%] 29616/295176 windows running_bpb=1.210192
+  sliding_eval [ 10.3%] 30416/295176 windows running_bpb=1.210669
+  sliding_eval [ 10.6%] 31216/295176 windows running_bpb=1.208367
+  sliding_eval [ 10.8%] 32016/295176 windows running_bpb=1.206227
+  sliding_eval [ 11.1%] 32816/295176 windows running_bpb=1.206910
+  sliding_eval [ 11.4%] 33616/295176 windows running_bpb=1.207631
+  sliding_eval [ 11.7%] 34416/295176 windows running_bpb=1.209636
+  sliding_eval [ 11.9%] 35216/295176 windows running_bpb=1.209754
+  sliding_eval [ 12.2%] 36016/295176 windows running_bpb=1.217122
+  sliding_eval [ 12.5%] 36816/295176 windows running_bpb=1.222224
+  sliding_eval [ 12.7%] 37616/295176 windows running_bpb=1.219769
+  sliding_eval [ 13.0%] 38416/295176 windows running_bpb=1.217949
+  sliding_eval [ 13.3%] 39216/295176 windows running_bpb=1.218314
+  sliding_eval [ 13.6%] 40016/295176 windows running_bpb=1.216593
+  sliding_eval [ 13.8%] 40816/295176 windows running_bpb=1.216863
+  sliding_eval [ 14.1%] 41616/295176 windows running_bpb=1.216663
+  sliding_eval [ 14.4%] 42416/295176 windows running_bpb=1.215296
+  sliding_eval [ 14.6%] 43216/295176 windows running_bpb=1.213779
+  sliding_eval [ 14.9%] 44016/295176 windows running_bpb=1.214539
+  sliding_eval [ 15.2%] 44816/295176 windows running_bpb=1.214725
+  sliding_eval [ 15.5%] 45616/295176 windows running_bpb=1.216563
+  sliding_eval [ 15.7%] 46416/295176 windows running_bpb=1.216664
+  sliding_eval [ 16.0%] 47216/295176 windows running_bpb=1.214547
+  sliding_eval [ 16.3%] 48016/295176 windows running_bpb=1.215252
+  sliding_eval [ 16.5%] 48816/295176 windows running_bpb=1.215407
+  sliding_eval [ 16.8%] 49616/295176 windows running_bpb=1.215396
+  sliding_eval [ 17.1%] 50416/295176 windows running_bpb=1.214293
+  sliding_eval [ 17.4%] 51216/295176 windows running_bpb=1.213542
+  sliding_eval [ 17.6%] 52016/295176 windows running_bpb=1.214285
+  sliding_eval [ 17.9%] 52816/295176 windows running_bpb=1.212719
+  sliding_eval [ 18.2%] 53616/295176 windows running_bpb=1.212445
+  sliding_eval [ 18.4%] 54416/295176 windows running_bpb=1.212359
+  sliding_eval [ 18.7%] 55216/295176 windows running_bpb=1.210876
+  sliding_eval [ 19.0%] 56016/295176 windows running_bpb=1.209542
+  sliding_eval [ 19.2%] 56816/295176 windows running_bpb=1.209357
+  sliding_eval [ 19.5%] 57616/295176 windows running_bpb=1.213068
+  sliding_eval [ 19.8%] 58416/295176 windows running_bpb=1.212262
+  sliding_eval [ 20.1%] 59216/295176 windows running_bpb=1.212802
+  sliding_eval [ 20.3%] 60016/295176 windows running_bpb=1.212496
+  sliding_eval [ 20.6%] 60816/295176 windows running_bpb=1.212335
+  sliding_eval [ 20.9%] 61616/295176 windows running_bpb=1.214158
+  sliding_eval [ 21.1%] 62416/295176 windows running_bpb=1.214287
+  sliding_eval [ 21.4%] 63216/295176 windows running_bpb=1.215663
+  sliding_eval [ 21.7%] 64016/295176 windows running_bpb=1.213483
+  sliding_eval [ 22.0%] 64816/295176 windows running_bpb=1.213859
+  sliding_eval [ 22.2%] 65616/295176 windows running_bpb=1.214894
+  sliding_eval [ 22.5%] 66416/295176 windows running_bpb=1.215380
+  sliding_eval [ 22.8%] 67216/295176 windows running_bpb=1.218177
+  sliding_eval [ 23.0%] 68016/295176 windows running_bpb=1.220645
+  sliding_eval [ 23.3%] 68816/295176 windows running_bpb=1.220739
+  sliding_eval [ 23.6%] 69616/295176 windows running_bpb=1.220938
+  sliding_eval [ 23.9%] 70416/295176 windows running_bpb=1.221590
+  sliding_eval [ 24.1%] 71216/295176 windows running_bpb=1.220805
+  sliding_eval [ 24.4%] 72016/295176 windows running_bpb=1.218942
+  sliding_eval [ 24.7%] 72816/295176 windows running_bpb=1.218838
+  sliding_eval [ 24.9%] 73616/295176 windows running_bpb=1.218602
+  sliding_eval [ 25.2%] 74416/295176 windows running_bpb=1.218989
+  sliding_eval [ 25.5%] 75216/295176 windows running_bpb=1.218620
+  sliding_eval [ 25.8%] 76016/295176 windows running_bpb=1.217464
+  sliding_eval [ 26.0%] 76816/295176 windows running_bpb=1.219074
+  sliding_eval [ 26.3%] 77616/295176 windows running_bpb=1.220086
+  sliding_eval [ 26.6%] 78416/295176 windows running_bpb=1.219938
+  sliding_eval [ 26.8%] 79216/295176 windows running_bpb=1.219283
+  sliding_eval [ 27.1%] 80016/295176 windows running_bpb=1.218730
+  sliding_eval [ 27.4%] 80816/295176 windows running_bpb=1.218408
+  sliding_eval [ 27.6%] 81616/295176 windows running_bpb=1.218434
+  sliding_eval [ 27.9%] 82416/295176 windows running_bpb=1.217834
+  sliding_eval [ 28.2%] 83216/295176 windows running_bpb=1.216998
+  sliding_eval [ 28.5%] 84016/295176 windows running_bpb=1.217495
+  sliding_eval [ 28.7%] 84816/295176 windows running_bpb=1.217760
+  sliding_eval [ 29.0%] 85616/295176 windows running_bpb=1.218394
+  sliding_eval [ 29.3%] 86416/295176 windows running_bpb=1.218308
+  sliding_eval [ 29.5%] 87216/295176 windows running_bpb=1.217530
+  sliding_eval [ 29.8%] 88016/295176 windows running_bpb=1.218229
+  sliding_eval [ 30.1%] 88816/295176 windows running_bpb=1.217549
+  sliding_eval [ 30.4%] 89616/295176 windows running_bpb=1.217610
+  sliding_eval [ 30.6%] 90416/295176 windows running_bpb=1.217646
+  sliding_eval [ 30.9%] 91216/295176 windows running_bpb=1.217436
+  sliding_eval [ 31.2%] 92016/295176 windows running_bpb=1.217907
+  sliding_eval [ 31.4%] 92816/295176 windows running_bpb=1.218226
+  sliding_eval [ 31.7%] 93616/295176 windows running_bpb=1.217252
+  sliding_eval [ 32.0%] 94416/295176 windows running_bpb=1.216275
+  sliding_eval [ 32.3%] 95216/295176 windows running_bpb=1.216423
+  sliding_eval [ 32.5%] 96016/295176 windows running_bpb=1.215930
+  sliding_eval [ 32.8%] 96816/295176 windows running_bpb=1.215359
+  sliding_eval [ 33.1%] 97616/295176 windows running_bpb=1.214725
+  sliding_eval [ 33.3%] 98416/295176 windows running_bpb=1.214958
+  sliding_eval [ 33.6%] 99216/295176 windows running_bpb=1.215573
+  sliding_eval [ 33.9%] 100016/295176 windows running_bpb=1.215092
+  sliding_eval [ 34.2%] 100816/295176 windows running_bpb=1.215731
+  sliding_eval [ 34.4%] 101616/295176 windows running_bpb=1.215600
+  sliding_eval [ 34.7%] 102416/295176 windows running_bpb=1.215432
+  sliding_eval [ 35.0%] 103216/295176 windows running_bpb=1.215484
+  sliding_eval [ 35.2%] 104016/295176 windows running_bpb=1.215450
+  sliding_eval [ 35.5%] 104816/295176 windows running_bpb=1.215280
+  sliding_eval [ 35.8%] 105616/295176 windows running_bpb=1.214468
+  sliding_eval [ 36.1%] 106416/295176 windows running_bpb=1.214661
+  sliding_eval [ 36.3%] 107216/295176 windows running_bpb=1.214101
+  sliding_eval [ 36.6%] 108016/295176 windows running_bpb=1.214378
+  sliding_eval [ 36.9%] 108816/295176 windows running_bpb=1.214343
+  sliding_eval [ 37.1%] 109616/295176 windows running_bpb=1.213823
+  sliding_eval [ 37.4%] 110416/295176 windows running_bpb=1.214008
+  sliding_eval [ 37.7%] 111216/295176 windows running_bpb=1.214111
+  sliding_eval [ 37.9%] 112016/295176 windows running_bpb=1.214180
+  sliding_eval [ 38.2%] 112816/295176 windows running_bpb=1.213539
+  sliding_eval [ 38.5%] 113616/295176 windows running_bpb=1.213174
+  sliding_eval [ 38.8%] 114416/295176 windows running_bpb=1.213485
+  sliding_eval [ 39.0%] 115216/295176 windows running_bpb=1.213146
+  sliding_eval [ 39.3%] 116016/295176 windows running_bpb=1.213729
+  sliding_eval [ 39.6%] 116816/295176 windows running_bpb=1.213619
+  sliding_eval [ 39.8%] 117616/295176 windows running_bpb=1.213288
+  sliding_eval [ 40.1%] 118416/295176 windows running_bpb=1.214223
+  sliding_eval [ 40.4%] 119216/295176 windows running_bpb=1.214361
+  sliding_eval [ 40.7%] 120016/295176 windows running_bpb=1.214568
+  sliding_eval [ 40.9%] 120816/295176 windows running_bpb=1.214884
+  sliding_eval [ 41.2%] 121616/295176 windows running_bpb=1.214610
+  sliding_eval [ 41.5%] 122416/295176 windows running_bpb=1.215146
+  sliding_eval [ 41.7%] 123216/295176 windows running_bpb=1.215526
+  sliding_eval [ 42.0%] 124016/295176 windows running_bpb=1.215205
+  sliding_eval [ 42.3%] 124816/295176 windows running_bpb=1.215267
+  sliding_eval [ 42.6%] 125616/295176 windows running_bpb=1.215864
+  sliding_eval [ 42.8%] 126416/295176 windows running_bpb=1.215594
+  sliding_eval [ 43.1%] 127216/295176 windows running_bpb=1.215605
+  sliding_eval [ 43.4%] 128016/295176 windows running_bpb=1.215699
+  sliding_eval [ 43.6%] 128816/295176 windows running_bpb=1.214988
+  sliding_eval [ 43.9%] 129616/295176 windows running_bpb=1.214999
+  sliding_eval [ 44.2%] 130416/295176 windows running_bpb=1.215341
+  sliding_eval [ 44.5%] 131216/295176 windows running_bpb=1.215251
+  sliding_eval [ 44.7%] 132016/295176 windows running_bpb=1.215268
+  sliding_eval [ 45.0%] 132816/295176 windows running_bpb=1.215661
+  sliding_eval [ 45.3%] 133616/295176 windows running_bpb=1.215733
+  sliding_eval [ 45.5%] 134416/295176 windows running_bpb=1.215660
+  sliding_eval [ 45.8%] 135216/295176 windows running_bpb=1.215645
+  sliding_eval [ 46.1%] 136016/295176 windows running_bpb=1.215505
+  sliding_eval [ 46.4%] 136816/295176 windows running_bpb=1.214953
+  sliding_eval [ 46.6%] 137616/295176 windows running_bpb=1.214665
+  sliding_eval [ 46.9%] 138416/295176 windows running_bpb=1.214957
+  sliding_eval [ 47.2%] 139216/295176 windows running_bpb=1.213387
+  sliding_eval [ 47.4%] 140016/295176 windows running_bpb=1.211964
+  sliding_eval [ 47.7%] 140816/295176 windows running_bpb=1.211510
+  sliding_eval [ 48.0%] 141616/295176 windows running_bpb=1.211562
+  sliding_eval [ 48.2%] 142416/295176 windows running_bpb=1.211378
+  sliding_eval [ 48.5%] 143216/295176 windows running_bpb=1.211429
+  sliding_eval [ 48.8%] 144016/295176 windows running_bpb=1.211490
+  sliding_eval [ 49.1%] 144816/295176 windows running_bpb=1.211173
+  sliding_eval [ 49.3%] 145616/295176 windows running_bpb=1.211598
+  sliding_eval [ 49.6%] 146416/295176 windows running_bpb=1.211780
+  sliding_eval [ 49.9%] 147216/295176 windows running_bpb=1.212121
+  sliding_eval [ 50.1%] 148016/295176 windows running_bpb=1.211688
+  sliding_eval [ 50.4%] 148816/295176 windows running_bpb=1.212485
+  sliding_eval [ 50.7%] 149616/295176 windows running_bpb=1.212358
+  sliding_eval [ 51.0%] 150416/295176 windows running_bpb=1.212512
+  sliding_eval [ 51.2%] 151216/295176 windows running_bpb=1.212188
+  sliding_eval [ 51.5%] 152016/295176 windows running_bpb=1.212225
+  sliding_eval [ 51.8%] 152816/295176 windows running_bpb=1.212617
+  sliding_eval [ 52.0%] 153616/295176 windows running_bpb=1.212503
+  sliding_eval [ 52.3%] 154416/295176 windows running_bpb=1.212887
+  sliding_eval [ 52.6%] 155216/295176 windows running_bpb=1.212502
+  sliding_eval [ 52.9%] 156016/295176 windows running_bpb=1.212447
+  sliding_eval [ 53.1%] 156816/295176 windows running_bpb=1.212093
+  sliding_eval [ 53.4%] 157616/295176 windows running_bpb=1.212212
+  sliding_eval [ 53.7%] 158416/295176 windows running_bpb=1.211594
+  sliding_eval [ 53.9%] 159216/295176 windows running_bpb=1.211661
+  sliding_eval [ 54.2%] 160016/295176 windows running_bpb=1.211528
+  sliding_eval [ 54.5%] 160816/295176 windows running_bpb=1.211283
+  sliding_eval [ 54.8%] 161616/295176 windows running_bpb=1.211110
+  sliding_eval [ 55.0%] 162416/295176 windows running_bpb=1.210999
+  sliding_eval [ 55.3%] 163216/295176 windows running_bpb=1.210776
+  sliding_eval [ 55.6%] 164016/295176 windows running_bpb=1.211118
+  sliding_eval [ 55.8%] 164816/295176 windows running_bpb=1.210681
+  sliding_eval [ 56.1%] 165616/295176 windows running_bpb=1.210621
+  sliding_eval [ 56.4%] 166416/295176 windows running_bpb=1.210314
+  sliding_eval [ 56.6%] 167216/295176 windows running_bpb=1.210445
+  sliding_eval [ 56.9%] 168016/295176 windows running_bpb=1.210408
+  sliding_eval [ 57.2%] 168816/295176 windows running_bpb=1.210233
+  sliding_eval [ 57.5%] 169616/295176 windows running_bpb=1.210188
+  sliding_eval [ 57.7%] 170416/295176 windows running_bpb=1.210336
+  sliding_eval [ 58.0%] 171216/295176 windows running_bpb=1.210285
+  sliding_eval [ 58.3%] 172016/295176 windows running_bpb=1.210065
+  sliding_eval [ 58.5%] 172816/295176 windows running_bpb=1.210083
+  sliding_eval [ 58.8%] 173616/295176 windows running_bpb=1.210155
+  sliding_eval [ 59.1%] 174416/295176 windows running_bpb=1.210118
+  sliding_eval [ 59.4%] 175216/295176 windows running_bpb=1.210220
+  sliding_eval [ 59.6%] 176016/295176 windows running_bpb=1.210050
+  sliding_eval [ 59.9%] 176816/295176 windows running_bpb=1.210097
+  sliding_eval [ 60.2%] 177616/295176 windows running_bpb=1.210358
+  sliding_eval [ 60.4%] 178416/295176 windows running_bpb=1.210369
+  sliding_eval [ 60.7%] 179216/295176 windows running_bpb=1.210655
+  sliding_eval [ 61.0%] 180016/295176 windows running_bpb=1.210768
+  sliding_eval [ 61.3%] 180816/295176 windows running_bpb=1.210351
+  sliding_eval [ 61.5%] 181616/295176 windows running_bpb=1.210542
+  sliding_eval [ 61.8%] 182416/295176 windows running_bpb=1.209568
+  sliding_eval [ 62.1%] 183216/295176 windows running_bpb=1.209502
+  sliding_eval [ 62.3%] 184016/295176 windows running_bpb=1.209529
+  sliding_eval [ 62.6%] 184816/295176 windows running_bpb=1.209822
+  sliding_eval [ 62.9%] 185616/295176 windows running_bpb=1.210162
+  sliding_eval [ 63.2%] 186416/295176 windows running_bpb=1.210352
+  sliding_eval [ 63.4%] 187216/295176 windows running_bpb=1.210202
+  sliding_eval [ 63.7%] 188016/295176 windows running_bpb=1.210385
+  sliding_eval [ 64.0%] 188816/295176 windows running_bpb=1.210582
+  sliding_eval [ 64.2%] 189616/295176 windows running_bpb=1.210402
+  sliding_eval [ 64.5%] 190416/295176 windows running_bpb=1.210461
+  sliding_eval [ 64.8%] 191216/295176 windows running_bpb=1.210658
+  sliding_eval [ 65.1%] 192016/295176 windows running_bpb=1.211042
+  sliding_eval [ 65.3%] 192816/295176 windows running_bpb=1.211090
+  sliding_eval [ 65.6%] 193616/295176 windows running_bpb=1.210864
+  sliding_eval [ 65.9%] 194416/295176 windows running_bpb=1.211363
+  sliding_eval [ 66.1%] 195216/295176 windows running_bpb=1.210990
+  sliding_eval [ 66.4%] 196016/295176 windows running_bpb=1.210861
+  sliding_eval [ 66.7%] 196816/295176 windows running_bpb=1.210904
+  sliding_eval [ 66.9%] 197616/295176 windows running_bpb=1.211488
+  sliding_eval [ 67.2%] 198416/295176 windows running_bpb=1.211489
+  sliding_eval [ 67.5%] 199216/295176 windows running_bpb=1.211569
+  sliding_eval [ 67.8%] 200016/295176 windows running_bpb=1.211741
+  sliding_eval [ 68.0%] 200816/295176 windows running_bpb=1.211784
+  sliding_eval [ 68.3%] 201616/295176 windows running_bpb=1.211894
+  sliding_eval [ 68.6%] 202416/295176 windows running_bpb=1.213654
+  sliding_eval [ 68.8%] 203216/295176 windows running_bpb=1.213867
+  sliding_eval [ 69.1%] 204016/295176 windows running_bpb=1.213829
+  sliding_eval [ 69.4%] 204816/295176 windows running_bpb=1.213822
+  sliding_eval [ 69.7%] 205616/295176 windows running_bpb=1.213274
+  sliding_eval [ 69.9%] 206416/295176 windows running_bpb=1.213066
+  sliding_eval [ 70.2%] 207216/295176 windows running_bpb=1.213207
+  sliding_eval [ 70.5%] 208016/295176 windows running_bpb=1.213234
+  sliding_eval [ 70.7%] 208816/295176 windows running_bpb=1.213140
+  sliding_eval [ 71.0%] 209616/295176 windows running_bpb=1.213389
+  sliding_eval [ 71.3%] 210416/295176 windows running_bpb=1.213724
+  sliding_eval [ 71.6%] 211216/295176 windows running_bpb=1.214094
+  sliding_eval [ 71.8%] 212016/295176 windows running_bpb=1.214323
+  sliding_eval [ 72.1%] 212816/295176 windows running_bpb=1.214355
+  sliding_eval [ 72.4%] 213616/295176 windows running_bpb=1.214424
+  sliding_eval [ 72.6%] 214416/295176 windows running_bpb=1.214283
+  sliding_eval [ 72.9%] 215216/295176 windows running_bpb=1.214410
+  sliding_eval [ 73.2%] 216016/295176 windows running_bpb=1.214824
+  sliding_eval [ 73.5%] 216816/295176 windows running_bpb=1.214896
+  sliding_eval [ 73.7%] 217616/295176 windows running_bpb=1.214770
+  sliding_eval [ 74.0%] 218416/295176 windows running_bpb=1.214666
+  sliding_eval [ 74.3%] 219216/295176 windows running_bpb=1.214629
+  sliding_eval [ 74.5%] 220016/295176 windows running_bpb=1.214137
+  sliding_eval [ 74.8%] 220816/295176 windows running_bpb=1.213799
+  sliding_eval [ 75.1%] 221616/295176 windows running_bpb=1.213782
+  sliding_eval [ 75.4%] 222416/295176 windows running_bpb=1.213627
+  sliding_eval [ 75.6%] 223216/295176 windows running_bpb=1.213935
+  sliding_eval [ 75.9%] 224016/295176 windows running_bpb=1.213815
+  sliding_eval [ 76.2%] 224816/295176 windows running_bpb=1.214018
+  sliding_eval [ 76.4%] 225616/295176 windows running_bpb=1.213970
+  sliding_eval [ 76.7%] 226416/295176 windows running_bpb=1.214134
+  sliding_eval [ 77.0%] 227216/295176 windows running_bpb=1.214278
+  sliding_eval [ 77.2%] 228016/295176 windows running_bpb=1.214207
+  sliding_eval [ 77.5%] 228816/295176 windows running_bpb=1.214321
+  sliding_eval [ 77.8%] 229616/295176 windows running_bpb=1.213855
+  sliding_eval [ 78.1%] 230416/295176 windows running_bpb=1.213577
+  sliding_eval [ 78.3%] 231216/295176 windows running_bpb=1.213482
+  sliding_eval [ 78.6%] 232016/295176 windows running_bpb=1.213575
+  sliding_eval [ 78.9%] 232816/295176 windows running_bpb=1.216898
+  sliding_eval [ 79.1%] 233616/295176 windows running_bpb=1.217088
+  sliding_eval [ 79.4%] 234416/295176 windows running_bpb=1.216697
+  sliding_eval [ 79.7%] 235216/295176 windows running_bpb=1.216388
+  sliding_eval [ 80.0%] 236016/295176 windows running_bpb=1.216537
+  sliding_eval [ 80.2%] 236816/295176 windows running_bpb=1.216697
+  sliding_eval [ 80.5%] 237616/295176 windows running_bpb=1.216601
+  sliding_eval [ 80.8%] 238416/295176 windows running_bpb=1.216340
+  sliding_eval [ 81.0%] 239216/295176 windows running_bpb=1.216378
+  sliding_eval [ 81.3%] 240016/295176 windows running_bpb=1.216400
+  sliding_eval [ 81.6%] 240816/295176 windows running_bpb=1.216071
+  sliding_eval [ 81.9%] 241616/295176 windows running_bpb=1.216229
+  sliding_eval [ 82.1%] 242416/295176 windows running_bpb=1.216366
+  sliding_eval [ 82.4%] 243216/295176 windows running_bpb=1.216587
+  sliding_eval [ 82.7%] 244016/295176 windows running_bpb=1.216711
+  sliding_eval [ 82.9%] 244816/295176 windows running_bpb=1.216589
+  sliding_eval [ 83.2%] 245616/295176 windows running_bpb=1.216385
+  sliding_eval [ 83.5%] 246416/295176 windows running_bpb=1.216051
+  sliding_eval [ 83.8%] 247216/295176 windows running_bpb=1.215913
+  sliding_eval [ 84.0%] 248016/295176 windows running_bpb=1.216041
+  sliding_eval [ 84.3%] 248816/295176 windows running_bpb=1.215708
+  sliding_eval [ 84.6%] 249616/295176 windows running_bpb=1.215852
+  sliding_eval [ 84.8%] 250416/295176 windows running_bpb=1.215626
+  sliding_eval [ 85.1%] 251216/295176 windows running_bpb=1.215963
+  sliding_eval [ 85.4%] 252016/295176 windows running_bpb=1.215325
+  sliding_eval [ 85.6%] 252816/295176 windows running_bpb=1.215177
+  sliding_eval [ 85.9%] 253616/295176 windows running_bpb=1.215042
+  sliding_eval [ 86.2%] 254416/295176 windows running_bpb=1.214877
+  sliding_eval [ 86.5%] 255216/295176 windows running_bpb=1.214845
+  sliding_eval [ 86.7%] 256016/295176 windows running_bpb=1.214820
+  sliding_eval [ 87.0%] 256816/295176 windows running_bpb=1.214925
+  sliding_eval [ 87.3%] 257616/295176 windows running_bpb=1.214790
+  sliding_eval [ 87.5%] 258416/295176 windows running_bpb=1.214702
+  sliding_eval [ 87.8%] 259216/295176 windows running_bpb=1.214738
+  sliding_eval [ 88.1%] 260016/295176 windows running_bpb=1.215243
+  sliding_eval [ 88.4%] 260816/295176 windows running_bpb=1.215607
+  sliding_eval [ 88.6%] 261616/295176 windows running_bpb=1.215518
+  sliding_eval [ 88.9%] 262416/295176 windows running_bpb=1.215724
+  sliding_eval [ 89.2%] 263216/295176 windows running_bpb=1.215358
+  sliding_eval [ 89.4%] 264016/295176 windows running_bpb=1.215748
+  sliding_eval [ 89.7%] 264816/295176 windows running_bpb=1.215505
+  sliding_eval [ 90.0%] 265616/295176 windows running_bpb=1.215518
+  sliding_eval [ 90.3%] 266416/295176 windows running_bpb=1.215777
+  sliding_eval [ 90.5%] 267216/295176 windows running_bpb=1.215734
+  sliding_eval [ 90.8%] 268016/295176 windows running_bpb=1.215602
+  sliding_eval [ 91.1%] 268816/295176 windows running_bpb=1.215441
+  sliding_eval [ 91.3%] 269616/295176 windows running_bpb=1.215650
+  sliding_eval [ 91.6%] 270416/295176 windows running_bpb=1.215662
+  sliding_eval [ 91.9%] 271216/295176 windows running_bpb=1.216088
+  sliding_eval [ 92.2%] 272016/295176 windows running_bpb=1.215960
+  sliding_eval [ 92.4%] 272816/295176 windows running_bpb=1.216054
+  sliding_eval [ 92.7%] 273616/295176 windows running_bpb=1.216030
+  sliding_eval [ 93.0%] 274416/295176 windows running_bpb=1.215792
+  sliding_eval [ 93.2%] 275216/295176 windows running_bpb=1.215794
+  sliding_eval [ 93.5%] 276016/295176 windows running_bpb=1.215562
+  sliding_eval [ 93.8%] 276816/295176 windows running_bpb=1.215698
+  sliding_eval [ 94.1%] 277616/295176 windows running_bpb=1.215881
+  sliding_eval [ 94.3%] 278416/295176 windows running_bpb=1.215828
+  sliding_eval [ 94.6%] 279216/295176 windows running_bpb=1.215676
+  sliding_eval [ 94.9%] 280016/295176 windows running_bpb=1.215393
+  sliding_eval [ 95.1%] 280816/295176 windows running_bpb=1.215355
+  sliding_eval [ 95.4%] 281616/295176 windows running_bpb=1.215375
+  sliding_eval [ 95.7%] 282416/295176 windows running_bpb=1.215644
+  sliding_eval [ 95.9%] 283216/295176 windows running_bpb=1.215592
+  sliding_eval [ 96.2%] 284016/295176 windows running_bpb=1.215791
+  sliding_eval [ 96.5%] 284816/295176 windows running_bpb=1.215890
+  sliding_eval [ 96.8%] 285616/295176 windows running_bpb=1.216016
+  sliding_eval [ 97.0%] 286416/295176 windows running_bpb=1.215965
+  sliding_eval [ 97.3%] 287216/295176 windows running_bpb=1.215953
+  sliding_eval [ 97.6%] 288016/295176 windows running_bpb=1.215786
+  sliding_eval [ 97.8%] 288816/295176 windows running_bpb=1.215829
+  sliding_eval [ 98.1%] 289616/295176 windows running_bpb=1.215938
+  sliding_eval [ 98.4%] 290416/295176 windows running_bpb=1.216060
+  sliding_eval [ 98.7%] 291216/295176 windows running_bpb=1.216471
+  sliding_eval [ 98.9%] 292016/295176 windows running_bpb=1.216254
+  sliding_eval [ 99.2%] 292816/295176 windows running_bpb=1.216354
+  sliding_eval [ 99.5%] 293616/295176 windows running_bpb=1.216377
+  sliding_eval [ 99.7%] 294416/295176 windows running_bpb=1.216506
+final_int6_gptq_sliding_window val_loss:0.8364 val_bpb:1.2070 eval_time:352322ms
+final_int6_gptq_sliding_window_exact val_loss:0.83636482 val_bpb:1.20701869
+:486841ms step_avg:93.62ms
+step:5400/500000 train_loss:0.9728 train_time:505428ms step_avg:93.60ms
+step:5600/500000 train_loss:0.9388 train_time:524479ms step_avg:93.66ms
+step:5800/500000 train_loss:0.9144 train_time:543833ms step_avg:93.76ms
+step:6000/500000 train_loss:0.9484 train_time:563056ms step_avg:93.84ms
+step:6200/500000 train_loss:0.9774 train_time:581207ms step_avg:93.74ms
+step:6400/500000 train_loss:0.9632 train_time:599648ms step_avg:93.69ms
+step:6600/500000 train_loss:0.9728 train_time:618030ms step_avg:93.64ms
+step:6800/500000 train_loss:0.9824 train_time:636521ms step_avg:93.61ms
+step:7000/500000 train_loss:0.9796 train_time:655043ms step_avg:93.58ms
+step:7200/500000 train_loss:0.9957 train_time:673255ms step_avg:93.51ms
+step:7400/500000 train_loss:1.0254 train_time:691712ms step_avg:93.47ms
+step:7600/500000 train_loss:0.9952 train_time:710173ms step_avg:93.44ms
+step:7800/500000 train_loss:1.0016 train_time:729181ms step_avg:93.48ms
+step:8000/500000 train_loss:0.9596 train_time:748881ms step_avg:93.61ms
+step:8200/500000 train_loss:1.0012 train_time:767957ms step_avg:93.65ms
+step:8400/500000 train_loss:1.0072 train_time:786481ms step_avg:93.63ms
+step:8600/500000 train_loss:0.9784 train_time:805003ms step_avg:93.61ms
+step:8800/500000 train_loss:0.9740 train_time:823135ms step_avg:93.54ms
+step:9000/500000 train_loss:0.9880 train_time:841563ms step_avg:93.51ms
+step:9200/500000 train_loss:0.9055 train_time:859925ms step_avg:93.47ms
+step:9400/500000 train_loss:0.9104 train_time:878144ms step_avg:93.42ms
+step:9600/500000 train_loss:0.9229 train_time:896614ms step_avg:93.40ms
+step:9800/500000 train_loss:0.9617 train_time:915318ms step_avg:93.40ms
+step:10000/500000 train_loss:0.9764 train_time:935283ms step_avg:93.53ms
+step:10000/500000 val_loss:0.9149 val_bpb:1.3204 train_time:935304ms step_avg:93.53ms
+step:10200/500000 train_loss:1.0136 train_time:954349ms step_avg:93.56ms
+step:10400/500000 train_loss:1.0051 train_time:972600ms step_avg:93.52ms
+step:10600/500000 train_loss:0.9058 train_time:990975ms step_avg:93.49ms
+step:10800/500000 train_loss:0.9501 train_time:1009330ms step_avg:93.46ms
+step:11000/500000 train_loss:0.9092 train_time:1027506ms step_avg:93.41ms
+step:11200/500000 train_loss:0.8851 train_time:1045957ms step_avg:93.39ms
+step:11400/500000 train_loss:1.0447 train_time:1064324ms step_avg:93.36ms
+step:11600/500000 train_loss:0.9509 train_time:1082603ms step_avg:93.33ms
+step:11800/500000 train_loss:0.9382 train_time:1100953ms step_avg:93.30ms
+step:12000/500000 train_loss:1.0288 train_time:1119509ms step_avg:93.29ms
+step:12200/500000 train_loss:1.0590 train_time:1139601ms step_avg:93.41ms
+step:12400/500000 train_loss:0.8633 train_time:1158644ms step_avg:93.44ms
+step:12600/500000 train_loss:1.0033 train_time:1176858ms step_avg:93.40ms
+step:12800/500000 train_loss:0.9474 train_time:1195187ms step_avg:93.37ms
+step:13000/500000 train_loss:0.9017 train_time:1213487ms step_avg:93.35ms
+step:13200/500000 train_loss:0.9307 train_time:1231924ms step_avg:93.33ms
+step:13400/500000 train_loss:0.9635 train_time:1250259ms step_avg:93.30ms
+step:13600/500000 train_loss:0.8734 train_time:1268427ms step_avg:93.27ms
+step:13800/500000 train_loss:0.9056 train_time:1286893ms step_avg:93.25ms
+step:14000/500000 train_loss:0.9059 train_time:1305261ms step_avg:93.23ms
+step:14200/500000 train_loss:0.9214 train_time:1324409ms step_avg:93.27ms
+step:14400/500000 train_loss:0.9664 train_time:1344179ms step_avg:93.35ms
+step:14600/500000 train_loss:0.9193 train_time:1363056ms step_avg:93.36ms
+step:14800/500000 train_loss:0.9604 train_time:1381609ms step_avg:93.35ms
+step:15000/500000 train_loss:0.9525 train_time:1400064ms step_avg:93.34ms
+step:15200/500000 train_loss:0.9748 train_time:1418202ms step_avg:93.30ms
+step:15400/500000 train_loss:0.9722 train_time:1436661ms step_avg:93.29ms
+step:15600/500000 train_loss:0.8736 train_time:1455116ms step_avg:93.28ms
+step:15800/500000 train_loss:0.9184 train_time:1473233ms step_avg:93.24ms
+step:16000/500000 train_loss:0.9539 train_time:1491659ms step_avg:93.23ms
+step:16200/500000 train_loss:0.9397 train_time:1509821ms step_avg:93.20ms
+step:16400/500000 train_loss:0.8480 train_time:1529920ms step_avg:93.29ms
+step:16600/500000 train_loss:0.9577 train_time:1549759ms step_avg:93.36ms
+step:16800/500000 train_loss:0.9524 train_time:1568022ms step_avg:93.33ms
+step:17000/500000 train_loss:0.9144 train_time:1586546ms step_avg:93.33ms
+step:17200/500000 train_loss:0.9754 train_time:1604947ms step_avg:93.31ms
+step:17400/500000 train_loss:0.8571 train_time:1623127ms step_avg:93.28ms
+step:17600/500000 train_loss:0.9715 train_time:1641848ms step_avg:93.29ms
+step:17800/500000 train_loss:0.8696 train_time:1660054ms step_avg:93.26ms
+step:18000/500000 train_loss:0.8578 train_time:1678453ms step_avg:93.25ms
+step:18200/500000 train_loss:0.9395 train_time:1696868ms step_avg:93.23ms
+step:18400/500000 train_loss:0.9019 train_time:1715472ms step_avg:93.23ms
+step:18600/500000 train_loss:0.9321 train_time:1735612ms step_avg:93.31ms
+step:18800/500000 train_loss:0.9363 train_time:1754922ms step_avg:93.35ms
+step:19000/500000 train_loss:0.9410 train_time:1773134ms step_avg:93.32ms
+step:19200/500000 train_loss:0.9673 train_time:1791624ms step_avg:93.31ms
+step:19400/500000 train_loss:0.9940 train_time:1809896ms step_avg:93.29ms
+step:19600/500000 train_loss:0.9792 train_time:1828271ms step_avg:93.28ms
+step:19800/500000 train_loss:0.9786 train_time:1846800ms step_avg:93.27ms
+step:20000/500000 train_loss:0.9101 train_time:1864981ms step_avg:93.25ms
+step:20000/500000 val_loss:0.8884 val_bpb:1.2821 train_time:1865003ms step_avg:93.25ms
+step:20200/500000 train_loss:0.9637 train_time:1883522ms step_avg:93.24ms
+step:20400/500000 train_loss:0.9564 train_time:1902052ms step_avg:93.24ms
+step:20600/500000 train_loss:0.9488 train_time:1921239ms step_avg:93.26ms
+step:20800/500000 train_loss:1.0018 train_time:1940859ms step_avg:93.31ms
+step:21000/500000 train_loss:0.9240 train_time:1960120ms step_avg:93.34ms
+step:21200/500000 train_loss:1.0104 train_time:1978443ms step_avg:93.32ms
+step:21400/500000 train_loss:0.8407 train_time:1996802ms step_avg:93.31ms
+step:21600/500000 train_loss:0.9112 train_time:2014945ms step_avg:93.28ms
+step:21800/500000 train_loss:0.8916 train_time:2033344ms step_avg:93.27ms
+step:22000/500000 train_loss:0.9796 train_time:2051694ms step_avg:93.26ms
+step:22200/500000 train_loss:0.9063 train_time:2069851ms step_avg:93.24ms
+step:22400/500000 train_loss:0.8800 train_time:2088265ms step_avg:93.23ms
+step:22600/500000 train_loss:1.0029 train_time:2106440ms step_avg:93.21ms
+step:22800/500000 train_loss:0.9401 train_time:2126509ms step_avg:93.27ms
+step:23000/500000 train_loss:0.8991 train_time:2146147ms step_avg:93.31ms
+step:23200/500000 train_loss:0.9744 train_time:2164396ms step_avg:93.29ms
+step:23400/500000 train_loss:0.8975 train_time:2182858ms step_avg:93.28ms
+step:23600/500000 train_loss:0.9171 train_time:2201605ms step_avg:93.29ms
+step:23800/500000 train_loss:0.9855 train_time:2219813ms step_avg:93.27ms
+step:24000/500000 train_loss:0.9585 train_time:2238247ms step_avg:93.26ms
+step:24200/500000 train_loss:0.8978 train_time:2256380ms step_avg:93.24ms
+step:24400/500000 train_loss:0.9325 train_time:2275075ms step_avg:93.24ms
+step:24600/500000 train_loss:0.8656 train_time:2293510ms step_avg:93.23ms
+step:24800/500000 train_loss:0.9574 train_time:2311819ms step_avg:93.22ms
+step:25000/500000 train_loss:0.8974 train_time:2331675ms step_avg:93.27ms
+step:25200/500000 train_loss:0.9013 train_time:2351463ms step_avg:93.31ms
+step:25400/500000 train_loss:0.9650 train_time:2369680ms step_avg:93.29ms
+step:25600/500000 train_loss:0.9204 train_time:2388154ms step_avg:93.29ms
+step:25800/500000 train_loss:0.8882 train_time:2406366ms step_avg:93.27ms
+step:26000/500000 train_loss:0.9185 train_time:2424727ms step_avg:93.26ms
+step:26200/500000 train_loss:0.8974 train_time:2443178ms step_avg:93.25ms
+step:26400/500000 train_loss:0.7991 train_time:2461356ms step_avg:93.23ms
+step:26600/500000 train_loss:0.8827 train_time:2479766ms step_avg:93.22ms
+step:26800/500000 train_loss:0.9009 train_time:2497922ms step_avg:93.21ms
+step:27000/500000 train_loss:0.8016 train_time:2517205ms step_avg:93.23ms
+step:27200/500000 train_loss:0.9653 train_time:2536988ms step_avg:93.27ms
+step:27400/500000 train_loss:0.9326 train_time:2555666ms step_avg:93.27ms
+step:27600/500000 train_loss:0.8790 train_time:2574132ms step_avg:93.27ms
+step:27800/500000 train_loss:0.9185 train_time:2592473ms step_avg:93.25ms
+step:28000/500000 train_loss:0.9588 train_time:2610664ms step_avg:93.24ms
+step:28200/500000 train_loss:0.9743 train_time:2629079ms step_avg:93.23ms
+step:28400/500000 train_loss:0.8707 train_time:2647361ms step_avg:93.22ms
+step:28600/500000 train_loss:0.8897 train_time:2665728ms step_avg:93.21ms
+step:28800/500000 train_loss:0.9231 train_time:2684113ms step_avg:93.20ms
+step:29000/500000 train_loss:0.8537 train_time:2702484ms step_avg:93.19ms
+step:29200/500000 train_loss:0.9602 train_time:2721665ms step_avg:93.21ms
+step:29400/500000 train_loss:0.9245 train_time:2741343ms step_avg:93.24ms
+step:29600/500000 train_loss:0.9644 train_time:2759938ms step_avg:93.24ms
+step:29800/500000 train_loss:0.9169 train_time:2778371ms step_avg:93.23ms
+step:30000/500000 train_loss:0.8512 train_time:2796511ms step_avg:93.22ms
+step:30000/500000 val_loss:0.8750 val_bpb:1.2628 train_time:2796532ms step_avg:93.22ms
+step:30200/500000 train_loss:0.8902 train_time:2814762ms step_avg:93.20ms
+step:30400/500000 train_loss:1.0666 train_time:2833140ms step_avg:93.20ms
+step:30600/500000 train_loss:0.7969 train_time:2851271ms step_avg:93.18ms
+step:30800/500000 train_loss:0.9510 train_time:2869652ms step_avg:93.17ms
+step:31000/500000 train_loss:0.8856 train_time:2888270ms step_avg:93.17ms
+step:31200/500000 train_loss:0.9226 train_time:2906492ms step_avg:93.16ms
+step:31400/500000 train_loss:0.9228 train_time:2926630ms step_avg:93.20ms
+step:31600/500000 train_loss:0.8921 train_time:2946337ms step_avg:93.24ms
+step:31800/500000 train_loss:0.8541 train_time:2964565ms step_avg:93.23ms
+step:32000/500000 train_loss:1.1194 train_time:2983115ms step_avg:93.22ms
+step:32200/500000 train_loss:0.9257 train_time:3001349ms step_avg:93.21ms
+step:32400/500000 train_loss:0.9001 train_time:3019749ms step_avg:93.20ms
+step:32600/500000 train_loss:0.9370 train_time:3038168ms step_avg:93.20ms
+step:32800/500000 train_loss:0.9268 train_time:3056316ms step_avg:93.18ms
+step:33000/500000 train_loss:0.9494 train_time:3074987ms step_avg:93.18ms
+step:33200/500000 train_loss:0.9265 train_time:3093141ms step_avg:93.17ms
+step:33400/500000 train_loss:0.9153 train_time:3112081ms step_avg:93.18ms
+step:33600/500000 train_loss:0.9069 train_time:3132181ms step_avg:93.22ms
+step:33800/500000 train_loss:0.8995 train_time:3151241ms step_avg:93.23ms
+step:34000/500000 train_loss:0.9207 train_time:3169673ms step_avg:93.23ms
+step:34200/500000 train_loss:0.8763 train_time:3188101ms step_avg:93.22ms
+step:34400/500000 train_loss:0.8484 train_time:3206200ms step_avg:93.20ms
+step:34600/500000 train_loss:0.9550 train_time:3224702ms step_avg:93.20ms
+step:34800/500000 train_loss:0.9618 train_time:3242859ms step_avg:93.19ms
+step:35000/500000 train_loss:0.9317 train_time:3261310ms step_avg:93.18ms
+step:35200/500000 train_loss:0.9289 train_time:3279684ms step_avg:93.17ms
+step:35400/500000 train_loss:0.8875 train_time:3297932ms step_avg:93.16ms
+step:35600/500000 train_loss:0.9080 train_time:3317637ms step_avg:93.19ms
+step:35800/500000 train_loss:0.8772 train_time:3337142ms step_avg:93.22ms
+step:36000/500000 train_loss:1.0079 train_time:3355793ms step_avg:93.22ms
+step:36200/500000 train_loss:0.9476 train_time:3374185ms step_avg:93.21ms
+step:36400/500000 train_loss:0.9459 train_time:3392345ms step_avg:93.20ms
+step:36600/500000 train_loss:0.9560 train_time:3410710ms step_avg:93.19ms
+step:36800/500000 train_loss:0.9798 train_time:3429114ms step_avg:93.18ms
+step:37000/500000 train_loss:0.9516 train_time:3447282ms step_avg:93.17ms
+step:37200/500000 train_loss:0.9333 train_time:3465914ms step_avg:93.17ms
+step:37400/500000 train_loss:0.9434 train_time:3484109ms step_avg:93.16ms
+step:37600/500000 train_loss:0.9991 train_time:3502415ms step_avg:93.15ms
+step:37800/500000 train_loss:0.9050 train_time:3522445ms step_avg:93.19ms
+step:38000/500000 train_loss:0.9059 train_time:3541926ms step_avg:93.21ms
+step:38200/500000 train_loss:0.9826 train_time:3560554ms step_avg:93.21ms
+step:38400/500000 train_loss:0.8973 train_time:3578917ms step_avg:93.20ms
+step:38600/500000 train_loss:0.8890 train_time:3597159ms step_avg:93.19ms
+step:38800/500000 train_loss:0.9621 train_time:3615593ms step_avg:93.19ms
+step:39000/500000 train_loss:0.9516 train_time:3633864ms step_avg:93.18ms
+step:39200/500000 train_loss:0.9720 train_time:3652337ms step_avg:93.17ms
+step:39400/500000 train_loss:0.8962 train_time:3670966ms step_avg:93.17ms
+step:39600/500000 train_loss:0.9070 train_time:3689111ms step_avg:93.16ms
+step:39800/500000 train_loss:0.9131 train_time:3707882ms step_avg:93.16ms
+step:40000/500000 train_loss:0.9677 train_time:3727929ms step_avg:93.20ms
+step:40000/500000 val_loss:0.8656 val_bpb:1.2492 train_time:3727950ms step_avg:93.20ms
+step:40200/500000 train_loss:0.9292 train_time:3746943ms step_avg:93.21ms
+step:40400/500000 train_loss:0.9182 train_time:3765394ms step_avg:93.20ms
+step:40600/500000 train_loss:1.0334 train_time:3783795ms step_avg:93.20ms
+step:40800/500000 train_loss:0.8485 train_time:3801963ms step_avg:93.19ms
+step:41000/500000 train_loss:0.8960 train_time:3820354ms step_avg:93.18ms
+step:41200/500000 train_loss:0.9149 train_time:3838695ms step_avg:93.17ms
+step:41400/500000 train_loss:0.8809 train_time:3857072ms step_avg:93.17ms
+step:41600/500000 train_loss:0.8015 train_time:3875408ms step_avg:93.16ms
+step:41800/500000 train_loss:0.8549 train_time:3893589ms step_avg:93.15ms
+step:42000/500000 train_loss:0.9770 train_time:3912476ms step_avg:93.15ms
+step:42200/500000 train_loss:0.8809 train_time:3932092ms step_avg:93.18ms
+step:42400/500000 train_loss:0.9155 train_time:3950748ms step_avg:93.18ms
+step:42600/500000 train_loss:0.9942 train_time:3969233ms step_avg:93.17ms
+step:42800/500000 train_loss:1.2681 train_time:3987377ms step_avg:93.16ms
+step:43000/500000 train_loss:0.9522 train_time:4005730ms step_avg:93.16ms
+step:43200/500000 train_loss:0.9392 train_time:4024305ms step_avg:93.16ms
+step:43400/500000 train_loss:0.8458 train_time:4042486ms step_avg:93.14ms
+step:43600/500000 train_loss:0.8995 train_time:4060914ms step_avg:93.14ms
+step:43800/500000 train_loss:0.8148 train_time:4079174ms step_avg:93.13ms
+step:44000/500000 train_loss:0.9790 train_time:4097750ms step_avg:93.13ms
+step:44200/500000 train_loss:0.9189 train_time:4118255ms step_avg:93.17ms
+step:44400/500000 train_loss:0.8832 train_time:4137388ms step_avg:93.18ms
+step:44600/500000 train_loss:0.8687 train_time:4155903ms step_avg:93.18ms
+step:44800/500000 train_loss:0.9476 train_time:4174285ms step_avg:93.18ms
+step:45000/500000 train_loss:0.8941 train_time:4192573ms step_avg:93.17ms
+step:45200/500000 train_loss:0.8711 train_time:4211061ms step_avg:93.17ms
+step:45400/500000 train_loss:0.9292 train_time:4229374ms step_avg:93.16ms
+step:45600/500000 train_loss:0.9008 train_time:4247760ms step_avg:93.15ms
+step:45800/500000 train_loss:0.9762 train_time:4266177ms step_avg:93.15ms
+step:46000/500000 train_loss:0.7978 train_time:4284354ms step_avg:93.14ms
+step:46200/500000 train_loss:0.8854 train_time:4302792ms step_avg:93.13ms
+step:46400/500000 train_loss:0.9072 train_time:4322462ms step_avg:93.16ms
+step:46600/500000 train_loss:0.9444 train_time:4341604ms step_avg:93.17ms
+step:46800/500000 train_loss:0.7754 train_time:4360107ms step_avg:93.16ms
+step:47000/500000 train_loss:0.9090 train_time:4378357ms step_avg:93.16ms
+step:47200/500000 train_loss:1.3480 train_time:4396847ms step_avg:93.15ms
+step:47400/500000 train_loss:0.9517 train_time:4415283ms step_avg:93.15ms
+step:47600/500000 train_loss:0.9439 train_time:4433495ms step_avg:93.14ms
+step:47800/500000 train_loss:0.9820 train_time:4451817ms step_avg:93.13ms
+step:48000/500000 train_loss:0.8999 train_time:4470000ms step_avg:93.12ms
+step:48200/500000 train_loss:0.9453 train_time:4488419ms step_avg:93.12ms
+step:48400/500000 train_loss:0.9758 train_time:4507184ms step_avg:93.12ms
+step:48600/500000 train_loss:0.9096 train_time:4527038ms step_avg:93.15ms
+step:48800/500000 train_loss:1.0319 train_time:4546237ms step_avg:93.16ms
+step:49000/500000 train_loss:0.8900 train_time:4564693ms step_avg:93.16ms
+step:49200/500000 train_loss:0.8963 train_time:4582807ms step_avg:93.15ms
+step:49400/500000 train_loss:0.9086 train_time:4601583ms step_avg:93.15ms
+step:49600/500000 train_loss:0.9163 train_time:4619784ms step_avg:93.14ms
+step:49800/500000 train_loss:0.8849 train_time:4638111ms step_avg:93.13ms
+step:50000/500000 train_loss:0.9125 train_time:4656445ms step_avg:93.13ms
+step:50000/500000 val_loss:0.8598 val_bpb:1.2408 train_time:4656469ms step_avg:93.13ms
+step:50200/500000 train_loss:0.9371 train_time:4674639ms step_avg:93.12ms
+step:50400/500000 train_loss:0.9027 train_time:4693104ms step_avg:93.12ms
+step:50600/500000 train_loss:1.0174 train_time:4712616ms step_avg:93.13ms
+step:50800/500000 train_loss:0.9137 train_time:4731672ms step_avg:93.14ms
+step:51000/500000 train_loss:0.8843 train_time:4750643ms step_avg:93.15ms
+step:51200/500000 train_loss:0.9057 train_time:4768968ms step_avg:93.14ms
+step:51400/500000 train_loss:0.8713 train_time:4787154ms step_avg:93.14ms
+step:51600/500000 train_loss:0.8741 train_time:4805495ms step_avg:93.13ms
+step:51800/500000 train_loss:0.8957 train_time:4823665ms step_avg:93.12ms
+step:52000/500000 train_loss:0.9577 train_time:4842099ms step_avg:93.12ms
+step:52200/500000 train_loss:0.9239 train_time:4860456ms step_avg:93.11ms
+step:52400/500000 train_loss:0.9532 train_time:4878644ms step_avg:93.10ms
+step:52600/500000 train_loss:0.8867 train_time:4897032ms step_avg:93.10ms
+step:52800/500000 train_loss:0.8645 train_time:4917431ms step_avg:93.13ms
+step:53000/500000 train_loss:0.8890 train_time:4936470ms step_avg:93.14ms
+step:53200/500000 train_loss:0.9593 train_time:4954923ms step_avg:93.14ms
+step:53400/500000 train_loss:0.8703 train_time:4973232ms step_avg:93.13ms
+step:53600/500000 train_loss:0.9052 train_time:4992030ms step_avg:93.13ms
+step:53800/500000 train_loss:0.8517 train_time:5010469ms step_avg:93.13ms
+step:54000/500000 train_loss:0.8612 train_time:5028700ms step_avg:93.12ms
+step:54200/500000 train_loss:0.9275 train_time:5047052ms step_avg:93.12ms
+step:54400/500000 train_loss:0.8667 train_time:5065271ms step_avg:93.11ms
+step:54600/500000 train_loss:1.0107 train_time:5083745ms step_avg:93.11ms
+step:54800/500000 train_loss:0.9132 train_time:5102741ms step_avg:93.12ms
+step:55000/500000 train_loss:0.9186 train_time:5122606ms step_avg:93.14ms
+step:55200/500000 train_loss:0.8188 train_time:5141857ms step_avg:93.15ms
+step:55400/500000 train_loss:0.9143 train_time:5160330ms step_avg:93.15ms
+step:55600/500000 train_loss:0.8622 train_time:5178450ms step_avg:93.14ms
+step:55800/500000 train_loss:0.8314 train_time:5196831ms step_avg:93.13ms
+step:56000/500000 train_loss:0.8815 train_time:5215110ms step_avg:93.13ms
+step:56200/500000 train_loss:0.8657 train_time:5233472ms step_avg:93.12ms
+step:56400/500000 train_loss:0.8938 train_time:5251933ms step_avg:93.12ms
+step:56600/500000 train_loss:0.8761 train_time:5270149ms step_avg:93.11ms
+step:56800/500000 train_loss:0.9170 train_time:5288541ms step_avg:93.11ms
+step:57000/500000 train_loss:0.8858 train_time:5308627ms step_avg:93.13ms
+step:57200/500000 train_loss:0.8311 train_time:5327716ms step_avg:93.14ms
+step:57400/500000 train_loss:1.0337 train_time:5346617ms step_avg:93.15ms
+step:57600/500000 train_loss:0.9143 train_time:5364789ms step_avg:93.14ms
+step:57800/500000 train_loss:0.8459 train_time:5383492ms step_avg:93.14ms
+step:58000/500000 train_loss:0.8830 train_time:5401932ms step_avg:93.14ms
+step:58200/500000 train_loss:0.8057 train_time:5420099ms step_avg:93.13ms
+step:58400/500000 train_loss:0.9057 train_time:5438494ms step_avg:93.12ms
+step:58600/500000 train_loss:1.0758 train_time:5456965ms step_avg:93.12ms
+step:58800/500000 train_loss:0.8391 train_time:5475092ms step_avg:93.11ms
+step:59000/500000 train_loss:1.0262 train_time:5493492ms step_avg:93.11ms
+step:59200/500000 train_loss:0.9234 train_time:5513306ms step_avg:93.13ms
+step:59400/500000 train_loss:0.8761 train_time:5532459ms step_avg:93.14ms
+step:59600/500000 train_loss:0.8939 train_time:5551534ms step_avg:93.15ms
+step:59800/500000 train_loss:0.8940 train_time:5569750ms step_avg:93.14ms
+step:60000/500000 train_loss:1.0463 train_time:5588205ms step_avg:93.14ms
+step:60000/500000 val_loss:0.8567 val_bpb:1.2364 train_time:5588226ms step_avg:93.14ms
+step:60200/500000 train_loss:0.8508 train_time:5606649ms step_avg:93.13ms
+step:60400/500000 train_loss:0.8837 train_time:5624805ms step_avg:93.13ms
+step:60600/500000 train_loss:1.2200 train_time:5643462ms step_avg:93.13ms
+step:60800/500000 train_loss:0.9086 train_time:5661613ms step_avg:93.12ms
+step:61000/500000 train_loss:0.8484 train_time:5680061ms step_avg:93.12ms
+step:61200/500000 train_loss:0.9358 train_time:5699595ms step_avg:93.13ms
+step:61400/500000 train_loss:1.0205 train_time:5718951ms step_avg:93.14ms
+step:61600/500000 train_loss:0.9139 train_time:5738624ms step_avg:93.16ms
+step:61800/500000 train_loss:0.8326 train_time:5757430ms step_avg:93.16ms
+step:62000/500000 train_loss:0.9129 train_time:5775559ms step_avg:93.15ms
+step:62200/500000 train_loss:0.8683 train_time:5793917ms step_avg:93.15ms
+step:62400/500000 train_loss:0.8965 train_time:5812328ms step_avg:93.15ms
+step:62600/500000 train_loss:1.0742 train_time:5830538ms step_avg:93.14ms
+step:62800/500000 train_loss:0.8567 train_time:5849005ms step_avg:93.14ms
+step:63000/500000 train_loss:0.8317 train_time:5867248ms step_avg:93.13ms
+step:63200/500000 train_loss:0.8495 train_time:5885756ms step_avg:93.13ms
+step:63400/500000 train_loss:0.8585 train_time:5905093ms step_avg:93.14ms
+step:63600/500000 train_loss:0.8741 train_time:5924690ms step_avg:93.16ms
+step:63800/500000 train_loss:0.8623 train_time:5943588ms step_avg:93.16ms
+step:64000/500000 train_loss:0.9306 train_time:5961781ms step_avg:93.15ms
+step:64200/500000 train_loss:0.9809 train_time:5980208ms step_avg:93.15ms
+step:64400/500000 train_loss:0.9477 train_time:5998676ms step_avg:93.15ms
+step:64600/500000 train_loss:0.9216 train_time:6016846ms step_avg:93.14ms
+step:64800/500000 train_loss:1.0239 train_time:6035239ms step_avg:93.14ms
+step:65000/500000 train_loss:0.9138 train_time:6053665ms step_avg:93.13ms
+step:65200/500000 train_loss:0.9199 train_time:6071824ms step_avg:93.13ms
+step:65400/500000 train_loss:0.9260 train_time:6090254ms step_avg:93.12ms
+step:65600/500000 train_loss:1.0365 train_time:6110058ms step_avg:93.14ms
+step:65800/500000 train_loss:1.1548 train_time:6129212ms step_avg:93.15ms
+step:66000/500000 train_loss:0.8494 train_time:6148317ms step_avg:93.16ms
+step:66200/500000 train_loss:0.9065 train_time:6166560ms step_avg:93.15ms
+step:66400/500000 train_loss:0.8210 train_time:6184944ms step_avg:93.15ms
+step:66600/500000 train_loss:0.8431 train_time:6203439ms step_avg:93.14ms
+step:66800/500000 train_loss:0.9818 train_time:6221629ms step_avg:93.14ms
+step:67000/500000 train_loss:0.9239 train_time:6240010ms step_avg:93.13ms
+step:67200/500000 train_loss:0.8302 train_time:6258150ms step_avg:93.13ms
+step:67400/500000 train_loss:0.9006 train_time:6276589ms step_avg:93.12ms
+step:67600/500000 train_loss:0.8887 train_time:6295825ms step_avg:93.13ms
+step:67800/500000 train_loss:0.9085 train_time:6315241ms step_avg:93.15ms
+step:68000/500000 train_loss:0.8968 train_time:6334090ms step_avg:93.15ms
+step:68200/500000 train_loss:0.9130 train_time:6353039ms step_avg:93.15ms
+step:68400/500000 train_loss:0.8554 train_time:6371218ms step_avg:93.15ms
+step:68600/500000 train_loss:0.8544 train_time:6389528ms step_avg:93.14ms
+step:68800/500000 train_loss:0.8774 train_time:6407742ms step_avg:93.14ms
+step:69000/500000 train_loss:0.9123 train_time:6426124ms step_avg:93.13ms
+step:69200/500000 train_loss:0.8960 train_time:6444453ms step_avg:93.13ms
+step:69400/500000 train_loss:0.9253 train_time:6462599ms step_avg:93.12ms
+step:69600/500000 train_loss:0.8809 train_time:6481020ms step_avg:93.12ms
+step:69800/500000 train_loss:0.9420 train_time:6500367ms step_avg:93.13ms
+step:70000/500000 train_loss:0.9124 train_time:6519666ms step_avg:93.14ms
+step:70000/500000 val_loss:0.8526 val_bpb:1.2304 train_time:6519688ms step_avg:93.14ms
+step:70200/500000 train_loss:0.9098 train_time:6539023ms step_avg:93.15ms
+step:70400/500000 train_loss:0.8804 train_time:6557220ms step_avg:93.14ms
+step:70600/500000 train_loss:0.8464 train_time:6575609ms step_avg:93.14ms
+step:70800/500000 train_loss:0.8994 train_time:6594010ms step_avg:93.14ms
+step:71000/500000 train_loss:0.9021 train_time:6612266ms step_avg:93.13ms
+step:71200/500000 train_loss:0.9345 train_time:6630724ms step_avg:93.13ms
+step:71400/500000 train_loss:0.8523 train_time:6649132ms step_avg:93.13ms
+step:71600/500000 train_loss:0.8466 train_time:6667307ms step_avg:93.12ms
+step:71800/500000 train_loss:0.8758 train_time:6685612ms step_avg:93.11ms
+step:72000/500000 train_loss:0.8549 train_time:6705535ms step_avg:93.13ms
+step:72200/500000 train_loss:0.8120 train_time:6724740ms step_avg:93.14ms
+step:72400/500000 train_loss:0.9164 train_time:6743841ms step_avg:93.15ms
+step:72600/500000 train_loss:0.9204 train_time:6762116ms step_avg:93.14ms
+step:72800/500000 train_loss:0.8253 train_time:6780458ms step_avg:93.14ms
+step:73000/500000 train_loss:0.8968 train_time:6798940ms step_avg:93.14ms
+step:73200/500000 train_loss:0.8657 train_time:6817154ms step_avg:93.13ms
+step:73400/500000 train_loss:0.9168 train_time:6835516ms step_avg:93.13ms
+step:73600/500000 train_loss:0.9449 train_time:6853711ms step_avg:93.12ms
+step:73800/500000 train_loss:0.8315 train_time:6872116ms step_avg:93.12ms
+step:74000/500000 train_loss:0.9208 train_time:6891471ms step_avg:93.13ms
+step:74200/500000 train_loss:0.8539 train_time:6910597ms step_avg:93.13ms
+step:74400/500000 train_loss:0.9307 train_time:6930034ms step_avg:93.15ms
+step:74600/500000 train_loss:0.9225 train_time:6949123ms step_avg:93.15ms
+step:74800/500000 train_loss:0.9780 train_time:6967260ms step_avg:93.15ms
+step:75000/500000 train_loss:0.9534 train_time:6985635ms step_avg:93.14ms
+step:75200/500000 train_loss:0.9287 train_time:7003818ms step_avg:93.14ms
+step:75400/500000 train_loss:0.8665 train_time:7022288ms step_avg:93.13ms
+step:75600/500000 train_loss:0.9988 train_time:7040770ms step_avg:93.13ms
+step:75800/500000 train_loss:0.9770 train_time:7058972ms step_avg:93.13ms
+step:76000/500000 train_loss:0.9629 train_time:7077366ms step_avg:93.12ms
+step:76200/500000 train_loss:0.9386 train_time:7096776ms step_avg:93.13ms
+step:76400/500000 train_loss:0.8257 train_time:7116142ms step_avg:93.14ms
+step:76600/500000 train_loss:0.8693 train_time:7134936ms step_avg:93.15ms
+step:76800/500000 train_loss:1.0731 train_time:7153636ms step_avg:93.15ms
+step:77000/500000 train_loss:1.0028 train_time:7172084ms step_avg:93.14ms
+step:77200/500000 train_loss:0.9502 train_time:7190721ms step_avg:93.14ms
+step:77400/500000 train_loss:0.8657 train_time:7208859ms step_avg:93.14ms
+step:77600/500000 train_loss:0.9391 train_time:7227251ms step_avg:93.13ms
+step:77800/500000 train_loss:0.9324 train_time:7245468ms step_avg:93.13ms
+step:78000/500000 train_loss:0.9193 train_time:7263806ms step_avg:93.13ms
+step:78200/500000 train_loss:0.8315 train_time:7282745ms step_avg:93.13ms
+step:78400/500000 train_loss:0.9203 train_time:7302308ms step_avg:93.14ms
+step:78600/500000 train_loss:0.8814 train_time:7321622ms step_avg:93.15ms
+step:78800/500000 train_loss:0.9117 train_time:7340597ms step_avg:93.15ms
+step:79000/500000 train_loss:0.9635 train_time:7358791ms step_avg:93.15ms
+step:79200/500000 train_loss:0.9501 train_time:7377247ms step_avg:93.15ms
+step:79400/500000 train_loss:0.9118 train_time:7395337ms step_avg:93.14ms
+step:79600/500000 train_loss:0.9322 train_time:7413852ms step_avg:93.14ms
+step:79800/500000 train_loss:0.9071 train_time:7432293ms step_avg:93.14ms
+step:80000/500000 train_loss:0.9132 train_time:7450452ms step_avg:93.13ms
+step:80000/500000 val_loss:0.8490 val_bpb:1.2252 train_time:7450473ms step_avg:93.13ms
+step:80200/500000 train_loss:0.9114 train_time:7468880ms step_avg:93.13ms
+step:80400/500000 train_loss:0.8950 train_time:7487706ms step_avg:93.13ms
+step:80600/500000 train_loss:0.8931 train_time:7507077ms step_avg:93.14ms
+step:80800/500000 train_loss:0.9463 train_time:7525865ms step_avg:93.14ms
+step:81000/500000 train_loss:0.8915 train_time:7544910ms step_avg:93.15ms
+step:81200/500000 train_loss:0.9432 train_time:7563078ms step_avg:93.14ms
+step:81400/500000 train_loss:0.8800 train_time:7581565ms step_avg:93.14ms
+step:81600/500000 train_loss:0.7996 train_time:7599790ms step_avg:93.13ms
+step:81800/500000 train_loss:0.8262 train_time:7618154ms step_avg:93.13ms
+step:82000/500000 train_loss:0.8652 train_time:7636501ms step_avg:93.13ms
+step:82200/500000 train_loss:0.9617 train_time:7654723ms step_avg:93.12ms
+step:82400/500000 train_loss:0.8405 train_time:7673335ms step_avg:93.12ms
+step:82600/500000 train_loss:0.9045 train_time:7692251ms step_avg:93.13ms
+step:82800/500000 train_loss:0.8767 train_time:7711509ms step_avg:93.13ms
+step:83000/500000 train_loss:0.9188 train_time:7730676ms step_avg:93.14ms
+step:83200/500000 train_loss:0.9337 train_time:7749385ms step_avg:93.14ms
+step:83400/500000 train_loss:0.8735 train_time:7767733ms step_avg:93.14ms
+step:83600/500000 train_loss:0.8184 train_time:7786225ms step_avg:93.14ms
+step:83800/500000 train_loss:0.9180 train_time:7804400ms step_avg:93.13ms
+step:84000/500000 train_loss:0.9060 train_time:7822831ms step_avg:93.13ms
+step:84200/500000 train_loss:0.9972 train_time:7840987ms step_avg:93.12ms
+step:84400/500000 train_loss:1.0239 train_time:7859396ms step_avg:93.12ms
+step:84600/500000 train_loss:0.8671 train_time:7878173ms step_avg:93.12ms
+step:84800/500000 train_loss:0.9093 train_time:7897561ms step_avg:93.13ms
+step:85000/500000 train_loss:0.9727 train_time:7916789ms step_avg:93.14ms
+step:85200/500000 train_loss:0.8674 train_time:7935265ms step_avg:93.14ms
+step:85400/500000 train_loss:0.8379 train_time:7953860ms step_avg:93.14ms
+step:85600/500000 train_loss:0.8477 train_time:7972253ms step_avg:93.13ms
+step:85800/500000 train_loss:0.8729 train_time:7990441ms step_avg:93.13ms
+step:86000/500000 train_loss:0.9136 train_time:8008755ms step_avg:93.13ms
+step:86200/500000 train_loss:0.8884 train_time:8027168ms step_avg:93.12ms
+step:86400/500000 train_loss:0.8971 train_time:8045319ms step_avg:93.12ms
+step:86600/500000 train_loss:0.8792 train_time:8063877ms step_avg:93.12ms
+step:86800/500000 train_loss:0.9327 train_time:8082508ms step_avg:93.12ms
+step:87000/500000 train_loss:0.9450 train_time:8102049ms step_avg:93.13ms
+step:87200/500000 train_loss:0.8781 train_time:8121212ms step_avg:93.13ms
+step:87400/500000 train_loss:0.9249 train_time:8139921ms step_avg:93.13ms
+step:87600/500000 train_loss:0.8834 train_time:8158288ms step_avg:93.13ms
+step:87800/500000 train_loss:0.8902 train_time:8176681ms step_avg:93.13ms
+step:88000/500000 train_loss:0.9238 train_time:8194863ms step_avg:93.12ms
+step:88200/500000 train_loss:0.8509 train_time:8213252ms step_avg:93.12ms
+step:88400/500000 train_loss:0.8646 train_time:8231436ms step_avg:93.12ms
+step:88600/500000 train_loss:0.8785 train_time:8250049ms step_avg:93.12ms
+step:88800/500000 train_loss:0.8639 train_time:8268447ms step_avg:93.11ms
+step:89000/500000 train_loss:0.9267 train_time:8287404ms step_avg:93.12ms
+step:89200/500000 train_loss:0.8439 train_time:8306602ms step_avg:93.12ms
+step:89400/500000 train_loss:0.8801 train_time:8325815ms step_avg:93.13ms
+step:89600/500000 train_loss:0.8575 train_time:8344395ms step_avg:93.13ms
+step:89800/500000 train_loss:0.8809 train_time:8362761ms step_avg:93.13ms
+step:90000/500000 train_loss:0.8878 train_time:8381028ms step_avg:93.12ms
+step:90000/500000 val_loss:0.8460 val_bpb:1.2209 train_time:8381049ms step_avg:93.12ms
+step:90200/500000 train_loss:0.9068 train_time:8399256ms step_avg:93.12ms
+step:90400/500000 train_loss:0.8162 train_time:8417906ms step_avg:93.12ms
+step:90600/500000 train_loss:0.9347 train_time:8436212ms step_avg:93.11ms
+step:90800/500000 train_loss:0.9195 train_time:8454520ms step_avg:93.11ms
+step:91000/500000 train_loss:0.9405 train_time:8473143ms step_avg:93.11ms
+step:91200/500000 train_loss:0.9029 train_time:8492513ms step_avg:93.12ms
+step:91400/500000 train_loss:0.9069 train_time:8511471ms step_avg:93.12ms
+step:91600/500000 train_loss:0.9354 train_time:8530331ms step_avg:93.13ms
+step:91800/500000 train_loss:0.8768 train_time:8548947ms step_avg:93.13ms
+step:92000/500000 train_loss:0.8941 train_time:8567504ms step_avg:93.13ms
+step:92200/500000 train_loss:0.8863 train_time:8585721ms step_avg:93.12ms
+step:92400/500000 train_loss:0.8996 train_time:8604049ms step_avg:93.12ms
+step:92600/500000 train_loss:0.9083 train_time:8622771ms step_avg:93.12ms
+step:92800/500000 train_loss:0.8202 train_time:8640897ms step_avg:93.11ms
+step:93000/500000 train_loss:0.8782 train_time:8659538ms step_avg:93.11ms
+step:93200/500000 train_loss:0.9395 train_time:8677990ms step_avg:93.11ms
+step:93400/500000 train_loss:0.9190 train_time:8697721ms step_avg:93.12ms
+step:93600/500000 train_loss:0.8757 train_time:8716807ms step_avg:93.13ms
+step:93800/500000 train_loss:0.8670 train_time:8734943ms step_avg:93.12ms
+step:94000/500000 train_loss:0.8666 train_time:8753749ms step_avg:93.12ms
+step:94200/500000 train_loss:0.9263 train_time:8772041ms step_avg:93.12ms
+step:94400/500000 train_loss:0.9090 train_time:8790181ms step_avg:93.12ms
+step:94600/500000 train_loss:0.9117 train_time:8808494ms step_avg:93.11ms
+step:94800/500000 train_loss:0.8963 train_time:8826545ms step_avg:93.11ms
+step:95000/500000 train_loss:0.8533 train_time:8844861ms step_avg:93.10ms
+step:95200/500000 train_loss:0.9194 train_time:8863635ms step_avg:93.11ms
+step:95400/500000 train_loss:0.8899 train_time:8882223ms step_avg:93.11ms
+step:95600/500000 train_loss:0.8753 train_time:8901297ms step_avg:93.11ms
+step:95800/500000 train_loss:0.8653 train_time:8920462ms step_avg:93.12ms
+step:96000/500000 train_loss:0.9190 train_time:8939044ms step_avg:93.12ms
+step:96200/500000 train_loss:0.8267 train_time:8957449ms step_avg:93.11ms
+step:96400/500000 train_loss:0.7358 train_time:8975548ms step_avg:93.11ms
+step:96600/500000 train_loss:0.8065 train_time:8993899ms step_avg:93.10ms
+step:96800/500000 train_loss:0.8875 train_time:9012233ms step_avg:93.10ms
+step:97000/500000 train_loss:0.8662 train_time:9030504ms step_avg:93.10ms
+step:97200/500000 train_loss:0.9109 train_time:9048907ms step_avg:93.10ms
+step:97400/500000 train_loss:0.8804 train_time:9067396ms step_avg:93.09ms
+step:97600/500000 train_loss:0.9476 train_time:9086836ms step_avg:93.10ms
+step:97800/500000 train_loss:0.8609 train_time:9105629ms step_avg:93.10ms
+step:98000/500000 train_loss:0.8611 train_time:9124191ms step_avg:93.10ms
+step:98200/500000 train_loss:0.9998 train_time:9143135ms step_avg:93.11ms
+step:98400/500000 train_loss:0.8971 train_time:9161438ms step_avg:93.10ms
+step:98600/500000 train_loss:0.8802 train_time:9179516ms step_avg:93.10ms
+step:98800/500000 train_loss:0.8739 train_time:9197858ms step_avg:93.10ms
+step:99000/500000 train_loss:0.8465 train_time:9216061ms step_avg:93.09ms
+step:99200/500000 train_loss:0.9280 train_time:9234411ms step_avg:93.09ms
+step:99400/500000 train_loss:0.8723 train_time:9252702ms step_avg:93.09ms
+step:99600/500000 train_loss:0.8544 train_time:9271234ms step_avg:93.08ms
+step:99800/500000 train_loss:1.0714 train_time:9290726ms step_avg:93.09ms
+step:100000/500000 train_loss:0.8744 train_time:9309410ms step_avg:93.09ms
+step:100000/500000 val_loss:0.8451 val_bpb:1.2197 train_time:9309430ms step_avg:93.09ms
+step:100200/500000 train_loss:0.9083 train_time:9327901ms step_avg:93.09ms
+step:100400/500000 train_loss:0.8725 train_time:9346611ms step_avg:93.09ms
+step:100600/500000 train_loss:0.9066 train_time:9364830ms step_avg:93.09ms
+step:100800/500000 train_loss:0.8643 train_time:9382900ms step_avg:93.08ms
+step:101000/500000 train_loss:0.9570 train_time:9401240ms step_avg:93.08ms
+step:101200/500000 train_loss:0.9434 train_time:9419331ms step_avg:93.08ms
+step:101400/500000 train_loss:0.9140 train_time:9437653ms step_avg:93.07ms
+step:101600/500000 train_loss:0.8880 train_time:9456508ms step_avg:93.08ms
+step:101800/500000 train_loss:1.2701 train_time:9475109ms step_avg:93.08ms
+step:102000/500000 train_loss:0.8532 train_time:9494293ms step_avg:93.08ms
+step:102200/500000 train_loss:0.8909 train_time:9513201ms step_avg:93.08ms
+step:102400/500000 train_loss:0.8874 train_time:9532039ms step_avg:93.09ms
+step:102600/500000 train_loss:0.9350 train_time:9550286ms step_avg:93.08ms
+step:102800/500000 train_loss:0.9506 train_time:9568473ms step_avg:93.08ms
+step:103000/500000 train_loss:0.8991 train_time:9586847ms step_avg:93.08ms
+step:103200/500000 train_loss:0.8385 train_time:9605192ms step_avg:93.07ms
+step:103400/500000 train_loss:0.8671 train_time:9623236ms step_avg:93.07ms
+step:103600/500000 train_loss:0.8962 train_time:9641498ms step_avg:93.06ms
+step:103800/500000 train_loss:0.8183 train_time:9659958ms step_avg:93.06ms
+step:104000/500000 train_loss:0.9274 train_time:9679066ms step_avg:93.07ms
+step:104200/500000 train_loss:0.9323 train_time:9698598ms step_avg:93.08ms
+step:104400/500000 train_loss:0.9007 train_time:9717130ms step_avg:93.08ms
+step:104600/500000 train_loss:0.8562 train_time:9736173ms step_avg:93.08ms
+step:104800/500000 train_loss:0.8985 train_time:9754402ms step_avg:93.08ms
+step:105000/500000 train_loss:0.8763 train_time:9772610ms step_avg:93.07ms
+step:105200/500000 train_loss:0.8325 train_time:9790928ms step_avg:93.07ms
+step:105400/500000 train_loss:0.8911 train_time:9809066ms step_avg:93.07ms
+step:105600/500000 train_loss:0.9726 train_time:9827355ms step_avg:93.06ms
+step:105800/500000 train_loss:0.8329 train_time:9845619ms step_avg:93.06ms
+step:106000/500000 train_loss:0.7651 train_time:9864200ms step_avg:93.06ms
+step:106200/500000 train_loss:0.9194 train_time:9883801ms step_avg:93.07ms
+step:106400/500000 train_loss:0.8794 train_time:9902292ms step_avg:93.07ms
+step:106600/500000 train_loss:0.9250 train_time:9920994ms step_avg:93.07ms
+step:106800/500000 train_loss:1.0348 train_time:9939768ms step_avg:93.07ms
+step:107000/500000 train_loss:0.8450 train_time:9957938ms step_avg:93.06ms
+step:107200/500000 train_loss:0.9058 train_time:9976178ms step_avg:93.06ms
+step:107400/500000 train_loss:0.8889 train_time:9994417ms step_avg:93.06ms
+step:107600/500000 train_loss:0.9046 train_time:10032914ms step_avg:93.24ms
+step:107800/500000 train_loss:0.8516 train_time:10051046ms step_avg:93.24ms
+step:108000/500000 train_loss:1.3196 train_time:10069787ms step_avg:93.24ms
+step:108200/500000 train_loss:0.8707 train_time:10088490ms step_avg:93.24ms
+step:108400/500000 train_loss:0.9037 train_time:10107405ms step_avg:93.24ms
+step:108600/500000 train_loss:0.8563 train_time:10126043ms step_avg:93.24ms
+step:108800/500000 train_loss:0.8549 train_time:10144718ms step_avg:93.24ms
+step:109000/500000 train_loss:0.8589 train_time:10163236ms step_avg:93.24ms
+step:109200/500000 train_loss:0.9023 train_time:10181793ms step_avg:93.24ms
+step:109400/500000 train_loss:0.8962 train_time:10199867ms step_avg:93.23ms
+step:109600/500000 train_loss:0.8403 train_time:10218312ms step_avg:93.23ms
+step:109800/500000 train_loss:0.9102 train_time:10236746ms step_avg:93.23ms
+step:110000/500000 train_loss:0.9439 train_time:10254886ms step_avg:93.23ms
+step:110000/500000 val_loss:0.8434 val_bpb:1.2172 train_time:10254907ms step_avg:93.23ms
+step:110200/500000 train_loss:0.9160 train_time:10273398ms step_avg:93.23ms
+step:110400/500000 train_loss:0.8705 train_time:10292570ms step_avg:93.23ms
+step:110600/500000 train_loss:0.9198 train_time:10311088ms step_avg:93.23ms
+step:110800/500000 train_loss:0.9278 train_time:10330236ms step_avg:93.23ms
+step:111000/500000 train_loss:0.8443 train_time:10348887ms step_avg:93.23ms
+step:111200/500000 train_loss:0.9047 train_time:10367209ms step_avg:93.23ms
+step:111400/500000 train_loss:0.8325 train_time:10385468ms step_avg:93.23ms
+step:111600/500000 train_loss:0.8964 train_time:10403595ms step_avg:93.22ms
+step:111800/500000 train_loss:0.9269 train_time:10421888ms step_avg:93.22ms
+step:112000/500000 train_loss:0.9103 train_time:10440141ms step_avg:93.22ms
+step:112200/500000 train_loss:0.8615 train_time:10458671ms step_avg:93.21ms
+step:112400/500000 train_loss:0.8787 train_time:10476969ms step_avg:93.21ms
+step:112600/500000 train_loss:0.9577 train_time:10496343ms step_avg:93.22ms
+step:112800/500000 train_loss:0.9020 train_time:10515081ms step_avg:93.22ms
+step:113000/500000 train_loss:0.8883 train_time:10533775ms step_avg:93.22ms
+step:113200/500000 train_loss:0.9038 train_time:10552347ms step_avg:93.22ms
+step:113400/500000 train_loss:0.8666 train_time:10570730ms step_avg:93.22ms
+step:113600/500000 train_loss:0.9325 train_time:10588829ms step_avg:93.21ms
+step:113800/500000 train_loss:0.8595 train_time:10607364ms step_avg:93.21ms
+step:114000/500000 train_loss:0.8486 train_time:10625571ms step_avg:93.21ms
+step:114200/500000 train_loss:0.9409 train_time:10643857ms step_avg:93.20ms
+step:114400/500000 train_loss:0.9117 train_time:10662483ms step_avg:93.20ms
+step:114600/500000 train_loss:0.9368 train_time:10681089ms step_avg:93.20ms
+step:114800/500000 train_loss:0.8733 train_time:10700113ms step_avg:93.21ms
+step:115000/500000 train_loss:0.9636 train_time:10718851ms step_avg:93.21ms
+step:115200/500000 train_loss:0.8467 train_time:10737334ms step_avg:93.21ms
+step:115400/500000 train_loss:0.8935 train_time:10756286ms step_avg:93.21ms
+step:115600/500000 train_loss:0.8498 train_time:10774597ms step_avg:93.21ms
+step:115800/500000 train_loss:0.9470 train_time:10792734ms step_avg:93.20ms
+step:116000/500000 train_loss:0.8852 train_time:10811126ms step_avg:93.20ms
+step:116200/500000 train_loss:0.9227 train_time:10829225ms step_avg:93.19ms
+step:116400/500000 train_loss:0.9175 train_time:10847486ms step_avg:93.19ms
+step:116600/500000 train_loss:0.8862 train_time:10866397ms step_avg:93.19ms
+step:116800/500000 train_loss:0.8455 train_time:10884943ms step_avg:93.19ms
+step:117000/500000 train_loss:0.8910 train_time:10903995ms step_avg:93.20ms
+step:117200/500000 train_loss:0.8799 train_time:10922641ms step_avg:93.20ms
+step:117400/500000 train_loss:0.8988 train_time:10941185ms step_avg:93.20ms
+step:117600/500000 train_loss:0.8448 train_time:10959920ms step_avg:93.20ms
+step:117800/500000 train_loss:0.9093 train_time:10978045ms step_avg:93.19ms
+step:118000/500000 train_loss:0.8548 train_time:10996320ms step_avg:93.19ms
+step:118200/500000 train_loss:0.7910 train_time:11014701ms step_avg:93.19ms
+step:118400/500000 train_loss:0.9902 train_time:11032766ms step_avg:93.18ms
+step:118600/500000 train_loss:0.7885 train_time:11051517ms step_avg:93.18ms
+step:118800/500000 train_loss:0.8849 train_time:11069664ms step_avg:93.18ms
+step:119000/500000 train_loss:0.8968 train_time:11089108ms step_avg:93.19ms
+step:119200/500000 train_loss:0.8444 train_time:11108080ms step_avg:93.19ms
+step:119400/500000 train_loss:0.9127 train_time:11126531ms step_avg:93.19ms
+step:119600/500000 train_loss:0.9083 train_time:11145244ms step_avg:93.19ms
+step:119800/500000 train_loss:0.8190 train_time:11163523ms step_avg:93.18ms
+step:120000/500000 train_loss:0.8309 train_time:11181595ms step_avg:93.18ms
+step:120000/500000 val_loss:0.8422 val_bpb:1.2154 train_time:11181617ms step_avg:93.18ms
+step:120200/500000 train_loss:0.8949 train_time:11199926ms step_avg:93.18ms
+step:120400/500000 train_loss:0.9346 train_time:11218429ms step_avg:93.18ms
+step:120600/500000 train_loss:0.9340 train_time:11236563ms step_avg:93.17ms
+step:120800/500000 train_loss:0.8871 train_time:11255325ms step_avg:93.17ms
+step:121000/500000 train_loss:0.8495 train_time:11273442ms step_avg:93.17ms
+step:121200/500000 train_loss:0.8854 train_time:11292862ms step_avg:93.18ms
+step:121400/500000 train_loss:0.8891 train_time:11311617ms step_avg:93.18ms
+step:121600/500000 train_loss:0.7929 train_time:11330105ms step_avg:93.18ms
+step:121800/500000 train_loss:0.8270 train_time:11348907ms step_avg:93.18ms
+step:122000/500000 train_loss:0.8795 train_time:11367213ms step_avg:93.17ms
+step:122200/500000 train_loss:0.8881 train_time:11385430ms step_avg:93.17ms
+step:122400/500000 train_loss:0.9193 train_time:11403748ms step_avg:93.17ms
+step:122600/500000 train_loss:0.8806 train_time:11421836ms step_avg:93.16ms
+step:122800/500000 train_loss:0.8919 train_time:11440116ms step_avg:93.16ms
+step:123000/500000 train_loss:0.9022 train_time:11458748ms step_avg:93.16ms
+step:123200/500000 train_loss:0.8538 train_time:11477286ms step_avg:93.16ms
+step:123400/500000 train_loss:0.9367 train_time:11496423ms step_avg:93.16ms
+step:123600/500000 train_loss:0.9333 train_time:11514926ms step_avg:93.16ms
+step:123800/500000 train_loss:0.8664 train_time:11533801ms step_avg:93.16ms
+step:124000/500000 train_loss:0.9384 train_time:11552595ms step_avg:93.17ms
+step:124200/500000 train_loss:0.8203 train_time:11570705ms step_avg:93.16ms
+step:124400/500000 train_loss:0.8643 train_time:11588965ms step_avg:93.16ms
+step:124600/500000 train_loss:0.8745 train_time:11607449ms step_avg:93.16ms
+step:124800/500000 train_loss:0.8872 train_time:11625513ms step_avg:93.15ms
+step:125000/500000 train_loss:0.9247 train_time:11644156ms step_avg:93.15ms
+step:125200/500000 train_loss:0.9327 train_time:11662256ms step_avg:93.15ms
+step:125400/500000 train_loss:0.8169 train_time:11681740ms step_avg:93.16ms
+step:125600/500000 train_loss:0.8931 train_time:11700375ms step_avg:93.16ms
+step:125800/500000 train_loss:0.8949 train_time:11718523ms step_avg:93.15ms
+step:126000/500000 train_loss:0.8690 train_time:11737187ms step_avg:93.15ms
+step:126200/500000 train_loss:0.8504 train_time:11755841ms step_avg:93.15ms
+step:126400/500000 train_loss:0.8395 train_time:11774027ms step_avg:93.15ms
+step:126600/500000 train_loss:0.9073 train_time:11792412ms step_avg:93.15ms
+step:126800/500000 train_loss:0.8746 train_time:11810515ms step_avg:93.14ms
+step:127000/500000 train_loss:0.8750 train_time:11828787ms step_avg:93.14ms
+step:127200/500000 train_loss:0.8296 train_time:11847574ms step_avg:93.14ms
+step:127400/500000 train_loss:0.8798 train_time:11865692ms step_avg:93.14ms
+step:127600/500000 train_loss:0.8898 train_time:11885260ms step_avg:93.14ms
+step:127800/500000 train_loss:0.9616 train_time:11903854ms step_avg:93.14ms
+step:128000/500000 train_loss:0.8671 train_time:11922609ms step_avg:93.15ms
+step:128200/500000 train_loss:0.9181 train_time:11941439ms step_avg:93.15ms
+step:128400/500000 train_loss:0.9380 train_time:11959578ms step_avg:93.14ms
+step:128600/500000 train_loss:0.8942 train_time:11977845ms step_avg:93.14ms
+step:128800/500000 train_loss:0.9493 train_time:11996170ms step_avg:93.14ms
+step:129000/500000 train_loss:0.8889 train_time:12014287ms step_avg:93.13ms
+step:129200/500000 train_loss:0.8263 train_time:12033145ms step_avg:93.14ms
+step:129400/500000 train_loss:0.9978 train_time:12051263ms step_avg:93.13ms
+step:129600/500000 train_loss:0.8364 train_time:12070071ms step_avg:93.13ms
+step:129800/500000 train_loss:0.9053 train_time:12089196ms step_avg:93.14ms
+step:130000/500000 train_loss:1.0166 train_time:12107732ms step_avg:93.14ms
+step:130000/500000 val_loss:0.8402 val_bpb:1.2125 train_time:12107753ms step_avg:93.14ms
+step:130200/500000 train_loss:0.8632 train_time:12126590ms step_avg:93.14ms
+step:130400/500000 train_loss:0.8902 train_time:12145773ms step_avg:93.14ms
+step:130600/500000 train_loss:0.8452 train_time:12163974ms step_avg:93.14ms
+step:130800/500000 train_loss:0.8814 train_time:12182405ms step_avg:93.14ms
+step:131000/500000 train_loss:0.8366 train_time:12200710ms step_avg:93.14ms
+step:131200/500000 train_loss:0.7830 train_time:12219154ms step_avg:93.13ms
+step:131400/500000 train_loss:0.8733 train_time:12237833ms step_avg:93.13ms
+step:131600/500000 train_loss:0.9006 train_time:12255926ms step_avg:93.13ms
+step:131800/500000 train_loss:0.8631 train_time:12275411ms step_avg:93.14ms
+step:132000/500000 train_loss:0.9362 train_time:12294107ms step_avg:93.14ms
+late_qat:enabled step:132075 scale:0.8500
+step:132200/500000 train_loss:1.0573 train_time:12312401ms step_avg:93.13ms
+step:132400/500000 train_loss:0.9566 train_time:12331194ms step_avg:93.14ms
+step:132600/500000 train_loss:0.8265 train_time:12349753ms step_avg:93.14ms
+step:132800/500000 train_loss:0.8961 train_time:12368056ms step_avg:93.13ms
+step:133000/500000 train_loss:0.9467 train_time:12386421ms step_avg:93.13ms
+step:133200/500000 train_loss:0.9768 train_time:12404442ms step_avg:93.13ms
+step:133400/500000 train_loss:0.8925 train_time:12422761ms step_avg:93.12ms
+step:133600/500000 train_loss:0.9167 train_time:12441582ms step_avg:93.13ms
+step:133800/500000 train_loss:0.9667 train_time:12459705ms step_avg:93.12ms
+step:134000/500000 train_loss:0.9430 train_time:12479542ms step_avg:93.13ms
+step:134200/500000 train_loss:0.9326 train_time:12498139ms step_avg:93.13ms
+step:134400/500000 train_loss:0.8825 train_time:12516582ms step_avg:93.13ms
+step:134600/500000 train_loss:0.9443 train_time:12535291ms step_avg:93.13ms
+step:134800/500000 train_loss:0.8333 train_time:12554032ms step_avg:93.13ms
+step:135000/500000 train_loss:0.9502 train_time:12572605ms step_avg:93.13ms
+step:135200/500000 train_loss:0.9392 train_time:12590728ms step_avg:93.13ms
+step:135400/500000 train_loss:0.9754 train_time:12609067ms step_avg:93.12ms
+step:135600/500000 train_loss:0.9397 train_time:12627931ms step_avg:93.13ms
+step:135800/500000 train_loss:0.9662 train_time:12646043ms step_avg:93.12ms
+step:136000/500000 train_loss:1.1170 train_time:12664958ms step_avg:93.12ms
+step:136200/500000 train_loss:0.9342 train_time:12684145ms step_avg:93.13ms
+step:136400/500000 train_loss:0.9926 train_time:12702650ms step_avg:93.13ms
+step:136600/500000 train_loss:0.9526 train_time:12721386ms step_avg:93.13ms
+step:136800/500000 train_loss:0.9317 train_time:12739944ms step_avg:93.13ms
+step:137000/500000 train_loss:0.9052 train_time:12758229ms step_avg:93.13ms
+step:137200/500000 train_loss:0.9044 train_time:12776506ms step_avg:93.12ms
+step:137400/500000 train_loss:0.9793 train_time:12795027ms step_avg:93.12ms
+step:137600/500000 train_loss:0.9037 train_time:12813350ms step_avg:93.12ms
+step:137800/500000 train_loss:0.8626 train_time:12832182ms step_avg:93.12ms
+step:138000/500000 train_loss:0.9240 train_time:12850263ms step_avg:93.12ms
+step:138200/500000 train_loss:0.8724 train_time:12869844ms step_avg:93.12ms
+step:138400/500000 train_loss:0.8780 train_time:12888309ms step_avg:93.12ms
+step:138600/500000 train_loss:0.9672 train_time:12906740ms step_avg:93.12ms
+step:138800/500000 train_loss:0.9803 train_time:12925593ms step_avg:93.12ms
+step:139000/500000 train_loss:1.0194 train_time:12944173ms step_avg:93.12ms
+step:139200/500000 train_loss:0.8961 train_time:12962417ms step_avg:93.12ms
+step:139400/500000 train_loss:0.8936 train_time:12980537ms step_avg:93.12ms
+step:139600/500000 train_loss:0.8748 train_time:12999050ms step_avg:93.12ms
+step:139800/500000 train_loss:0.8752 train_time:13017392ms step_avg:93.11ms
+step:140000/500000 train_loss:0.9011 train_time:13035918ms step_avg:93.11ms
+step:140000/500000 val_loss:0.8637 val_bpb:1.2465 train_time:13035921ms step_avg:93.11ms
+step:140200/500000 train_loss:0.8033 train_time:13054493ms step_avg:93.11ms
+step:140400/500000 train_loss:0.9034 train_time:13074288ms step_avg:93.12ms
+step:140600/500000 train_loss:0.7248 train_time:13092831ms step_avg:93.12ms
+step:140800/500000 train_loss:0.9066 train_time:13111383ms step_avg:93.12ms
+step:141000/500000 train_loss:0.9065 train_time:13130195ms step_avg:93.12ms
+step:141200/500000 train_loss:0.9280 train_time:13149048ms step_avg:93.12ms
+step:141400/500000 train_loss:0.9119 train_time:13167402ms step_avg:93.12ms
+step:141600/500000 train_loss:0.9180 train_time:13185482ms step_avg:93.12ms
+step:141800/500000 train_loss:0.9553 train_time:13203962ms step_avg:93.12ms
+step:142000/500000 train_loss:0.8340 train_time:13222929ms step_avg:93.12ms
+step:142200/500000 train_loss:0.8951 train_time:13241042ms step_avg:93.12ms
+step:142400/500000 train_loss:0.9086 train_time:13259711ms step_avg:93.12ms
+step:142600/500000 train_loss:0.9028 train_time:13279036ms step_avg:93.12ms
+step:142800/500000 train_loss:1.0509 train_time:13297567ms step_avg:93.12ms
+step:143000/500000 train_loss:0.9483 train_time:13316021ms step_avg:93.12ms
+step:143200/500000 train_loss:0.8903 train_time:13334551ms step_avg:93.12ms
+step:143400/500000 train_loss:0.8314 train_time:13353318ms step_avg:93.12ms
+step:143600/500000 train_loss:0.8552 train_time:13371834ms step_avg:93.12ms
+step:143800/500000 train_loss:0.8351 train_time:13390015ms step_avg:93.12ms
+step:144000/500000 train_loss:0.9297 train_time:13408638ms step_avg:93.12ms
+step:144200/500000 train_loss:0.9698 train_time:13427379ms step_avg:93.12ms
+step:144400/500000 train_loss:0.9134 train_time:13445518ms step_avg:93.11ms
+step:144600/500000 train_loss:0.9023 train_time:13464900ms step_avg:93.12ms
+step:144800/500000 train_loss:0.9239 train_time:13483778ms step_avg:93.12ms
+step:145000/500000 train_loss:0.9301 train_time:13502264ms step_avg:93.12ms
+step:145200/500000 train_loss:0.8776 train_time:13521150ms step_avg:93.12ms
+step:145400/500000 train_loss:0.9259 train_time:13539688ms step_avg:93.12ms
+step:145600/500000 train_loss:0.8930 train_time:13558197ms step_avg:93.12ms
+step:145800/500000 train_loss:0.8825 train_time:13576376ms step_avg:93.12ms
+step:146000/500000 train_loss:0.9235 train_time:13594678ms step_avg:93.11ms
+step:146200/500000 train_loss:0.9322 train_time:13613343ms step_avg:93.11ms
+step:146400/500000 train_loss:0.9304 train_time:13631441ms step_avg:93.11ms
+step:146600/500000 train_loss:0.8734 train_time:13649783ms step_avg:93.11ms
+step:146800/500000 train_loss:0.9564 train_time:13669565ms step_avg:93.12ms
+step:147000/500000 train_loss:0.8547 train_time:13688084ms step_avg:93.12ms
+step:147200/500000 train_loss:0.9105 train_time:13706483ms step_avg:93.11ms
+step:147400/500000 train_loss:0.9218 train_time:13725060ms step_avg:93.11ms
+step:147600/500000 train_loss:0.9570 train_time:13743840ms step_avg:93.12ms
+step:147800/500000 train_loss:0.8876 train_time:13762211ms step_avg:93.11ms
+step:148000/500000 train_loss:0.8984 train_time:13780300ms step_avg:93.11ms
+step:148200/500000 train_loss:0.8387 train_time:13798615ms step_avg:93.11ms
+step:148400/500000 train_loss:0.8684 train_time:13817447ms step_avg:93.11ms
+step:148600/500000 train_loss:0.8961 train_time:13835487ms step_avg:93.11ms
+step:148800/500000 train_loss:0.8929 train_time:13854291ms step_avg:93.11ms
+step:149000/500000 train_loss:0.8994 train_time:13873188ms step_avg:93.11ms
+step:149200/500000 train_loss:0.9032 train_time:13892046ms step_avg:93.11ms
+step:149400/500000 train_loss:0.9412 train_time:13910459ms step_avg:93.11ms
+step:149600/500000 train_loss:0.9359 train_time:13929010ms step_avg:93.11ms
+step:149800/500000 train_loss:0.9125 train_time:13947874ms step_avg:93.11ms
+step:150000/500000 train_loss:0.9140 train_time:13965922ms step_avg:93.11ms
+step:150000/500000 val_loss:0.8528 val_bpb:1.2307 train_time:13965925ms step_avg:93.11ms
+step:150200/500000 train_loss:0.8668 train_time:13984044ms step_avg:93.10ms
+step:150400/500000 train_loss:0.9186 train_time:14002423ms step_avg:93.10ms
+step:150600/500000 train_loss:0.9345 train_time:14020895ms step_avg:93.10ms
+step:150800/500000 train_loss:0.8613 train_time:14039429ms step_avg:93.10ms
+step:151000/500000 train_loss:0.9197 train_time:14058662ms step_avg:93.10ms
+step:151200/500000 train_loss:0.8892 train_time:14077345ms step_avg:93.10ms
+step:151400/500000 train_loss:0.9329 train_time:14096120ms step_avg:93.11ms
+step:151600/500000 train_loss:0.8629 train_time:14114466ms step_avg:93.10ms
+step:151800/500000 train_loss:0.8865 train_time:14132995ms step_avg:93.10ms
+step:152000/500000 train_loss:0.8903 train_time:14151780ms step_avg:93.10ms
+step:152200/500000 train_loss:0.8625 train_time:14169873ms step_avg:93.10ms
+step:152400/500000 train_loss:0.7995 train_time:14188249ms step_avg:93.10ms
+step:152600/500000 train_loss:0.8970 train_time:14207122ms step_avg:93.10ms
+step:152800/500000 train_loss:0.9028 train_time:14225226ms step_avg:93.10ms
+step:153000/500000 train_loss:0.9238 train_time:14243765ms step_avg:93.10ms
+step:153200/500000 train_loss:0.9279 train_time:14263209ms step_avg:93.10ms
+step:153381/500000 val_loss:0.8524 val_bpb:1.2302 train_time:14280042ms step_avg:93.10ms
+stopping_early: wallclock_cap train_time:14280042ms step:153381/500000 (reserving 120.0s for GPTQ)
+peak memory allocated: 10054 MiB reserved: 10290 MiB
+gptq:calibrating with 512 batches...
+gptq:collected hessians for 75 layers in 46678ms
+Serialized model: 91657491 bytes
+Code size: 83709 bytes
+Total submission size: 91741200 bytes
+prune:zeroed 1840730 int6 weights (threshold=0)
+gptq:quantized 75 layers with GPTQ, 0 naive, 1 INT8 embeds
+artifact int6+gptq+zstd-22: 15697770 bytes + 83709 code = 15781479 total (payload:23125896 payload_ratio:3.96x)
+artifact headroom: 218521 bytes (0.219MB)
+artifact int8+zlib: 20691531 bytes (for comparison)
+final_int6_gptq_roundtrip val_loss:0.8623 val_bpb:1.2444 eval_time:4553ms
+final_int6_gptq_roundtrip_exact val_loss:0.86225433 val_bpb:1.24438173
+sliding_eval: stride=64 batch_seqs=16 seq_len=2048
+final_int6_gptq_sliding_window val_loss:0.8364 val_bpb:1.2070 eval_time:352322ms
+final_int6_gptq_sliding_window_exact val_loss:0.83636482 val_bpb:1.20701869

--- a/records/track_non_record_16mb/2026-04-01_Scaled_HNet_Byte260_and_Sp1024/logs/sp1024_chunked_divisor_2_4hrs.log
+++ b/records/track_non_record_16mb/2026-04-01_Scaled_HNet_Byte260_and_Sp1024/logs/sp1024_chunked_divisor_2_4hrs.log
@@ -1,0 +1,1971 @@
+W0403 03:38:14.327000 3964154 torch/distributed/run.py:851]
+W0403 03:38:14.327000 3964154 torch/distributed/run.py:851] *****************************************
+W0403 03:38:14.327000 3964154 torch/distributed/run.py:851] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed.
+W0403 03:38:14.327000 3964154 torch/distributed/run.py:851] *****************************************
+[W403 03:38:27.496457927 Utils.hpp:137] Warning: Environment variable TORCH_NCCL_TRACE_BUFFER_SIZE is deprecated; use TORCH_FR_BUFFER_SIZE instead (function operator())
+[W403 03:38:27.497736362 Utils.hpp:137] Warning: Environment variable TORCH_NCCL_TRACE_BUFFER_SIZE is deprecated; use TORCH_FR_BUFFER_SIZE instead (function operator())
+[W403 03:38:27.498217697 Utils.hpp:137] Warning: Environment variable TORCH_NCCL_TRACE_BUFFER_SIZE is deprecated; use TORCH_FR_BUFFER_SIZE instead (function operator())
+[W403 03:38:27.499034259 Utils.hpp:137] Warning: Environment variable TORCH_NCCL_TRACE_BUFFER_SIZE is deprecated; use TORCH_FR_BUFFER_SIZE instead (function operator())
+[W403 03:38:27.499062491 Utils.hpp:137] Warning: Environment variable TORCH_NCCL_TRACE_BUFFER_SIZE is deprecated; use TORCH_FR_BUFFER_SIZE instead (function operator())
+[W403 03:38:27.500458286 Utils.hpp:137] Warning: Environment variable TORCH_NCCL_TRACE_BUFFER_SIZE is deprecated; use TORCH_FR_BUFFER_SIZE instead (function operator())
+[W403 03:38:27.501051977 Utils.hpp:137] Warning: Environment variable TORCH_NCCL_TRACE_BUFFER_SIZE is deprecated; use TORCH_FR_BUFFER_SIZE instead (function operator())
+[W403 03:38:27.505403095 Utils.hpp:137] Warning: Environment variable TORCH_NCCL_TRACE_BUFFER_SIZE is deprecated; use TORCH_FR_BUFFER_SIZE instead (function operator())
+logs/sp1024_gptq_11l_ol3_april2_v2_kv4_chunkdiv2_4hr.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:21520472
+world_size:8 grad_accum_steps:1
+outer_layers:3 main_layers:5
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:524288 train_seq_len:2048 iterations:500000 warmup_steps:20 max_wallclock_seconds:14400.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+ema:disabled
+late_qat:will enable when lr_scale < 0.85
+step:0/500000 val_loss:6.9229 val_bpb:4.1002 train_time:0ms step_avg:0.02ms
+step:1/500000 train_loss:7.0140 train_time:154ms step_avg:154.35ms
+step:2/500000 train_loss:10.4964 train_time:318ms step_avg:159.20ms
+step:3/500000 train_loss:9.1430 train_time:488ms step_avg:162.73ms
+step:4/500000 train_loss:8.7838 train_time:662ms step_avg:165.40ms
+step:5/500000 train_loss:8.3833 train_time:829ms step_avg:165.86ms
+step:6/500000 train_loss:8.4107 train_time:999ms step_avg:166.43ms
+step:7/500000 train_loss:7.5177 train_time:1169ms step_avg:167.07ms
+step:8/500000 train_loss:6.9990 train_time:1339ms step_avg:167.36ms
+step:9/500000 train_loss:6.7264 train_time:1509ms step_avg:167.66ms
+step:10/500000 train_loss:6.3606 train_time:1679ms step_avg:167.91ms
+step:200/500000 train_loss:3.0607 train_time:34247ms step_avg:171.23ms
+step:400/500000 train_loss:2.4975 train_time:69390ms step_avg:173.47ms
+step:600/500000 train_loss:2.6840 train_time:103447ms step_avg:172.41ms
+step:800/500000 train_loss:2.4230 train_time:137158ms step_avg:171.45ms
+step:1000/500000 train_loss:2.4936 train_time:171087ms step_avg:171.09ms
+step:1200/500000 train_loss:2.5136 train_time:204853ms step_avg:170.71ms
+step:1400/500000 train_loss:2.5378 train_time:238545ms step_avg:170.39ms
+step:1600/500000 train_loss:2.1978 train_time:273033ms step_avg:170.65ms
+step:1800/500000 train_loss:2.3170 train_time:306747ms step_avg:170.41ms
+step:2000/500000 train_loss:2.3610 train_time:340411ms step_avg:170.21ms
+step:2200/500000 train_loss:2.1788 train_time:374320ms step_avg:170.15ms
+step:2400/500000 train_loss:2.3103 train_time:407959ms step_avg:169.98ms
+step:2600/500000 train_loss:2.5164 train_time:441853ms step_avg:169.94ms
+step:2800/500000 train_loss:2.3439 train_time:475559ms step_avg:169.84ms
+step:3000/500000 train_loss:2.3299 train_time:509342ms step_avg:169.78ms
+step:3200/500000 train_loss:2.2934 train_time:543216ms step_avg:169.75ms
+step:3400/500000 train_loss:2.2579 train_time:577784ms step_avg:169.94ms
+step:3600/500000 train_loss:2.2006 train_time:611911ms step_avg:169.98ms
+step:3800/500000 train_loss:2.3086 train_time:645830ms step_avg:169.96ms
+step:4000/500000 train_loss:2.2684 train_time:680129ms step_avg:170.03ms
+step:4200/500000 train_loss:2.2638 train_time:714072ms step_avg:170.02ms
+step:4400/500000 train_loss:2.2039 train_time:748022ms step_avg:170.00ms
+step:4600/500000 train_loss:2.0735 train_time:781865ms step_avg:169.97ms
+step:4800/500000 train_loss:2.3459 train_time:815777ms step_avg:169.95ms
+step:5000/500000 train_loss:2.1062 train_time:849722ms step_avg:169.94ms
+step:5200/500000 train_loss:2.2663 train_time:884436ms step_avg:170.08ms
+step:5400/500000 train_loss:2.2749 train_time:918298ms step_avg:170.06ms
+step:5600/500000 train_loss:2.2688 train_time:952218ms step_avg:170.04ms
+step:5800/500000 train_loss:2.2233 train_time:986035ms step_avg:170.01ms
+step:6000/500000 train_loss:2.2987 train_time:1019732ms step_avg:169.96ms
+step:6200/500000 train_loss:2.1753 train_time:1053718ms step_avg:169.95ms
+step:6400/500000 train_loss:2.2516 train_time:1087418ms step_avg:169.91ms
+step:6600/500000 train_loss:2.2111 train_time:1121426ms step_avg:169.91ms
+step:6800/500000 train_loss:2.2698 train_time:1155184ms step_avg:169.88ms
+step:7000/500000 train_loss:2.3139 train_time:1190128ms step_avg:170.02ms
+step:7200/500000 train_loss:2.2890 train_time:1224037ms step_avg:170.01ms
+step:7400/500000 train_loss:2.2055 train_time:1257918ms step_avg:169.99ms
+step:7600/500000 train_loss:2.0849 train_time:1291807ms step_avg:169.97ms
+step:7800/500000 train_loss:2.2284 train_time:1325615ms step_avg:169.95ms
+step:8000/500000 train_loss:2.1982 train_time:1359514ms step_avg:169.94ms
+step:8200/500000 train_loss:2.2682 train_time:1393260ms step_avg:169.91ms
+step:8400/500000 train_loss:2.2196 train_time:1427280ms step_avg:169.91ms
+step:8600/500000 train_loss:2.2285 train_time:1461175ms step_avg:169.90ms
+step:8800/500000 train_loss:2.1900 train_time:1495709ms step_avg:169.97ms
+step:9000/500000 train_loss:2.1036 train_time:1529801ms step_avg:169.98ms
+step:9200/500000 train_loss:2.1630 train_time:1563838ms step_avg:169.98ms
+step:9400/500000 train_loss:2.2091 train_time:1597789ms step_avg:169.98ms
+step:9600/500000 train_loss:2.2295 train_time:1631459ms step_avg:169.94ms
+step:9800/500000 train_loss:2.1407 train_time:1665201ms step_avg:169.92ms
+step:10000/500000 train_loss:2.1897 train_time:1699077ms step_avg:169.91ms
+step:10000/500000 val_loss:2.1374 val_bpb:1.2659 train_time:1699104ms step_avg:169.91ms
+step:10200/500000 train_loss:2.1526 train_time:1733017ms step_avg:169.90ms
+step:10400/500000 train_loss:2.1716 train_time:1767044ms step_avg:169.91ms
+step:10600/500000 train_loss:2.0530 train_time:1801679ms step_avg:169.97ms
+step:10800/500000 train_loss:2.2626 train_time:1835597ms step_avg:169.96ms
+step:11000/500000 train_loss:2.1838 train_time:1869297ms step_avg:169.94ms
+step:11200/500000 train_loss:2.1506 train_time:1902998ms step_avg:169.91ms
+step:11400/500000 train_loss:2.1320 train_time:1936833ms step_avg:169.90ms
+step:11600/500000 train_loss:2.1267 train_time:1971089ms step_avg:169.92ms
+step:11800/500000 train_loss:2.1768 train_time:2005005ms step_avg:169.92ms
+step:12000/500000 train_loss:2.1283 train_time:2038677ms step_avg:169.89ms
+step:12200/500000 train_loss:2.2707 train_time:2072400ms step_avg:169.87ms
+step:12400/500000 train_loss:1.9252 train_time:2107240ms step_avg:169.94ms
+step:12600/500000 train_loss:2.1667 train_time:2141217ms step_avg:169.94ms
+step:12800/500000 train_loss:2.1889 train_time:2175181ms step_avg:169.94ms
+step:13000/500000 train_loss:2.2550 train_time:2209268ms step_avg:169.94ms
+step:13200/500000 train_loss:2.2688 train_time:2243067ms step_avg:169.93ms
+step:13400/500000 train_loss:2.1591 train_time:2276838ms step_avg:169.91ms
+step:13600/500000 train_loss:2.0020 train_time:2310596ms step_avg:169.90ms
+step:13800/500000 train_loss:2.1084 train_time:2344411ms step_avg:169.88ms
+step:14000/500000 train_loss:2.1701 train_time:2378351ms step_avg:169.88ms
+step:14200/500000 train_loss:2.2494 train_time:2413039ms step_avg:169.93ms
+step:14400/500000 train_loss:2.1565 train_time:2446945ms step_avg:169.93ms
+step:14600/500000 train_loss:2.1967 train_time:2481023ms step_avg:169.93ms
+step:14800/500000 train_loss:1.9720 train_time:2515009ms step_avg:169.93ms
+step:15000/500000 train_loss:2.1094 train_time:2548799ms step_avg:169.92ms
+step:15200/500000 train_loss:2.2259 train_time:2582631ms step_avg:169.91ms
+step:15400/500000 train_loss:2.1067 train_time:2616339ms step_avg:169.89ms
+step:15600/500000 train_loss:2.1468 train_time:2650066ms step_avg:169.88ms
+step:15800/500000 train_loss:1.9870 train_time:2683700ms step_avg:169.85ms
+step:16000/500000 train_loss:2.2027 train_time:2718354ms step_avg:169.90ms
+step:16200/500000 train_loss:2.0622 train_time:2752093ms step_avg:169.88ms
+step:16400/500000 train_loss:2.1042 train_time:2785911ms step_avg:169.87ms
+step:16600/500000 train_loss:2.0324 train_time:2819706ms step_avg:169.86ms
+step:16800/500000 train_loss:2.2563 train_time:2853458ms step_avg:169.85ms
+step:17000/500000 train_loss:2.1750 train_time:2887168ms step_avg:169.83ms
+step:17200/500000 train_loss:2.1646 train_time:2920807ms step_avg:169.81ms
+step:17400/500000 train_loss:2.0670 train_time:2954458ms step_avg:169.80ms
+step:17600/500000 train_loss:2.1518 train_time:2988773ms step_avg:169.82ms
+step:17800/500000 train_loss:2.2250 train_time:3023168ms step_avg:169.84ms
+step:18000/500000 train_loss:2.1370 train_time:3057055ms step_avg:169.84ms
+step:18200/500000 train_loss:2.3683 train_time:3090800ms step_avg:169.82ms
+step:18400/500000 train_loss:2.1288 train_time:3124560ms step_avg:169.81ms
+step:18600/500000 train_loss:2.1636 train_time:3158260ms step_avg:169.80ms
+step:18800/500000 train_loss:2.2199 train_time:3192078ms step_avg:169.79ms
+step:19000/500000 train_loss:2.1396 train_time:3225961ms step_avg:169.79ms
+step:19200/500000 train_loss:1.9992 train_time:3259844ms step_avg:169.78ms
+step:19400/500000 train_loss:2.2184 train_time:3293794ms step_avg:169.78ms
+step:19600/500000 train_loss:2.3042 train_time:3327737ms step_avg:169.78ms
+step:19800/500000 train_loss:1.9833 train_time:3362055ms step_avg:169.80ms
+step:20000/500000 train_loss:2.1806 train_time:3395886ms step_avg:169.79ms
+step:20000/500000 val_loss:2.0919 val_bpb:1.2389 train_time:3395911ms step_avg:169.80ms
+step:20200/500000 train_loss:2.1565 train_time:3429689ms step_avg:169.79ms
+step:20400/500000 train_loss:2.1639 train_time:3463464ms step_avg:169.78ms
+step:20600/500000 train_loss:2.1850 train_time:3497670ms step_avg:169.79ms
+step:20800/500000 train_loss:2.1416 train_time:3531306ms step_avg:169.77ms
+step:21000/500000 train_loss:2.2301 train_time:3565186ms step_avg:169.77ms
+step:21200/500000 train_loss:2.0569 train_time:3598918ms step_avg:169.76ms
+step:21400/500000 train_loss:2.0643 train_time:3633153ms step_avg:169.77ms
+step:21600/500000 train_loss:2.1451 train_time:3667339ms step_avg:169.78ms
+step:21800/500000 train_loss:2.0989 train_time:3701273ms step_avg:169.78ms
+step:22000/500000 train_loss:2.1265 train_time:3735083ms step_avg:169.78ms
+step:22200/500000 train_loss:2.1341 train_time:3769123ms step_avg:169.78ms
+step:22400/500000 train_loss:2.1873 train_time:3802974ms step_avg:169.78ms
+step:22600/500000 train_loss:2.1013 train_time:3836717ms step_avg:169.77ms
+step:22800/500000 train_loss:2.0600 train_time:3870466ms step_avg:169.76ms
+step:23000/500000 train_loss:2.1715 train_time:3904154ms step_avg:169.75ms
+step:23200/500000 train_loss:2.1865 train_time:3938158ms step_avg:169.75ms
+step:23400/500000 train_loss:2.0170 train_time:3972191ms step_avg:169.75ms
+step:23600/500000 train_loss:2.1525 train_time:4006096ms step_avg:169.75ms
+step:23800/500000 train_loss:2.0206 train_time:4039806ms step_avg:169.74ms
+step:24000/500000 train_loss:2.1197 train_time:4073544ms step_avg:169.73ms
+step:24200/500000 train_loss:1.9307 train_time:4107441ms step_avg:169.73ms
+step:24400/500000 train_loss:2.1386 train_time:4141190ms step_avg:169.72ms
+step:24600/500000 train_loss:2.0781 train_time:4175016ms step_avg:169.72ms
+step:24800/500000 train_loss:2.0133 train_time:4208845ms step_avg:169.71ms
+step:25000/500000 train_loss:2.2238 train_time:4242820ms step_avg:169.71ms
+step:25200/500000 train_loss:2.1164 train_time:4277143ms step_avg:169.73ms
+step:25400/500000 train_loss:2.0973 train_time:4310813ms step_avg:169.72ms
+step:25600/500000 train_loss:2.1682 train_time:4344545ms step_avg:169.71ms
+step:25800/500000 train_loss:2.1212 train_time:4378210ms step_avg:169.70ms
+step:26000/500000 train_loss:2.0310 train_time:4412034ms step_avg:169.69ms
+step:26200/500000 train_loss:2.1305 train_time:4445745ms step_avg:169.68ms
+step:26400/500000 train_loss:2.1050 train_time:4479640ms step_avg:169.68ms
+step:26600/500000 train_loss:2.2097 train_time:4513554ms step_avg:169.68ms
+step:26800/500000 train_loss:2.0843 train_time:4547779ms step_avg:169.69ms
+step:27000/500000 train_loss:2.2975 train_time:4582105ms step_avg:169.71ms
+step:27200/500000 train_loss:2.0531 train_time:4615764ms step_avg:169.70ms
+step:27400/500000 train_loss:2.2392 train_time:4649656ms step_avg:169.70ms
+step:27600/500000 train_loss:2.0779 train_time:4683337ms step_avg:169.69ms
+step:27800/500000 train_loss:2.1325 train_time:4717167ms step_avg:169.68ms
+step:28000/500000 train_loss:2.1379 train_time:4750910ms step_avg:169.68ms
+step:28200/500000 train_loss:2.1292 train_time:4784588ms step_avg:169.67ms
+step:28400/500000 train_loss:2.2199 train_time:4818546ms step_avg:169.67ms
+step:28600/500000 train_loss:2.0943 train_time:4852617ms step_avg:169.67ms
+step:28800/500000 train_loss:2.2630 train_time:4886829ms step_avg:169.68ms
+step:29000/500000 train_loss:2.2282 train_time:4920765ms step_avg:169.68ms
+step:29200/500000 train_loss:1.8236 train_time:4954459ms step_avg:169.67ms
+step:29400/500000 train_loss:2.2062 train_time:4988370ms step_avg:169.67ms
+step:29600/500000 train_loss:2.2905 train_time:5022044ms step_avg:169.66ms
+step:29800/500000 train_loss:1.9971 train_time:5056066ms step_avg:169.67ms
+step:30000/500000 train_loss:2.0906 train_time:5089683ms step_avg:169.66ms
+step:30000/500000 val_loss:2.0720 val_bpb:1.2272 train_time:5089725ms step_avg:169.66ms
+step:30200/500000 train_loss:2.0646 train_time:5123377ms step_avg:169.65ms
+step:30400/500000 train_loss:2.2369 train_time:5157386ms step_avg:169.65ms
+step:30600/500000 train_loss:2.1698 train_time:5191498ms step_avg:169.66ms
+step:30800/500000 train_loss:2.1080 train_time:5225267ms step_avg:169.65ms
+step:31000/500000 train_loss:1.9463 train_time:5259039ms step_avg:169.65ms
+step:31200/500000 train_loss:2.1445 train_time:5292824ms step_avg:169.64ms
+step:31400/500000 train_loss:2.1699 train_time:5326724ms step_avg:169.64ms
+step:31600/500000 train_loss:2.0307 train_time:5360515ms step_avg:169.64ms
+step:31800/500000 train_loss:1.9897 train_time:5394239ms step_avg:169.63ms
+step:32000/500000 train_loss:2.0823 train_time:5428058ms step_avg:169.63ms
+step:32200/500000 train_loss:2.2209 train_time:5462343ms step_avg:169.64ms
+step:32400/500000 train_loss:1.9591 train_time:5496589ms step_avg:169.65ms
+step:32600/500000 train_loss:2.2264 train_time:5530342ms step_avg:169.64ms
+step:32800/500000 train_loss:2.0253 train_time:5564208ms step_avg:169.64ms
+step:33000/500000 train_loss:2.0931 train_time:5598001ms step_avg:169.64ms
+step:33200/500000 train_loss:2.0958 train_time:5631753ms step_avg:169.63ms
+step:33400/500000 train_loss:2.1561 train_time:5665472ms step_avg:169.62ms
+step:33600/500000 train_loss:2.1457 train_time:5699137ms step_avg:169.62ms
+step:33800/500000 train_loss:2.0746 train_time:5732914ms step_avg:169.61ms
+step:34000/500000 train_loss:2.0160 train_time:5766996ms step_avg:169.62ms
+step:34200/500000 train_loss:2.1815 train_time:5801086ms step_avg:169.62ms
+step:34400/500000 train_loss:2.1054 train_time:5835012ms step_avg:169.62ms
+step:34600/500000 train_loss:2.1014 train_time:5868826ms step_avg:169.62ms
+step:34800/500000 train_loss:2.0540 train_time:5902573ms step_avg:169.61ms
+step:35000/500000 train_loss:2.1722 train_time:5936254ms step_avg:169.61ms
+step:35200/500000 train_loss:2.1175 train_time:5969994ms step_avg:169.60ms
+step:35400/500000 train_loss:2.0543 train_time:6003674ms step_avg:169.60ms
+step:35600/500000 train_loss:2.2712 train_time:6037302ms step_avg:169.59ms
+step:35800/500000 train_loss:2.0725 train_time:6071362ms step_avg:169.59ms
+step:36000/500000 train_loss:1.9516 train_time:6105696ms step_avg:169.60ms
+step:36200/500000 train_loss:2.0939 train_time:6139493ms step_avg:169.60ms
+step:36400/500000 train_loss:2.0617 train_time:6173080ms step_avg:169.59ms
+step:36600/500000 train_loss:2.0735 train_time:6206672ms step_avg:169.58ms
+step:36800/500000 train_loss:2.2281 train_time:6240283ms step_avg:169.57ms
+step:37000/500000 train_loss:2.1545 train_time:6274042ms step_avg:169.57ms
+step:37200/500000 train_loss:2.0958 train_time:6307874ms step_avg:169.57ms
+step:37400/500000 train_loss:2.0195 train_time:6341577ms step_avg:169.56ms
+step:37600/500000 train_loss:2.2135 train_time:6375702ms step_avg:169.57ms
+step:37800/500000 train_loss:2.1198 train_time:6410076ms step_avg:169.58ms
+step:38000/500000 train_loss:1.9920 train_time:6443726ms step_avg:169.57ms
+step:38200/500000 train_loss:2.1540 train_time:6477641ms step_avg:169.57ms
+step:38400/500000 train_loss:2.0606 train_time:6511339ms step_avg:169.57ms
+step:38600/500000 train_loss:2.1499 train_time:6545067ms step_avg:169.56ms
+step:38800/500000 train_loss:2.0837 train_time:6578849ms step_avg:169.56ms
+step:39000/500000 train_loss:2.2491 train_time:6612586ms step_avg:169.55ms
+step:39200/500000 train_loss:2.0852 train_time:6646429ms step_avg:169.55ms
+step:39400/500000 train_loss:2.0536 train_time:6680442ms step_avg:169.55ms
+step:39600/500000 train_loss:2.0032 train_time:6714545ms step_avg:169.56ms
+step:39800/500000 train_loss:2.1094 train_time:6748233ms step_avg:169.55ms
+step:40000/500000 train_loss:2.3382 train_time:6782132ms step_avg:169.55ms
+step:40000/500000 val_loss:2.0613 val_bpb:1.2208 train_time:6782157ms step_avg:169.55ms
+step:40200/500000 train_loss:2.1918 train_time:6815875ms step_avg:169.55ms
+step:40400/500000 train_loss:2.0971 train_time:6849668ms step_avg:169.55ms
+step:40600/500000 train_loss:2.0846 train_time:6883595ms step_avg:169.55ms
+step:40800/500000 train_loss:2.1479 train_time:6917328ms step_avg:169.54ms
+step:41000/500000 train_loss:2.3786 train_time:6951037ms step_avg:169.54ms
+step:41200/500000 train_loss:2.0205 train_time:6985263ms step_avg:169.55ms
+step:41400/500000 train_loss:2.2257 train_time:7019472ms step_avg:169.55ms
+step:41600/500000 train_loss:2.1411 train_time:7053142ms step_avg:169.55ms
+step:41800/500000 train_loss:2.1872 train_time:7086909ms step_avg:169.54ms
+step:42000/500000 train_loss:1.9927 train_time:7120646ms step_avg:169.54ms
+step:42200/500000 train_loss:2.0798 train_time:7154399ms step_avg:169.54ms
+step:42400/500000 train_loss:2.0076 train_time:7188012ms step_avg:169.53ms
+step:42600/500000 train_loss:2.1304 train_time:7221790ms step_avg:169.53ms
+step:42800/500000 train_loss:2.1677 train_time:7255551ms step_avg:169.52ms
+step:43000/500000 train_loss:2.1548 train_time:7289598ms step_avg:169.53ms
+step:43200/500000 train_loss:2.1497 train_time:7323664ms step_avg:169.53ms
+step:43400/500000 train_loss:2.1200 train_time:7357302ms step_avg:169.52ms
+step:43600/500000 train_loss:2.1372 train_time:7391179ms step_avg:169.52ms
+step:43800/500000 train_loss:2.0843 train_time:7425112ms step_avg:169.52ms
+step:44000/500000 train_loss:2.0841 train_time:7458916ms step_avg:169.52ms
+step:44200/500000 train_loss:2.1849 train_time:7492709ms step_avg:169.52ms
+step:44400/500000 train_loss:2.0930 train_time:7526334ms step_avg:169.51ms
+step:44600/500000 train_loss:2.1554 train_time:7560076ms step_avg:169.51ms
+step:44800/500000 train_loss:2.1367 train_time:7594039ms step_avg:169.51ms
+step:45000/500000 train_loss:2.1006 train_time:7628089ms step_avg:169.51ms
+step:45200/500000 train_loss:2.1287 train_time:7661995ms step_avg:169.51ms
+step:45400/500000 train_loss:2.1336 train_time:7695868ms step_avg:169.51ms
+step:45600/500000 train_loss:2.1573 train_time:7729553ms step_avg:169.51ms
+step:45800/500000 train_loss:2.0724 train_time:7763352ms step_avg:169.51ms
+step:46000/500000 train_loss:2.1991 train_time:7797085ms step_avg:169.50ms
+step:46200/500000 train_loss:2.1389 train_time:7830782ms step_avg:169.50ms
+step:46400/500000 train_loss:1.9186 train_time:7864555ms step_avg:169.49ms
+step:46600/500000 train_loss:2.0536 train_time:7898534ms step_avg:169.50ms
+step:46800/500000 train_loss:2.0774 train_time:7932353ms step_avg:169.49ms
+step:47000/500000 train_loss:2.1115 train_time:7966426ms step_avg:169.50ms
+step:47200/500000 train_loss:2.1009 train_time:8000132ms step_avg:169.49ms
+step:47400/500000 train_loss:2.1132 train_time:8033850ms step_avg:169.49ms
+step:47600/500000 train_loss:2.1153 train_time:8067780ms step_avg:169.49ms
+step:47800/500000 train_loss:2.0268 train_time:8101544ms step_avg:169.49ms
+step:48000/500000 train_loss:2.1608 train_time:8135184ms step_avg:169.48ms
+step:48200/500000 train_loss:2.0617 train_time:8168921ms step_avg:169.48ms
+step:48400/500000 train_loss:2.1455 train_time:8202976ms step_avg:169.48ms
+step:48600/500000 train_loss:2.0158 train_time:8236715ms step_avg:169.48ms
+step:48800/500000 train_loss:2.1375 train_time:8270799ms step_avg:169.48ms
+step:49000/500000 train_loss:2.1525 train_time:8304628ms step_avg:169.48ms
+step:49200/500000 train_loss:1.9730 train_time:8338254ms step_avg:169.48ms
+step:49400/500000 train_loss:2.1314 train_time:8372024ms step_avg:169.47ms
+step:49600/500000 train_loss:2.0449 train_time:8405680ms step_avg:169.47ms
+step:49800/500000 train_loss:2.0866 train_time:8439504ms step_avg:169.47ms
+step:50000/500000 train_loss:2.2122 train_time:8473448ms step_avg:169.47ms
+step:50000/500000 val_loss:2.0515 val_bpb:1.2150 train_time:8473472ms step_avg:169.47ms
+step:50200/500000 train_loss:2.1399 train_time:8507381ms step_avg:169.47ms
+step:50400/500000 train_loss:2.0869 train_time:8541046ms step_avg:169.47ms
+step:50600/500000 train_loss:2.0022 train_time:8575063ms step_avg:169.47ms
+step:50800/500000 train_loss:2.0432 train_time:8608758ms step_avg:169.46ms
+step:51000/500000 train_loss:2.0449 train_time:8642506ms step_avg:169.46ms
+step:51200/500000 train_loss:2.0966 train_time:8676303ms step_avg:169.46ms
+step:51400/500000 train_loss:1.8729 train_time:8710209ms step_avg:169.46ms
+step:51600/500000 train_loss:2.1335 train_time:8743850ms step_avg:169.45ms
+step:51800/500000 train_loss:2.0893 train_time:8777498ms step_avg:169.45ms
+step:52000/500000 train_loss:2.1570 train_time:8811584ms step_avg:169.45ms
+step:52200/500000 train_loss:2.1165 train_time:8845223ms step_avg:169.45ms
+step:52400/500000 train_loss:2.1231 train_time:8879344ms step_avg:169.45ms
+step:52600/500000 train_loss:2.3117 train_time:8913107ms step_avg:169.45ms
+step:52800/500000 train_loss:2.1086 train_time:8946675ms step_avg:169.44ms
+step:53000/500000 train_loss:2.0479 train_time:8980432ms step_avg:169.44ms
+step:53200/500000 train_loss:2.2167 train_time:9014120ms step_avg:169.44ms
+step:53400/500000 train_loss:2.1793 train_time:9047850ms step_avg:169.44ms
+step:53600/500000 train_loss:2.0322 train_time:9081775ms step_avg:169.44ms
+step:53800/500000 train_loss:1.9763 train_time:9115883ms step_avg:169.44ms
+step:54000/500000 train_loss:2.1329 train_time:9149634ms step_avg:169.44ms
+step:54200/500000 train_loss:2.2285 train_time:9183709ms step_avg:169.44ms
+step:54400/500000 train_loss:2.1092 train_time:9217434ms step_avg:169.44ms
+step:54600/500000 train_loss:2.0704 train_time:9251225ms step_avg:169.44ms
+step:54800/500000 train_loss:2.1056 train_time:9284973ms step_avg:169.43ms
+step:55000/500000 train_loss:2.0178 train_time:9318650ms step_avg:169.43ms
+step:55200/500000 train_loss:2.0188 train_time:9352411ms step_avg:169.43ms
+step:55400/500000 train_loss:2.0410 train_time:9386078ms step_avg:169.42ms
+step:55600/500000 train_loss:2.1974 train_time:9420015ms step_avg:169.42ms
+step:55800/500000 train_loss:2.0778 train_time:9453698ms step_avg:169.42ms
+step:56000/500000 train_loss:2.1492 train_time:9487996ms step_avg:169.43ms
+step:56200/500000 train_loss:2.0753 train_time:9521942ms step_avg:169.43ms
+step:56400/500000 train_loss:1.9880 train_time:9555712ms step_avg:169.43ms
+step:56600/500000 train_loss:2.1121 train_time:9589439ms step_avg:169.42ms
+step:56800/500000 train_loss:2.0449 train_time:9623124ms step_avg:169.42ms
+step:57000/500000 train_loss:2.1901 train_time:9656849ms step_avg:169.42ms
+step:57200/500000 train_loss:2.0973 train_time:9690717ms step_avg:169.42ms
+step:57400/500000 train_loss:2.0432 train_time:9724616ms step_avg:169.42ms
+step:57600/500000 train_loss:2.0962 train_time:9758297ms step_avg:169.41ms
+step:57800/500000 train_loss:1.9947 train_time:9792565ms step_avg:169.42ms
+step:58000/500000 train_loss:2.2452 train_time:9826234ms step_avg:169.42ms
+step:58200/500000 train_loss:2.0570 train_time:9859988ms step_avg:169.42ms
+step:58400/500000 train_loss:2.2599 train_time:9893547ms step_avg:169.41ms
+step:58600/500000 train_loss:2.1607 train_time:9927243ms step_avg:169.41ms
+step:58800/500000 train_loss:2.0393 train_time:9960898ms step_avg:169.40ms
+step:59000/500000 train_loss:2.0819 train_time:9994545ms step_avg:169.40ms
+step:59200/500000 train_loss:2.1481 train_time:10028661ms step_avg:169.40ms
+step:59400/500000 train_loss:2.0225 train_time:10062800ms step_avg:169.41ms
+step:59600/500000 train_loss:2.0964 train_time:10097009ms step_avg:169.41ms
+step:59800/500000 train_loss:2.0291 train_time:10130802ms step_avg:169.41ms
+step:60000/500000 train_loss:1.9972 train_time:10164563ms step_avg:169.41ms
+step:60000/500000 val_loss:2.0465 val_bpb:1.2120 train_time:10164588ms step_avg:169.41ms
+step:60200/500000 train_loss:2.1275 train_time:10198159ms step_avg:169.40ms
+step:60400/500000 train_loss:2.2563 train_time:10231966ms step_avg:169.40ms
+step:60600/500000 train_loss:2.0858 train_time:10265584ms step_avg:169.40ms
+step:60800/500000 train_loss:1.9902 train_time:10299700ms step_avg:169.40ms
+step:61000/500000 train_loss:2.0551 train_time:10333718ms step_avg:169.41ms
+step:61200/500000 train_loss:2.1053 train_time:10367421ms step_avg:169.40ms
+step:61400/500000 train_loss:1.6975 train_time:10401532ms step_avg:169.41ms
+step:61600/500000 train_loss:2.0216 train_time:10435242ms step_avg:169.40ms
+step:61800/500000 train_loss:2.0529 train_time:10469135ms step_avg:169.40ms
+step:62000/500000 train_loss:2.1304 train_time:10502805ms step_avg:169.40ms
+step:62200/500000 train_loss:2.0714 train_time:10536521ms step_avg:169.40ms
+step:62400/500000 train_loss:2.0922 train_time:10570444ms step_avg:169.40ms
+step:62600/500000 train_loss:2.0446 train_time:10604148ms step_avg:169.40ms
+step:62800/500000 train_loss:2.1549 train_time:10638257ms step_avg:169.40ms
+step:63000/500000 train_loss:2.1301 train_time:10672035ms step_avg:169.40ms
+late_qat:enabled step:63050 scale:0.8500
+step:63200/500000 train_loss:2.2227 train_time:10706065ms step_avg:169.40ms
+step:63400/500000 train_loss:2.1958 train_time:10739773ms step_avg:169.40ms
+step:63600/500000 train_loss:2.3582 train_time:10773494ms step_avg:169.39ms
+step:63800/500000 train_loss:2.2031 train_time:10807206ms step_avg:169.39ms
+step:64000/500000 train_loss:2.1209 train_time:10841008ms step_avg:169.39ms
+step:64200/500000 train_loss:2.1704 train_time:10874703ms step_avg:169.39ms
+step:64400/500000 train_loss:2.3202 train_time:10908448ms step_avg:169.39ms
+step:64600/500000 train_loss:1.9219 train_time:10942402ms step_avg:169.39ms
+step:64800/500000 train_loss:2.1827 train_time:10976123ms step_avg:169.38ms
+step:65000/500000 train_loss:2.1968 train_time:11010429ms step_avg:169.39ms
+step:65200/500000 train_loss:2.2015 train_time:11044142ms step_avg:169.39ms
+step:65400/500000 train_loss:1.9902 train_time:11077870ms step_avg:169.39ms
+step:65600/500000 train_loss:2.1181 train_time:11111516ms step_avg:169.38ms
+step:65800/500000 train_loss:2.1945 train_time:11145340ms step_avg:169.38ms
+step:66000/500000 train_loss:1.8931 train_time:11179256ms step_avg:169.38ms
+step:66200/500000 train_loss:2.2619 train_time:11212932ms step_avg:169.38ms
+step:66400/500000 train_loss:3.3647 train_time:11246876ms step_avg:169.38ms
+step:66600/500000 train_loss:1.9584 train_time:11280602ms step_avg:169.38ms
+step:66800/500000 train_loss:2.1801 train_time:11314622ms step_avg:169.38ms
+step:67000/500000 train_loss:2.1182 train_time:11348528ms step_avg:169.38ms
+step:67200/500000 train_loss:2.3519 train_time:11382293ms step_avg:169.38ms
+step:67400/500000 train_loss:2.1087 train_time:11416016ms step_avg:169.38ms
+step:67600/500000 train_loss:2.1273 train_time:11449923ms step_avg:169.38ms
+step:67800/500000 train_loss:2.0241 train_time:11483836ms step_avg:169.38ms
+step:68000/500000 train_loss:2.2169 train_time:11517571ms step_avg:169.38ms
+step:68200/500000 train_loss:2.1326 train_time:11551704ms step_avg:169.38ms
+step:68400/500000 train_loss:2.0946 train_time:11585561ms step_avg:169.38ms
+step:68600/500000 train_loss:1.8763 train_time:11619778ms step_avg:169.38ms
+step:68800/500000 train_loss:2.0383 train_time:11653494ms step_avg:169.38ms
+step:69000/500000 train_loss:2.1097 train_time:11687338ms step_avg:169.38ms
+step:69200/500000 train_loss:2.2047 train_time:11721086ms step_avg:169.38ms
+step:69400/500000 train_loss:2.1294 train_time:11754727ms step_avg:169.38ms
+step:69600/500000 train_loss:2.1669 train_time:11788505ms step_avg:169.38ms
+step:69800/500000 train_loss:1.9954 train_time:11822492ms step_avg:169.38ms
+step:70000/500000 train_loss:2.2395 train_time:11856598ms step_avg:169.38ms
+step:70000/500000 val_loss:2.0699 val_bpb:1.2259 train_time:11856601ms step_avg:169.38ms
+step:70200/500000 train_loss:2.1486 train_time:11890398ms step_avg:169.38ms
+step:70400/500000 train_loss:2.1470 train_time:11924504ms step_avg:169.38ms
+step:70600/500000 train_loss:2.0537 train_time:11958557ms step_avg:169.38ms
+step:70800/500000 train_loss:2.1305 train_time:11992227ms step_avg:169.38ms
+step:71000/500000 train_loss:2.1577 train_time:12026012ms step_avg:169.38ms
+step:71200/500000 train_loss:2.1940 train_time:12059931ms step_avg:169.38ms
+step:71400/500000 train_loss:2.0527 train_time:12093824ms step_avg:169.38ms
+step:71600/500000 train_loss:2.2020 train_time:12127953ms step_avg:169.38ms
+step:71800/500000 train_loss:2.2122 train_time:12161971ms step_avg:169.39ms
+step:72000/500000 train_loss:2.1476 train_time:12195662ms step_avg:169.38ms
+step:72200/500000 train_loss:2.0795 train_time:12229760ms step_avg:169.39ms
+step:72400/500000 train_loss:2.1155 train_time:12263486ms step_avg:169.39ms
+step:72600/500000 train_loss:2.0505 train_time:12297267ms step_avg:169.38ms
+step:72800/500000 train_loss:2.0682 train_time:12330826ms step_avg:169.38ms
+step:73000/500000 train_loss:2.0925 train_time:12364598ms step_avg:169.38ms
+step:73200/500000 train_loss:2.0335 train_time:12398490ms step_avg:169.38ms
+step:73400/500000 train_loss:1.9893 train_time:12432245ms step_avg:169.38ms
+step:73600/500000 train_loss:1.9891 train_time:12466406ms step_avg:169.38ms
+step:73800/500000 train_loss:2.1010 train_time:12500085ms step_avg:169.38ms
+step:74000/500000 train_loss:2.0233 train_time:12534259ms step_avg:169.38ms
+step:74200/500000 train_loss:2.1469 train_time:12567982ms step_avg:169.38ms
+step:74400/500000 train_loss:2.0764 train_time:12601680ms step_avg:169.38ms
+step:74600/500000 train_loss:2.1775 train_time:12635456ms step_avg:169.38ms
+step:74800/500000 train_loss:2.1319 train_time:12669272ms step_avg:169.38ms
+step:75000/500000 train_loss:1.9817 train_time:12702950ms step_avg:169.37ms
+step:75200/500000 train_loss:2.0694 train_time:12736621ms step_avg:169.37ms
+step:75400/500000 train_loss:2.1182 train_time:12770700ms step_avg:169.37ms
+step:75600/500000 train_loss:2.2678 train_time:12804495ms step_avg:169.37ms
+step:75800/500000 train_loss:2.1429 train_time:12838312ms step_avg:169.37ms
+step:76000/500000 train_loss:2.1440 train_time:12872574ms step_avg:169.38ms
+step:76200/500000 train_loss:1.9596 train_time:12906502ms step_avg:169.38ms
+step:76400/500000 train_loss:2.0887 train_time:12940419ms step_avg:169.38ms
+step:76600/500000 train_loss:2.1316 train_time:12974092ms step_avg:169.37ms
+step:76800/500000 train_loss:2.1624 train_time:13007746ms step_avg:169.37ms
+step:77000/500000 train_loss:2.1418 train_time:13041448ms step_avg:169.37ms
+step:77200/500000 train_loss:2.2462 train_time:13075414ms step_avg:169.37ms
+step:77400/500000 train_loss:1.9196 train_time:13109186ms step_avg:169.37ms
+step:77600/500000 train_loss:1.9850 train_time:13143017ms step_avg:169.37ms
+step:77800/500000 train_loss:2.0299 train_time:13177709ms step_avg:169.38ms
+step:78000/500000 train_loss:2.0174 train_time:13211539ms step_avg:169.38ms
+step:78200/500000 train_loss:2.0625 train_time:13245239ms step_avg:169.38ms
+step:78400/500000 train_loss:2.1635 train_time:13279287ms step_avg:169.38ms
+step:78600/500000 train_loss:2.0172 train_time:13318149ms step_avg:169.44ms
+step:78800/500000 train_loss:1.9244 train_time:13352067ms step_avg:169.44ms
+step:79000/500000 train_loss:2.0747 train_time:13386465ms step_avg:169.45ms
+step:79200/500000 train_loss:1.9833 train_time:13420186ms step_avg:169.45ms
+step:79400/500000 train_loss:2.1199 train_time:13453876ms step_avg:169.44ms
+step:79600/500000 train_loss:2.1815 train_time:13488090ms step_avg:169.45ms
+step:79800/500000 train_loss:2.0853 train_time:13521958ms step_avg:169.45ms
+step:80000/500000 train_loss:2.1676 train_time:13555873ms step_avg:169.45ms
+step:80000/500000 val_loss:2.0498 val_bpb:1.2140 train_time:13555876ms step_avg:169.45ms
+step:80200/500000 train_loss:2.1571 train_time:13589467ms step_avg:169.44ms
+step:80400/500000 train_loss:2.1771 train_time:13623222ms step_avg:169.44ms
+step:80600/500000 train_loss:2.0329 train_time:13657367ms step_avg:169.45ms
+step:80800/500000 train_loss:2.0233 train_time:13691407ms step_avg:169.45ms
+step:81000/500000 train_loss:2.2020 train_time:13725226ms step_avg:169.45ms
+step:81200/500000 train_loss:2.8223 train_time:13758818ms step_avg:169.44ms
+step:81400/500000 train_loss:2.1113 train_time:13792990ms step_avg:169.45ms
+step:81600/500000 train_loss:2.0870 train_time:13826746ms step_avg:169.45ms
+step:81800/500000 train_loss:2.1230 train_time:13860430ms step_avg:169.44ms
+step:82000/500000 train_loss:2.0146 train_time:13894697ms step_avg:169.45ms
+step:82200/500000 train_loss:2.0932 train_time:13928486ms step_avg:169.45ms
+step:82400/500000 train_loss:2.0145 train_time:13962276ms step_avg:169.45ms
+step:82600/500000 train_loss:2.0748 train_time:13996271ms step_avg:169.45ms
+step:82800/500000 train_loss:2.0498 train_time:14030147ms step_avg:169.45ms
+step:83000/500000 train_loss:2.0651 train_time:14063874ms step_avg:169.44ms
+step:83200/500000 train_loss:2.1033 train_time:14098191ms step_avg:169.45ms
+step:83400/500000 train_loss:1.9961 train_time:14132055ms step_avg:169.45ms
+step:83600/500000 train_loss:2.0622 train_time:14166030ms step_avg:169.45ms
+step:83800/500000 train_loss:2.0604 train_time:14199726ms step_avg:169.45ms
+step:84000/500000 train_loss:2.0984 train_time:14233390ms step_avg:169.45ms
+step:84200/500000 train_loss:2.1044 train_time:14267104ms step_avg:169.44ms
+step:84278/500000 val_loss:2.0522 val_bpb:1.2154 train_time:14280127ms step_avg:169.44ms
+stopping_early: wallclock_cap train_time:14280127ms step:84278/500000 (reserving 120.0s for GPTQ)
+peak memory allocated: 11293 MiB reserved: 11422 MiB
+gptq:calibrating with 512 batches...
+gptq:collected hessians for 69 layers in 46433ms
+Serialized model: 85084941 bytes
+Code size: 84487 bytes
+Total submission size: 85169428 bytes
+prune:zeroed 1578366 int6 weights (threshold=0)
+gptq:quantized 69 layers with GPTQ, 0 naive, 1 INT8 embeds
+artifact int6+gptq+zstd-22: 14528266 bytes + 84487 code = 14612753 total (payload:21667168 payload_ratio:3.92x)
+artifact headroom: 1387247 bytes (1.387MB)
+artifact int8+zlib: 19405206 bytes (for comparison)
+final_int6_gptq_roundtrip val_loss:2.0819 val_bpb:1.2330 eval_time:1919ms
+final_int6_gptq_roundtrip_exact val_loss:2.08190354 val_bpb:1.23302055
+sliding_eval: stride=64 batch_seqs=16 seq_len=2048
+  sliding_eval [  0.0%] 16/121136 windows running_bpb=1.226171
+  sliding_eval [  0.7%] 816/121136 windows running_bpb=1.276717
+  sliding_eval [  1.3%] 1616/121136 windows running_bpb=1.205917
+  sliding_eval [  2.0%] 2416/121136 windows running_bpb=1.221103
+  sliding_eval [  2.7%] 3216/121136 windows running_bpb=1.207450
+  sliding_eval [  3.3%] 4016/121136 windows running_bpb=1.205424
+  sliding_eval [  4.0%] 4816/121136 windows running_bpb=1.202122
+  sliding_eval [  4.6%] 5616/121136 windows running_bpb=1.204484
+  sliding_eval [  5.3%] 6416/121136 windows running_bpb=1.213791
+  sliding_eval [  6.0%] 7216/121136 windows running_bpb=1.214020
+  sliding_eval [  6.6%] 8016/121136 windows running_bpb=1.214836
+  sliding_eval [  7.3%] 8816/121136 windows running_bpb=1.219470
+  sliding_eval [  7.9%] 9616/121136 windows running_bpb=1.216169
+  sliding_eval [  8.6%] 10416/121136 windows running_bpb=1.213290
+  sliding_eval [  9.3%] 11216/121136 windows running_bpb=1.211829
+  sliding_eval [  9.9%] 12016/121136 windows running_bpb=1.210270
+  sliding_eval [ 10.6%] 12816/121136 windows running_bpb=1.208947
+  sliding_eval [ 11.2%] 13616/121136 windows running_bpb=1.207613
+  sliding_eval [ 11.9%] 14416/121136 windows running_bpb=1.210968
+  sliding_eval [ 12.6%] 15216/121136 windows running_bpb=1.222654
+  sliding_eval [ 13.2%] 16016/121136 windows running_bpb=1.219599
+  sliding_eval [ 13.9%] 16816/121136 windows running_bpb=1.219094
+  sliding_eval [ 14.5%] 17616/121136 windows running_bpb=1.217561
+  sliding_eval [ 15.2%] 18416/121136 windows running_bpb=1.217016
+  sliding_eval [ 15.9%] 19216/121136 windows running_bpb=1.218802
+  sliding_eval [ 16.5%] 20016/121136 windows running_bpb=1.217414
+  sliding_eval [ 17.2%] 20816/121136 windows running_bpb=1.217266
+  sliding_eval [ 17.8%] 21616/121136 windows running_bpb=1.216673
+  sliding_eval [ 18.5%] 22416/121136 windows running_bpb=1.215724
+  sliding_eval [ 19.2%] 23216/121136 windows running_bpb=1.213217
+  sliding_eval [ 19.8%] 24016/121136 windows running_bpb=1.216219
+  sliding_eval [ 20.5%] 24816/121136 windows running_bpb=1.216121
+  sliding_eval [ 21.1%] 25616/121136 windows running_bpb=1.217487
+  sliding_eval [ 21.8%] 26416/121136 windows running_bpb=1.217393
+  sliding_eval [ 22.5%] 27216/121136 windows running_bpb=1.218058
+  sliding_eval [ 23.1%] 28016/121136 windows running_bpb=1.222321
+  sliding_eval [ 23.8%] 28816/121136 windows running_bpb=1.224031
+  sliding_eval [ 24.4%] 29616/121136 windows running_bpb=1.223842
+  sliding_eval [ 25.1%] 30416/121136 windows running_bpb=1.221563
+  sliding_eval [ 25.8%] 31216/121136 windows running_bpb=1.222125
+  sliding_eval [ 26.4%] 32016/121136 windows running_bpb=1.222802
+  sliding_eval [ 27.1%] 32816/121136 windows running_bpb=1.222253
+  sliding_eval [ 27.8%] 33616/121136 windows running_bpb=1.221316
+  sliding_eval [ 28.4%] 34416/121136 windows running_bpb=1.220425
+  sliding_eval [ 29.1%] 35216/121136 windows running_bpb=1.220531
+  sliding_eval [ 29.7%] 36016/121136 windows running_bpb=1.221035
+  sliding_eval [ 30.4%] 36816/121136 windows running_bpb=1.219946
+  sliding_eval [ 31.1%] 37616/121136 windows running_bpb=1.220322
+  sliding_eval [ 31.7%] 38416/121136 windows running_bpb=1.220699
+  sliding_eval [ 32.4%] 39216/121136 windows running_bpb=1.218747
+  sliding_eval [ 33.0%] 40016/121136 windows running_bpb=1.218299
+  sliding_eval [ 33.7%] 40816/121136 windows running_bpb=1.217043
+  sliding_eval [ 34.4%] 41616/121136 windows running_bpb=1.217335
+  sliding_eval [ 35.0%] 42416/121136 windows running_bpb=1.217509
+  sliding_eval [ 35.7%] 43216/121136 windows running_bpb=1.217643
+  sliding_eval [ 36.3%] 44016/121136 windows running_bpb=1.216977
+  sliding_eval [ 37.0%] 44816/121136 windows running_bpb=1.216615
+  sliding_eval [ 37.7%] 45616/121136 windows running_bpb=1.216262
+  sliding_eval [ 38.3%] 46416/121136 windows running_bpb=1.216546
+  sliding_eval [ 39.0%] 47216/121136 windows running_bpb=1.215677
+  sliding_eval [ 39.6%] 48016/121136 windows running_bpb=1.215657
+  sliding_eval [ 40.3%] 48816/121136 windows running_bpb=1.215640
+  sliding_eval [ 41.0%] 49616/121136 windows running_bpb=1.216960
+  sliding_eval [ 41.6%] 50416/121136 windows running_bpb=1.217651
+  sliding_eval [ 42.3%] 51216/121136 windows running_bpb=1.218051
+  sliding_eval [ 42.9%] 52016/121136 windows running_bpb=1.218051
+  sliding_eval [ 43.6%] 52816/121136 windows running_bpb=1.218573
+  sliding_eval [ 44.3%] 53616/121136 windows running_bpb=1.217694
+  sliding_eval [ 44.9%] 54416/121136 windows running_bpb=1.218081
+  sliding_eval [ 45.6%] 55216/121136 windows running_bpb=1.218422
+  sliding_eval [ 46.2%] 56016/121136 windows running_bpb=1.218463
+  sliding_eval [ 46.9%] 56816/121136 windows running_bpb=1.217825
+  sliding_eval [ 47.6%] 57616/121136 windows running_bpb=1.217431
+  sliding_eval [ 48.2%] 58416/121136 windows running_bpb=1.213926
+  sliding_eval [ 48.9%] 59216/121136 windows running_bpb=1.213599
+  sliding_eval [ 49.5%] 60016/121136 windows running_bpb=1.213530
+  sliding_eval [ 50.2%] 60816/121136 windows running_bpb=1.213534
+  sliding_eval [ 50.9%] 61616/121136 windows running_bpb=1.213639
+  sliding_eval [ 51.5%] 62416/121136 windows running_bpb=1.214415
+  sliding_eval [ 52.2%] 63216/121136 windows running_bpb=1.214172
+  sliding_eval [ 52.8%] 64016/121136 windows running_bpb=1.214417
+  sliding_eval [ 53.5%] 64816/121136 windows running_bpb=1.214606
+  sliding_eval [ 54.2%] 65616/121136 windows running_bpb=1.214319
+  sliding_eval [ 54.8%] 66416/121136 windows running_bpb=1.213525
+  sliding_eval [ 55.5%] 67216/121136 windows running_bpb=1.213105
+  sliding_eval [ 56.1%] 68016/121136 windows running_bpb=1.213015
+  sliding_eval [ 56.8%] 68816/121136 windows running_bpb=1.212658
+  sliding_eval [ 57.5%] 69616/121136 windows running_bpb=1.212384
+  sliding_eval [ 58.1%] 70416/121136 windows running_bpb=1.212047
+  sliding_eval [ 58.8%] 71216/121136 windows running_bpb=1.212170
+  sliding_eval [ 59.5%] 72016/121136 windows running_bpb=1.212178
+  sliding_eval [ 60.1%] 72816/121136 windows running_bpb=1.212114
+  sliding_eval [ 60.8%] 73616/121136 windows running_bpb=1.212186
+  sliding_eval [ 61.4%] 74416/121136 windows running_bpb=1.212580
+  sliding_eval [ 62.1%] 75216/121136 windows running_bpb=1.212415
+  sliding_eval [ 62.8%] 76016/121136 windows running_bpb=1.211757
+  sliding_eval [ 63.4%] 76816/121136 windows running_bpb=1.212066
+  sliding_eval [ 64.1%] 77616/121136 windows running_bpb=1.212268
+  sliding_eval [ 64.7%] 78416/121136 windows running_bpb=1.212692
+  sliding_eval [ 65.4%] 79216/121136 windows running_bpb=1.212398
+  sliding_eval [ 66.1%] 80016/121136 windows running_bpb=1.212939
+  sliding_eval [ 66.7%] 80816/121136 windows running_bpb=1.213249
+  sliding_eval [ 67.4%] 81616/121136 windows running_bpb=1.212650
+  sliding_eval [ 68.0%] 82416/121136 windows running_bpb=1.213253
+  sliding_eval [ 68.7%] 83216/121136 windows running_bpb=1.213713
+  sliding_eval [ 69.4%] 84016/121136 windows running_bpb=1.215531
+  sliding_eval [ 70.0%] 84816/121136 windows running_bpb=1.215605
+  sliding_eval [ 70.7%] 85616/121136 windows running_bpb=1.214607
+  sliding_eval [ 71.3%] 86416/121136 windows running_bpb=1.214919
+  sliding_eval [ 72.0%] 87216/121136 windows running_bpb=1.215181
+  sliding_eval [ 72.7%] 88016/121136 windows running_bpb=1.215639
+  sliding_eval [ 73.3%] 88816/121136 windows running_bpb=1.215731
+  sliding_eval [ 74.0%] 89616/121136 windows running_bpb=1.215886
+  sliding_eval [ 74.6%] 90416/121136 windows running_bpb=1.216143
+  sliding_eval [ 75.3%] 91216/121136 windows running_bpb=1.215949
+  sliding_eval [ 76.0%] 92016/121136 windows running_bpb=1.215338
+  sliding_eval [ 76.6%] 92816/121136 windows running_bpb=1.215451
+  sliding_eval [ 77.3%] 93616/121136 windows running_bpb=1.215601
+  sliding_eval [ 77.9%] 94416/121136 windows running_bpb=1.215742
+  sliding_eval [ 78.6%] 95216/121136 windows running_bpb=1.215647
+  sliding_eval [ 79.3%] 96016/121136 windows running_bpb=1.215165
+  sliding_eval [ 79.9%] 96816/121136 windows running_bpb=1.218436
+  sliding_eval [ 80.6%] 97616/121136 windows running_bpb=1.218071
+  sliding_eval [ 81.2%] 98416/121136 windows running_bpb=1.218077
+  sliding_eval [ 81.9%] 99216/121136 windows running_bpb=1.218016
+  sliding_eval [ 82.6%] 100016/121136 windows running_bpb=1.217861
+  sliding_eval [ 83.2%] 100816/121136 windows running_bpb=1.218039
+  sliding_eval [ 83.9%] 101616/121136 windows running_bpb=1.218393
+  sliding_eval [ 84.5%] 102416/121136 windows running_bpb=1.217708
+  sliding_eval [ 85.2%] 103216/121136 windows running_bpb=1.217562
+  sliding_eval [ 85.9%] 104016/121136 windows running_bpb=1.217189
+  sliding_eval [ 86.5%] 104816/121136 windows running_bpb=1.216729
+  sliding_eval [ 87.2%] 105616/121136 windows running_bpb=1.216479
+  sliding_eval [ 87.8%] 106416/121136 windows running_bpb=1.216397
+  sliding_eval [ 88.5%] 107216/121136 windows running_bpb=1.216433
+  sliding_eval [ 89.2%] 108016/121136 windows running_bpb=1.216527
+  sliding_eval [ 89.8%] 108816/121136 windows running_bpb=1.216975
+  sliding_eval [ 90.5%] 109616/121136 windows running_bpb=1.217162
+  sliding_eval [ 91.2%] 110416/121136 windows running_bpb=1.217007
+  sliding_eval [ 91.8%] 111216/121136 windows running_bpb=1.217185
+  sliding_eval [ 92.5%] 112016/121136 windows running_bpb=1.216954
+  sliding_eval [ 93.1%] 112816/121136 windows running_bpb=1.217620
+  sliding_eval [ 93.8%] 113616/121136 windows running_bpb=1.217430
+  sliding_eval [ 94.5%] 114416/121136 windows running_bpb=1.217288
+  sliding_eval [ 95.1%] 115216/121136 windows running_bpb=1.217198
+  sliding_eval [ 95.8%] 116016/121136 windows running_bpb=1.217133
+  sliding_eval [ 96.4%] 116816/121136 windows running_bpb=1.216827
+  sliding_eval [ 97.1%] 117616/121136 windows running_bpb=1.217238
+  sliding_eval [ 97.8%] 118416/121136 windows running_bpb=1.217139
+  sliding_eval [ 98.4%] 119216/121136 windows running_bpb=1.217243
+  sliding_eval [ 99.1%] 120016/121136 windows running_bpb=1.217217
+  sliding_eval [ 99.7%] 120816/121136 windows running_bpb=1.217472
+final_int6_gptq_sliding_window val_loss:2.0437 val_bpb:1.2104 eval_time:154595ms
+final_int6_gptq_sliding_window_exact val_loss:2.04369275 val_bpb:1.21039316
+ndary_mask.sum(dim=-1)  # [B]
+        num_chunks = num_chunks.clamp(max=max_chunks)
+
+        token_idx = torch.arange(L, device=hidden_states.device)[None, :] + (~boundary_mask).long() * L
+        sorted_idx = torch.argsort(token_idx, dim=1)
+        take_idx = sorted_idx[:, :max_chunks]
+
+        chunked = torch.gather(
+            hidden_states,
+            dim=1,
+            index=take_idx.unsqueeze(-1).expand(-1, -1, D),
+        )
+
+        pad_mask = torch.arange(max_chunks, device=hidden_states.device)[None, :] < num_chunks[:, None]
+        chunked = chunked * pad_mask.unsqueeze(-1).to(chunked.dtype)
+
+        return chunked, pad_mask, take_idx
+
+
+class DeChunkLayer(nn.Module):
+    """
+    Paper dechunking:
+    1. smooth chunk states with parallel EMA via associative_scan (same-shape tuple)
+    2. plug chunk states back to original sequence positions by cumulative chunk id
+    """
+    def forward(
+        self,
+        hidden_states: Tensor,   # [B, C, D] output of main stage on chunked sequence
+        boundary_mask: Tensor,   # [B, L] hard boundaries on original sequence
+        boundary_prob: Tensor,   # [B, L] p_t on original sequence
+        take_idx: Tensor,        # [B, C] cached indices from ChunkLayer
+    ) -> Tensor:
+        B, L = boundary_mask.shape
+        _, C, D = hidden_states.shape
+
+        p_chunked = torch.gather(boundary_prob, dim=1, index=take_idx)  # [B, C]
+        p_chunked = p_chunked.clamp(1e-4, 1.0 - 1e-4)
+
+        # Parallel EMA via associative scan.
+        # Recurrence: s_t = p_t * x_t + (1 - p_t) * s_{t-1}
+        # Pack into single tensor: row = [decay, weighted_x_1, ..., weighted_x_D]
+        # so both elements of the tuple have identical shape [B, C, D].
+        decay = (1.0 - p_chunked).unsqueeze(-1).expand_as(hidden_states)  # [B, C, D]
+        weighted_x = p_chunked.unsqueeze(-1) * hidden_states              # [B, C, D]
+
+        # Fix position 0: decay=0 and weighted_x=x_0 so s_0 = x_0 exactly.
+        decay = decay.clone()
+        weighted_x = weighted_x.clone()
+        decay[:, 0] = 0.0
+        weighted_x[:, 0] = hidden_states[:, 0]
+
+        # combine_fn: (d1, v1) o (d2, v2) = (d1*d2, v2 + d2*v1)
+        def combine_fn(left: tuple[Tensor, Tensor], right: tuple[Tensor, Tensor]) -> tuple[Tensor, Tensor]:
+            d_left, v_left = left
+            d_right, v_right = right
+            return (d_left * d_right, v_right + d_right * v_left)
+
+        _, smoothed = associative_scan(combine_fn, (decay, weighted_x), dim=1)
+
+        # Plug chunk states back to original positions
+        chunk_id = torch.cumsum(boundary_mask.long(), dim=1) - 1  # [B, L]
+        chunk_id = chunk_id.clamp(max=C - 1)  # prevent OOB when boundaries > max_chunks
+        out = torch.gather(
+            smoothed,
+            dim=1,
+            index=chunk_id.unsqueeze(-1).expand(-1, -1, D),
+        )
+        return out
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        outer_layers: int,
+        target_avg_chunk_len: float,
+        ratio_loss_weight: float,
+        hnet_lr_diff: float = 0.75,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.hnet_lr_diff = hnet_lr_diff
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        main_layers = num_layers - 2 * outer_layers
+        if main_layers < 0:
+            raise ValueError(
+                f"NUM_LAYERS must be >= 2 * OUTER_LAYERS, got "
+                f"NUM_LAYERS={num_layers}, OUTER_LAYERS={outer_layers}"
+            )
+
+        self.main_stage = TransformerStage(
+            num_layers=main_layers,
+            dim=model_dim,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            mlp_mult=mlp_mult,
+            rope_base=rope_base,
+            qk_gain_init=qk_gain_init,
+        )
+
+        self.outer_layers = outer_layers
+        self.main_layers = main_layers
+        self.use_hnet = outer_layers > 0
+        if self.use_hnet:
+            self.encoder_stage = TransformerStage(
+                num_layers=outer_layers,
+                dim=model_dim,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                mlp_mult=mlp_mult,
+                rope_base=rope_base,
+                qk_gain_init=qk_gain_init,
+            )
+            self.decoder_stage = TransformerStage(
+                num_layers=outer_layers,
+                dim=model_dim,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                mlp_mult=mlp_mult,
+                rope_base=rope_base,
+                qk_gain_init=qk_gain_init,
+            )
+            self.routing0 = RoutingModule(model_dim)
+            self.chunk0 = ChunkLayer()
+            self.residual_proj0 = CastedLinear(model_dim, model_dim, bias=False)
+            self.residual_proj0._zero_init = True
+            self.dechunk0 = DeChunkLayer()
+            self.target_avg_chunk_len = target_avg_chunk_len
+            self.ratio_loss_weight = ratio_loss_weight
+
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+
+    def _compute_ratio_loss(self, boundary_mask: Tensor, boundary_prob: Tensor) -> Tensor:
+        """
+        Encourage the average boundary rate to match a target average chunk length.
+        boundary_mask: [B, L] bool
+        boundary_prob: [B, L] float
+        """
+        N = self.target_avg_chunk_len
+        if N <= 1.0:
+            raise ValueError(f"TARGET_AVG_CHUNK_LEN must be > 1, got {N}")
+
+        F_val = boundary_mask.float().mean(dim=-1)   # hard boundary rate per example
+        G_val = boundary_prob.mean(dim=-1)           # soft boundary rate per example
+
+        ratio_loss = N / (N - 1.0) * (
+            (N - 1.0) * F_val * G_val + (1.0 - F_val) * (1.0 - G_val)
+        )
+        return ratio_loss.mean() * self.ratio_loss_weight
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids) # [BATCH_SIZE, SEQ_LEN, MODEL_DIM] = [B, T, D]
+
+        if self.use_hnet:
+            # E -> M -> D (1 stage)
+            # Encode
+            x = self.encoder_stage(x)
+            encoder_out = x
+
+            # Routing and chunking
+            p0, bmask0, conf0 = self.routing0(x)
+            chunked0, pad_mask0, take_idx0 = self.chunk0(x, bmask0)
+
+
+            chunked0 = frac_gradient(chunked0, self.hnet_lr_diff ** -1)
+
+            # Main stage on chunked sequence
+            chunked0 = self.main_stage(chunked0)
+
+            dechunked0 = self.dechunk0(chunked0, bmask0, p0, take_idx0) # Dechunk (upsample)
+
+            ste_conf0 = ste_to_one(conf0).unsqueeze(-1)  # [B, L, 1]
+            x = ste_conf0 * dechunked0 + self.residual_proj0(encoder_out.to(self.residual_proj0.weight.dtype))
+
+
+            x = frac_gradient(x, self.hnet_lr_diff)
+            x = x.to(self.tok_emb.weight.dtype) # Cast back to embedding dtype for decoder stage
+
+            # Decoder
+            x = self.decoder_stage(x)
+
+            aux_loss = self._compute_ratio_loss(bmask0, p0) if self.training else None
+
+        else:
+            x = self.main_stage(x)
+            aux_loss = None
+
+
+        x = x.reshape(-1, x.size(-1)) # x.size(-1) = MODEL_DIM, reshape to [B*T, D] for LM head
+        targets = target_ids.reshape(-1)
+
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        ce_loss = F.cross_entropy(logits.float(), targets, reduction="mean")
+        return ce_loss + aux_loss if aux_loss is not None else ce_loss
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Forward pass returning logits [B, T, V] instead of loss. Used for sliding window eval."""
+        x = self.tok_emb(input_ids)
+
+        if self.use_hnet:
+            x = self.encoder_stage(x)
+            encoder_out = x
+            p0, bmask0, conf0 = self.routing0(x)
+            chunked0, pad_mask0, take_idx0 = self.chunk0(x, bmask0)
+            chunked0 = frac_gradient(chunked0, self.hnet_lr_diff ** -1)
+            chunked0 = self.main_stage(chunked0)
+            dechunked0 = self.dechunk0(chunked0, bmask0, p0, take_idx0)
+            ste_conf0 = ste_to_one(conf0).unsqueeze(-1)
+            x = ste_conf0 * dechunked0 + self.residual_proj0(encoder_out.to(self.residual_proj0.weight.dtype))
+            x = frac_gradient(x, self.hnet_lr_diff)
+            x = x.to(self.tok_emb.weight.dtype)
+            x = self.decoder_stage(x)
+        else:
+            x = self.main_stage(x)
+
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    if args.compile_model:
+        zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        spm.SentencePieceProcessor(model_file=args.tokenizer_path), args.vocab_size, device)
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        outer_layers=args.outer_layers,
+        target_avg_chunk_len=args.target_avg_chunk_len,
+        ratio_loss_weight=args.ratio_loss_weight,
+        hnet_lr_diff=args.hnet_lr_diff,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    CastedLinear._qat_enabled = torch.tensor([0], dtype=torch.int32, device=device)
+    compiled_model = torch.compile(base_model, dynamic=False) if args.compile_model else base_model
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False, find_unused_parameters=False) if distributed else compiled_model
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    backbone_named_params = (
+        [(f"main_stage.{n}", p) for n, p in base_model.main_stage.named_parameters()]
+    )
+    if base_model.use_hnet:
+        backbone_named_params += (
+            [(f"encoder_stage.{n}", p) for n, p in base_model.encoder_stage.named_parameters()] +
+            [(f"decoder_stage.{n}", p) for n, p in base_model.decoder_stage.named_parameters()] +
+            [(f"routing0.{n}", p) for n, p in base_model.routing0.named_parameters()] +
+            [(f"residual_proj0.{n}", p) for n, p in base_model.residual_proj0.named_parameters()]
+        )
+    matrix_params = [
+        p for name, p in backbone_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+
+    scalar_params = [
+        p for name, p in backbone_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"outer_layers:{args.outer_layers} main_layers:{base_model.main_layers}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    gptq_reserve_ms = 1000.0 * args.gptq_reserve_seconds
+    train_loop_cap_ms = max_wallclock_ms - gptq_reserve_ms if max_wallclock_ms is not None else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if train_loop_cap_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(train_loop_cap_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    # EMA: initialize from current model weights (disabled when decay <= 0)
+    ema_enabled = args.ema_decay > 0
+    ema_state = None
+    if ema_enabled:
+        ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+        log0(f"ema:initialized with decay={args.ema_decay}")
+    else:
+        log0("ema:disabled")
+
+    # QAT: will be enabled dynamically when LR scale drops below threshold
+    if args.late_qat_threshold > 0:
+        log0(f"late_qat:will enable when lr_scale < {args.late_qat_threshold}")
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            # if hasattr(base_model, "_debug_last_chunk_mask"):
+            #     avg_chunk_rate = base_model._debug_last_chunk_mask.float().mean().item()
+            #     avg_chunk_len = 1.0 / max(avg_chunk_rate, 1e-8)
+            #     log0(
+            #         f"chunk_stats step:{step}/{args.iterations} "
+            #         f"avg_chunk_rate:{avg_chunk_rate:.4f} avg_chunk_len:{avg_chunk_len:.2f} "
+            #         f"chunked_shape:{getattr(base_model, '_debug_last_chunked_shape', None)}"
+            #     )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations} (reserving {args.gptq_reserve_seconds}s for GPTQ)"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        # EMA update
+        if ema_state is not None:
+            with torch.no_grad():
+                for name, t in base_model.state_dict().items():
+                    ema_state[name].mul_(args.ema_decay).add_(t.detach().float(), alpha=1.0 - args.ema_decay)
+
+        # Late QAT: enable fake int6 quantization when LR drops low enough
+        if args.late_qat_threshold > 0 and scale < args.late_qat_threshold and CastedLinear._qat_enabled[0].item() == 0:
+            CastedLinear._qat_enabled[0] = 1
+            log0(f"late_qat:enabled step:{step} scale:{scale:.4f}")
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = train_loop_cap_ms is not None and approx_training_time_ms >= train_loop_cap_ms
+        if distributed and train_loop_cap_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # -----------------------------
+    # SERIALIZATION + GPTQ + ROUNDTRIP VALIDATION
+    # -----------------------------
+
+    # Disable QAT for serialization
+    CastedLinear._qat_enabled[0] = 0
+
+    # Apply EMA weights before saving (if enabled)
+    if ema_state is not None:
+        log0("ema:applying EMA weights")
+        current_dtypes = {name: t.dtype for name, t in base_model.state_dict().items()}
+        avg_state = {name: t.to(dtype=current_dtypes[name]) for name, t in ema_state.items()}
+        del ema_state
+        base_model.load_state_dict(avg_state, strict=True)
+
+    # GPTQ calibration: collect Hessians
+    torch.cuda.synchronize()
+    t_gptq = time.perf_counter()
+    log0(f"gptq:calibrating with {args.gptq_calib_batches} batches...")
+    calib_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    hessians = collect_hessians(base_model, calib_loader, args, device, grad_accum_steps,
+                                num_batches=args.gptq_calib_batches)
+    torch.cuda.synchronize()
+    gptq_time_ms = 1000.0 * (time.perf_counter() - t_gptq)
+    log0(f"gptq:collected hessians for {len(hessians)} layers in {gptq_time_ms:.0f}ms")
+
+    if master_process:
+        torch.save(base_model.state_dict(), args.model_save_path)
+        model_bytes = os.path.getsize(args.model_save_path)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    # INT6+GPTQ mixed quantization + zstd compression
+    save_stem = Path(args.model_save_path).stem
+    artifact_path = str(Path(args.model_save_path).parent / f"{save_stem}.int6.ptz")
+    artifact_path_int8 = str(Path(args.model_save_path).parent / f"{save_stem}.int8.ptz")
+    quant_obj, quant_stats = quantize_state_dict_int6_gptq(
+        base_model.state_dict(),
+        hessians=hessians,
+        block_size=args.gptq_block_size,
+        prune_pct=args.prune_pct,
+    )
+    if quant_stats.get("pruned_count", 0) > 0:
+        log0(f"prune:zeroed {quant_stats['pruned_count']} int6 weights (threshold={quant_stats.get('prune_threshold', 0):.0f})")
+    log0(f"gptq:quantized {quant_stats.get('gptq_layers', 0)} layers with GPTQ, "
+         f"{quant_stats.get('naive_layers', 0)} naive, {quant_stats.get('embed_layers', 0)} INT8 embeds")
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_blob = compress_bytes(quant_buf.getvalue())
+    if master_process:
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        code_bytes = len(code.encode("utf-8"))
+        compressor = "zstd-22" if _HAS_ZSTD else "zlib-9"
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int6_payload_bytes"], 1)
+        total_artifact = len(quant_blob) + code_bytes
+        log0(
+            f"artifact int6+gptq+{compressor}: {len(quant_blob)} bytes + {code_bytes} code = {total_artifact} total "
+            f"(payload:{quant_stats['int6_payload_bytes']} payload_ratio:{ratio:.2f}x)"
+        )
+        if total_artifact > 16_000_000:
+            log0(f"WARNING: artifact {total_artifact} exceeds 16,000,000 byte cap by {total_artifact - 16_000_000} bytes!")
+        else:
+            log0(f"artifact headroom: {16_000_000 - total_artifact} bytes ({(16_000_000 - total_artifact)/1e6:.3f}MB)")
+
+    # Also produce INT8+zlib for comparison
+    quant_obj8, quant_stats8 = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf8 = io.BytesIO()
+    torch.save(quant_obj8, quant_buf8)
+    quant_blob8 = zlib.compress(quant_buf8.getvalue(), level=9)
+    if master_process:
+        with open(artifact_path_int8, "wb") as f:
+            f.write(quant_blob8)
+        log0(f"artifact int8+zlib: {len(quant_blob8)} bytes (for comparison)")
+
+    # Roundtrip validation with INT6+GPTQ
+    if distributed:
+        dist.barrier()
+    with open(artifact_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(decompress_bytes(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int6(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_gptq_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int6_gptq_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    # Sliding window evaluation (with INT6+GPTQ roundtripped weights already loaded)
+    if args.eval_stride > 0 and args.eval_stride < args.train_seq_len:
+        log0(f"sliding_eval: stride={args.eval_stride} batch_seqs={args.eval_batch_seqs} seq_len={args.train_seq_len}")
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args,
+            base_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            stride=args.eval_stride,
+            batch_seqs=args.eval_batch_seqs,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_gptq_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"final_int6_gptq_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
+Running Python 3.12.4 | packaged by Anaconda, Inc. | (main, Jun 18 2024, 15:12:24) [GCC 11.2.0]
+Running PyTorch 2.11.0+cu130
+Fri Apr  3 03:38:28 2026
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:1A:00.0 Off |                    0 |
+| N/A   44C    P0            126W /  700W |    1505MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:40:00.0 Off |                    0 |
+| N/A   36C    P0            116W /  700W |    1505MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:53:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1505MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:66:00.0 Off |                    0 |
+| N/A   41C    P0            118W /  700W |    1505MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9C:00.0 Off |                    0 |
+| N/A   45C    P0            122W /  700W |    1505MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:C0:00.0 Off |                    0 |
+| N/A   37C    P0            121W /  700W |    1505MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:D2:00.0 Off |                    0 |
+| N/A   43C    P0            131W /  700W |    1505MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:E4:00.0 Off |                    0 |
+| N/A   36C    P0            122W /  700W |    1505MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A         3964182      C   ...ameter-golf/.venv/bin/python3       1496MiB |
+|    1   N/A  N/A         3964183      C   ...ameter-golf/.venv/bin/python3       1496MiB |
+|    2   N/A  N/A         3964184      C   ...ameter-golf/.venv/bin/python3       1496MiB |
+|    3   N/A  N/A         3964185      C   ...ameter-golf/.venv/bin/python3       1496MiB |
+|    4   N/A  N/A         3964186      C   ...ameter-golf/.venv/bin/python3       1496MiB |
+|    5   N/A  N/A         3964187      C   ...ameter-golf/.venv/bin/python3       1496MiB |
+|    6   N/A  N/A         3964188      C   ...ameter-golf/.venv/bin/python3       1496MiB |
+|    7   N/A  N/A         3964189      C   ...ameter-golf/.venv/bin/python3       1496MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:21520472
+world_size:8 grad_accum_steps:1
+outer_layers:3 main_layers:5
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:524288 train_seq_len:2048 iterations:500000 warmup_steps:20 max_wallclock_seconds:14400.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+ema:disabled
+late_qat:will enable when lr_scale < 0.85
+step:0/500000 val_loss:6.9229 val_bpb:4.1002 train_time:0ms step_avg:0.02ms
+step:1/500000 train_loss:7.0140 train_time:154ms step_avg:154.35ms
+step:2/500000 train_loss:10.4964 train_time:318ms step_avg:159.20ms
+step:3/500000 train_loss:9.1430 train_time:488ms step_avg:162.73ms
+step:4/500000 train_loss:8.7838 train_time:662ms step_avg:165.40ms
+step:5/500000 train_loss:8.3833 train_time:829ms step_avg:165.86ms
+step:6/500000 train_loss:8.4107 train_time:999ms step_avg:166.43ms
+step:7/500000 train_loss:7.5177 train_time:1169ms step_avg:167.07ms
+step:8/500000 train_loss:6.9990 train_time:1339ms step_avg:167.36ms
+step:9/500000 train_loss:6.7264 train_time:1509ms step_avg:167.66ms
+step:10/500000 train_loss:6.3606 train_time:1679ms step_avg:167.91ms
+step:200/500000 train_loss:3.0607 train_time:34247ms step_avg:171.23ms
+step:400/500000 train_loss:2.4975 train_time:69390ms step_avg:173.47ms
+step:600/500000 train_loss:2.6840 train_time:103447ms step_avg:172.41ms
+step:800/500000 train_loss:2.4230 train_time:137158ms step_avg:171.45ms
+step:1000/500000 train_loss:2.4936 train_time:171087ms step_avg:171.09ms
+step:1200/500000 train_loss:2.5136 train_time:204853ms step_avg:170.71ms
+step:1400/500000 train_loss:2.5378 train_time:238545ms step_avg:170.39ms
+step:1600/500000 train_loss:2.1978 train_time:273033ms step_avg:170.65ms
+step:1800/500000 train_loss:2.3170 train_time:306747ms step_avg:170.41ms
+step:2000/500000 train_loss:2.3610 train_time:340411ms step_avg:170.21ms
+step:2200/500000 train_loss:2.1788 train_time:374320ms step_avg:170.15ms
+step:2400/500000 train_loss:2.3103 train_time:407959ms step_avg:169.98ms
+step:2600/500000 train_loss:2.5164 train_time:441853ms step_avg:169.94ms
+step:2800/500000 train_loss:2.3439 train_time:475559ms step_avg:169.84ms
+step:3000/500000 train_loss:2.3299 train_time:509342ms step_avg:169.78ms
+step:3200/500000 train_loss:2.2934 train_time:543216ms step_avg:169.75ms
+step:3400/500000 train_loss:2.2579 train_time:577784ms step_avg:169.94ms
+step:3600/500000 train_loss:2.2006 train_time:611911ms step_avg:169.98ms
+step:3800/500000 train_loss:2.3086 train_time:645830ms step_avg:169.96ms
+step:4000/500000 train_loss:2.2684 train_time:680129ms step_avg:170.03ms
+step:4200/500000 train_loss:2.2638 train_time:714072ms step_avg:170.02ms
+step:4400/500000 train_loss:2.2039 train_time:748022ms step_avg:170.00ms
+step:4600/500000 train_loss:2.0735 train_time:781865ms step_avg:169.97ms
+step:4800/500000 train_loss:2.3459 train_time:815777ms step_avg:169.95ms
+step:5000/500000 train_loss:2.1062 train_time:849722ms step_avg:169.94ms
+step:5200/500000 train_loss:2.2663 train_time:884436ms step_avg:170.08ms
+step:5400/500000 train_loss:2.2749 train_time:918298ms step_avg:170.06ms
+step:5600/500000 train_loss:2.2688 train_time:952218ms step_avg:170.04ms
+step:5800/500000 train_loss:2.2233 train_time:986035ms step_avg:170.01ms
+step:6000/500000 train_loss:2.2987 train_time:1019732ms step_avg:169.96ms
+step:6200/500000 train_loss:2.1753 train_time:1053718ms step_avg:169.95ms
+step:6400/500000 train_loss:2.2516 train_time:1087418ms step_avg:169.91ms
+step:6600/500000 train_loss:2.2111 train_time:1121426ms step_avg:169.91ms
+step:6800/500000 train_loss:2.2698 train_time:1155184ms step_avg:169.88ms
+step:7000/500000 train_loss:2.3139 train_time:1190128ms step_avg:170.02ms
+step:7200/500000 train_loss:2.2890 train_time:1224037ms step_avg:170.01ms
+step:7400/500000 train_loss:2.2055 train_time:1257918ms step_avg:169.99ms
+step:7600/500000 train_loss:2.0849 train_time:1291807ms step_avg:169.97ms
+step:7800/500000 train_loss:2.2284 train_time:1325615ms step_avg:169.95ms
+step:8000/500000 train_loss:2.1982 train_time:1359514ms step_avg:169.94ms
+step:8200/500000 train_loss:2.2682 train_time:1393260ms step_avg:169.91ms
+step:8400/500000 train_loss:2.2196 train_time:1427280ms step_avg:169.91ms
+step:8600/500000 train_loss:2.2285 train_time:1461175ms step_avg:169.90ms
+step:8800/500000 train_loss:2.1900 train_time:1495709ms step_avg:169.97ms
+step:9000/500000 train_loss:2.1036 train_time:1529801ms step_avg:169.98ms
+step:9200/500000 train_loss:2.1630 train_time:1563838ms step_avg:169.98ms
+step:9400/500000 train_loss:2.2091 train_time:1597789ms step_avg:169.98ms
+step:9600/500000 train_loss:2.2295 train_time:1631459ms step_avg:169.94ms
+step:9800/500000 train_loss:2.1407 train_time:1665201ms step_avg:169.92ms
+step:10000/500000 train_loss:2.1897 train_time:1699077ms step_avg:169.91ms
+step:10000/500000 val_loss:2.1374 val_bpb:1.2659 train_time:1699104ms step_avg:169.91ms
+step:10200/500000 train_loss:2.1526 train_time:1733017ms step_avg:169.90ms
+step:10400/500000 train_loss:2.1716 train_time:1767044ms step_avg:169.91ms
+step:10600/500000 train_loss:2.0530 train_time:1801679ms step_avg:169.97ms
+step:10800/500000 train_loss:2.2626 train_time:1835597ms step_avg:169.96ms
+step:11000/500000 train_loss:2.1838 train_time:1869297ms step_avg:169.94ms
+step:11200/500000 train_loss:2.1506 train_time:1902998ms step_avg:169.91ms
+step:11400/500000 train_loss:2.1320 train_time:1936833ms step_avg:169.90ms
+step:11600/500000 train_loss:2.1267 train_time:1971089ms step_avg:169.92ms
+step:11800/500000 train_loss:2.1768 train_time:2005005ms step_avg:169.92ms
+step:12000/500000 train_loss:2.1283 train_time:2038677ms step_avg:169.89ms
+step:12200/500000 train_loss:2.2707 train_time:2072400ms step_avg:169.87ms
+step:12400/500000 train_loss:1.9252 train_time:2107240ms step_avg:169.94ms
+step:12600/500000 train_loss:2.1667 train_time:2141217ms step_avg:169.94ms
+step:12800/500000 train_loss:2.1889 train_time:2175181ms step_avg:169.94ms
+step:13000/500000 train_loss:2.2550 train_time:2209268ms step_avg:169.94ms
+step:13200/500000 train_loss:2.2688 train_time:2243067ms step_avg:169.93ms
+step:13400/500000 train_loss:2.1591 train_time:2276838ms step_avg:169.91ms
+step:13600/500000 train_loss:2.0020 train_time:2310596ms step_avg:169.90ms
+step:13800/500000 train_loss:2.1084 train_time:2344411ms step_avg:169.88ms
+step:14000/500000 train_loss:2.1701 train_time:2378351ms step_avg:169.88ms
+step:14200/500000 train_loss:2.2494 train_time:2413039ms step_avg:169.93ms
+step:14400/500000 train_loss:2.1565 train_time:2446945ms step_avg:169.93ms
+step:14600/500000 train_loss:2.1967 train_time:2481023ms step_avg:169.93ms
+step:14800/500000 train_loss:1.9720 train_time:2515009ms step_avg:169.93ms
+step:15000/500000 train_loss:2.1094 train_time:2548799ms step_avg:169.92ms
+step:15200/500000 train_loss:2.2259 train_time:2582631ms step_avg:169.91ms
+step:15400/500000 train_loss:2.1067 train_time:2616339ms step_avg:169.89ms
+step:15600/500000 train_loss:2.1468 train_time:2650066ms step_avg:169.88ms
+step:15800/500000 train_loss:1.9870 train_time:2683700ms step_avg:169.85ms
+step:16000/500000 train_loss:2.2027 train_time:2718354ms step_avg:169.90ms
+step:16200/500000 train_loss:2.0622 train_time:2752093ms step_avg:169.88ms
+step:16400/500000 train_loss:2.1042 train_time:2785911ms step_avg:169.87ms
+step:16600/500000 train_loss:2.0324 train_time:2819706ms step_avg:169.86ms
+step:16800/500000 train_loss:2.2563 train_time:2853458ms step_avg:169.85ms
+step:17000/500000 train_loss:2.1750 train_time:2887168ms step_avg:169.83ms
+step:17200/500000 train_loss:2.1646 train_time:2920807ms step_avg:169.81ms
+step:17400/500000 train_loss:2.0670 train_time:2954458ms step_avg:169.80ms
+step:17600/500000 train_loss:2.1518 train_time:2988773ms step_avg:169.82ms
+step:17800/500000 train_loss:2.2250 train_time:3023168ms step_avg:169.84ms
+step:18000/500000 train_loss:2.1370 train_time:3057055ms step_avg:169.84ms
+step:18200/500000 train_loss:2.3683 train_time:3090800ms step_avg:169.82ms
+step:18400/500000 train_loss:2.1288 train_time:3124560ms step_avg:169.81ms
+step:18600/500000 train_loss:2.1636 train_time:3158260ms step_avg:169.80ms
+step:18800/500000 train_loss:2.2199 train_time:3192078ms step_avg:169.79ms
+step:19000/500000 train_loss:2.1396 train_time:3225961ms step_avg:169.79ms
+step:19200/500000 train_loss:1.9992 train_time:3259844ms step_avg:169.78ms
+step:19400/500000 train_loss:2.2184 train_time:3293794ms step_avg:169.78ms
+step:19600/500000 train_loss:2.3042 train_time:3327737ms step_avg:169.78ms
+step:19800/500000 train_loss:1.9833 train_time:3362055ms step_avg:169.80ms
+step:20000/500000 train_loss:2.1806 train_time:3395886ms step_avg:169.79ms
+step:20000/500000 val_loss:2.0919 val_bpb:1.2389 train_time:3395911ms step_avg:169.80ms
+step:20200/500000 train_loss:2.1565 train_time:3429689ms step_avg:169.79ms
+step:20400/500000 train_loss:2.1639 train_time:3463464ms step_avg:169.78ms
+step:20600/500000 train_loss:2.1850 train_time:3497670ms step_avg:169.79ms
+step:20800/500000 train_loss:2.1416 train_time:3531306ms step_avg:169.77ms
+step:21000/500000 train_loss:2.2301 train_time:3565186ms step_avg:169.77ms
+step:21200/500000 train_loss:2.0569 train_time:3598918ms step_avg:169.76ms
+step:21400/500000 train_loss:2.0643 train_time:3633153ms step_avg:169.77ms
+step:21600/500000 train_loss:2.1451 train_time:3667339ms step_avg:169.78ms
+step:21800/500000 train_loss:2.0989 train_time:3701273ms step_avg:169.78ms
+step:22000/500000 train_loss:2.1265 train_time:3735083ms step_avg:169.78ms
+step:22200/500000 train_loss:2.1341 train_time:3769123ms step_avg:169.78ms
+step:22400/500000 train_loss:2.1873 train_time:3802974ms step_avg:169.78ms
+step:22600/500000 train_loss:2.1013 train_time:3836717ms step_avg:169.77ms
+step:22800/500000 train_loss:2.0600 train_time:3870466ms step_avg:169.76ms
+step:23000/500000 train_loss:2.1715 train_time:3904154ms step_avg:169.75ms
+step:23200/500000 train_loss:2.1865 train_time:3938158ms step_avg:169.75ms
+step:23400/500000 train_loss:2.0170 train_time:3972191ms step_avg:169.75ms
+step:23600/500000 train_loss:2.1525 train_time:4006096ms step_avg:169.75ms
+step:23800/500000 train_loss:2.0206 train_time:4039806ms step_avg:169.74ms
+step:24000/500000 train_loss:2.1197 train_time:4073544ms step_avg:169.73ms
+step:24200/500000 train_loss:1.9307 train_time:4107441ms step_avg:169.73ms
+step:24400/500000 train_loss:2.1386 train_time:4141190ms step_avg:169.72ms
+step:24600/500000 train_loss:2.0781 train_time:4175016ms step_avg:169.72ms
+step:24800/500000 train_loss:2.0133 train_time:4208845ms step_avg:169.71ms
+step:25000/500000 train_loss:2.2238 train_time:4242820ms step_avg:169.71ms
+step:25200/500000 train_loss:2.1164 train_time:4277143ms step_avg:169.73ms
+step:25400/500000 train_loss:2.0973 train_time:4310813ms step_avg:169.72ms
+step:25600/500000 train_loss:2.1682 train_time:4344545ms step_avg:169.71ms
+step:25800/500000 train_loss:2.1212 train_time:4378210ms step_avg:169.70ms
+step:26000/500000 train_loss:2.0310 train_time:4412034ms step_avg:169.69ms
+step:26200/500000 train_loss:2.1305 train_time:4445745ms step_avg:169.68ms
+step:26400/500000 train_loss:2.1050 train_time:4479640ms step_avg:169.68ms
+step:26600/500000 train_loss:2.2097 train_time:4513554ms step_avg:169.68ms
+step:26800/500000 train_loss:2.0843 train_time:4547779ms step_avg:169.69ms
+step:27000/500000 train_loss:2.2975 train_time:4582105ms step_avg:169.71ms
+step:27200/500000 train_loss:2.0531 train_time:4615764ms step_avg:169.70ms
+step:27400/500000 train_loss:2.2392 train_time:4649656ms step_avg:169.70ms
+step:27600/500000 train_loss:2.0779 train_time:4683337ms step_avg:169.69ms
+step:27800/500000 train_loss:2.1325 train_time:4717167ms step_avg:169.68ms
+step:28000/500000 train_loss:2.1379 train_time:4750910ms step_avg:169.68ms
+step:28200/500000 train_loss:2.1292 train_time:4784588ms step_avg:169.67ms
+step:28400/500000 train_loss:2.2199 train_time:4818546ms step_avg:169.67ms
+step:28600/500000 train_loss:2.0943 train_time:4852617ms step_avg:169.67ms
+step:28800/500000 train_loss:2.2630 train_time:4886829ms step_avg:169.68ms
+step:29000/500000 train_loss:2.2282 train_time:4920765ms step_avg:169.68ms
+step:29200/500000 train_loss:1.8236 train_time:4954459ms step_avg:169.67ms
+step:29400/500000 train_loss:2.2062 train_time:4988370ms step_avg:169.67ms
+step:29600/500000 train_loss:2.2905 train_time:5022044ms step_avg:169.66ms
+step:29800/500000 train_loss:1.9971 train_time:5056066ms step_avg:169.67ms
+step:30000/500000 train_loss:2.0906 train_time:5089683ms step_avg:169.66ms
+step:30000/500000 val_loss:2.0720 val_bpb:1.2272 train_time:5089725ms step_avg:169.66ms
+step:30200/500000 train_loss:2.0646 train_time:5123377ms step_avg:169.65ms
+step:30400/500000 train_loss:2.2369 train_time:5157386ms step_avg:169.65ms
+step:30600/500000 train_loss:2.1698 train_time:5191498ms step_avg:169.66ms
+step:30800/500000 train_loss:2.1080 train_time:5225267ms step_avg:169.65ms
+step:31000/500000 train_loss:1.9463 train_time:5259039ms step_avg:169.65ms
+step:31200/500000 train_loss:2.1445 train_time:5292824ms step_avg:169.64ms
+step:31400/500000 train_loss:2.1699 train_time:5326724ms step_avg:169.64ms
+step:31600/500000 train_loss:2.0307 train_time:5360515ms step_avg:169.64ms
+step:31800/500000 train_loss:1.9897 train_time:5394239ms step_avg:169.63ms
+step:32000/500000 train_loss:2.0823 train_time:5428058ms step_avg:169.63ms
+step:32200/500000 train_loss:2.2209 train_time:5462343ms step_avg:169.64ms
+step:32400/500000 train_loss:1.9591 train_time:5496589ms step_avg:169.65ms
+step:32600/500000 train_loss:2.2264 train_time:5530342ms step_avg:169.64ms
+step:32800/500000 train_loss:2.0253 train_time:5564208ms step_avg:169.64ms
+step:33000/500000 train_loss:2.0931 train_time:5598001ms step_avg:169.64ms
+step:33200/500000 train_loss:2.0958 train_time:5631753ms step_avg:169.63ms
+step:33400/500000 train_loss:2.1561 train_time:5665472ms step_avg:169.62ms
+step:33600/500000 train_loss:2.1457 train_time:5699137ms step_avg:169.62ms
+step:33800/500000 train_loss:2.0746 train_time:5732914ms step_avg:169.61ms
+step:34000/500000 train_loss:2.0160 train_time:5766996ms step_avg:169.62ms
+step:34200/500000 train_loss:2.1815 train_time:5801086ms step_avg:169.62ms
+step:34400/500000 train_loss:2.1054 train_time:5835012ms step_avg:169.62ms
+step:34600/500000 train_loss:2.1014 train_time:5868826ms step_avg:169.62ms
+step:34800/500000 train_loss:2.0540 train_time:5902573ms step_avg:169.61ms
+step:35000/500000 train_loss:2.1722 train_time:5936254ms step_avg:169.61ms
+step:35200/500000 train_loss:2.1175 train_time:5969994ms step_avg:169.60ms
+step:35400/500000 train_loss:2.0543 train_time:6003674ms step_avg:169.60ms
+step:35600/500000 train_loss:2.2712 train_time:6037302ms step_avg:169.59ms
+step:35800/500000 train_loss:2.0725 train_time:6071362ms step_avg:169.59ms
+step:36000/500000 train_loss:1.9516 train_time:6105696ms step_avg:169.60ms
+step:36200/500000 train_loss:2.0939 train_time:6139493ms step_avg:169.60ms
+step:36400/500000 train_loss:2.0617 train_time:6173080ms step_avg:169.59ms
+step:36600/500000 train_loss:2.0735 train_time:6206672ms step_avg:169.58ms
+step:36800/500000 train_loss:2.2281 train_time:6240283ms step_avg:169.57ms
+step:37000/500000 train_loss:2.1545 train_time:6274042ms step_avg:169.57ms
+step:37200/500000 train_loss:2.0958 train_time:6307874ms step_avg:169.57ms
+step:37400/500000 train_loss:2.0195 train_time:6341577ms step_avg:169.56ms
+step:37600/500000 train_loss:2.2135 train_time:6375702ms step_avg:169.57ms
+step:37800/500000 train_loss:2.1198 train_time:6410076ms step_avg:169.58ms
+step:38000/500000 train_loss:1.9920 train_time:6443726ms step_avg:169.57ms
+step:38200/500000 train_loss:2.1540 train_time:6477641ms step_avg:169.57ms
+step:38400/500000 train_loss:2.0606 train_time:6511339ms step_avg:169.57ms
+step:38600/500000 train_loss:2.1499 train_time:6545067ms step_avg:169.56ms
+step:38800/500000 train_loss:2.0837 train_time:6578849ms step_avg:169.56ms
+step:39000/500000 train_loss:2.2491 train_time:6612586ms step_avg:169.55ms
+step:39200/500000 train_loss:2.0852 train_time:6646429ms step_avg:169.55ms
+step:39400/500000 train_loss:2.0536 train_time:6680442ms step_avg:169.55ms
+step:39600/500000 train_loss:2.0032 train_time:6714545ms step_avg:169.56ms
+step:39800/500000 train_loss:2.1094 train_time:6748233ms step_avg:169.55ms
+step:40000/500000 train_loss:2.3382 train_time:6782132ms step_avg:169.55ms
+step:40000/500000 val_loss:2.0613 val_bpb:1.2208 train_time:6782157ms step_avg:169.55ms
+step:40200/500000 train_loss:2.1918 train_time:6815875ms step_avg:169.55ms
+step:40400/500000 train_loss:2.0971 train_time:6849668ms step_avg:169.55ms
+step:40600/500000 train_loss:2.0846 train_time:6883595ms step_avg:169.55ms
+step:40800/500000 train_loss:2.1479 train_time:6917328ms step_avg:169.54ms
+step:41000/500000 train_loss:2.3786 train_time:6951037ms step_avg:169.54ms
+step:41200/500000 train_loss:2.0205 train_time:6985263ms step_avg:169.55ms
+step:41400/500000 train_loss:2.2257 train_time:7019472ms step_avg:169.55ms
+step:41600/500000 train_loss:2.1411 train_time:7053142ms step_avg:169.55ms
+step:41800/500000 train_loss:2.1872 train_time:7086909ms step_avg:169.54ms
+step:42000/500000 train_loss:1.9927 train_time:7120646ms step_avg:169.54ms
+step:42200/500000 train_loss:2.0798 train_time:7154399ms step_avg:169.54ms
+step:42400/500000 train_loss:2.0076 train_time:7188012ms step_avg:169.53ms
+step:42600/500000 train_loss:2.1304 train_time:7221790ms step_avg:169.53ms
+step:42800/500000 train_loss:2.1677 train_time:7255551ms step_avg:169.52ms
+step:43000/500000 train_loss:2.1548 train_time:7289598ms step_avg:169.53ms
+step:43200/500000 train_loss:2.1497 train_time:7323664ms step_avg:169.53ms
+step:43400/500000 train_loss:2.1200 train_time:7357302ms step_avg:169.52ms
+step:43600/500000 train_loss:2.1372 train_time:7391179ms step_avg:169.52ms
+step:43800/500000 train_loss:2.0843 train_time:7425112ms step_avg:169.52ms
+step:44000/500000 train_loss:2.0841 train_time:7458916ms step_avg:169.52ms
+step:44200/500000 train_loss:2.1849 train_time:7492709ms step_avg:169.52ms
+step:44400/500000 train_loss:2.0930 train_time:7526334ms step_avg:169.51ms
+step:44600/500000 train_loss:2.1554 train_time:7560076ms step_avg:169.51ms
+step:44800/500000 train_loss:2.1367 train_time:7594039ms step_avg:169.51ms
+step:45000/500000 train_loss:2.1006 train_time:7628089ms step_avg:169.51ms
+step:45200/500000 train_loss:2.1287 train_time:7661995ms step_avg:169.51ms
+step:45400/500000 train_loss:2.1336 train_time:7695868ms step_avg:169.51ms
+step:45600/500000 train_loss:2.1573 train_time:7729553ms step_avg:169.51ms
+step:45800/500000 train_loss:2.0724 train_time:7763352ms step_avg:169.51ms
+step:46000/500000 train_loss:2.1991 train_time:7797085ms step_avg:169.50ms
+step:46200/500000 train_loss:2.1389 train_time:7830782ms step_avg:169.50ms
+step:46400/500000 train_loss:1.9186 train_time:7864555ms step_avg:169.49ms
+step:46600/500000 train_loss:2.0536 train_time:7898534ms step_avg:169.50ms
+step:46800/500000 train_loss:2.0774 train_time:7932353ms step_avg:169.49ms
+step:47000/500000 train_loss:2.1115 train_time:7966426ms step_avg:169.50ms
+step:47200/500000 train_loss:2.1009 train_time:8000132ms step_avg:169.49ms
+step:47400/500000 train_loss:2.1132 train_time:8033850ms step_avg:169.49ms
+step:47600/500000 train_loss:2.1153 train_time:8067780ms step_avg:169.49ms
+step:47800/500000 train_loss:2.0268 train_time:8101544ms step_avg:169.49ms
+step:48000/500000 train_loss:2.1608 train_time:8135184ms step_avg:169.48ms
+step:48200/500000 train_loss:2.0617 train_time:8168921ms step_avg:169.48ms
+step:48400/500000 train_loss:2.1455 train_time:8202976ms step_avg:169.48ms
+step:48600/500000 train_loss:2.0158 train_time:8236715ms step_avg:169.48ms
+step:48800/500000 train_loss:2.1375 train_time:8270799ms step_avg:169.48ms
+step:49000/500000 train_loss:2.1525 train_time:8304628ms step_avg:169.48ms
+step:49200/500000 train_loss:1.9730 train_time:8338254ms step_avg:169.48ms
+step:49400/500000 train_loss:2.1314 train_time:8372024ms step_avg:169.47ms
+step:49600/500000 train_loss:2.0449 train_time:8405680ms step_avg:169.47ms
+step:49800/500000 train_loss:2.0866 train_time:8439504ms step_avg:169.47ms
+step:50000/500000 train_loss:2.2122 train_time:8473448ms step_avg:169.47ms
+step:50000/500000 val_loss:2.0515 val_bpb:1.2150 train_time:8473472ms step_avg:169.47ms
+step:50200/500000 train_loss:2.1399 train_time:8507381ms step_avg:169.47ms
+step:50400/500000 train_loss:2.0869 train_time:8541046ms step_avg:169.47ms
+step:50600/500000 train_loss:2.0022 train_time:8575063ms step_avg:169.47ms
+step:50800/500000 train_loss:2.0432 train_time:8608758ms step_avg:169.46ms
+step:51000/500000 train_loss:2.0449 train_time:8642506ms step_avg:169.46ms
+step:51200/500000 train_loss:2.0966 train_time:8676303ms step_avg:169.46ms
+step:51400/500000 train_loss:1.8729 train_time:8710209ms step_avg:169.46ms
+step:51600/500000 train_loss:2.1335 train_time:8743850ms step_avg:169.45ms
+step:51800/500000 train_loss:2.0893 train_time:8777498ms step_avg:169.45ms
+step:52000/500000 train_loss:2.1570 train_time:8811584ms step_avg:169.45ms
+step:52200/500000 train_loss:2.1165 train_time:8845223ms step_avg:169.45ms
+step:52400/500000 train_loss:2.1231 train_time:8879344ms step_avg:169.45ms
+step:52600/500000 train_loss:2.3117 train_time:8913107ms step_avg:169.45ms
+step:52800/500000 train_loss:2.1086 train_time:8946675ms step_avg:169.44ms
+step:53000/500000 train_loss:2.0479 train_time:8980432ms step_avg:169.44ms
+step:53200/500000 train_loss:2.2167 train_time:9014120ms step_avg:169.44ms
+step:53400/500000 train_loss:2.1793 train_time:9047850ms step_avg:169.44ms
+step:53600/500000 train_loss:2.0322 train_time:9081775ms step_avg:169.44ms
+step:53800/500000 train_loss:1.9763 train_time:9115883ms step_avg:169.44ms
+step:54000/500000 train_loss:2.1329 train_time:9149634ms step_avg:169.44ms
+step:54200/500000 train_loss:2.2285 train_time:9183709ms step_avg:169.44ms
+step:54400/500000 train_loss:2.1092 train_time:9217434ms step_avg:169.44ms
+step:54600/500000 train_loss:2.0704 train_time:9251225ms step_avg:169.44ms
+step:54800/500000 train_loss:2.1056 train_time:9284973ms step_avg:169.43ms
+step:55000/500000 train_loss:2.0178 train_time:9318650ms step_avg:169.43ms
+step:55200/500000 train_loss:2.0188 train_time:9352411ms step_avg:169.43ms
+step:55400/500000 train_loss:2.0410 train_time:9386078ms step_avg:169.42ms
+step:55600/500000 train_loss:2.1974 train_time:9420015ms step_avg:169.42ms
+step:55800/500000 train_loss:2.0778 train_time:9453698ms step_avg:169.42ms
+step:56000/500000 train_loss:2.1492 train_time:9487996ms step_avg:169.43ms
+step:56200/500000 train_loss:2.0753 train_time:9521942ms step_avg:169.43ms
+step:56400/500000 train_loss:1.9880 train_time:9555712ms step_avg:169.43ms
+step:56600/500000 train_loss:2.1121 train_time:9589439ms step_avg:169.42ms
+step:56800/500000 train_loss:2.0449 train_time:9623124ms step_avg:169.42ms
+step:57000/500000 train_loss:2.1901 train_time:9656849ms step_avg:169.42ms
+step:57200/500000 train_loss:2.0973 train_time:9690717ms step_avg:169.42ms
+step:57400/500000 train_loss:2.0432 train_time:9724616ms step_avg:169.42ms
+step:57600/500000 train_loss:2.0962 train_time:9758297ms step_avg:169.41ms
+step:57800/500000 train_loss:1.9947 train_time:9792565ms step_avg:169.42ms
+step:58000/500000 train_loss:2.2452 train_time:9826234ms step_avg:169.42ms
+step:58200/500000 train_loss:2.0570 train_time:9859988ms step_avg:169.42ms
+step:58400/500000 train_loss:2.2599 train_time:9893547ms step_avg:169.41ms
+step:58600/500000 train_loss:2.1607 train_time:9927243ms step_avg:169.41ms
+step:58800/500000 train_loss:2.0393 train_time:9960898ms step_avg:169.40ms
+step:59000/500000 train_loss:2.0819 train_time:9994545ms step_avg:169.40ms
+step:59200/500000 train_loss:2.1481 train_time:10028661ms step_avg:169.40ms
+step:59400/500000 train_loss:2.0225 train_time:10062800ms step_avg:169.41ms
+step:59600/500000 train_loss:2.0964 train_time:10097009ms step_avg:169.41ms
+step:59800/500000 train_loss:2.0291 train_time:10130802ms step_avg:169.41ms
+step:60000/500000 train_loss:1.9972 train_time:10164563ms step_avg:169.41ms
+step:60000/500000 val_loss:2.0465 val_bpb:1.2120 train_time:10164588ms step_avg:169.41ms
+step:60200/500000 train_loss:2.1275 train_time:10198159ms step_avg:169.40ms
+step:60400/500000 train_loss:2.2563 train_time:10231966ms step_avg:169.40ms
+step:60600/500000 train_loss:2.0858 train_time:10265584ms step_avg:169.40ms
+step:60800/500000 train_loss:1.9902 train_time:10299700ms step_avg:169.40ms
+step:61000/500000 train_loss:2.0551 train_time:10333718ms step_avg:169.41ms
+step:61200/500000 train_loss:2.1053 train_time:10367421ms step_avg:169.40ms
+step:61400/500000 train_loss:1.6975 train_time:10401532ms step_avg:169.41ms
+step:61600/500000 train_loss:2.0216 train_time:10435242ms step_avg:169.40ms
+step:61800/500000 train_loss:2.0529 train_time:10469135ms step_avg:169.40ms
+step:62000/500000 train_loss:2.1304 train_time:10502805ms step_avg:169.40ms
+step:62200/500000 train_loss:2.0714 train_time:10536521ms step_avg:169.40ms
+step:62400/500000 train_loss:2.0922 train_time:10570444ms step_avg:169.40ms
+step:62600/500000 train_loss:2.0446 train_time:10604148ms step_avg:169.40ms
+step:62800/500000 train_loss:2.1549 train_time:10638257ms step_avg:169.40ms
+step:63000/500000 train_loss:2.1301 train_time:10672035ms step_avg:169.40ms
+late_qat:enabled step:63050 scale:0.8500
+step:63200/500000 train_loss:2.2227 train_time:10706065ms step_avg:169.40ms
+step:63400/500000 train_loss:2.1958 train_time:10739773ms step_avg:169.40ms
+step:63600/500000 train_loss:2.3582 train_time:10773494ms step_avg:169.39ms
+step:63800/500000 train_loss:2.2031 train_time:10807206ms step_avg:169.39ms
+step:64000/500000 train_loss:2.1209 train_time:10841008ms step_avg:169.39ms
+step:64200/500000 train_loss:2.1704 train_time:10874703ms step_avg:169.39ms
+step:64400/500000 train_loss:2.3202 train_time:10908448ms step_avg:169.39ms
+step:64600/500000 train_loss:1.9219 train_time:10942402ms step_avg:169.39ms
+step:64800/500000 train_loss:2.1827 train_time:10976123ms step_avg:169.38ms
+step:65000/500000 train_loss:2.1968 train_time:11010429ms step_avg:169.39ms
+step:65200/500000 train_loss:2.2015 train_time:11044142ms step_avg:169.39ms
+step:65400/500000 train_loss:1.9902 train_time:11077870ms step_avg:169.39ms
+step:65600/500000 train_loss:2.1181 train_time:11111516ms step_avg:169.38ms
+step:65800/500000 train_loss:2.1945 train_time:11145340ms step_avg:169.38ms
+step:66000/500000 train_loss:1.8931 train_time:11179256ms step_avg:169.38ms
+step:66200/500000 train_loss:2.2619 train_time:11212932ms step_avg:169.38ms
+step:66400/500000 train_loss:3.3647 train_time:11246876ms step_avg:169.38ms
+step:66600/500000 train_loss:1.9584 train_time:11280602ms step_avg:169.38ms
+step:66800/500000 train_loss:2.1801 train_time:11314622ms step_avg:169.38ms
+step:67000/500000 train_loss:2.1182 train_time:11348528ms step_avg:169.38ms
+step:67200/500000 train_loss:2.3519 train_time:11382293ms step_avg:169.38ms
+step:67400/500000 train_loss:2.1087 train_time:11416016ms step_avg:169.38ms
+step:67600/500000 train_loss:2.1273 train_time:11449923ms step_avg:169.38ms
+step:67800/500000 train_loss:2.0241 train_time:11483836ms step_avg:169.38ms
+step:68000/500000 train_loss:2.2169 train_time:11517571ms step_avg:169.38ms
+step:68200/500000 train_loss:2.1326 train_time:11551704ms step_avg:169.38ms
+step:68400/500000 train_loss:2.0946 train_time:11585561ms step_avg:169.38ms
+step:68600/500000 train_loss:1.8763 train_time:11619778ms step_avg:169.38ms
+step:68800/500000 train_loss:2.0383 train_time:11653494ms step_avg:169.38ms
+step:69000/500000 train_loss:2.1097 train_time:11687338ms step_avg:169.38ms
+step:69200/500000 train_loss:2.2047 train_time:11721086ms step_avg:169.38ms
+step:69400/500000 train_loss:2.1294 train_time:11754727ms step_avg:169.38ms
+step:69600/500000 train_loss:2.1669 train_time:11788505ms step_avg:169.38ms
+step:69800/500000 train_loss:1.9954 train_time:11822492ms step_avg:169.38ms
+step:70000/500000 train_loss:2.2395 train_time:11856598ms step_avg:169.38ms
+step:70000/500000 val_loss:2.0699 val_bpb:1.2259 train_time:11856601ms step_avg:169.38ms
+step:70200/500000 train_loss:2.1486 train_time:11890398ms step_avg:169.38ms
+step:70400/500000 train_loss:2.1470 train_time:11924504ms step_avg:169.38ms
+step:70600/500000 train_loss:2.0537 train_time:11958557ms step_avg:169.38ms
+step:70800/500000 train_loss:2.1305 train_time:11992227ms step_avg:169.38ms
+step:71000/500000 train_loss:2.1577 train_time:12026012ms step_avg:169.38ms
+step:71200/500000 train_loss:2.1940 train_time:12059931ms step_avg:169.38ms
+step:71400/500000 train_loss:2.0527 train_time:12093824ms step_avg:169.38ms
+step:71600/500000 train_loss:2.2020 train_time:12127953ms step_avg:169.38ms
+step:71800/500000 train_loss:2.2122 train_time:12161971ms step_avg:169.39ms
+step:72000/500000 train_loss:2.1476 train_time:12195662ms step_avg:169.38ms
+step:72200/500000 train_loss:2.0795 train_time:12229760ms step_avg:169.39ms
+step:72400/500000 train_loss:2.1155 train_time:12263486ms step_avg:169.39ms
+step:72600/500000 train_loss:2.0505 train_time:12297267ms step_avg:169.38ms
+step:72800/500000 train_loss:2.0682 train_time:12330826ms step_avg:169.38ms
+step:73000/500000 train_loss:2.0925 train_time:12364598ms step_avg:169.38ms
+step:73200/500000 train_loss:2.0335 train_time:12398490ms step_avg:169.38ms
+step:73400/500000 train_loss:1.9893 train_time:12432245ms step_avg:169.38ms
+step:73600/500000 train_loss:1.9891 train_time:12466406ms step_avg:169.38ms
+step:73800/500000 train_loss:2.1010 train_time:12500085ms step_avg:169.38ms
+step:74000/500000 train_loss:2.0233 train_time:12534259ms step_avg:169.38ms
+step:74200/500000 train_loss:2.1469 train_time:12567982ms step_avg:169.38ms
+step:74400/500000 train_loss:2.0764 train_time:12601680ms step_avg:169.38ms
+step:74600/500000 train_loss:2.1775 train_time:12635456ms step_avg:169.38ms
+step:74800/500000 train_loss:2.1319 train_time:12669272ms step_avg:169.38ms
+step:75000/500000 train_loss:1.9817 train_time:12702950ms step_avg:169.37ms
+step:75200/500000 train_loss:2.0694 train_time:12736621ms step_avg:169.37ms
+step:75400/500000 train_loss:2.1182 train_time:12770700ms step_avg:169.37ms
+step:75600/500000 train_loss:2.2678 train_time:12804495ms step_avg:169.37ms
+step:75800/500000 train_loss:2.1429 train_time:12838312ms step_avg:169.37ms
+step:76000/500000 train_loss:2.1440 train_time:12872574ms step_avg:169.38ms
+step:76200/500000 train_loss:1.9596 train_time:12906502ms step_avg:169.38ms
+step:76400/500000 train_loss:2.0887 train_time:12940419ms step_avg:169.38ms
+step:76600/500000 train_loss:2.1316 train_time:12974092ms step_avg:169.37ms
+step:76800/500000 train_loss:2.1624 train_time:13007746ms step_avg:169.37ms
+step:77000/500000 train_loss:2.1418 train_time:13041448ms step_avg:169.37ms
+step:77200/500000 train_loss:2.2462 train_time:13075414ms step_avg:169.37ms
+step:77400/500000 train_loss:1.9196 train_time:13109186ms step_avg:169.37ms
+step:77600/500000 train_loss:1.9850 train_time:13143017ms step_avg:169.37ms
+step:77800/500000 train_loss:2.0299 train_time:13177709ms step_avg:169.38ms
+step:78000/500000 train_loss:2.0174 train_time:13211539ms step_avg:169.38ms
+step:78200/500000 train_loss:2.0625 train_time:13245239ms step_avg:169.38ms
+step:78400/500000 train_loss:2.1635 train_time:13279287ms step_avg:169.38ms
+step:78600/500000 train_loss:2.0172 train_time:13318149ms step_avg:169.44ms
+step:78800/500000 train_loss:1.9244 train_time:13352067ms step_avg:169.44ms
+step:79000/500000 train_loss:2.0747 train_time:13386465ms step_avg:169.45ms
+step:79200/500000 train_loss:1.9833 train_time:13420186ms step_avg:169.45ms
+step:79400/500000 train_loss:2.1199 train_time:13453876ms step_avg:169.44ms
+step:79600/500000 train_loss:2.1815 train_time:13488090ms step_avg:169.45ms
+step:79800/500000 train_loss:2.0853 train_time:13521958ms step_avg:169.45ms
+step:80000/500000 train_loss:2.1676 train_time:13555873ms step_avg:169.45ms
+step:80000/500000 val_loss:2.0498 val_bpb:1.2140 train_time:13555876ms step_avg:169.45ms
+step:80200/500000 train_loss:2.1571 train_time:13589467ms step_avg:169.44ms
+step:80400/500000 train_loss:2.1771 train_time:13623222ms step_avg:169.44ms
+step:80600/500000 train_loss:2.0329 train_time:13657367ms step_avg:169.45ms
+step:80800/500000 train_loss:2.0233 train_time:13691407ms step_avg:169.45ms
+step:81000/500000 train_loss:2.2020 train_time:13725226ms step_avg:169.45ms
+step:81200/500000 train_loss:2.8223 train_time:13758818ms step_avg:169.44ms
+step:81400/500000 train_loss:2.1113 train_time:13792990ms step_avg:169.45ms
+step:81600/500000 train_loss:2.0870 train_time:13826746ms step_avg:169.45ms
+step:81800/500000 train_loss:2.1230 train_time:13860430ms step_avg:169.44ms
+step:82000/500000 train_loss:2.0146 train_time:13894697ms step_avg:169.45ms
+step:82200/500000 train_loss:2.0932 train_time:13928486ms step_avg:169.45ms
+step:82400/500000 train_loss:2.0145 train_time:13962276ms step_avg:169.45ms
+step:82600/500000 train_loss:2.0748 train_time:13996271ms step_avg:169.45ms
+step:82800/500000 train_loss:2.0498 train_time:14030147ms step_avg:169.45ms
+step:83000/500000 train_loss:2.0651 train_time:14063874ms step_avg:169.44ms
+step:83200/500000 train_loss:2.1033 train_time:14098191ms step_avg:169.45ms
+step:83400/500000 train_loss:1.9961 train_time:14132055ms step_avg:169.45ms
+step:83600/500000 train_loss:2.0622 train_time:14166030ms step_avg:169.45ms
+step:83800/500000 train_loss:2.0604 train_time:14199726ms step_avg:169.45ms
+step:84000/500000 train_loss:2.0984 train_time:14233390ms step_avg:169.45ms
+step:84200/500000 train_loss:2.1044 train_time:14267104ms step_avg:169.44ms
+step:84278/500000 val_loss:2.0522 val_bpb:1.2154 train_time:14280127ms step_avg:169.44ms
+stopping_early: wallclock_cap train_time:14280127ms step:84278/500000 (reserving 120.0s for GPTQ)
+peak memory allocated: 11293 MiB reserved: 11422 MiB
+gptq:calibrating with 512 batches...
+gptq:collected hessians for 69 layers in 46433ms
+Serialized model: 85084941 bytes
+Code size: 84487 bytes
+Total submission size: 85169428 bytes
+prune:zeroed 1578366 int6 weights (threshold=0)
+gptq:quantized 69 layers with GPTQ, 0 naive, 1 INT8 embeds
+artifact int6+gptq+zstd-22: 14528266 bytes + 84487 code = 14612753 total (payload:21667168 payload_ratio:3.92x)
+artifact headroom: 1387247 bytes (1.387MB)
+artifact int8+zlib: 19405206 bytes (for comparison)
+final_int6_gptq_roundtrip val_loss:2.0819 val_bpb:1.2330 eval_time:1919ms
+final_int6_gptq_roundtrip_exact val_loss:2.08190354 val_bpb:1.23302055
+sliding_eval: stride=64 batch_seqs=16 seq_len=2048
+final_int6_gptq_sliding_window val_loss:2.0437 val_bpb:1.2104 eval_time:154595ms
+final_int6_gptq_sliding_window_exact val_loss:2.04369275 val_bpb:1.21039316

--- a/records/track_non_record_16mb/2026-04-01_Scaled_HNet_Byte260_and_Sp1024/submission.json
+++ b/records/track_non_record_16mb/2026-04-01_Scaled_HNet_Byte260_and_Sp1024/submission.json
@@ -1,0 +1,44 @@
+{
+  "author": "Darius Feher",
+  "github_id": "DariusFeher",
+  "name": "Scaled Byte-level H-Net matches 4-hour subword-level baseline (1.2070 BPB)",
+  "blurb": "12L H-Net (3 Encoder + 6 Main + 3 Decoder) + byte260 + GQA KV4 + INT6 GPTQ + QAT + zstd-22 + Stride-64 Sliding Eval. Closes the gap from 1.36 BPB (PR #1104) to 1.2070 BPB, matching the 4-hour baseline (1.2074) and a comparable sp1024 H-Net (1.2107). Includes byte260 vs sp1024 comparison, analysis of compile-chunking truncation effects, and dynamic chunking at inference.",
+  "date": "2026-04-03",
+  "track": "non-record-unlimited-compute-16mb",
+  "val_loss": 0.83842396,
+  "val_bpb": 1.20701869,
+  "step_stop": 153381,
+  "wallclock_seconds": 14400,
+  "step_avg_ms": 93.10,
+  "model_params": 22966880,
+  "bytes_model_int6_gptq_zstd": 15697770,
+  "bytes_code": 83709,
+  "bytes_total": 15781479,
+  "eval_method": "sliding_window_stride64",
+  "quantization": "INT6_GPTQ_zstd22",
+  "qat_threshold": 0.85,
+  "warmdown_iters": 25000,
+  "chunk_divisor": 4,
+  "architecture": {
+    "num_layers": 12,
+    "outer_layers": 3,
+    "main_layers": 6,
+    "model_dim": 512,
+    "num_heads": 8,
+    "num_kv_heads": 4,
+    "mlp_mult": 2,
+    "vocab_size": 260,
+    "tokenizer": "byte260",
+    "target_chunk_size": 6
+  },
+  "best_10min_val_bpb": 1.31232470,
+  "sp1024_comparison": {
+    "sp1024_div2_4hr_val_bpb": 1.2107,
+    "sp1024_div4_10min_val_bpb": 1.2754
+  },
+  "previous_submission": {
+    "pr": "#1104",
+    "val_bpb": 1.35945128,
+    "pre_quant_val_bpb": 1.3250
+  }
+}

--- a/records/track_non_record_16mb/2026-04-01_Scaled_HNet_Byte260_and_Sp1024/train_gpt_byte_hnet.py
+++ b/records/track_non_record_16mb/2026-04-01_Scaled_HNet_Byte260_and_Sp1024/train_gpt_byte_hnet.py
@@ -1,0 +1,2004 @@
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: To keep readable for newcomers, let's make sure `train_gpt.py` and `train_gpt_mlx.py` never are longer than 1500 lines.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import torch
+
+try:
+    import zstandard as zstd
+    _HAS_ZSTD = True
+except ImportError:
+    _HAS_ZSTD = False
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch._higher_order_ops.associative_scan import associative_scan
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_byte260")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+    checkpoint_every = int(os.environ.get("CHECKPOINT_EVERY", 0))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 260))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 2))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # H-Net tokenization.
+    outer_layers = int(os.environ.get("OUTER_LAYERS", 0))
+    target_avg_chunk_len = float(os.environ.get("TARGET_AVG_CHUNK_LEN", 6.0))
+    ratio_loss_weight = float(os.environ.get("RATIO_LOSS_WEIGHT", 0.03))
+    hnet_lr_diff = float(os.environ.get("HNET_LR_DIFF", 0.75))
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+
+    # Sliding window eval.
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))
+
+    # EMA.
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+
+    # QAT (late quantization-aware training).
+    late_qat_threshold = float(os.environ.get("LATE_QAT_THRESHOLD", 0.15))
+
+    # GPTQ calibration.
+    gptq_reserve_seconds = float(os.environ.get("GPTQ_RESERVE_SECONDS", 45.0))
+    gptq_calib_batches = int(os.environ.get("GPTQ_CALIB_BATCHES", 256))
+    gptq_block_size = int(os.environ.get("GPTQ_BLOCK_SIZE", 128))
+    prune_pct = float(os.environ.get("PRUNE_PCT", 0.03))
+
+    compile_model = bool(int(os.environ.get("COMPILE_MODEL", "1")))
+    chunk_divisor = int(os.environ.get("CHUNK_DIVISOR", "4"))
+    model_save_path = os.environ.get("MODEL_SAVE_PATH", "final_model.pt")
+
+# -----------------------------
+# MUON OPTIMIZER
+# -----------------------------
+#
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_byte_luts(vocab_size: int, device: torch.device) -> tuple[Tensor, Tensor, Tensor]:
+    BYTE_OFFSET = 4  # pad=0, bos=1, eos=2, unk=3
+    base_bytes = torch.zeros(vocab_size, dtype=torch.int16, device=device)
+    base_bytes[BYTE_OFFSET:] = 1  # each byte token = 1 byte
+    has_leading_space = torch.zeros(vocab_size, dtype=torch.bool, device=device)  # not applicable
+    is_boundary = torch.ones(vocab_size, dtype=torch.bool, device=device)
+    is_boundary[BYTE_OFFSET:] = False  # byte tokens are not boundary tokens
+    return base_bytes, has_leading_space, is_boundary
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context.
+
+    Windows of train_seq_len advance by `stride`. Only the last `stride` tokens
+    per window contribute to the score (first window scores all).
+    """
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= 1]
+    total_windows = len(window_starts)
+
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = base_model.forward_logits(x_batch)
+
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+
+            if rank == 0 and (bi // batch_seqs) % 50 == 0:
+                done = min(bi + batch_seqs, len(my_windows))
+                pct = done / len(my_windows) * 100
+                running_bpb = 0.0
+                if token_count.item() > 0:
+                    rl = (loss_sum / token_count).item()
+                    running_bpb = rl / math.log(2.0) * (token_count.item() / byte_count.item())
+                print(f"  sliding_eval [{pct:5.1f}%] {done}/{len(my_windows)} windows running_bpb={running_bpb:.6f}", flush=True)
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Int6 Quantization + zstd Compression
+# ---------------------------------------------------------------------------
+
+INT6_MAX_VAL = 31
+
+def quantize_float_tensor_int6(t: Tensor) -> tuple[Tensor, Tensor]:
+    """Quantize a float tensor to 6-bit signed integers [-31, 31] with per-row scaling."""
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+        scale = (clip_abs / INT6_MAX_VAL).clamp_min(1.0 / INT6_MAX_VAL)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -INT6_MAX_VAL, INT6_MAX_VAL).to(torch.int8).contiguous()
+        return q, scale.to(dtype=torch.float16).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / INT6_MAX_VAL if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -INT6_MAX_VAL, INT6_MAX_VAL).to(torch.int8).contiguous()
+    return q, scale
+
+
+def quantize_state_dict_int6(state_dict: dict[str, Tensor]):
+    """Pure INT6 quantization for all large float tensors."""
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors",
+         "baseline_tensor_bytes", "int6_payload_bytes"), 0,
+    )
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int6_payload_bytes"] += tensor_nbytes(t)
+            continue
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int6_payload_bytes"] += tensor_nbytes(kept)
+            continue
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor_int6(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int6_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+    obj: dict[str, object] = {
+        "__quant_format__": "int6_per_row_v1",
+        "quantized": quantized, "scales": scales, "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+
+def dequantize_state_dict_int6(obj: dict[str, object]) -> dict[str, Tensor]:
+    """Dequantize int6 state dict — same logic as int8, scale multiplication is identical."""
+    return dequantize_state_dict_int8(obj)
+
+
+# ---------------------------------------------------------------------------
+# GPTQ: Hessian-aware INT6 quantization
+# ---------------------------------------------------------------------------
+
+def _classify_param(name: str) -> str:
+    """Classify parameter for mixed quantization: embeddings get INT8, rest gets INT6+GPTQ."""
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    return "quant"  # everything else gets INT6+GPTQ
+
+
+def quantize_int6_gptq(weight: Tensor, hessian: Tensor | None = None,
+                        clip_range: int = 31, block_size: int = 128) -> tuple[Tensor, Tensor]:
+    """Full GPTQ: Hessian-aware int6 quantization with Cholesky error compensation."""
+    t32 = weight.float()
+    if t32.ndim != 2 or hessian is None:
+        return _quantize_int6_multi_pct(t32, clip_range)
+
+    rows, cols = t32.shape
+    H = hessian.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * torch.mean(torch.diag(H))
+    H[torch.arange(cols), torch.arange(cols)] += damp
+
+    perm = torch.argsort(torch.diag(H), descending=True)
+    inv_perm = torch.argsort(perm)
+    W = t32[:, perm].clone()
+    W[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+
+    try:
+        Hinv = torch.linalg.cholesky(H)
+        Hinv = torch.cholesky_inverse(Hinv)
+        Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    except torch.linalg.LinAlgError:
+        return _quantize_int6_multi_pct(t32, clip_range)
+
+    best_q, best_scale, best_err = None, None, float('inf')
+    for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+        if pct < 1.0:
+            row_clip = torch.quantile(t32.abs(), pct, dim=1)
+        else:
+            row_clip = t32.abs().amax(dim=1)
+        s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+        sf = s.float()
+
+        Q = torch.zeros_like(W, dtype=torch.int8)
+        W_work = W.clone()
+
+        for i1 in range(0, cols, block_size):
+            i2 = min(i1 + block_size, cols)
+            count = i2 - i1
+            W1 = W_work[:, i1:i2].clone()
+            Q1 = torch.zeros(rows, count, dtype=torch.int8)
+            Err1 = torch.zeros(rows, count)
+            Hinv1 = Hinv[i1:i2, i1:i2]
+
+            for i in range(count):
+                w = W1[:, i]
+                d = Hinv1[i, i]
+                q = torch.clamp(torch.round(w / sf), -clip_range, clip_range).to(torch.int8)
+                Q1[:, i] = q
+                err = (w - q.float() * sf) / d
+                W1[:, i:] -= err.unsqueeze(1) * Hinv1[i, i:].unsqueeze(0)
+                Err1[:, i] = err
+
+            Q[:, i1:i2] = Q1
+            if i2 < cols:
+                W_work[:, i2:] -= Err1 @ Hinv[i1:i2, i2:]
+
+        recon = Q.float() * sf[:, None]
+        mse = (W - recon).pow(2).mean().item()
+        if mse < best_err:
+            best_q, best_scale, best_err = Q, s, mse
+
+    best_q = best_q[:, inv_perm]
+    return best_q, best_scale
+
+
+def _quantize_int6_multi_pct(t32: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+    """Fallback: naive INT6 with multi-percentile search for best clip."""
+    if t32.ndim == 2:
+        best_q, best_s, best_err = None, None, float('inf')
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            if pct < 1.0:
+                row_clip = torch.quantile(t32.abs(), pct, dim=1)
+            else:
+                row_clip = t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+            recon = q.float() * s.float()[:, None]
+            err = (t32 - recon).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_s, best_err = q, s, err
+        return best_q, best_s
+    # scalar/vector
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+
+
+def collect_hessians(base_model: nn.Module, train_loader, args, device, grad_accum_steps,
+                     num_batches: int = 256) -> dict[str, Tensor]:
+    """Collect Hessian H = X^T X per CastedLinear layer for GPTQ."""
+    hessians: dict[str, Tensor] = {}
+    hooks = []
+
+    for name, module in base_model.named_modules():
+        if isinstance(module, CastedLinear):
+            param_name = name + ".weight"
+            cols = module.weight.shape[1]
+            hessians[param_name] = torch.zeros(cols, cols, dtype=torch.float32, device='cpu')
+
+            def make_hook(pname, ncols):
+                def hook_fn(module, input, output):
+                    x = input[0].detach().float()
+                    if x.ndim == 3:
+                        x = x.reshape(-1, x.shape[-1])
+                    xtx = (x.T @ x).cpu()
+                    hessians[pname] += xtx
+                return hook_fn
+            h = module.register_forward_hook(make_hook(param_name, cols))
+            hooks.append(h)
+
+    base_model.eval()
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        for _ in range(num_batches):
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            _ = base_model(x, y)
+
+    for h in hooks:
+        h.remove()
+    for name in hessians:
+        H = hessians[name]
+        H /= num_batches
+        damp = 0.01 * torch.diag(H).mean().clamp_min(1e-6)
+        H += damp * torch.eye(H.shape[0])
+        hessians[name] = H
+
+    base_model.train()
+    return hessians
+
+
+def quantize_state_dict_int6_gptq(state_dict: dict[str, Tensor],
+                                   hessians: dict[str, Tensor] | None = None,
+                                   block_size: int = 128,
+                                   prune_pct: float = 0.0):
+    """Mixed INT6+GPTQ quantization: INT8 for embeddings, INT6+GPTQ for attn/mlp."""
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors",
+         "baseline_tensor_bytes", "int6_payload_bytes", "gptq_layers", "naive_layers", "embed_layers"), 0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int6_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int6_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        cat = _classify_param(name)
+        stats["num_float_tensors"] += 1
+
+        if cat == "embed":
+            # Embeddings get INT8 (127 levels) — more precision for critical params
+            stats["embed_layers"] += 1
+            q, s = quantize_float_tensor(t)  # existing INT8 quantizer
+            if s.ndim > 0:
+                qmeta[name] = {"scheme": "per_row", "axis": 0}
+            quantized[name] = q
+            scales[name] = s
+            dtypes[name] = str(t.dtype).removeprefix("torch.")
+            stats["int6_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+        else:
+            # Everything else gets INT6+GPTQ
+            H = hessians.get(name) if hessians else None
+            if H is not None:
+                stats["gptq_layers"] += 1
+                q, s = quantize_int6_gptq(t, hessian=H, block_size=block_size)
+            else:
+                stats["naive_layers"] += 1
+                q, s = _quantize_int6_multi_pct(t.float())
+            if s.ndim > 0:
+                qmeta[name] = {"scheme": "per_row", "axis": 0}
+            quantized[name] = q
+            scales[name] = s
+            dtypes[name] = str(t.dtype).removeprefix("torch.")
+            stats["int6_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    # Post-quant pruning: zero out smallest INT6 weights for better compression
+    if prune_pct > 0:
+        all_int6_vals = []
+        for name in quantized:
+            cat = _classify_param(name)
+            if cat != "embed":
+                all_int6_vals.append(quantized[name].flatten().abs().float())
+        if all_int6_vals:
+            all_vals = torch.cat(all_int6_vals)
+            k = max(1, int(prune_pct * all_vals.numel()))
+            threshold = all_vals.kthvalue(k).values.item()
+            pruned_count = 0
+            for name in quantized:
+                cat = _classify_param(name)
+                if cat != "embed":
+                    mask = quantized[name].abs() <= int(threshold)
+                    pruned_count += mask.sum().item()
+                    quantized[name][mask] = 0
+            stats["pruned_count"] = pruned_count
+            stats["prune_threshold"] = threshold
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int6_gptq_mixed_v1",
+        "quantized": quantized, "scales": scales, "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+
+def compress_bytes(data: bytes) -> bytes:
+    """Compress using zstd-22 if available, otherwise zlib-9."""
+    if _HAS_ZSTD:
+        cctx = zstd.ZstdCompressor(level=22)
+        return b"ZSTD" + cctx.compress(data)
+    return b"ZLIB" + zlib.compress(data, level=9)
+
+
+def decompress_bytes(data: bytes) -> bytes:
+    """Decompress, auto-detecting zstd vs zlib from header."""
+    if data[:4] == b"ZSTD":
+        if not _HAS_ZSTD:
+            raise RuntimeError("zstandard package required to decompress ZSTD data")
+        dctx = zstd.ZstdDecompressor()
+        return dctx.decompress(data[4:])
+    if data[:4] == b"ZLIB":
+        return zlib.decompress(data[4:])
+    return zlib.decompress(data)
+
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.
+    # QAT: when _qat_enabled[0] is nonzero, fake-quantize weights during training (STE).
+    # Using a tensor so torch.compile treats it as dynamic (not a compile-time constant).
+    _qat_enabled: Tensor = torch.tensor([0], dtype=torch.int32)
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if self.training and w.ndim == 2:
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                scale = (row_max / INT6_MAX_VAL).clamp_min(1.0 / INT6_MAX_VAL)
+                w_q = (torch.clamp(torch.round(w32 / scale[:, None]), -INT6_MAX_VAL, INT6_MAX_VAL) * scale[:, None]).to(x.dtype)
+            # STE: forward uses quantized, backward passes through
+            # Blend: when _qat_enabled=0, alpha=0 so w_q contribution is zero (just w)
+            alpha = CastedLinear._qat_enabled[0].float()
+            w = w + alpha * (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+            or self._cos_cached.is_inference()  # stale from inference_mode eval
+        ):
+            with torch.no_grad():
+                t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+                freqs = torch.outer(t, self.inv_freq.to(device))
+                self._cos_cached = freqs.cos()[None, None, :, :]
+                self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    # relu^2 MLP from the original modded-nanogpt setup
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class TransformerStage(nn.Module):
+    """
+    Same-resolution stage:
+    - first half of blocks store skip activations
+    - second half consume them in reverse order
+    - final RMSNorm at the end
+
+    GPT backbone factored into a reusable module.
+    """
+    def __init__(
+        self,
+        num_layers: int,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+
+        if self.num_skip_weights > 0:
+            self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, dim, dtype=torch.float32))
+        else:
+            self.skip_weights = nn.Parameter(torch.empty(0, dim, dtype=torch.float32))
+
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    dim=dim,
+                    num_heads=num_heads,
+                    num_kv_heads=num_kv_heads,
+                    mlp_mult=mlp_mult,
+                    rope_base=rope_base,
+                    qk_gain_init=qk_gain_init,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm()
+
+    def forward(self, x: Tensor) -> Tensor:
+        if len(self.blocks) == 0:
+            return x
+
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+
+        return self.final_norm(x)
+
+
+def straight_through(soft: Tensor, hard: Tensor) -> Tensor:
+    return soft + (hard - soft).detach()
+
+def ste_to_one(x: Tensor) -> Tensor:
+    # Forward value is 1, gradient wrt x is 1.
+    return straight_through(x, torch.ones_like(x))
+
+def frac_gradient(t: Tensor, frac: float = 1.0) -> Tensor:
+    """Scale gradients by frac in backward, identity in forward."""
+    if frac == 1.0:
+        return t
+    return straight_through(t * frac, t)
+
+class RoutingModule(nn.Module):
+    """
+    Paper Eq. 4:
+      q_t = W_q xhat_t
+      k_t = W_k xhat_t
+      p_t = 0.5 * (1 - cos(q_t, k_{t-1}))
+      b_t = 1[p_t >= 0.5]
+    with p_1 = 1.
+    """
+    def __init__(self, d_model: int):
+        super().__init__()
+        self.q_proj = CastedLinear(d_model, d_model, bias=False)
+        self.k_proj = CastedLinear(d_model, d_model, bias=False)
+        with torch.no_grad():
+            self.q_proj.weight.copy_(torch.eye(d_model))
+            self.k_proj.weight.copy_(torch.eye(d_model))
+
+    def forward(self, x: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+        q = F.normalize(self.q_proj(x[:, 1:]), dim=-1)   # [B, L-1, D]
+        k = F.normalize(self.k_proj(x[:, :-1]), dim=-1)  # [B, L-1, D]
+        cos_sim = torch.einsum("bld,bld->bl", q, k)      # [B, L-1]
+
+        p = ((1.0 - cos_sim) * 0.5).clamp(0.0, 1.0)
+        p = F.pad(p, (1, 0), value=1.0)                  # [B, L]
+        boundary_mask = p >= 0.5                         # [B, L]
+
+        confidence = torch.where(boundary_mask, p, 1.0 - p)  # [B, L]
+        return p, boundary_mask, confidence
+
+
+class ChunkLayer(nn.Module):
+    """
+    Direct selection downsampler:
+    keep positions where b_t = 1, gather them to the front, and right-pad with zeros.
+    Uses a fixed max_chunks = L // CHUNK_DIVISOR for torch.compile compatibility.
+    """
+
+    def __init__(self, chunk_divisor: int = 4):
+        super().__init__()
+        self.CHUNK_DIVISOR = chunk_divisor
+
+    def forward(self, hidden_states: Tensor, boundary_mask: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+        """
+        Args:
+            hidden_states: [B, L, D]
+            boundary_mask: [B, L] (bool)
+
+        Returns:
+            chunked:   [B, max_chunks, D]  (max_chunks = L // CHUNK_DIVISOR)
+            pad_mask:  [B, max_chunks] (bool)
+            take_idx:  [B, max_chunks] original positions selected
+        """
+        _, L, D = hidden_states.shape
+        max_chunks = L // self.CHUNK_DIVISOR  # fixed at compile time
+
+        num_chunks = boundary_mask.sum(dim=-1)  # [B]
+        num_chunks = num_chunks.clamp(max=max_chunks)
+
+        token_idx = torch.arange(L, device=hidden_states.device)[None, :] + (~boundary_mask).long() * L
+        sorted_idx = torch.argsort(token_idx, dim=1)
+        take_idx = sorted_idx[:, :max_chunks]
+
+        chunked = torch.gather(
+            hidden_states,
+            dim=1,
+            index=take_idx.unsqueeze(-1).expand(-1, -1, D),
+        )
+
+        pad_mask = torch.arange(max_chunks, device=hidden_states.device)[None, :] < num_chunks[:, None]
+        chunked = chunked * pad_mask.unsqueeze(-1).to(chunked.dtype)
+
+        return chunked, pad_mask, take_idx
+
+
+class DeChunkLayer(nn.Module):
+    """
+    Paper dechunking:
+    1. smooth chunk states with parallel EMA via associative_scan (same-shape tuple)
+    2. plug chunk states back to original sequence positions by cumulative chunk id
+    """
+    def forward(
+        self,
+        hidden_states: Tensor,   # [B, C, D] output of main stage on chunked sequence
+        boundary_mask: Tensor,   # [B, L] hard boundaries on original sequence
+        boundary_prob: Tensor,   # [B, L] p_t on original sequence
+        take_idx: Tensor,        # [B, C] cached indices from ChunkLayer
+    ) -> Tensor:
+        B, L = boundary_mask.shape
+        _, C, D = hidden_states.shape
+
+        p_chunked = torch.gather(boundary_prob, dim=1, index=take_idx)  # [B, C]
+        p_chunked = p_chunked.clamp(1e-4, 1.0 - 1e-4)
+
+        # Parallel EMA via associative scan.
+        # Recurrence: s_t = p_t * x_t + (1 - p_t) * s_{t-1}
+        # Pack into single tensor: row = [decay, weighted_x_1, ..., weighted_x_D]
+        # so both elements of the tuple have identical shape [B, C, D].
+        decay = (1.0 - p_chunked).unsqueeze(-1).expand_as(hidden_states)  # [B, C, D]
+        weighted_x = p_chunked.unsqueeze(-1) * hidden_states              # [B, C, D]
+
+        # Fix position 0: decay=0 and weighted_x=x_0 so s_0 = x_0 exactly.
+        # Without this, the clamp(1e-4, 1-1e-4) makes decay[:,0]=1e-4 instead of 0,
+        # contaminating the first chunk state.
+        decay = decay.clone()
+        weighted_x = weighted_x.clone()
+        decay[:, 0] = 0.0
+        weighted_x[:, 0] = hidden_states[:, 0]
+
+        # combine_fn: (d1, v1) o (d2, v2) = (d1*d2, v2 + d2*v1)
+        def combine_fn(left: tuple[Tensor, Tensor], right: tuple[Tensor, Tensor]) -> tuple[Tensor, Tensor]:
+            d_left, v_left = left
+            d_right, v_right = right
+            return (d_left * d_right, v_right + d_right * v_left)
+
+        _, smoothed = associative_scan(combine_fn, (decay, weighted_x), dim=1)
+
+        # Plug chunk states back to original positions
+        chunk_id = torch.cumsum(boundary_mask.long(), dim=1) - 1  # [B, L]
+        chunk_id = chunk_id.clamp(max=C - 1)  # prevent OOB when boundaries > max_chunks
+        out = torch.gather(
+            smoothed,
+            dim=1,
+            index=chunk_id.unsqueeze(-1).expand(-1, -1, D),
+        )
+        return out
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        outer_layers: int,
+        target_avg_chunk_len: float,
+        ratio_loss_weight: float,
+        hnet_lr_diff: float = 0.75,
+        chunk_divisor: int = 4,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.hnet_lr_diff = hnet_lr_diff
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        main_layers = num_layers - 2 * outer_layers
+        if main_layers < 0:
+            raise ValueError(
+                f"NUM_LAYERS must be >= 2 * OUTER_LAYERS, got "
+                f"NUM_LAYERS={num_layers}, OUTER_LAYERS={outer_layers}"
+            )
+
+        self.main_stage = TransformerStage(
+            num_layers=main_layers,
+            dim=model_dim,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            mlp_mult=mlp_mult,
+            rope_base=rope_base,
+            qk_gain_init=qk_gain_init,
+        )
+
+        self.outer_layers = outer_layers
+        self.main_layers = main_layers
+        self.use_hnet = outer_layers > 0
+        if self.use_hnet:
+            self.encoder_stage = TransformerStage(
+                num_layers=outer_layers,
+                dim=model_dim,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                mlp_mult=mlp_mult,
+                rope_base=rope_base,
+                qk_gain_init=qk_gain_init,
+            )
+            self.decoder_stage = TransformerStage(
+                num_layers=outer_layers,
+                dim=model_dim,
+                num_heads=num_heads,
+                num_kv_heads=num_kv_heads,
+                mlp_mult=mlp_mult,
+                rope_base=rope_base,
+                qk_gain_init=qk_gain_init,
+            )
+            self.routing0 = RoutingModule(model_dim)
+            self.chunk0 = ChunkLayer(chunk_divisor=chunk_divisor)
+            self.residual_proj0 = CastedLinear(model_dim, model_dim, bias=False)
+            self.residual_proj0._zero_init = True
+            self.dechunk0 = DeChunkLayer()
+            self.target_avg_chunk_len = target_avg_chunk_len
+            self.ratio_loss_weight = ratio_loss_weight
+
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+
+    def _compute_ratio_loss(self, boundary_mask: Tensor, boundary_prob: Tensor) -> Tensor:
+        """
+        Encourage the average boundary rate to match a target average chunk length.
+        boundary_mask: [B, L] bool
+        boundary_prob: [B, L] float
+        """
+        N = self.target_avg_chunk_len
+        if N <= 1.0:
+            raise ValueError(f"TARGET_AVG_CHUNK_LEN must be > 1, got {N}")
+
+        F_val = boundary_mask.float().mean(dim=-1)   # hard boundary rate per example
+        G_val = boundary_prob.mean(dim=-1)           # soft boundary rate per example
+
+        ratio_loss = N / (N - 1.0) * (
+            (N - 1.0) * F_val * G_val + (1.0 - F_val) * (1.0 - G_val)
+        )
+        return ratio_loss.mean() * self.ratio_loss_weight
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids) # [BATCH_SIZE, SEQ_LEN, MODEL_DIM] = [B, T, D]
+
+        if self.use_hnet:
+            # E -> M -> D (1 stage)
+            # Encode
+            x = self.encoder_stage(x)
+            encoder_out = x
+
+            # Routing and chunking
+            p0, bmask0, conf0 = self.routing0(x)
+            chunked0, pad_mask0, take_idx0 = self.chunk0(x, bmask0)
+
+
+            chunked0 = frac_gradient(chunked0, self.hnet_lr_diff ** -1)
+
+            # Main stage on chunked sequence
+            chunked0 = self.main_stage(chunked0)
+
+            dechunked0 = self.dechunk0(chunked0, bmask0, p0, take_idx0) # Dechunk (upsample)
+
+            ste_conf0 = ste_to_one(conf0).unsqueeze(-1)  # [B, L, 1]
+            x = ste_conf0 * dechunked0 + self.residual_proj0(encoder_out.to(self.residual_proj0.weight.dtype))
+
+
+            x = frac_gradient(x, self.hnet_lr_diff)
+            x = x.to(self.tok_emb.weight.dtype) # Cast back to embedding dtype for decoder stage
+
+            # Decoder
+            x = self.decoder_stage(x)
+
+            aux_loss = self._compute_ratio_loss(bmask0, p0) if self.training else None
+
+        else:
+            x = self.main_stage(x)
+            aux_loss = None
+
+
+        x = x.reshape(-1, x.size(-1)) # x.size(-1) = MODEL_DIM, reshape to [B*T, D] for LM head
+        targets = target_ids.reshape(-1)
+
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        ce_loss = F.cross_entropy(logits.float(), targets, reduction="mean")
+        return ce_loss + aux_loss if aux_loss is not None else ce_loss
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Forward pass returning logits [B, T, V] instead of loss. Used for sliding window eval."""
+        x = self.tok_emb(input_ids)
+
+        if self.use_hnet:
+            x = self.encoder_stage(x)
+            encoder_out = x
+            p0, bmask0, conf0 = self.routing0(x)
+            chunked0, pad_mask0, take_idx0 = self.chunk0(x, bmask0)
+            chunked0 = frac_gradient(chunked0, self.hnet_lr_diff ** -1)
+            chunked0 = self.main_stage(chunked0)
+            dechunked0 = self.dechunk0(chunked0, bmask0, p0, take_idx0)
+            ste_conf0 = ste_to_one(conf0).unsqueeze(-1)
+            x = ste_conf0 * dechunked0 + self.residual_proj0(encoder_out.to(self.residual_proj0.weight.dtype))
+            x = frac_gradient(x, self.hnet_lr_diff)
+            x = x.to(self.tok_emb.weight.dtype)
+            x = self.decoder_stage(x)
+        else:
+            x = self.main_stage(x)
+
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    if args.compile_model:
+        zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_byte_luts(args.vocab_size, device)
+    log0(f"val_bpb:enabled tokenizer_kind=byte vocab_size={args.vocab_size}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        outer_layers=args.outer_layers,
+        target_avg_chunk_len=args.target_avg_chunk_len,
+        ratio_loss_weight=args.ratio_loss_weight,
+        hnet_lr_diff=args.hnet_lr_diff,
+        chunk_divisor=args.chunk_divisor,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    CastedLinear._qat_enabled = torch.tensor([0], dtype=torch.int32, device=device)
+    compiled_model = torch.compile(base_model, dynamic=False) if args.compile_model else base_model
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False, find_unused_parameters=False) if distributed else compiled_model
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    backbone_named_params = (
+        [(f"main_stage.{n}", p) for n, p in base_model.main_stage.named_parameters()]
+    )
+    if base_model.use_hnet:
+        backbone_named_params += (
+            [(f"encoder_stage.{n}", p) for n, p in base_model.encoder_stage.named_parameters()] +
+            [(f"decoder_stage.{n}", p) for n, p in base_model.decoder_stage.named_parameters()] +
+            [(f"routing0.{n}", p) for n, p in base_model.routing0.named_parameters()] +
+            [(f"residual_proj0.{n}", p) for n, p in base_model.residual_proj0.named_parameters()]
+        )
+    matrix_params = [
+        p for name, p in backbone_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+
+    scalar_params = [
+        p for name, p in backbone_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"outer_layers:{args.outer_layers} main_layers:{base_model.main_layers} chunk_divisor:{args.chunk_divisor}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    gptq_reserve_ms = 1000.0 * args.gptq_reserve_seconds
+    train_loop_cap_ms = max_wallclock_ms - gptq_reserve_ms if max_wallclock_ms is not None else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if train_loop_cap_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(train_loop_cap_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    # EMA: initialize from current model weights (disabled when decay <= 0)
+    ema_enabled = args.ema_decay > 0
+    ema_state = None
+    if ema_enabled:
+        ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+        log0(f"ema:initialized with decay={args.ema_decay}")
+    else:
+        log0("ema:disabled")
+
+    # QAT: will be enabled dynamically when LR scale drops below threshold
+    if args.late_qat_threshold > 0:
+        log0(f"late_qat:will enable when lr_scale < {args.late_qat_threshold}")
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            # if hasattr(base_model, "_debug_last_chunk_mask"):
+            #     avg_chunk_rate = base_model._debug_last_chunk_mask.float().mean().item()
+            #     avg_chunk_len = 1.0 / max(avg_chunk_rate, 1e-8)
+            #     log0(
+            #         f"chunk_stats step:{step}/{args.iterations} "
+            #         f"avg_chunk_rate:{avg_chunk_rate:.4f} avg_chunk_len:{avg_chunk_len:.2f} "
+            #         f"chunked_shape:{getattr(base_model, '_debug_last_chunked_shape', None)}"
+            #     )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations} (reserving {args.gptq_reserve_seconds}s for GPTQ)"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        # EMA update
+        if ema_state is not None:
+            with torch.no_grad():
+                for name, t in base_model.state_dict().items():
+                    ema_state[name].mul_(args.ema_decay).add_(t.detach().float(), alpha=1.0 - args.ema_decay)
+
+        # Late QAT: enable fake int6 quantization when LR drops low enough
+        if args.late_qat_threshold > 0 and scale < args.late_qat_threshold and CastedLinear._qat_enabled[0].item() == 0:
+            CastedLinear._qat_enabled[0] = 1
+            log0(f"late_qat:enabled step:{step} scale:{scale:.4f}")
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Periodic checkpoint saving (rank 0 only)
+        if args.checkpoint_every > 0 and step % args.checkpoint_every == 0 and rank == 0:
+            ckpt_path = str(Path(args.model_save_path).parent / f"{Path(args.model_save_path).stem}.step{step}.pt")
+            torch.save(base_model.state_dict(), ckpt_path)
+            log0(f"checkpoint:saved {ckpt_path} at step {step}")
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = train_loop_cap_ms is not None and approx_training_time_ms >= train_loop_cap_ms
+        if distributed and train_loop_cap_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # -----------------------------
+    # SERIALIZATION + GPTQ + ROUNDTRIP VALIDATION
+    # -----------------------------
+
+    # Disable QAT for serialization
+    CastedLinear._qat_enabled[0] = 0
+
+    # Apply EMA weights before saving (if enabled)
+    if ema_state is not None:
+        log0("ema:applying EMA weights")
+        current_dtypes = {name: t.dtype for name, t in base_model.state_dict().items()}
+        avg_state = {name: t.to(dtype=current_dtypes[name]) for name, t in ema_state.items()}
+        del ema_state
+        base_model.load_state_dict(avg_state, strict=True)
+
+    # GPTQ calibration: collect Hessians
+    torch.cuda.synchronize()
+    t_gptq = time.perf_counter()
+    log0(f"gptq:calibrating with {args.gptq_calib_batches} batches...")
+    calib_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    hessians = collect_hessians(base_model, calib_loader, args, device, grad_accum_steps,
+                                num_batches=args.gptq_calib_batches)
+    torch.cuda.synchronize()
+    gptq_time_ms = 1000.0 * (time.perf_counter() - t_gptq)
+    log0(f"gptq:collected hessians for {len(hessians)} layers in {gptq_time_ms:.0f}ms")
+
+    if master_process:
+        torch.save(base_model.state_dict(), args.model_save_path)
+        model_bytes = os.path.getsize(args.model_save_path)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    # INT6+GPTQ mixed quantization + zstd compression
+    save_stem = Path(args.model_save_path).stem
+    artifact_path = str(Path(args.model_save_path).parent / f"{save_stem}.int6.ptz")
+    artifact_path_int8 = str(Path(args.model_save_path).parent / f"{save_stem}.int8.ptz")
+    quant_obj, quant_stats = quantize_state_dict_int6_gptq(
+        base_model.state_dict(),
+        hessians=hessians,
+        block_size=args.gptq_block_size,
+        prune_pct=args.prune_pct,
+    )
+    if quant_stats.get("pruned_count", 0) > 0:
+        log0(f"prune:zeroed {quant_stats['pruned_count']} int6 weights (threshold={quant_stats.get('prune_threshold', 0):.0f})")
+    log0(f"gptq:quantized {quant_stats.get('gptq_layers', 0)} layers with GPTQ, "
+         f"{quant_stats.get('naive_layers', 0)} naive, {quant_stats.get('embed_layers', 0)} INT8 embeds")
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_blob = compress_bytes(quant_buf.getvalue())
+    if master_process:
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        code_bytes = len(code.encode("utf-8"))
+        compressor = "zstd-22" if _HAS_ZSTD else "zlib-9"
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int6_payload_bytes"], 1)
+        total_artifact = len(quant_blob) + code_bytes
+        log0(
+            f"artifact int6+gptq+{compressor}: {len(quant_blob)} bytes + {code_bytes} code = {total_artifact} total "
+            f"(payload:{quant_stats['int6_payload_bytes']} payload_ratio:{ratio:.2f}x)"
+        )
+        if total_artifact > 16_000_000:
+            log0(f"WARNING: artifact {total_artifact} exceeds 16,000,000 byte cap by {total_artifact - 16_000_000} bytes!")
+        else:
+            log0(f"artifact headroom: {16_000_000 - total_artifact} bytes ({(16_000_000 - total_artifact)/1e6:.3f}MB)")
+
+    # Also produce INT8+zlib for comparison
+    quant_obj8, quant_stats8 = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf8 = io.BytesIO()
+    torch.save(quant_obj8, quant_buf8)
+    quant_blob8 = zlib.compress(quant_buf8.getvalue(), level=9)
+    if master_process:
+        with open(artifact_path_int8, "wb") as f:
+            f.write(quant_blob8)
+        log0(f"artifact int8+zlib: {len(quant_blob8)} bytes (for comparison)")
+
+    # Roundtrip validation with INT6+GPTQ
+    if distributed:
+        dist.barrier()
+    with open(artifact_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(decompress_bytes(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int6(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_gptq_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int6_gptq_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    # Sliding window evaluation (with INT6+GPTQ roundtripped weights already loaded)
+    if args.eval_stride > 0 and args.eval_stride < args.train_seq_len:
+        log0(f"sliding_eval: stride={args.eval_stride} batch_seqs={args.eval_batch_seqs} seq_len={args.train_seq_len}")
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args,
+            base_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            stride=args.eval_stride,
+            batch_seqs=args.eval_batch_seqs,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_gptq_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"final_int6_gptq_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

>**12L H-Net (3 Encoder + 6 Main + 3 Decoder) + byte260 + GQA KV4 + INT6 GPTQ + QAT + zstd-22 + Stride-64 Sliding Eval; val_bpb: 1.2070**

Follow-up to [PR #1104](https://github.com/openai/parameter-golf/pull/1104), which introduced a byte-level H-Net that learns whitespace-aligned, word-like boundaries from raw bytes but reached only 1.36 BPB on a 4 hours run, significantly worse than the competition's 4 hours baseline of 1.20.

This submission closes that gap. By scaling the architecture from 9 layers (2 outer layers x2; Encoder + Decoder) to 12 layers (3 outer layers x2; Encoder + Decoder), adding INT6 GPTQ quantization, quantization-aware training (QAT), sliding window eval, and a `torch.compile` compatible chunking strategy, the H-Net `byte260` model now reaches **1.2070 BPB** in a 4-hour set-up, matching the 4-hour baseline (1.2074) and a comparable `sp1024` H-Net (1.2107).

We also include a detailed comparison of `byte260` vs `sp1024` H-Net, analysis of how the fixed chunking strategy impacts sliding window eval, and results on dynamic chunking (rather than fixed cap chunking) at inference (see README for more details).

## Key Results

#### 4 hours runs

| Config | BPB | Steps | Artifact size |
|--------|-----|------:|--------:|
| **H-Net `byte260` 12L (3 OLs, KV=4)** | **1.2070** | 153,381 | 15.8 MB |
| H-Net `sp1024` 11L (3 OLs, KV=4, div=2) | 1.2107 | 84,278 | 14.6 MB |
|**Baselines**||
| 4-hour baseline | 1.2074 | 329,430 | 15.8 MB |
| H-Net `byte260` 9L ([PR #1104](https://github.com/openai/parameter-golf/pull/1104)) | 1.3595 | 85,242 | 16.0 MB |

#### 10 min runs

| Config | BPB | Steps | Artifact size |
|--------|-----|------:|--------:|
| H-Net `byte260` 12L (3 OLs, KV=4) chunk_size=6 | 1.3123 | 5,957 | 15.2 MB |
| H-Net `sp1024` 11L (3 OLs, KV=4) chunk_size=6 | 1.2754 | 6,161 | 14.1 MB |
|**Baselines**||
| Naive baseline (9L 512dim `sp1024` KV4) | 1.2244 | 13,780 | 15.9 MB |
| H-Net `byte260` 9L OL2 chunk_size=9 ([PR #1104](https://github.com/openai/parameter-golf/pull/1104)) | 1.4116 | 4,520 | 15.8 MB |
| H-Net `sp1024` 9L OL2 chunk_size=12 ([PR #1104](https://github.com/openai/parameter-golf/pull/1104)) | 1.3734 | 4,466 | 16.0 MB |


(*OL = Outer Layers, used for H-Net Encoders and Decoders*)

`sp1024` H-Net represents the subword-level H-Net. For more details about chunk_divisor, see README

## Changes compared to [PR #1104](https://github.com/openai/parameter-golf/pull/1104)

| | #1104 | This PR |
|--|-------|---------|
| Architecture | 9L, OL2 | 12L, OL3 |
| Parameters | 17.5M | 23.0M |
| Quantization | int8+zlib | int6 GPTQ + zstd-22 |
| QAT | None | 85% of warmdown |
| Evaluation | Roundtrip | Sliding window (stride 64) |
| Best 4hr BPB | 1.3595 | **1.2070** |

## Architecture

Same 1-stage H-Net layout as [PR #1104](https://github.com/openai/parameter-golf/pull/1104), scaled up:

```
Input -> Embedding -> Encoder (3 blocks) -> Routing -> ChunkLayer (L -> C)
      -> Main Transformer (6 blocks) -> DeChunkLayer (C -> L)
      -> + Residual Skip -> Decoder (3 blocks) -> LM Head
```

- **12 layers total**: 3 encoder + 6 main + 3 decoder (OL3)
- **512 model dim**, 8 heads, 4 KV heads (GQA)
- **22.97M parameters**, `byte260` tokenizer (vocab=260)
- **Chunk target size**: 6


## Additional findings / analysis (see README for  details)

- At 10 minutes, `byte260` still has a significant gap compared to `sp1024` (+0.037 BPB) With a 4-hour budget, `byte260` closes the gap, matching both the `sp1024` H-Net (1.2070 `byte260` vs 1.2107 `sp1024`) and the naive baseline (1.2074).

- The byte H-Net still has clear optimization headroom as val BPB is still decreasing at the 4 hours cutoff. This suggests that part of the remaining gap is due to optimization budget rather than a hard limit of byte-level H-Net.

- To enable torch.compile, we choose a simple solution of capping the number of boundaries at a fixed value per batch.  If the router predicts more than this cap, excess boundaries at the tail are silently dropped. Since sliding window eval only scores the tail of the sequence, this directly degrades sliding eval results. We analyze this effect and a fix in the README.

- Models trained with a fixed boundary cap transfer well to dynamic chunking at inference (no cap). Some see significant improvements, especially those that were truncated during training (see `sp1024` with chunk_divisor=4), and none show any degradation. Removing the cap at inference restores the dropped boundaries, but can't undo the training-time 'damage'.

- Both `byte260` and `sp1024` use shared hyperparameters (except number of layers). Per-model tuning of QAT and chunking settings would likely improve both.

## Reproduction

```bash
# Best byte260 4-hour run (1.2070 BPB)
COMPILE_MODEL=1 OUTER_LAYERS=3 NUM_LAYERS=12 MODEL_DIM=512 \
    TRAIN_SEQ_LEN=2048 MAX_WALLCLOCK_SECONDS=14400 ITERATIONS=500000 \
    RATIO_LOSS_WEIGHT=0.05 LATE_QAT_THRESHOLD=0.85 WARMDOWN_ITERS=25000 \
    EMA_DECAY=0 EVAL_STRIDE=64 EVAL_BATCH_SEQS=16 \
    GPTQ_RESERVE_SECONDS=120 GPTQ_CALIB_BATCHES=512 PRUNE_PCT=0.03 \
    CHUNK_DIVISOR=4 CHECKPOINT_EVERY=50000 \
    MODEL_SAVE_PATH=models/byte260_compile_12L_OL3_4hr_qat85.pt \
    RUN_ID=byte260_compile_12L_OL3_4hr_qat85 \
    torchrun --standalone --nproc_per_node=8 hnet/train_gpt_hnet_compile_gptq.py

# 10 min byte260 equivalent
COMPILE_MODEL=1 OUTER_LAYERS=3 NUM_LAYERS=12 MODEL_DIM=512 \
    TRAIN_SEQ_LEN=2048 MAX_WALLCLOCK_SECONDS=600 ITERATIONS=20000 \
    RATIO_LOSS_WEIGHT=0.05 LATE_QAT_THRESHOLD=0.15 EMA_DECAY=0 \
    EVAL_STRIDE=64 EVAL_BATCH_SEQS=16 \
    GPTQ_RESERVE_SECONDS=45 GPTQ_CALIB_BATCHES=256 PRUNE_PCT=0.03 \
    CHUNK_DIVISOR=4 \
    MODEL_SAVE_PATH=models/sweep_div4_compile_10min.pt \
    RUN_ID=sweep_div4_compile_10min \
    torchrun --standalone --nproc_per_node=8 hnet/train_gpt_hnet_compile_gptq.py
```

> *Note*: Both experiments use `seed=1337`

## Compliance

- [x] Artifact ≤ 16 MB (15.8 MB)
- [x] 8×H100 training
- [x] No training on validation data
- [x] No network calls during evaluation
- [x] Non-record: extended run (153k steps / 4h)

## Credits

- Hwang et al. (2025), [*Dynamic Chunking for End-to-End Hierarchical Sequence Modeling*](https://arxiv.org/abs/2507.07955). Official code: [goombalab/hnet](https://github.com/goombalab/hnet)
- PRs with QAT / GPTQ / INT6 quantization / sliding window eval
