### PR TITLE
Add shared compile-cache sweep helper and exploratory byte260 evidence

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -50,6 +50,18 @@ python3 data/download_hf_docs_and_tokenize.py \
   --tokenizer-config ./data/tokenizer_specs.json
 ```
 
+If you only want the raw byte export and do not want to spend time downloading or training SentencePiece artifacts, use the dedicated byte-only config:
+
+```bash
+python3 data/download_hf_docs_and_tokenize.py \
+  --repo-id your-hf-username/your-dataset-repo \
+  --remote-root your_50B_export_root \
+  --output-root /tmp/my_byte260_export \
+  --tokenizer-config ./data/tokenizer_specs.byte260_only.json
+```
+
+The default `tokenizer_specs.json` includes both `sp_bpe_1024` and `pure_byte_260`, so it will build both exports. The byte-only config is the faster option when you are rebuilding `byte260` specifically for RunPod staging.
+
 The sidecar `docs_selected.source_manifest.json` includes `docs_sha256`, so users can verify they are rebuilding from the exact same document list and order as the baseline export.
 
 ## Useful Knobs

--- a/data/tokenizer_specs.byte260_only.json
+++ b/data/tokenizer_specs.byte260_only.json
@@ -1,0 +1,9 @@
+{
+  "tokenizers": [
+    {
+      "name": "pure_byte_260",
+      "dataset_suffix": "byte260",
+      "kind": "byte"
+    }
+  ]
+}

--- a/logs/runpod_lossy_byte260_h100.txt
+++ b/logs/runpod_lossy_byte260_h100.txt
@@ -1890,3 +1890,66 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
+====================================================================================================
+Running Python 3.12.3 (main, Nov  6 2025, 13:44:16) [GCC 13.3.0]
+Running PyTorch 2.9.1+cu128
+Sat Apr  4 22:10:14 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 565.57.01              Driver Version: 565.57.01      CUDA Version: 12.7     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:11:00.0 Off |                    0 |
+| N/A   37C    P0            132W /  700W |    1184MiB /  81559MiB |      6%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+val_bpb:enabled tokenizer_kind=byte260 tokenizer=byte260
+train_loader:dataset:fineweb10B_byte260 train_shards:1
+val_loader:shards pattern=/workspace/parameter-golf/data/datasets/fineweb10B_byte260/fineweb_val_*.bin tokens:151130112
+kan_triton:available=1 enabled_modules=6/6 env_KAN_TRITON=1
+model_params:94080278
+world_size:1 grad_accum_steps:8
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+backbone:recursive unique_blocks:6 num_loops:8 effective_layers:48
+attention_mode:mla_absorbed num_heads:8 mla_q_rank:384 mla_kv_rank:512
+ffn:kan_style mlp_mult:2 kan_basis_scale:1.0 mol_lora:experts:32 rank:32 alpha:8.0 alflb:decay:0.95 eta:0.02 clip:2.0
+mtp:steps:4 rank:64 loss_weight:0.5 strip_at_export:True
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:16384 train_seq_len:1024 iterations:10 warmup_steps:0 max_wallclock_seconds:0.000
+bitnet_ternary_backbone:1 bitnet_ternary_eps:1e-06 muon_momentum:0.9900 swa_final_seconds:60.0
+nca_backbone_init:1 mats:36 steps:4 mix:0.3 gain:1.0
+nuclear_ttt:1 lr:0.0002 trailing_seqs:8
+seed:1337
+swa:enter_final_window
+step:1/10 train_loss:10.2340 train_time:335087ms step_avg:335086.97ms
+step:2/10 train_loss:25.0677 train_time:336626ms step_avg:168312.84ms
+step:3/10 train_loss:14.4480 train_time:338124ms step_avg:112708.08ms
+step:4/10 train_loss:16.0452 train_time:339602ms step_avg:84900.51ms
+step:5/10 train_loss:7.3960 train_time:341343ms step_avg:68268.60ms
+step:6/10 train_loss:6.8970 train_time:343050ms step_avg:57175.08ms
+step:7/10 train_loss:6.7318 train_time:344445ms step_avg:49206.36ms
+step:8/10 train_loss:6.5355 train_time:345937ms step_avg:43242.18ms
+step:9/10 train_loss:6.4199 train_time:347403ms step_avg:38600.34ms
+step:10/10 train_loss:6.2151 train_time:348905ms step_avg:34890.53ms
+step:10/10 val_loss:4.1514 val_bpb:5.9911 train_time:348908ms step_avg:34890.81ms
+swa:applied count:10
+peak memory allocated: 20719 MiB reserved: 21910 MiB
+Serialized model: 334042233 bytes
+Code size: 82344 bytes
+Total submission size: 334124577 bytes
+Serialized model int8+zlib: 12385322 bytes (payload:34564988 raw_torch:34627195 fp8_payload:18971520 ternary_payload:14923932 ternary_tensors:48 ternary_params:74139648 payload_ratio:9.66x)
+Total submission size int8+zlib: 12467666 bytes
+final_int8_zlib_roundtrip val_loss:4.1544 val_bpb:5.9955 eval_time:1239467ms
+final_int8_zlib_roundtrip_exact val_loss:4.15436745 val_bpb:5.99546883

--- a/nca_sweep_cluster.py
+++ b/nca_sweep_cluster.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import fcntl
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+FINAL_STEP_VAL_RE = re.compile(
+    r"step:(?P<step>\d+)/(?P<iters>\d+)\s+val_loss:(?P<val_loss>[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)"
+)
+FINAL_INT8_VAL_RE = re.compile(
+    r"final_int8_zlib_roundtrip_exact\s+val_loss:(?P<val_loss>[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?)"
+)
+FIELDS = [
+    "timestamp_utc",
+    "nca_mix",
+    "nca_steps",
+    "max_wallclock_seconds",
+    "seed",
+    "returncode",
+    "status",
+    "val_loss",
+    "val_loss_source",
+    "run_id",
+    "log_path",
+    "error",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    root = Path(__file__).resolve().parent
+    p = argparse.ArgumentParser(description="Cluster NCA sweep via torchrun --nproc_per_node=8.")
+    p.add_argument("--train-script", default=str(root / "train_gpt.py"))
+    p.add_argument("--output-csv", default=str(root / "cluster_nca_results.csv"))
+    p.add_argument("--logs-dir", default=str(root / "logs" / "nca_sweep_cluster"))
+    p.add_argument("--seed", type=int, default=1337)
+    p.add_argument("--max-wallclock-seconds", type=int, default=120)
+    # Default subprocess timeout: 900s (15 min) covers first-run torch.compile warmup
+    # (~10 min compilation) + 120s training + eval/export overhead.  Set to 0 to disable.
+    p.add_argument("--timeout-sec", type=float, default=900.0, help="Subprocess timeout; <=0 disables.")
+    # Shared Inductor / Triton cache dirs — all subprocesses point here so only the
+    # first combo pays the torch.compile compilation cost (~10 min on H100).
+    p.add_argument(
+        "--inductor-cache-dir",
+        default=str(root / ".cache" / "inductor"),
+        help="Persistent torch.compile / Inductor cache shared across all sweep runs.",
+    )
+    p.add_argument(
+        "--triton-cache-dir",
+        default=str(root / ".cache" / "triton"),
+        help="Persistent Triton JIT cache shared across all sweep runs.",
+    )
+    p.add_argument("--resume", action="store_true", default=True)
+    p.add_argument("--no-resume", dest="resume", action="store_false")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--extra-env", action="append", default=[], metavar="KEY=VALUE")
+    return p.parse_args()
+
+
+def iter_mix_values() -> Iterable[float]:
+    for i in range(1, 10):
+        yield round(i / 10.0, 1)
+
+
+def ensure_csv_header_locked(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+", newline="", encoding="utf-8") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        f.seek(0, os.SEEK_END)
+        if f.tell() == 0:
+            w = csv.DictWriter(f, fieldnames=FIELDS)
+            w.writeheader()
+            f.flush()
+            os.fsync(f.fileno())
+        fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+
+def load_completed(path: Path) -> set[tuple[float, int]]:
+    done: set[tuple[float, int]] = set()
+    if not path.exists():
+        return done
+    with path.open("r", newline="", encoding="utf-8") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+        for row in csv.DictReader(f):
+            try:
+                if row.get("status") == "ok" and row.get("val_loss"):
+                    done.add((round(float(row["nca_mix"]), 1), int(row["nca_steps"])))
+            except Exception:
+                continue
+        fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+    return done
+
+
+def append_row_locked(path: Path, row: dict[str, object]) -> None:
+    with path.open("a+", newline="", encoding="utf-8") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        f.seek(0, os.SEEK_END)
+        if f.tell() == 0:
+            w = csv.DictWriter(f, fieldnames=FIELDS)
+            w.writeheader()
+        w = csv.DictWriter(f, fieldnames=FIELDS)
+        w.writerow(row)
+        f.flush()
+        os.fsync(f.fileno())
+        fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+
+def apply_extra_env(env: dict[str, str], extra_env_items: list[str]) -> None:
+    for item in extra_env_items:
+        if "=" not in item:
+            raise ValueError(f"Invalid --extra-env value {item!r}; expected KEY=VALUE.")
+        k, v = item.split("=", 1)
+        k = k.strip()
+        if not k:
+            raise ValueError(f"Invalid --extra-env value {item!r}; empty key.")
+        env[k] = v
+
+
+def run_one(
+    train_script: str,
+    logs_dir: Path,
+    seed: int,
+    timeout_sec: float,
+    max_wallclock_seconds: int,
+    nca_mix: float,
+    nca_steps: int,
+    extra_env: list[str],
+    inductor_cache_dir: str = "",
+    triton_cache_dir: str = "",
+) -> dict[str, object]:
+    ts = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_id = f"nca_cluster_mix{nca_mix:.1f}_steps{nca_steps}_{ts}"
+    log_path = logs_dir / f"{run_id}.log"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PYTHONUNBUFFERED": "1",
+            "RUN_ID": run_id,
+            "SEED": str(seed),
+            "NCA_MIX": f"{nca_mix:.1f}",
+            "NCA_STEPS": str(nca_steps),
+            "WARMUP_STEPS": "0",
+            "MAX_WALLCLOCK_SECONDS": str(max_wallclock_seconds),
+        }
+    )
+    # Share compiled kernel cache across all subprocesses so only the first run
+    # pays the torch.compile (~10 min) and Triton JIT compilation cost.
+    if inductor_cache_dir:
+        Path(inductor_cache_dir).mkdir(parents=True, exist_ok=True)
+        env["TORCHINDUCTOR_CACHE_DIR"] = inductor_cache_dir
+    if triton_cache_dir:
+        Path(triton_cache_dir).mkdir(parents=True, exist_ok=True)
+        env["TRITON_CACHE_DIR"] = triton_cache_dir
+    apply_extra_env(env, extra_env)
+
+    cmd = ["torchrun", "--nproc_per_node=8", train_script]
+    rc = -1
+    err = ""
+    last_val: float | None = None
+    last_src = ""
+    line_idx = 0
+
+    with log_path.open("w", encoding="utf-8") as lf:
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                env=env,
+            )
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                line_idx += 1
+                lf.write(line)
+                m = FINAL_STEP_VAL_RE.search(line)
+                if m:
+                    last_val = float(m.group("val_loss"))
+                    last_src = f"step_val_loss@{line_idx}"
+                m2 = FINAL_INT8_VAL_RE.search(line)
+                if m2:
+                    last_val = float(m2.group("val_loss"))
+                    last_src = "final_int8_zlib_roundtrip_exact"
+            rc = proc.wait(timeout=timeout_sec if timeout_sec > 0 else None)
+        except subprocess.TimeoutExpired:
+            err = f"timeout>{timeout_sec}s"
+            proc.kill()
+            rc = proc.wait()
+        except Exception as e:
+            err = str(e)
+
+    status = "ok" if rc == 0 and last_val is not None else "failed"
+    if not err and last_val is None:
+        err = "no_val_loss_found"
+    return {
+        "timestamp_utc": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "nca_mix": f"{nca_mix:.1f}",
+        "nca_steps": nca_steps,
+        "max_wallclock_seconds": max_wallclock_seconds,
+        "seed": seed,
+        "returncode": rc,
+        "status": status,
+        "val_loss": f"{last_val:.8f}" if last_val is not None else "",
+        "val_loss_source": last_src,
+        "run_id": run_id,
+        "log_path": str(log_path),
+        "error": err,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    output_csv = Path(args.output_csv).resolve()
+    logs_dir = Path(args.logs_dir).resolve()
+    ensure_csv_header_locked(output_csv)
+    completed = load_completed(output_csv) if args.resume else set()
+
+    total = 0
+    queued = 0
+    for mix in iter_mix_values():
+        for steps in range(2, 9):
+            total += 1
+            if (mix, steps) in completed:
+                continue
+            queued += 1
+            if args.dry_run:
+                print(f"[plan] mix={mix:.1f} steps={steps}")
+                continue
+            print(f"[run] mix={mix:.1f} steps={steps}")
+            row = run_one(
+                train_script=args.train_script,
+                logs_dir=logs_dir,
+                seed=args.seed,
+                timeout_sec=args.timeout_sec,
+                max_wallclock_seconds=args.max_wallclock_seconds,
+                nca_mix=mix,
+                nca_steps=steps,
+                extra_env=args.extra_env,
+                inductor_cache_dir=args.inductor_cache_dir,
+                triton_cache_dir=args.triton_cache_dir,
+            )
+            append_row_locked(output_csv, row)
+            print(
+                f"[{row['status']}] mix={row['nca_mix']} steps={row['nca_steps']} "
+                f"val_loss={row['val_loss'] or 'NA'} rc={row['returncode']}"
+            )
+    print(f"[done] total={total} queued={queued} csv={output_csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `nca_sweep_cluster.py`, a cluster sweep helper that propagates shared `TORCHINDUCTOR_CACHE_DIR` and `TRITON_CACHE_DIR` into each `torchrun` subprocess
- add `data/tokenizer_specs.byte260_only.json` for byte260-only rebuilds without unnecessary SentencePiece work
- update `data/README.md` with the byte-only export path
- include the current `train_gpt.py` snapshot and the completed remote H100 exploratory log used during this setup work

## Experiment evidence included in this PR
This PR now includes the actual exploratory RunPod log at `logs/runpod_lossy_byte260_h100.txt` so the remote execution is visible in the PR itself.

- hardware: 1x H100 SXM on RunPod
- training config: 10 iterations, `NUCLEAR_TTT=1`, `TRAIN_BATCH_TOKENS=16384`, `VAL_BATCH_SIZE=524288`
- pre-quant metric: `step:10/10 val_bpb:5.9911`
- final roundtrip metric: `final_int8_zlib_roundtrip_exact val_bpb:5.99546883`
- compressed model bytes: `12,385,322`
- total bytes with code: `12,467,666`

## Why this helps
These changes are enabling infrastructure for later challenge-valid byte260 runs on H100s.
The sweep helper avoids recompiling the same model in every subprocess, and the byte260-only tokenizer config trims setup cost when the goal is a pure byte export.

Including the exact `train_gpt.py` snapshot and exploratory log makes the PR self-contained: reviewers can see both the code path and the remote run that validated cache population, export, and end-to-end execution.

Because `train_gpt.py` keeps per-rank batch shapes constant via `grad_accum_steps = 8 / world_size`, warmed Triton/Inductor caches from 1xH100 should transfer well to 8xH100 when the same global batch settings are used.

## Notes
- this PR is not a leaderboard claim and does not add a `/records` submission folder
- the attached H100 log is exploratory evidence only
- this specific exploratory run used a temporary lossy `sp1024 -> byte260` staging path; the later record attempt will use the official challenge-valid byte260 data pipeline
- the PR intentionally excludes the broader `documentation/` tree and research notes file
