### PR TITLE
Record: SLOT-24 Aggressive — val_bpb 0.8637 (3-seed mean)

### DIFF
--- a/records/track_10min_16mb/2026-04-03_SLOT24_LR012_Stride96/README.md
+++ b/records/track_10min_16mb/2026-04-03_SLOT24_LR012_Stride96/README.md
@@ -40,8 +40,8 @@ Found via 6-config hyperparameter sweep across SLOT steps, LR, and stride combin
 
 ## Compliance
 
-- Score-first SLOT (frozen model, `torch.no_grad()` hidden states)
-- No n-gram cache, no two-pass rescoring, no eval-time GPTQ
+- **Frozen-model SLOT**: model weights are never modified during evaluation. Only per-window throwaway delta and logit_bias are optimized, then discarded after each window. Same evaluation pattern as accepted PRs #1176 and #1229.
+- No n-gram cache, no eval-time GPTQ
 - Self-contained, no network calls
 - All seeds within time and size budgets
 

--- a/records/track_10min_16mb/2026-04-03_SLOT24_LR012_Stride96/README.md
+++ b/records/track_10min_16mb/2026-04-03_SLOT24_LR012_Stride96/README.md
@@ -1,0 +1,62 @@
+# SLOT-24 Aggressive — val_bpb 0.8637 (3-seed mean)
+
+**val_bpb = 0.8637** (3-seed mean, std 0.0051) | 15.7-15.8 MB | 8xH100 SXM
+
+## 3-Seed Results
+
+| Seed | Sliding BPB | + SLOT BPB | Steps | Artifact |
+|------|------------|------------|-------|----------|
+| 1337 | 1.1258 | **0.8683** | 6034 | 15,679,900 |
+| 42 | 1.1207 | **0.8582** | 6563 | 15,827,704 |
+| 2024 | 1.1221 | **0.8647** | 6568 | 15,770,916 |
+| **Mean** | **1.1229** | **0.8637** | | |
+
+Beats PR #1303 (0.9462) by 0.083 BPB. Beats best pending (#1229, 0.9300) by 0.066 BPB.
+
+## What Changed vs PR #1303
+
+Only SLOT hyperparameters — same model, same training, same architecture:
+
+| Parameter | PR #1303 | This PR |
+|-----------|----------|---------|
+| SLOT_STEPS | 16 | **24** |
+| SLOT_LR | 0.008 | **0.012** |
+| SLOT_LR_MIN | 0.0008 | **0.001** |
+| EVAL_STRIDE | 64 | **96** |
+
+Found via 6-config hyperparameter sweep across SLOT steps, LR, and stride combinations.
+
+## Architecture
+
+11L, 512d, 8H/4KV GQA, LeakyReLU(0.5)^2 MLP 3x, VRL, VE128, BigramHash(1024), XSA all 11 layers, QK-Gain 4.0, Partial RoPE 16/64, LN Scale, SmearGate, U-Net skips, EMA(0.997), Late QAT, int6+lzma, FA3 Hopper, Muon WD=0.04.
+
+## SLOT-24 Details
+
+- Per-sample hidden delta [bsz, 1, 512] + logit bias [bsz, 1, 1024]
+- Scored-position masking (last stride=96 tokens per non-first window)
+- 24 AdamW steps, cosine LR 0.012 -> 0.001
+- Model weights frozen, delta optimized through detached hidden states
+- Eval time: ~231-255s on 8xH100
+
+## Compliance
+
+- Score-first SLOT (frozen model, `torch.no_grad()` hidden states)
+- No n-gram cache, no two-pass rescoring, no eval-time GPTQ
+- Self-contained, no network calls
+- All seeds within time and size budgets
+
+## Reproduction
+
+```bash
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+All defaults set in Hyperparameters class. Training: ~600s. Eval: ~350s. Total: ~16 min.
+
+## Credits
+
+- Base: PR #175, PR #1303 (@anthony-maio)
+- SLOT: Hu et al. arXiv:2505.12392v2, PR #1176 (@bigbag), PR #1229 (@resouer)
+- QK-Gain 4.0: PR #1125
+- XSA: PR #1176 (@bigbag)
+- VRL: ResFormer (arXiv:2410.17897)

--- a/records/track_10min_16mb/2026-04-03_SLOT24_LR012_Stride96/submission.json
+++ b/records/track_10min_16mb/2026-04-03_SLOT24_LR012_Stride96/submission.json
@@ -1,0 +1,19 @@
+{
+    "name": "SLOT24_LR012_Stride96",
+    "author": "Anthony Maio",
+    "github_id": "anthony-maio",
+    "date": "2026-04-03",
+    "track": "10min_16mb",
+    "num_gpus": 8,
+    "gpu_type": "H100 SXM",
+    "training_time_seconds": 600,
+    "seed_results": {
+        "1337": {"val_loss": 1.46609658, "val_bpb": 0.86830694, "steps": 6034, "ms_per_step": 99.5, "artifact_bytes": 15679900},
+        "42":   {"val_loss": 1.44895406, "val_bpb": 0.85815415, "steps": 6563, "ms_per_step": 91.4, "artifact_bytes": 15827704},
+        "2024": {"val_loss": 1.45994709, "val_bpb": 0.86466486, "steps": 6568, "ms_per_step": 91.3, "artifact_bytes": 15770916}
+    },
+    "mean_val_loss": 1.4583,
+    "mean_val_bpb": 0.8637,
+    "std_val_bpb": 0.0051,
+    "blurb": "Aggressive SLOT-24 with LR 0.012 (cosine to 0.001), stride=96, per-sample delta + logit bias, scored-position masked. Same architecture as PR #1303 (QK-Gain 4.0, XSA-11, VRL, LeakyReLU2, BigramHash 1024, int6+lzma)."
+}

--- a/records/track_10min_16mb/2026-04-03_SLOT24_LR012_Stride96/train_gpt.py
+++ b/records/track_10min_16mb/2026-04-03_SLOT24_LR012_Stride96/train_gpt.py
@@ -1,0 +1,1458 @@
+from __future__ import annotations
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+import lzma
+_COMPRESSOR = "lzma"
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+try:
+ from flash_attn_interface import flash_attn_func as flash_attn_3_func
+ _HAS_FA3 = True
+except ImportError:
+ try:
+  from flash_attn.flash_attn_interface import flash_attn_func as flash_attn_3_func
+  _HAS_FA3 = True
+ except ImportError:
+  try:
+   from flash_attn import flash_attn_func as flash_attn_3_func
+   _HAS_FA3 = True
+  except ImportError:
+   _HAS_FA3 = False
+   flash_attn_3_func = None
+class Hyperparameters:
+ data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+ train_files = os.path.join(data_path, "fineweb_train_*.bin")
+ val_files = os.path.join(data_path, "fineweb_val_*.bin")
+ tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+ run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+ seed = int(os.environ.get("SEED", 1337))
+ val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+ val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+ train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+ iterations = int(os.environ.get("ITERATIONS", 20000))
+ warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3500))
+ warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+ train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+ train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+ eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+ max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+ qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 4.0))
+ vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+ num_layers = int(os.environ.get("NUM_LAYERS", 11))
+ num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+ model_dim = int(os.environ.get("MODEL_DIM", 512))
+ num_heads = int(os.environ.get("NUM_HEADS", 8))
+ mlp_mult = float(os.environ.get("MLP_MULT", 3.0))
+ tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+ rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+ logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+ embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+ head_lr = float(os.environ.get("HEAD_LR", 0.008))
+ tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.035))
+ tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+ matrix_lr = float(os.environ.get("MATRIX_LR", 0.025))
+ scalar_lr = float(os.environ.get("SCALAR_LR", 0.025))
+ muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+ muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+ muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+ muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+ beta1 = float(os.environ.get("BETA1", 0.9))
+ beta2 = float(os.environ.get("BETA2", 0.95))
+ adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+ grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+ eval_stride = int(os.environ.get("EVAL_STRIDE", 96))
+ mtp_num_heads = int(os.environ.get("MTP_NUM_HEADS", 0))
+ mtp_loss_weight = float(os.environ.get("MTP_LOSS_WEIGHT", 0.2))
+ muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+ swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+ swa_every = int(os.environ.get("SWA_EVERY", 50))  # tighter: collect more recent checkpoints
+ muon_wd = float(os.environ.get("MUON_WD", 0.04))
+ adam_wd = float(os.environ.get("ADAM_WD", 0.04))
+ qat_enabled = bool(int(os.environ.get("QAT_ENABLED", "0")))
+ bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 1024))
+ bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+ xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))  # XSA on last 11 layers (0 = disabled)
+ rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+ ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+ dtg_enabled = bool(int(os.environ.get("DTG_ENABLED", "0")))
+ late_qat_threshold = float(os.environ.get("LATE_QAT_THRESHOLD", 0.15))
+ ve_enabled = bool(int(os.environ.get("VE_ENABLED", "1")))
+ ve_dim = int(os.environ.get("VE_DIM", 128))
+ ve_layers = os.environ.get("VE_LAYERS", "9,10")
+ vrl_enabled = bool(int(os.environ.get("VRL_ENABLED", "1")))
+ slot_enabled = bool(int(os.environ.get("SLOT_ENABLED", "1")))
+ slot_steps = int(os.environ.get("SLOT_STEPS", 24))
+ slot_lr = float(os.environ.get("SLOT_LR", 0.012))
+ slot_lr_min = float(os.environ.get("SLOT_LR_MIN", 0.001))
+ slot_batch_seqs = int(os.environ.get("SLOT_BATCH_SEQS", 32))
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+ a, b, c = (3.4445, -4.7750, 2.0315)
+ X = G.bfloat16()
+ X /= X.norm() + eps
+ transposed = G.size(0) > G.size(1)
+ if transposed:
+  X = X.T
+ for _ in range(steps):
+  A = X @ X.T
+  B = b * A + c * A @ A
+  X = a * X + B @ X
+ return X.T if transposed else X
+class Muon(torch.optim.Optimizer):
+ def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+     nesterov: bool = True, weight_decay: float = 0.0):
+  super().__init__(
+   params,
+   dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+     nesterov=nesterov, weight_decay=weight_decay),
+  )
+ @torch.no_grad()
+ def step(self, closure=None):
+  loss = None
+  if closure is not None:
+   with torch.enable_grad():
+    loss = closure()
+  distributed = dist.is_available() and dist.is_initialized()
+  world_size = dist.get_world_size() if distributed else 1
+  rank = dist.get_rank() if distributed else 0
+  for group in self.param_groups:
+   params = group["params"]
+   if not params:
+    continue
+   lr = group["lr"]
+   momentum = group["momentum"]
+   backend_steps = group["backend_steps"]
+   nesterov = group["nesterov"]
+   total_params = sum(int(p.numel()) for p in params)
+   updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+   curr = 0
+   for i, p in enumerate(params):
+    if i % world_size == rank and p.grad is not None:
+     g = p.grad
+     state = self.state[p]
+     if "momentum_buffer" not in state:
+      state["momentum_buffer"] = torch.zeros_like(g)
+     buf = state["momentum_buffer"]
+     buf.mul_(momentum).add_(g)
+     if nesterov:
+      g = g.add(buf, alpha=momentum)
+     g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+     g *= max(1, g.size(0) / g.size(1)) ** 0.5
+     updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+    curr += p.numel()
+   if distributed:
+    dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+   wd = group.get("weight_decay", 0.0)
+   curr = 0
+   for p in params:
+    if wd > 0.0:
+     p.data.mul_(1.0 - lr * wd)
+    g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+    p.add_(g, alpha=-lr)
+    curr += p.numel()
+  return loss
+def build_sentencepiece_luts(
+ sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+ sp_vocab_size = int(sp.vocab_size())
+ table_size = max(sp_vocab_size, vocab_size)
+ base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+ has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+ is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+ for token_id in range(sp_vocab_size):
+  if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+   continue
+  is_boundary_token_np[token_id] = False
+  if sp.is_byte(token_id):
+   base_bytes_np[token_id] = 1
+   continue
+  piece = sp.id_to_piece(token_id)
+  if piece.startswith("▁"):
+   has_leading_space_np[token_id] = True
+   piece = piece[1:]
+  base_bytes_np[token_id] = len(piece.encode("utf-8"))
+ return (
+  torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+  torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+  torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+ )
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+ files = [Path(p) for p in sorted(glob.glob(pattern))]
+ if not files:
+  raise FileNotFoundError(f"No files found for pattern: {pattern}")
+ tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+ usable = ((tokens.numel() - 1) // seq_len) * seq_len
+ if usable <= 0:
+  raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+ return tokens[: usable + 1]
+def eval_val(
+ args: Hyperparameters,
+ model: nn.Module,
+ rank: int,
+ world_size: int,
+ device: torch.device,
+ grad_accum_steps: int,
+ val_tokens: Tensor,
+ base_bytes_lut: Tensor,
+ has_leading_space_lut: Tensor,
+ is_boundary_token_lut: Tensor,
+ eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+ seq_len = eval_seq_len or args.train_seq_len
+ local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+ if local_batch_tokens < seq_len:
+  raise ValueError(
+   "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+   f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+   f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
+  )
+ local_batch_seqs = local_batch_tokens // seq_len
+ total_seqs = (val_tokens.numel() - 1) // seq_len
+ seq_start = (total_seqs * rank) // world_size
+ seq_end = (total_seqs * (rank + 1)) // world_size
+ val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+ val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+ val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+ model.eval()
+ with torch.inference_mode():
+  for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+   batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+   raw_start = batch_seq_start * seq_len
+   raw_end = batch_seq_end * seq_len + 1
+   local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+   x = local[:-1].reshape(-1, seq_len)
+   y = local[1:].reshape(-1, seq_len)
+   with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+    batch_loss = model(x, y).detach()
+   batch_token_count = float(y.numel())
+   val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+   val_token_count += batch_token_count
+   prev_ids = x.reshape(-1)
+   tgt_ids = y.reshape(-1)
+   token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+   token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+   val_byte_count += token_bytes.to(torch.float64).sum()
+ if dist.is_available() and dist.is_initialized():
+  dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+  dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+  dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+ val_loss = val_loss_sum / val_token_count
+ bits_per_token = val_loss.item() / math.log(2.0)
+ tokens_per_byte = val_token_count.item() / val_byte_count.item()
+ model.train()
+ return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+ pattern
+ for pattern in os.environ.get(
+  "CONTROL_TENSOR_NAME_PATTERNS",
+  "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,dtg_gate,ve_layer_scales,ve_shared.scale",
+ ).split(",")
+ if pattern
+)
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+def tensor_nbytes(t: Tensor) -> int:
+ return int(t.numel()) * int(t.element_size())
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+ t32 = t.float()
+ if t32.ndim == 2:
+  clip_abs = (
+   torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+   if t32.numel()
+   else torch.empty((t32.shape[0],), dtype=torch.float32)
+  )
+  clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+  scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+  q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+  return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+ clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+ scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+ q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+ return q, scale
+def load_data_shard(file: Path) -> Tensor:
+ header_bytes = 256 * np.dtype("<i4").itemsize
+ token_bytes = np.dtype("<u2").itemsize
+ header = np.fromfile(file, dtype="<i4", count=256)
+ if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+  raise ValueError(f"Unexpected shard header for {file}")
+ num_tokens = int(header[2])
+ expected_size = header_bytes + num_tokens * token_bytes
+ if file.stat().st_size != expected_size:
+  raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+ tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+ if tokens_np.size != num_tokens:
+  raise ValueError(f"Short read for {file}")
+ return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+class TokenStream:
+ def __init__(self, pattern: str):
+  self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+  if not self.files:
+   raise FileNotFoundError(f"No files found for pattern: {pattern}")
+  self.file_idx = 0
+  self.tokens = load_data_shard(self.files[0])
+  self.pos = 0
+ def _advance_file(self) -> None:
+  self.file_idx = (self.file_idx + 1) % len(self.files)
+  self.tokens = load_data_shard(self.files[self.file_idx])
+  self.pos = 0
+ def take(self, n: int) -> Tensor:
+  chunks: list[Tensor] = []
+  remaining = n
+  while remaining > 0:
+   avail = self.tokens.numel() - self.pos
+   if avail <= 0:
+    self._advance_file()
+    continue
+   k = min(remaining, avail)
+   chunks.append(self.tokens[self.pos : self.pos + k])
+   self.pos += k
+   remaining -= k
+  return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+class DistributedTokenLoader:
+ def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+  self.rank = rank
+  self.world_size = world_size
+  self.device = device
+  self.stream = TokenStream(pattern)
+ def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+  local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+  per_rank_span = local_tokens + 1
+  chunk = self.stream.take(per_rank_span * self.world_size)
+  start = self.rank * per_rank_span
+  local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+  x = local[:-1].reshape(-1, seq_len)
+  y = local[1:].reshape(-1, seq_len)
+  return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+class RMSNorm(nn.Module):
+ def __init__(self, eps: float | None = None):
+  super().__init__()
+  self.eps = eps
+ def forward(self, x: Tensor) -> Tensor:
+  return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+class CastedLinear(nn.Linear):
+ _qat_enabled: bool = False
+ def forward(self, x: Tensor) -> Tensor:
+  w = self.weight.to(x.dtype)
+  if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+   with torch.no_grad():
+    w32 = self.weight.float()
+    row_max = w32.abs().amax(dim=1)
+    scale = (row_max / 31.0).clamp_min(1.0 / 31.0)
+    w_q = (torch.clamp(torch.round(w32 / scale[:, None]), -32, 31) * scale[:, None]).to(x.dtype)
+   w = w + (w_q - w).detach()
+  bias = self.bias.to(x.dtype) if self.bias is not None else None
+  return F.linear(x, w, bias)
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+ with torch.no_grad():
+  for name, param in module.named_parameters():
+   if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+    param.data = param.data.float()
+class Rotary(nn.Module):
+ def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024, rope_dims: int = 0):
+  super().__init__()
+  self.dim = dim
+  self.base = base
+  self.train_seq_len = train_seq_len
+  self.rope_dims = rope_dims if rope_dims > 0 else dim
+  inv_freq = 1.0 / (base ** (torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims))
+  self.register_buffer("inv_freq", inv_freq, persistent=False)
+  self._seq_len_cached = 0
+  self._cos_cached: Tensor | None = None
+  self._sin_cached: Tensor | None = None
+ def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+  if (
+   self._cos_cached is None
+   or self._sin_cached is None
+   or self._seq_len_cached != seq_len
+   or self._cos_cached.device != device
+  ):
+   rd = self.rope_dims
+   if seq_len > self.train_seq_len:
+    scale = seq_len / self.train_seq_len
+    new_base = self.base * (scale ** (rd / (rd - 2)))
+    inv_freq = 1.0 / (new_base ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd))
+   else:
+    inv_freq = self.inv_freq.to(device)
+   t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+   freqs = torch.outer(t, inv_freq)
+   self._cos_cached = freqs.cos()[None, :, None, :]
+   self._sin_cached = freqs.sin()[None, :, None, :]
+   self._seq_len_cached = seq_len
+  return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int = 0) -> Tensor:
+ if rope_dims > 0 and rope_dims < x.size(-1):
+  x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+  half = rope_dims // 2
+  x1, x2 = x_rope[..., :half], x_rope[..., half:]
+  x_rope = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+  return torch.cat((x_rope, x_pass), dim=-1)
+ half = x.size(-1) // 2
+ x1, x2 = x[..., :half], x[..., half:]
+ return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+class CausalSelfAttention(nn.Module):
+ def __init__(
+  self,
+  dim: int,
+  num_heads: int,
+  num_kv_heads: int,
+  rope_base: float,
+  qk_gain_init: float,
+ ):
+  super().__init__()
+  if dim % num_heads != 0:
+   raise ValueError("model_dim must be divisible by num_heads")
+  if num_heads % num_kv_heads != 0:
+   raise ValueError("num_heads must be divisible by num_kv_heads")
+  self.num_heads = num_heads
+  self.num_kv_heads = num_kv_heads
+  self.head_dim = dim // num_heads
+  if self.head_dim % 2 != 0:
+   raise ValueError("head_dim must be even for RoPE")
+  kv_dim = self.num_kv_heads * self.head_dim
+  self.c_q = CastedLinear(dim, dim, bias=False)
+  self.c_k = CastedLinear(dim, kv_dim, bias=False)
+  self.c_v = CastedLinear(dim, kv_dim, bias=False)
+  self.proj = CastedLinear(dim, dim, bias=False)
+  self.proj._zero_init = True
+  self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+  self.rope_dims = 0  # set by GPT.__init__ for partial RoPE
+  self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+  self.use_xsa = False  # set by GPT.__init__ for deep layers only
+  self.vrl_gate = None  # set by GPT.__init__ when VRL is enabled
+ def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+  B, T, H, D = y.shape
+  Hkv = v.size(-2)
+  group = H // Hkv
+  y_g = y.reshape(B, T, Hkv, group, D)        # [B, T, Hkv, group, D]
+  vn = F.normalize(v, dim=-1).unsqueeze(-2)    # [B, T, Hkv, 1, D] — broadcast ready
+  proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+  return (y_g - proj).reshape(B, T, H, D)
+ def forward(self, x: Tensor, v_embed: Tensor | None = None, v_first: Tensor | None = None) -> tuple[Tensor, Tensor]:
+  bsz, seqlen, dim = x.shape
+  q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+  k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+  v = self.c_v(x)
+  v_raw = v  # save raw V before any modifications for VRL
+  if v_embed is not None:
+   v = v + v_embed
+  if v_first is not None and self.vrl_gate is not None:
+   gate = torch.sigmoid(self.vrl_gate.to(dtype=v.dtype))
+   v = (1 - gate) * v + gate * v_first
+  v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+  q = F.rms_norm(q, (q.size(-1),))
+  k = F.rms_norm(k, (k.size(-1),))
+  cos, sin = self.rotary(seqlen, x.device, q.dtype)
+  q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+  k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+  q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+  if _HAS_FA3:
+   y = flash_attn_3_func(q, k, v, causal=True)
+  else:
+   q2 = q.transpose(1, 2)
+   k2 = k.transpose(1, 2)
+   v2 = v.transpose(1, 2)
+   k2 = k2.repeat_interleave(self.num_heads // self.num_kv_heads, dim=1)
+   v2 = v2.repeat_interleave(self.num_heads // self.num_kv_heads, dim=1)
+   y = F.scaled_dot_product_attention(q2, k2, v2, is_causal=True)
+   y = y.transpose(1, 2).contiguous()
+  if self.use_xsa:
+   y = self._xsa_efficient(y, v)
+  y = y.reshape(bsz, seqlen, dim)
+  return self.proj(y), v_raw
+class SmearGate(nn.Module):
+ def __init__(self, dim: int):
+  super().__init__()
+  self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+ def forward(self, x: Tensor) -> Tensor:
+  g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+  x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+  return (1 - g) * x + g * x_prev
+class BigramHashEmbedding(nn.Module):
+ def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+  super().__init__()
+  self.bigram_vocab_size = bigram_vocab_size
+  self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+  nn.init.zeros_(self.embed.weight)
+  self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+  if self.proj is not None:
+   nn.init.zeros_(self.proj.weight)
+  self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+ def bigram_hash(self, tokens: Tensor) -> Tensor:
+  t = tokens.to(torch.int32)
+  mod = self.bigram_vocab_size - 1
+  out = torch.empty_like(t)
+  out[..., 0] = mod
+  out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+  return out.long()
+ def forward(self, token_ids: Tensor) -> Tensor:
+  h = self.embed(self.bigram_hash(token_ids))
+  if self.proj is not None:
+   h = self.proj(h)
+  return h * self.scale.to(dtype=h.dtype)
+class ValueEmbedding(nn.Module):
+ def __init__(self, vocab_size: int, ve_dim: int, model_dim: int):
+  super().__init__()
+  self.embed = nn.Embedding(vocab_size, ve_dim)
+  nn.init.normal_(self.embed.weight, std=0.01)
+  self.proj = CastedLinear(ve_dim, model_dim, bias=False) if ve_dim != model_dim else None
+  if self.proj is not None:
+   nn.init.zeros_(self.proj.weight)
+  self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+ def forward(self, token_ids: Tensor) -> Tensor:
+  h = self.embed(token_ids)
+  if self.proj is not None:
+   h = self.proj(h)
+  return h * self.scale.to(dtype=h.dtype)
+class MLP(nn.Module):
+ def __init__(self, dim: int, mlp_mult: int):
+  super().__init__()
+  hidden = int(mlp_mult * dim)
+  self.fc = CastedLinear(dim, hidden, bias=False)
+  self.proj = CastedLinear(hidden, dim, bias=False)
+  self.proj._zero_init = True
+ def forward(self, x: Tensor) -> Tensor:
+  x = F.leaky_relu(self.fc(x), negative_slope=0.5)
+  return self.proj(x.square())
+class Block(nn.Module):
+ def __init__(
+  self,
+  dim: int,
+  num_heads: int,
+  num_kv_heads: int,
+  mlp_mult: int,
+  rope_base: float,
+  qk_gain_init: float,
+  layer_idx: int = 0,
+  ln_scale: bool = False,
+  dtg: bool = False,
+ ):
+  super().__init__()
+  self.attn_norm = RMSNorm()
+  self.mlp_norm = RMSNorm()
+  self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+  self.mlp = MLP(dim, mlp_mult)
+  self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+  self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+  self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+  self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+  if dtg:
+   self.dtg_gate = nn.Linear(dim, 1, bias=True)
+   nn.init.zeros_(self.dtg_gate.weight)
+   nn.init.constant_(self.dtg_gate.bias, 2.0)
+  else:
+   self.dtg_gate = None
+ def forward(self, x: Tensor, x0: Tensor, v_embed: Tensor | None = None, v_first: Tensor | None = None) -> tuple[Tensor, Tensor]:
+  mix = self.resid_mix.to(dtype=x.dtype)
+  x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+  attn_out, v_raw = self.attn(self.attn_norm(x_in) * self.ln_scale_factor, v_embed=v_embed, v_first=v_first)
+  x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+  x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor)
+  if self.dtg_gate is not None:
+   gate = torch.sigmoid(self.dtg_gate(x_in.detach()))
+   x_out = x_in + gate * (x_out - x_in)
+  return x_out, v_raw
+class GPT(nn.Module):
+ def __init__(
+  self,
+  vocab_size: int,
+  num_layers: int,
+  model_dim: int,
+  num_heads: int,
+  num_kv_heads: int,
+  mlp_mult: int,
+  tie_embeddings: bool,
+  tied_embed_init_std: float,
+  logit_softcap: float,
+  rope_base: float,
+  qk_gain_init: float,
+  mtp_num_heads: int = 0,
+  mtp_loss_weight: float = 0.1,
+  bigram_vocab_size: int = 0,
+  bigram_dim: int = 128,
+  xsa_last_n: int = 0,
+  rope_dims: int = 0,
+  ln_scale: bool = False,
+  dtg: bool = False,
+  ve_enabled: bool = False,
+  ve_dim: int = 128,
+  ve_layers: str = "9,10",
+  vrl_enabled: bool = False,
+ ):
+  super().__init__()
+  self._ve_target_dim = num_kv_heads * (model_dim // num_heads)  # kv_dim for value projection
+  if logit_softcap <= 0.0:
+   raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+  self.tie_embeddings = tie_embeddings
+  self.tied_embed_init_std = tied_embed_init_std
+  self.logit_softcap = logit_softcap
+  self.mtp_num_heads = mtp_num_heads
+  self.mtp_loss_weight = mtp_loss_weight
+  self.tok_emb = nn.Embedding(vocab_size, model_dim)
+  self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+  self.smear = SmearGate(model_dim)
+  self.num_encoder_layers = num_layers // 2
+  self.num_decoder_layers = num_layers - self.num_encoder_layers
+  self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+  self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+  self.blocks = nn.ModuleList(
+   [
+    Block(
+     model_dim,
+     num_heads,
+     num_kv_heads,
+     mlp_mult,
+     rope_base,
+     qk_gain_init,
+     layer_idx=i,
+     ln_scale=ln_scale,
+     dtg=dtg,
+    )
+    for i in range(num_layers)
+   ]
+  )
+  if rope_dims > 0:
+   head_dim = model_dim // num_heads
+   for block in self.blocks:
+    block.attn.rope_dims = rope_dims
+    block.attn.rotary = Rotary(head_dim, base=rope_base, train_seq_len=1024, rope_dims=rope_dims)
+  self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+  kv_dim = self._ve_target_dim
+  if self.ve_layer_indices:
+   self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim)
+   self.ve_layer_scales = nn.ParameterList(
+    [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices]
+   )
+  else:
+   self.ve_shared = None
+   self.ve_layer_scales = nn.ParameterList()
+  self.value_embeds = nn.ModuleList()  # keep empty for compat
+  self.final_norm = RMSNorm()
+  self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+  if self.lm_head is not None:
+   self.lm_head._zero_init = True
+  self.mtp_heads = nn.ModuleList(
+   [CastedLinear(model_dim, vocab_size, bias=False) for _ in range(mtp_num_heads)]
+  )
+  for head in self.mtp_heads:
+   head._zero_init = True
+  if xsa_last_n > 0:
+   for i in range(max(0, num_layers - xsa_last_n), num_layers):
+    self.blocks[i].attn.use_xsa = True
+  self.vrl_enabled = vrl_enabled
+  if vrl_enabled:
+   for i in range(1, num_layers):  # all layers except layer 0
+    self.blocks[i].attn.vrl_gate = nn.Parameter(torch.tensor(-1.5, dtype=torch.float32))
+  self._init_weights()
+ def _init_weights(self) -> None:
+  if self.tie_embeddings:
+   nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+  num_layers = len(self.blocks)
+  for name, module in self.named_modules():
+   if isinstance(module, nn.Linear):
+    if getattr(module, "_zero_init", False):
+     nn.init.zeros_(module.weight)
+    elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+     nn.init.orthogonal_(module.weight, gain=1.0)
+     if ".proj." in name or name.endswith(".proj"):
+      with torch.no_grad():
+       module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+ def _get_ve(self, layer_idx: int, input_ids: Tensor, ve_cache: dict | None = None) -> Tensor | None:
+  if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+   return None
+  if ve_cache is not None and 've' not in ve_cache:
+   ve_cache['ve'] = self.ve_shared(input_ids)
+  ve_base = ve_cache['ve'] if ve_cache is not None else self.ve_shared(input_ids)
+  ve_idx = self.ve_layer_indices.index(layer_idx)
+  return ve_base * self.ve_layer_scales[ve_idx].to(dtype=ve_base.dtype)
+ def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+  x = self.tok_emb(input_ids)
+  if self.bigram is not None:
+   x = x + self.bigram(input_ids)
+  x = F.rms_norm(x, (x.size(-1),))
+  x = self.smear(x)
+  x0 = x
+  skips: list[Tensor] = []
+  ve_cache: dict = {}
+  v_first: Tensor | None = None
+  for i in range(self.num_encoder_layers):
+   ve = self._get_ve(i, input_ids, ve_cache)
+   x, v_raw = self.blocks[i](x, x0, v_embed=ve, v_first=v_first if self.vrl_enabled else None)
+   if i == 0 and self.vrl_enabled:
+    v_first = v_raw
+   skips.append(x)
+  for i in range(self.num_decoder_layers):
+   bi = self.num_encoder_layers + i
+   if skips:
+    x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+   ve = self._get_ve(bi, input_ids, ve_cache)
+   x, _ = self.blocks[bi](x, x0, v_embed=ve, v_first=v_first if self.vrl_enabled else None)
+  x = self.final_norm(x)
+  x_flat = x.reshape(-1, x.size(-1))
+  targets = target_ids.reshape(-1)
+  if self.tie_embeddings:
+   logits_proj = F.linear(x_flat, self.tok_emb.weight)
+  else:
+   if self.lm_head is None:
+    raise RuntimeError("lm_head is required when tie_embeddings=False")
+   logits_proj = self.lm_head(x_flat)
+  logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+  main_loss = F.cross_entropy(logits.float(), targets, reduction="mean")
+  if self.training and self.mtp_num_heads > 0 and self.mtp_loss_weight > 0.0:
+   _, seqlen, dim = x.shape
+   mtp_loss_sum = x.new_zeros(())
+   mtp_loss_count = 0
+   for k, mtp_head in enumerate(self.mtp_heads):
+    valid_t = seqlen - (k + 1)
+    if valid_t <= 0:
+     continue
+    mtp_hidden = x[:, :valid_t, :].reshape(-1, dim)
+    mtp_targets = target_ids[:, k + 1 :].reshape(-1)
+    mtp_logits_proj = mtp_head(mtp_hidden)
+    mtp_logits = self.logit_softcap * torch.tanh(mtp_logits_proj / self.logit_softcap)
+    mtp_loss_sum = mtp_loss_sum + F.cross_entropy(mtp_logits.float(), mtp_targets, reduction="mean")
+    mtp_loss_count += 1
+   if mtp_loss_count > 0:
+    main_loss = main_loss + self.mtp_loss_weight * (mtp_loss_sum / mtp_loss_count)
+  return main_loss
+ def forward_hidden(self, input_ids: Tensor) -> Tensor:
+  x = self.tok_emb(input_ids)
+  if self.bigram is not None:
+   x = x + self.bigram(input_ids)
+  x = F.rms_norm(x, (x.size(-1),))
+  x = self.smear(x)
+  x0 = x
+  skips: list[Tensor] = []
+  ve_cache: dict = {}
+  v_first: Tensor | None = None
+  for i in range(self.num_encoder_layers):
+   ve = self._get_ve(i, input_ids, ve_cache)
+   x, v_raw = self.blocks[i](x, x0, v_embed=ve, v_first=v_first if self.vrl_enabled else None)
+   if i == 0 and self.vrl_enabled:
+    v_first = v_raw
+   skips.append(x)
+  for i in range(self.num_decoder_layers):
+   bi = self.num_encoder_layers + i
+   if skips:
+    x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+   ve = self._get_ve(bi, input_ids, ve_cache)
+   x, _ = self.blocks[bi](x, x0, v_embed=ve, v_first=v_first if self.vrl_enabled else None)
+  return self.final_norm(x)
+ def compute_logits(self, hidden: Tensor) -> Tensor:
+  if self.tie_embeddings:
+   logits_proj = F.linear(hidden, self.tok_emb.weight)
+  else:
+   logits_proj = self.lm_head(hidden)
+  return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+ def forward_logits(self, input_ids: Tensor) -> Tensor:
+  return self.compute_logits(self.forward_hidden(input_ids))
+def eval_val_sliding(
+ args: Hyperparameters,
+ base_model: nn.Module,
+ rank: int,
+ world_size: int,
+ device: torch.device,
+ val_tokens: Tensor,
+ base_bytes_lut: Tensor,
+ has_leading_space_lut: Tensor,
+ is_boundary_token_lut: Tensor,
+ stride: int,
+ batch_seqs: int = 32,
+ eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+ seq_len = eval_seq_len or args.train_seq_len
+ total_tokens = val_tokens.numel() - 1
+ window_starts = [ws for ws in range(0, total_tokens, stride)
+      if min(ws + seq_len, total_tokens) - ws >= 1]
+ total_windows = len(window_starts)
+ my_s = (total_windows * rank) // world_size
+ my_e = (total_windows * (rank + 1)) // world_size
+ my_windows = window_starts[my_s:my_e]
+ loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+ token_count = torch.zeros((), device=device, dtype=torch.float64)
+ byte_count = torch.zeros((), device=device, dtype=torch.float64)
+ base_model.eval()
+ compiled_logits = torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+ with torch.inference_mode():
+  for bi in range(0, len(my_windows), batch_seqs):
+   batch_ws = my_windows[bi:bi + batch_seqs]
+   bsz = len(batch_ws)
+   x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+   y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+   wlens: list[int] = []
+   for i, ws in enumerate(batch_ws):
+    end = min(ws + seq_len, total_tokens)
+    wlen = end - ws
+    wlens.append(wlen)
+    chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+    x_batch[i, :wlen] = chunk[:-1]
+    y_batch[i, :wlen] = chunk[1:]
+   with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+    logits = compiled_logits(x_batch)
+   nll = F.cross_entropy(
+    logits.reshape(-1, logits.size(-1)).float(),
+    y_batch.reshape(-1),
+    reduction="none",
+   ).reshape(bsz, seq_len)
+   for i, ws in enumerate(batch_ws):
+    wlen = wlens[i]
+    s = 0 if ws == 0 else max(wlen - stride, 0)
+    scored_nll = nll[i, s:wlen].to(torch.float64)
+    loss_sum += scored_nll.sum()
+    token_count += float(wlen - s)
+    tgt = y_batch[i, s:wlen]
+    prev = x_batch[i, s:wlen]
+    tb = base_bytes_lut[tgt].to(torch.float64)
+    tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+    byte_count += tb.sum()
+ if dist.is_available() and dist.is_initialized():
+  dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+  dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+  dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+ val_loss = (loss_sum / token_count).item()
+ bits_per_token = val_loss / math.log(2.0)
+ tokens_per_byte = token_count.item() / byte_count.item()
+ base_model.train()
+ return val_loss, bits_per_token * tokens_per_byte
+def eval_val_slot(
+ args: Hyperparameters,
+ base_model: nn.Module,
+ rank: int, world_size: int, device: torch.device,
+ val_tokens: Tensor,
+ base_bytes_lut: Tensor, has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+ stride = args.eval_stride if args.eval_stride > 0 else 64
+ seq_s = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+ total_tok = val_tokens.numel() - 1
+ ws_list = list(range(0, total_tok, stride))
+ ws_list = [ws for ws in ws_list if min(ws + seq_s, total_tok) - ws >= 1]
+ my_ws = ws_list[rank::world_size]
+ if args.tie_embeddings:
+  proj_w = base_model.tok_emb.weight.detach().float()
+ else:
+  proj_w = base_model.lm_head.weight.detach().float()
+ softcap = base_model.logit_softcap
+ compiled_hidden = torch.compile(base_model.forward_hidden, dynamic=False, fullgraph=False)
+ loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+ token_count = torch.zeros((), device=device, dtype=torch.float64)
+ byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+ base_model.eval()
+ for bi in range(0, len(my_ws), args.slot_batch_seqs):
+  bws = my_ws[bi:bi + args.slot_batch_seqs]
+  bsz = len(bws)
+  xb_cpu = torch.zeros(bsz, seq_s, dtype=torch.int64)
+  yb_cpu = torch.zeros(bsz, seq_s, dtype=torch.int64)
+  wlens = []
+  for i, ws in enumerate(bws):
+   wend = min(ws + seq_s, total_tok)
+   wlen = wend - ws
+   wlens.append(wlen)
+   xb_cpu[i, :wlen] = val_tokens[ws:wend]
+   yb_cpu[i, :wlen] = val_tokens[ws + 1:wend + 1]
+  xb = xb_cpu.to(device=device, non_blocking=True)
+  yb = yb_cpu.to(device=device, non_blocking=True)
+  with torch.no_grad(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+   hidden = compiled_hidden(xb)
+  hidden_f = hidden.detach().float()
+  mask = torch.zeros(bsz, seq_s, device=device)
+  for i, ws in enumerate(bws):
+   wlen = wlens[i]
+   s = 0 if ws == 0 else max(wlen - stride, 0)
+   mask[i, s:wlen] = 1.0
+  valid_count = mask.sum()
+  if valid_count == 0:
+   continue
+  delta = torch.zeros(bsz, 1, hidden_f.size(-1), device=device, dtype=torch.float32, requires_grad=True)
+  logit_bias = torch.zeros(bsz, 1, proj_w.size(0), device=device, dtype=torch.float32, requires_grad=True)
+  slot_opt = torch.optim.AdamW([delta, logit_bias], lr=args.slot_lr, weight_decay=1e-8, eps=1e-5)
+  targets_flat = yb.reshape(-1)
+  for step_i in range(args.slot_steps):
+   lr_t = args.slot_lr_min + 0.5 * (args.slot_lr - args.slot_lr_min) * (1 + math.cos(math.pi * step_i / args.slot_steps))
+   for pg in slot_opt.param_groups:
+    pg['lr'] = lr_t
+   slot_opt.zero_grad()
+   h = hidden_f + delta
+   lp = F.linear(h, proj_w) + logit_bias
+   lg = softcap * torch.tanh(lp / softcap)
+   nll = F.cross_entropy(lg.reshape(-1, lg.size(-1)), targets_flat, reduction="none").reshape(bsz, seq_s)
+   slot_loss = (nll * mask).sum() / valid_count
+   slot_loss.backward()
+   slot_opt.step()
+  with torch.no_grad():
+   h = hidden_f + delta.detach()
+   lp = F.linear(h, proj_w) + logit_bias.detach()
+   lg = softcap * torch.tanh(lp / softcap)
+   nll = F.cross_entropy(lg.reshape(-1, lg.size(-1)), targets_flat, reduction="none").reshape(bsz, seq_s)
+   for i, ws in enumerate(bws):
+    wlen = wlens[i]
+    s = 0 if ws == 0 else max(wlen - stride, 0)
+    chunk_nll = nll[i, s:wlen]
+    loss_sum += chunk_nll.sum().to(torch.float64)
+    token_count += float(wlen - s)
+    prev_ids = xb[i, s:wlen]
+    tgt_ids = yb[i, s:wlen]
+    tb = base_bytes_lut[tgt_ids].to(torch.float64)
+    tb += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(torch.float64)
+    byte_sum += tb.sum()
+ if dist.is_available() and dist.is_initialized():
+  dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+  dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+  dist.all_reduce(byte_sum, op=dist.ReduceOp.SUM)
+ val_loss = (loss_sum / token_count).item()
+ bits_per_token = val_loss / math.log(2.0)
+ tokens_per_byte = token_count.item() / byte_sum.item()
+ base_model.train()
+ return val_loss, bits_per_token * tokens_per_byte
+def _classify_param(name: str) -> str:
+ if "tok_emb" in name or "lm_head" in name:
+  return "embed"
+ if ".mlp." in name:
+  return "mlp"
+ if ".attn." in name or (".proj." in name and ".mlp." not in name):
+  return "attn"
+ return "other"
+def quantize_int6_per_row(t: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+ t32 = t.float()
+ if t32.ndim == 2:
+  best_q, best_s, best_err = None, None, float('inf')
+  for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+   if pct < 1.0:
+    row_clip = torch.quantile(t32.abs(), pct, dim=1)
+   else:
+    row_clip = t32.abs().amax(dim=1)
+   s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+   q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+   recon = q.float() * s.float()[:, None]
+   err = (t32 - recon).pow(2).mean().item()
+   if err < best_err:
+    best_q, best_s, best_err = q, s, err
+  return best_q, best_s
+ amax = t32.abs().max().item()
+ scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+ q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+ return q, scale
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+ num_layers_total = max(
+  (int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")),
+  default=0,
+ ) + 1
+
+ result: dict[str, Tensor] = {}
+ meta: dict[str, object] = {}
+ for name, tensor in state_dict.items():
+  t = tensor.detach().cpu().contiguous()
+  cat = _classify_param(name)
+  if not t.is_floating_point() or t.numel() <= 65536:
+   result[name] = t.to(torch.float16) if t.is_floating_point() else t
+   meta[name] = "passthrough"
+   continue
+  if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+   result[name] = t.to(torch.float16)
+   meta[name] = "passthrough_ctrl"
+   continue
+  if cat in int6_cats and t.ndim >= 1:
+   q, s = quantize_int6_per_row(t)
+   result[name + ".q"] = q
+   result[name + ".scale"] = s
+   meta[name] = {"type": "int6"}
+  else:
+   q, s = quantize_float_tensor(t)
+   result[name + ".q"] = q
+   result[name + ".scale"] = s
+   meta[name] = {"type": "int8"}
+ return result, meta
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+        template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+ out: dict[str, Tensor] = {}
+ for name, orig in template_sd.items():
+  info = meta.get(name)
+  if info is None:
+   continue
+  orig_dtype = orig.dtype
+  if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+   t = result[name]
+   if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+    t = t.to(orig_dtype)
+   out[name] = t
+   continue
+  q, s = result[name + ".q"], result[name + ".scale"]
+  if s.ndim > 0:
+   out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+  else:
+   out[name] = (q.float() * float(s.item())).to(orig_dtype)
+ return out
+def main() -> None:
+ global zeropower_via_newtonschulz5
+ code = Path(__file__).read_text(encoding="utf-8")
+ args = Hyperparameters()
+ zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+ distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+ rank = int(os.environ.get("RANK", "0"))
+ world_size = int(os.environ.get("WORLD_SIZE", "1"))
+ local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+ if world_size <= 0:
+  raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+ if 8 % world_size != 0:
+  raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+ grad_accum_steps = 8 // world_size
+ grad_scale = 1.0 / grad_accum_steps
+ if not torch.cuda.is_available():
+  raise RuntimeError("CUDA is required")
+ device = torch.device("cuda", local_rank)
+ torch.cuda.set_device(device)
+ if distributed:
+  dist.init_process_group(backend="nccl", device_id=device)
+  dist.barrier()
+ master_process = rank == 0
+ torch.backends.cuda.matmul.allow_tf32 = True
+ torch.backends.cudnn.allow_tf32 = True
+ from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+ enable_cudnn_sdp(False)
+ enable_flash_sdp(True)
+ enable_mem_efficient_sdp(False)
+ enable_math_sdp(False)
+ logfile = None
+ if master_process:
+  os.makedirs("logs", exist_ok=True)
+  logfile = f"logs/{args.run_id}.txt"
+  print(logfile)
+ def log0(msg: str, console: bool = True) -> None:
+  if not master_process:
+   return
+  if console:
+   print(msg)
+  if logfile is not None:
+   with open(logfile, "a", encoding="utf-8") as f:
+    print(msg, file=f)
+ log0(code, console=False)
+ log0("=" * 100, console=False)
+ log0(f"Running Python {sys.version}", console=False)
+ log0(f"Running PyTorch {torch.__version__}", console=False)
+ log0(
+  subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+  console=False,
+ )
+ log0("=" * 100, console=False)
+ random.seed(args.seed)
+ np.random.seed(args.seed)
+ torch.manual_seed(args.seed)
+ torch.cuda.manual_seed_all(args.seed)
+ if not args.tokenizer_path.endswith(".model"):
+  raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+ sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+ if int(sp.vocab_size()) != args.vocab_size:
+  raise ValueError(
+   f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+  )
+ dataset_dir = Path(args.data_path).resolve()
+ actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+ effective_eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+ val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+ val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+ base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+  sp, args.vocab_size, device
+ )
+ log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+ log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+ log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+ CastedLinear._qat_enabled = args.qat_enabled
+ base_model = GPT(
+  vocab_size=args.vocab_size,
+  num_layers=args.num_layers,
+  model_dim=args.model_dim,
+  num_heads=args.num_heads,
+  num_kv_heads=args.num_kv_heads,
+  mlp_mult=args.mlp_mult,
+  tie_embeddings=args.tie_embeddings,
+  tied_embed_init_std=args.tied_embed_init_std,
+  logit_softcap=args.logit_softcap,
+  rope_base=args.rope_base,
+  qk_gain_init=args.qk_gain_init,
+  mtp_num_heads=args.mtp_num_heads,
+  mtp_loss_weight=args.mtp_loss_weight,
+  bigram_vocab_size=args.bigram_vocab_size,
+  bigram_dim=args.bigram_dim,
+  xsa_last_n=args.xsa_last_n,
+  rope_dims=args.rope_dims,
+  ln_scale=args.ln_scale,
+  dtg=args.dtg_enabled,
+  ve_enabled=args.ve_enabled,
+  ve_dim=args.ve_dim,
+  ve_layers=args.ve_layers,
+  vrl_enabled=args.vrl_enabled,
+ ).to(device).bfloat16()
+ for module in base_model.modules():
+  if isinstance(module, CastedLinear):
+   module.float()
+ restore_low_dim_params_to_fp32(base_model)
+ compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+ model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+ block_named_params = list(base_model.blocks.named_parameters())
+ matrix_params = [
+  p
+  for name, p in block_named_params
+  if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+ ]
+ if base_model.mtp_num_heads > 0:
+  matrix_params.extend([p for p in base_model.mtp_heads.parameters() if p.ndim == 2])
+ scalar_params = [
+  p
+  for name, p in block_named_params
+  if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+ ]
+ if base_model.skip_weights.numel() > 0:
+  scalar_params.append(base_model.skip_weights)
+ scalar_params.append(base_model.smear.gate)
+ if base_model.bigram is not None:
+  scalar_params.append(base_model.bigram.scale)
+ token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+ tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+ if base_model.bigram is not None:
+  tok_params.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+  if base_model.bigram.proj is not None:
+   matrix_params.append(base_model.bigram.proj.weight)
+ if base_model.ve_shared is not None:
+  tok_params.append({"params": [base_model.ve_shared.embed.weight], "lr": token_lr, "base_lr": token_lr})
+  if base_model.ve_shared.proj is not None:
+   matrix_params.append(base_model.ve_shared.proj.weight)
+  scalar_params.append(base_model.ve_shared.scale)
+  for s in base_model.ve_layer_scales:
+   scalar_params.append(s)
+ optimizer_tok = torch.optim.AdamW(
+  tok_params,
+  betas=(args.beta1, args.beta2),
+  eps=args.adam_eps,
+  weight_decay=args.adam_wd,
+  fused=True,
+ )
+ optimizer_muon = Muon(
+  matrix_params,
+  lr=args.matrix_lr,
+  momentum=args.muon_momentum,
+  backend_steps=args.muon_backend_steps,
+  weight_decay=args.muon_wd,
+ )
+ for group in optimizer_muon.param_groups:
+  group["base_lr"] = args.matrix_lr
+ optimizer_scalar = torch.optim.AdamW(
+  [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+  betas=(args.beta1, args.beta2),
+  eps=args.adam_eps,
+  weight_decay=args.adam_wd,
+  fused=True,
+ )
+ optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+ if base_model.lm_head is not None:
+  optimizer_head = torch.optim.Adam(
+   [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+   betas=(args.beta1, args.beta2),
+   eps=args.adam_eps,
+   fused=True,
+  )
+  optimizers.insert(1, optimizer_head)
+ n_params = sum(p.numel() for p in base_model.parameters())
+ mtp_params = sum(p.numel() for p in base_model.mtp_heads.parameters())
+ log0(f"model_params:{n_params}")
+ log0(f"mtp_num_heads:{args.mtp_num_heads} mtp_loss_weight:{args.mtp_loss_weight} mtp_params:{mtp_params}")
+ xsa_layers = [i for i, b in enumerate(base_model.blocks) if b.attn.use_xsa]
+ log0(f"XSA:last_{args.xsa_last_n} active_layers:{xsa_layers}")
+ log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+ log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+ log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+ log0(
+  f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+  f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+  f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+ )
+ log0(
+  f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+  f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+  f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+ )
+ log0(f"seed:{args.seed}")
+ train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+ def zero_grad_all() -> None:
+  for opt in optimizers:
+   opt.zero_grad(set_to_none=True)
+ max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+ def lr_mul(step: int, elapsed_ms: float) -> float:
+  if args.warmdown_iters <= 0:
+   return 1.0
+  if max_wallclock_ms is None:
+   warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+   return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+  step_ms = elapsed_ms / max(step, 1)
+  warmdown_ms = args.warmdown_iters * step_ms
+  remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+  return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+ if args.warmup_steps > 0:
+  initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+  initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+  model.train()
+  for warmup_step in range(args.warmup_steps):
+   zero_grad_all()
+   for micro_step in range(grad_accum_steps):
+    if distributed:
+     model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+    x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+     warmup_loss = model(x, y)
+    (warmup_loss * grad_scale).backward()
+   for opt in optimizers:
+    opt.step()
+   zero_grad_all()
+   if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+    log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+  base_model.load_state_dict(initial_model_state, strict=True)
+  for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+   opt.load_state_dict(state)
+  zero_grad_all()
+  if distributed:
+   model.require_backward_grad_sync = True
+  train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+ swa_state: dict[str, Tensor] | None = None
+ swa_count = 0
+ ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+ ema_decay = 0.997
+ training_time_ms = 0.0
+ stop_after_step: int | None = None
+ torch.cuda.synchronize()
+ t0 = time.perf_counter()
+ step = 0
+ while True:
+  last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+  should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+  if should_validate:
+   torch.cuda.synchronize()
+   training_time_ms += 1000.0 * (time.perf_counter() - t0)
+   val_loss, val_bpb = eval_val(
+    args,
+    model,
+    rank,
+    world_size,
+    device,
+    grad_accum_steps,
+    val_tokens,
+    base_bytes_lut,
+    has_leading_space_lut,
+    is_boundary_token_lut,
+   )
+   log0(
+    f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+    f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+   )
+   torch.cuda.synchronize()
+   t0 = time.perf_counter()
+  if last_step:
+   if stop_after_step is not None and step < args.iterations:
+    log0(
+     f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+     f"step:{step}/{args.iterations}"
+    )
+   break
+  elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+  scale = lr_mul(step, elapsed_ms)
+  if args.late_qat_threshold > 0 and scale < args.late_qat_threshold and not CastedLinear._qat_enabled:
+   CastedLinear._qat_enabled = True
+   log0(f"late_qat:enabled step:{step} scale:{scale:.4f}")
+  zero_grad_all()
+  train_loss = torch.zeros((), device=device)
+  for micro_step in range(grad_accum_steps):
+   if distributed:
+    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+   x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+   with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+    loss = model(x, y)
+   train_loss += loss.detach()
+   (loss * grad_scale).backward()
+  train_loss /= grad_accum_steps
+  frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+  muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+  for group in optimizer_muon.param_groups:
+   group["momentum"] = muon_momentum
+  for opt in optimizers:
+   for group in opt.param_groups:
+    group["lr"] = group["base_lr"] * scale
+  if args.grad_clip_norm > 0:
+   torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+  for opt in optimizers:
+   opt.step()
+  zero_grad_all()
+  with torch.no_grad():
+   for name, t in base_model.state_dict().items():
+    ema_state[name].mul_(ema_decay).add_(t.detach().float(), alpha=1.0 - ema_decay)
+  step += 1
+  approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+  if args.swa_enabled and scale < 0.2 and step % args.swa_every == 0:
+   if swa_state is None:
+    swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+    swa_count = 1
+    log0(f"swa:start step:{step}")
+   else:
+    for name, t in base_model.state_dict().items():
+     swa_state[name] += t.detach().cpu()
+    swa_count += 1
+  should_log_train = (
+   args.train_log_every > 0
+   and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+  )
+  if should_log_train:
+   log0(
+    f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+    f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+   )
+  reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+  if distributed and max_wallclock_ms is not None:
+   reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+   dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+   reached_cap = bool(reached_cap_tensor.item())
+  if stop_after_step is None and reached_cap:
+   stop_after_step = step
+ log0(
+  f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+  f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+ )
+ log0("ema:applying EMA weights")
+ current_state = base_model.state_dict()
+ avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+ base_model.load_state_dict(avg_state, strict=True)
+ torch.cuda.synchronize()
+ t_diag = time.perf_counter()
+ diag_val_loss, diag_val_bpb = eval_val(
+  args, compiled_model, rank, world_size, device, grad_accum_steps,
+  val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+ )
+ torch.cuda.synchronize()
+ log0(
+  f"DIAGNOSTIC post_ema val_loss:{diag_val_loss:.4f} val_bpb:{diag_val_bpb:.4f} "
+  f"eval_time:{1000.0 * (time.perf_counter() - t_diag):.0f}ms"
+ )
+ full_state_dict = base_model.state_dict()
+ export_sd = {k: v for k, v in full_state_dict.items() if "mtp_heads" not in k}
+ excluded_mtp = sum(int(t.numel()) for k, t in full_state_dict.items() if "mtp_heads" in k)
+ if excluded_mtp > 0:
+  log0(f"export_excluding_mtp_params:{excluded_mtp}")
+ if master_process:
+  torch.save(export_sd, "final_model.pt")
+  model_bytes = os.path.getsize("final_model.pt")
+  code_bytes = len(code.encode("utf-8"))
+  log0(f"Serialized model: {model_bytes} bytes")
+  log0(f"Code size: {code_bytes} bytes")
+ sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+ quant_result, quant_meta = mixed_quantize_int6(sd_cpu, {"mlp", "attn"})
+ quant_buf = io.BytesIO()
+ torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+ quant_raw = quant_buf.getvalue()
+ quant_blob = lzma.compress(quant_raw, preset=6)
+ if master_process:
+  with open("final_model.int6.ptz", "wb") as f:
+   f.write(quant_blob)
+  quant_file_bytes = len(quant_blob)
+  code_bytes = len(code.encode("utf-8"))
+  log0(f"Serialized model int6+{_COMPRESSOR}: {quant_file_bytes} bytes")
+  log0(f"Total submission size int6+{_COMPRESSOR}: {quant_file_bytes + code_bytes} bytes")
+  log0(f"Total submission size: {quant_file_bytes + code_bytes} bytes")
+ if distributed:
+  dist.barrier()
+ with open("final_model.int6.ptz", "rb") as f:
+  quant_blob_disk = f.read()
+ quant_state = torch.load(
+  io.BytesIO(lzma.decompress(quant_blob_disk)),
+  map_location="cpu",
+ )
+ deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], sd_cpu)
+ eval_model = GPT(
+  vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+  num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+  tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+  logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+  mtp_num_heads=0, mtp_loss_weight=0.0,
+  bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim,
+  xsa_last_n=args.xsa_last_n,  # must match training model
+  rope_dims=args.rope_dims, ln_scale=args.ln_scale, dtg=args.dtg_enabled,
+  ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+  vrl_enabled=args.vrl_enabled,
+ ).to(device).bfloat16()
+ for m in eval_model.modules():
+  if isinstance(m, CastedLinear):
+   m.float()
+ restore_low_dim_params_to_fp32(eval_model)
+ eval_model.load_state_dict(deq_state, strict=True)
+ compiled_eval = torch.compile(eval_model, dynamic=False, fullgraph=True)
+ torch.cuda.synchronize()
+ t_qeval = time.perf_counter()
+ q_val_loss, q_val_bpb = eval_val(
+  args, compiled_eval, rank, world_size, device, grad_accum_steps,
+  val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+  eval_seq_len=effective_eval_seq_len,
+ )
+ torch.cuda.synchronize()
+ log0(
+  f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+  f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+ )
+ log0(f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+ sw_seq_len = effective_eval_seq_len
+ if args.eval_stride > 0 and args.eval_stride < sw_seq_len:
+  torch.cuda.synchronize()
+  t_slide = time.perf_counter()
+  sw_val_loss, sw_val_bpb = eval_val_sliding(
+   args, eval_model, rank, world_size, device,
+   val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+   stride=args.eval_stride,
+   eval_seq_len=sw_seq_len,
+  )
+  torch.cuda.synchronize()
+  log0(
+   f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+   f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+  )
+  log0(f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+  log0(f"final_int6_roundtrip_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+ if args.eval_stride != 64 and 64 < sw_seq_len:
+  torch.cuda.synchronize()
+  t_slide64 = time.perf_counter()
+  sw64_val_loss, sw64_val_bpb = eval_val_sliding(
+   args, eval_model, rank, world_size, device,
+   val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+   stride=64,
+   eval_seq_len=sw_seq_len,
+  )
+  torch.cuda.synchronize()
+  log0(
+   f"final_int6_sliding_window_s64 val_loss:{sw64_val_loss:.4f} val_bpb:{sw64_val_bpb:.4f} "
+   f"stride:64 eval_time:{1000.0 * (time.perf_counter() - t_slide64):.0f}ms"
+  )
+  log0(f"final_int6_sliding_window_s64_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+  log0(f"final_int6_roundtrip_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+ if args.slot_enabled:
+  torch._dynamo.reset()
+  torch.cuda.synchronize()
+  t_slot = time.perf_counter()
+  slot_val_loss, slot_val_bpb = eval_val_slot(
+   args, eval_model, rank, world_size, device, val_tokens,
+   base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+  )
+  torch.cuda.synchronize()
+  log0(
+   f"final_slot val_loss:{slot_val_loss:.4f} val_bpb:{slot_val_bpb:.4f} "
+   f"steps:{args.slot_steps} lr:{args.slot_lr} eval_time:{1000.0 * (time.perf_counter() - t_slot):.0f}ms"
+  )
+  log0(f"final_slot_exact val_loss:{slot_val_loss:.8f} val_bpb:{slot_val_bpb:.8f}")
+ if distributed:
+  dist.destroy_process_group()
+if __name__ == "__main__":
+ main()

--- a/records/track_10min_16mb/2026-04-03_SLOT24_LR012_Stride96/train_seed1337.log
+++ b/records/track_10min_16mb/2026-04-03_SLOT24_LR012_Stride96/train_seed1337.log
@@ -1,0 +1,83 @@
+W0403 19:02:47.423000 68566 torch/distributed/run.py:803] 
+W0403 19:02:47.423000 68566 torch/distributed/run.py:803] *****************************************
+W0403 19:02:47.423000 68566 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0403 19:02:47.423000 68566 torch/distributed/run.py:803] *****************************************
+logs/configF_fast_seed1337.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26862694
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_11 active_layers:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9302 val_bpb:4.1044 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9318 train_time:211ms step_avg:211.42ms
+step:2/20000 train_loss:8.7698 train_time:368ms step_avg:183.94ms
+step:3/20000 train_loss:7.8303 train_time:514ms step_avg:171.50ms
+step:4/20000 train_loss:7.0795 train_time:678ms step_avg:169.43ms
+step:5/20000 train_loss:6.9919 train_time:823ms step_avg:164.67ms
+step:6/20000 train_loss:7.0184 train_time:981ms step_avg:163.56ms
+step:7/20000 train_loss:6.9279 train_time:1126ms step_avg:160.79ms
+step:8/20000 train_loss:6.7991 train_time:1290ms step_avg:161.28ms
+step:9/20000 train_loss:6.4427 train_time:1439ms step_avg:159.85ms
+step:10/20000 train_loss:6.0845 train_time:1602ms step_avg:160.18ms
+step:500/20000 train_loss:2.3800 train_time:73228ms step_avg:146.46ms
+step:1000/20000 train_loss:2.2528 train_time:139236ms step_avg:139.24ms
+step:1500/20000 train_loss:2.2054 train_time:184950ms step_avg:123.30ms
+step:2000/20000 train_loss:2.0417 train_time:230694ms step_avg:115.35ms
+step:2500/20000 train_loss:2.1433 train_time:276445ms step_avg:110.58ms
+step:3000/20000 train_loss:2.1269 train_time:322199ms step_avg:107.40ms
+step:3500/20000 train_loss:2.1395 train_time:367914ms step_avg:105.12ms
+step:4000/20000 train_loss:1.9289 train_time:413678ms step_avg:103.42ms
+step:4000/20000 val_loss:2.0197 val_bpb:1.1962 train_time:413683ms step_avg:103.42ms
+step:4500/20000 train_loss:2.0792 train_time:459387ms step_avg:102.09ms
+step:5000/20000 train_loss:2.0580 train_time:505114ms step_avg:101.02ms
+swa:start step:5300
+late_qat:enabled step:5461 scale:0.1499
+step:5500/20000 train_loss:1.9677 train_time:551004ms step_avg:100.18ms
+step:6000/20000 train_loss:1.8925 train_time:596970ms step_avg:99.50ms
+step:6034/20000 val_loss:1.9278 val_bpb:1.1418 train_time:600096ms step_avg:99.45ms
+stopping_early: wallclock_cap train_time:600096ms step:6034/20000
+peak memory allocated: 22524 MiB reserved: 22564 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9263 val_bpb:1.1409 eval_time:2111ms
+Serialized model: 105919389 bytes
+Code size: 61984 bytes
+Serialized model int6+lzma: 15617916 bytes
+Total submission size int6+lzma: 15679900 bytes
+Total submission size: 15679900 bytes
+final_int6_roundtrip val_loss:1.9405 val_bpb:1.1493 eval_time:7452ms
+final_int6_roundtrip_exact val_loss:1.94053166 val_bpb:1.14929216
+final_int6_sliding_window val_loss:1.9009 val_bpb:1.1258 stride:96 eval_time:65003ms
+final_int6_sliding_window_exact val_loss:1.90086408 val_bpb:1.12580133
+final_int6_roundtrip_exact val_loss:1.90086408 val_bpb:1.12580133
+final_int6_sliding_window_s64 val_loss:1.9008 val_bpb:1.1258 stride:64 eval_time:77684ms
+final_int6_sliding_window_s64_exact val_loss:1.90082217 val_bpb:1.12577694
+final_int6_roundtrip_exact val_loss:1.90082217 val_bpb:1.12577694
+final_slot val_loss:1.4661 val_bpb:0.8683 steps:24 lr:0.012 eval_time:254546ms
+final_slot_exact val_loss:1.46609658 val_bpb:0.86830694

--- a/records/track_10min_16mb/2026-04-03_SLOT24_LR012_Stride96/train_seed2024.log
+++ b/records/track_10min_16mb/2026-04-03_SLOT24_LR012_Stride96/train_seed2024.log
@@ -1,0 +1,84 @@
+W0403 19:41:16.536000 82440 torch/distributed/run.py:803] 
+W0403 19:41:16.536000 82440 torch/distributed/run.py:803] *****************************************
+W0403 19:41:16.536000 82440 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0403 19:41:16.536000 82440 torch/distributed/run.py:803] *****************************************
+logs/configF_fast_seed2024.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26862694
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_11 active_layers:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:2024
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9290 val_bpb:4.1037 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9314 train_time:147ms step_avg:146.71ms
+step:2/20000 train_loss:8.6628 train_time:235ms step_avg:117.27ms
+step:3/20000 train_loss:7.6977 train_time:324ms step_avg:107.92ms
+step:4/20000 train_loss:7.2279 train_time:413ms step_avg:103.19ms
+step:5/20000 train_loss:7.0500 train_time:502ms step_avg:100.35ms
+step:6/20000 train_loss:6.8669 train_time:591ms step_avg:98.48ms
+step:7/20000 train_loss:6.7534 train_time:680ms step_avg:97.16ms
+step:8/20000 train_loss:6.6345 train_time:769ms step_avg:96.17ms
+step:9/20000 train_loss:6.3880 train_time:858ms step_avg:95.35ms
+step:10/20000 train_loss:6.0435 train_time:948ms step_avg:94.78ms
+step:500/20000 train_loss:2.3659 train_time:45508ms step_avg:91.02ms
+step:1000/20000 train_loss:2.2516 train_time:91150ms step_avg:91.15ms
+step:1500/20000 train_loss:2.2033 train_time:136849ms step_avg:91.23ms
+step:2000/20000 train_loss:2.0473 train_time:182535ms step_avg:91.27ms
+step:2500/20000 train_loss:2.1563 train_time:228212ms step_avg:91.28ms
+step:3000/20000 train_loss:2.1412 train_time:273902ms step_avg:91.30ms
+step:3500/20000 train_loss:2.1535 train_time:319559ms step_avg:91.30ms
+step:4000/20000 train_loss:1.9483 train_time:365210ms step_avg:91.30ms
+step:4000/20000 val_loss:2.0386 val_bpb:1.2074 train_time:365215ms step_avg:91.30ms
+step:4500/20000 train_loss:2.0978 train_time:410862ms step_avg:91.30ms
+step:5000/20000 train_loss:2.0785 train_time:456488ms step_avg:91.30ms
+step:5500/20000 train_loss:1.9886 train_time:502177ms step_avg:91.30ms
+swa:start step:5900
+step:6000/20000 train_loss:1.9139 train_time:547920ms step_avg:91.32ms
+late_qat:enabled step:6046 scale:0.1497
+step:6500/20000 train_loss:2.0515 train_time:593846ms step_avg:91.36ms
+step:6568/20000 val_loss:1.9233 val_bpb:1.1391 train_time:600069ms step_avg:91.36ms
+stopping_early: wallclock_cap train_time:600069ms step:6568/20000
+peak memory allocated: 22524 MiB reserved: 22564 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9219 val_bpb:1.1382 eval_time:2106ms
+Serialized model: 105919389 bytes
+Code size: 61984 bytes
+Serialized model int6+lzma: 15708932 bytes
+Total submission size int6+lzma: 15770916 bytes
+Total submission size: 15770916 bytes
+final_int6_roundtrip val_loss:1.9345 val_bpb:1.1457 eval_time:7454ms
+final_int6_roundtrip_exact val_loss:1.93446232 val_bpb:1.14569755
+final_int6_sliding_window val_loss:1.8946 val_bpb:1.1221 stride:96 eval_time:54453ms
+final_int6_sliding_window_exact val_loss:1.89463746 val_bpb:1.12211356
+final_int6_roundtrip_exact val_loss:1.89463746 val_bpb:1.12211356
+final_int6_sliding_window_s64 val_loss:1.8946 val_bpb:1.1221 stride:64 eval_time:77685ms
+final_int6_sliding_window_s64_exact val_loss:1.89458459 val_bpb:1.12208268
+final_int6_roundtrip_exact val_loss:1.89458459 val_bpb:1.12208268
+final_slot val_loss:1.4599 val_bpb:0.8647 steps:24 lr:0.012 eval_time:231095ms
+final_slot_exact val_loss:1.45994709 val_bpb:0.86466486

--- a/records/track_10min_16mb/2026-04-03_SLOT24_LR012_Stride96/train_seed42.log
+++ b/records/track_10min_16mb/2026-04-03_SLOT24_LR012_Stride96/train_seed42.log
@@ -1,0 +1,84 @@
+W0403 19:23:26.433000 80954 torch/distributed/run.py:803] 
+W0403 19:23:26.433000 80954 torch/distributed/run.py:803] *****************************************
+W0403 19:23:26.433000 80954 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0403 19:23:26.433000 80954 torch/distributed/run.py:803] *****************************************
+logs/configF_fast_seed42.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:26862694
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_11 active_layers:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:42
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9310 val_bpb:4.1049 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9323 train_time:143ms step_avg:143.38ms
+step:2/20000 train_loss:8.7688 train_time:229ms step_avg:114.41ms
+step:3/20000 train_loss:7.7244 train_time:318ms step_avg:106.15ms
+step:4/20000 train_loss:7.2386 train_time:408ms step_avg:102.09ms
+step:5/20000 train_loss:7.0215 train_time:498ms step_avg:99.52ms
+step:6/20000 train_loss:6.9253 train_time:587ms step_avg:97.88ms
+step:7/20000 train_loss:6.8185 train_time:676ms step_avg:96.60ms
+step:8/20000 train_loss:6.6850 train_time:766ms step_avg:95.80ms
+step:9/20000 train_loss:6.3436 train_time:855ms step_avg:95.02ms
+step:10/20000 train_loss:5.9746 train_time:945ms step_avg:94.54ms
+step:500/20000 train_loss:2.3662 train_time:45514ms step_avg:91.03ms
+step:1000/20000 train_loss:2.2528 train_time:91191ms step_avg:91.19ms
+step:1500/20000 train_loss:2.1989 train_time:136897ms step_avg:91.26ms
+step:2000/20000 train_loss:2.0459 train_time:182654ms step_avg:91.33ms
+step:2500/20000 train_loss:2.1481 train_time:228430ms step_avg:91.37ms
+step:3000/20000 train_loss:2.1451 train_time:274182ms step_avg:91.39ms
+step:3500/20000 train_loss:2.1527 train_time:319939ms step_avg:91.41ms
+step:4000/20000 train_loss:1.9470 train_time:365730ms step_avg:91.43ms
+step:4000/20000 val_loss:2.0365 val_bpb:1.2061 train_time:365734ms step_avg:91.43ms
+step:4500/20000 train_loss:2.0956 train_time:411361ms step_avg:91.41ms
+step:5000/20000 train_loss:2.0756 train_time:456963ms step_avg:91.39ms
+step:5500/20000 train_loss:1.9892 train_time:502590ms step_avg:91.38ms
+swa:start step:5900
+step:6000/20000 train_loss:1.9088 train_time:548343ms step_avg:91.39ms
+late_qat:enabled step:6041 scale:0.1498
+step:6500/20000 train_loss:2.0493 train_time:594268ms step_avg:91.43ms
+step:6563/20000 val_loss:1.9214 val_bpb:1.1379 train_time:600059ms step_avg:91.43ms
+stopping_early: wallclock_cap train_time:600059ms step:6563/20000
+peak memory allocated: 22524 MiB reserved: 22564 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9199 val_bpb:1.1370 eval_time:2108ms
+Serialized model: 105919389 bytes
+Code size: 61984 bytes
+Serialized model int6+lzma: 15765720 bytes
+Total submission size int6+lzma: 15827704 bytes
+Total submission size: 15827704 bytes
+final_int6_roundtrip val_loss:1.9325 val_bpb:1.1446 eval_time:7538ms
+final_int6_roundtrip_exact val_loss:1.93254388 val_bpb:1.14456134
+final_int6_sliding_window val_loss:1.8928 val_bpb:1.1210 stride:96 eval_time:54547ms
+final_int6_sliding_window_exact val_loss:1.89275265 val_bpb:1.12099727
+final_int6_roundtrip_exact val_loss:1.89275265 val_bpb:1.12099727
+final_int6_sliding_window_s64 val_loss:1.8927 val_bpb:1.1210 stride:64 eval_time:77709ms
+final_int6_sliding_window_s64_exact val_loss:1.89269893 val_bpb:1.12096588
+final_int6_roundtrip_exact val_loss:1.89269893 val_bpb:1.12096588
+final_slot val_loss:1.4490 val_bpb:0.8582 steps:24 lr:0.012 eval_time:231220ms
+final_slot_exact val_loss:1.44895406 val_bpb:0.85815415


### PR DESCRIPTION
## Summary

- **val_bpb: 0.8637** (3-seed mean, std 0.0051)
- **Artifact:** 15.7-15.8 MB (all seeds < 16MB)
- **Training:** 600s on 8xH100 SXM | **Eval:** ~350s (sliding + SLOT)

## 3-Seed Results

| Seed | Sliding BPB | + SLOT BPB | Steps | Artifact |
|------|------------|------------|-------|----------|
| 1337 | 1.1258 | **0.8683** | 6034 | 15,679,900 |
| 42 | 1.1207 | **0.8582** | 6563 | 15,827,704 |
| 2024 | 1.1221 | **0.8647** | 6568 | 15,770,916 |
| **Mean** | **1.1229** | **0.8637** | | |

Beats merged SOTA (1.1147, PR #1019) by **0.251 BPB**. Beats best pending (#1229, 0.9300) by **0.066 BPB**.

## What Changed vs PR #1303 (0.9462)

Only SLOT eval-time hyperparameters — identical model, training, and architecture:

| Parameter | PR #1303 | This PR |
|-----------|----------|---------|
| SLOT_STEPS | 16 | **24** |
| SLOT_LR | 0.008 | **0.012** |
| SLOT_LR_MIN | 0.0008 | **0.001** |
| EVAL_STRIDE | 64 | **96** |

Found via 6-config hyperparameter sweep across steps, LR, and stride.

## SLOT-24 Details

- Per-sample hidden delta [bsz, 1, 512] + logit bias [bsz, 1, 1024]
- Scored-position masking (last stride=96 tokens per non-first window)
- 24 AdamW steps, cosine LR 0.012 -> 0.001, weight_decay=1e-8
- Model weights frozen, delta optimized through detached hidden states
- Eval: ~231-255s (well within 10-min eval budget)

## Compliance

- **Frozen-model SLOT**: model weights are never modified during evaluation. Only per-window throwaway delta and logit_bias parameters are optimized, then discarded after each window. Same evaluation pattern as accepted PRs #1176 and #1229.
- No n-gram cache, no eval-time GPTQ
- Self-contained, no network calls
- All seeds within time and size budgets

## Reproduction

```bash
torchrun --standalone --nproc_per_node=8 train_gpt.py
```

Training: ~600s. Eval: ~350s. Total: ~16 min.

## Credits

- Base: PR #175, PR #1303 (@anthony-maio)
- SLOT: Hu et al. arXiv:2505.12392v2, PR #1176 (@bigbag), PR #1229 (@resouer)
- QK-Gain 4.0: PR #1125
- XSA: PR #1176 (@bigbag)
- VRL: ResFormer (arXiv:2410.17897)