### PR TITLE
Non-record: Negative results from gated multi-order hash n-grams

### DIFF
--- a/records/track_non_record_16mb/2026-04-04_NegativeResults_GatedMultiOrderHash/README.md
+++ b/records/track_non_record_16mb/2026-04-04_NegativeResults_GatedMultiOrderHash/README.md
@@ -1,0 +1,221 @@
+# Non-Record Submission: Negative Results from Gated Multi-Order Hash N-grams
+
+This non-record submission documents a small line of experiments that tried to replace the simple `BigramHashEmbedding` prior with a more expressive **multi-order hash n-gram** module using scalar gates and, in earlier runs, per-order hard top-1 routing across hash heads.
+
+The main result is negative but, we think, informative:
+
+- the more complex gated hash-n-gram line did **not** beat the March 25 BigramHash SOTA stack in this 10 minute / 16MB regime
+- the main gap showed up **before compression**, not only after GPTQ/pruning
+- once systems regressions were fixed, the best simplified variant got very close in pre-quant quality, but still lost after post-training compression
+
+Our best legal run in this line reached:
+
+- `post_ema val_bpb = 1.1347`
+- `final_int6_sliding_window_exact val_bpb = 1.11959957`
+- `bytes_total = 15,937,956`
+
+This is competitive for a non-record submission, but still behind the March 25 BigramHash reference:
+
+- `post_ema val_bpb = 1.1340`
+- `final_int6_sliding_window_exact val_bpb = 1.11437394`
+
+## High-Level Takeaways
+
+1. More expressive candidate-level gating did not help in this regime.
+   The original `2,3,4-gram` + `2,2,2` hash design underperformed the simpler baseline even before compression.
+
+2. Hard top-1 over multiple hash heads appears risky.
+   Our working hypothesis is that near-zero initialization plus top-1 routing caused early winner-take-all behavior: once one hash slot got a little training signal, it kept winning even when semantics were weak.
+
+3. Tail-loss emphasis did not improve sliding-window relative gain.
+   The `roundtrip -> sliding` improvement stayed almost unchanged, while the absolute numbers got slightly worse. In particular, the legal multi-hash run with tail emphasis had almost the same `roundtrip_exact - sliding_exact` gap as the earlier no-tail run, suggesting that suffix-weighted training did not actually buy extra stride-64 specialization in this setup.
+
+4. System fixes mattered, but did not change the final conclusion.
+   This experiment originally paid hidden runtime taxes from training-time calibration caching, synchronous shard reloads, and synchronous logging. After fixing these, throughput matched the baseline regime much better, but the model family still did not surpass BigramHash.
+
+5. Collision "noise" may not be purely harmful.
+   One interpretation of these results is that stable hash collisions can act as cheap identity features. Aggressive semantic gating may destroy useful fixed pseudo-identifiers instead of removing only harmful noise.
+
+6. For this model family, the largest remaining gap was post-training.
+   The best legal run in this line got very close to the March 25 BigramHash SOTA before compression, but still lost a few additional points after GPTQ + selective pruning. We do **not** think this means GPTQ is bad for the challenge in general, since the March 25 SOTA itself uses GPTQ successfully. Rather, our evidence suggests that this particular gated hash-n-gram family was not a great fit for our post-training stack.
+
+## Representative Runs
+
+| Run | Key idea | post_ema bpb | roundtrip exact | sliding exact | total bytes | Notes |
+|-----|----------|-------------:|----------------:|--------------:|------------:|-------|
+| `run_overcap_multi_hash.log` | `2,3,4-gram`, `2,2,2` hash, no tail emphasis | 1.1376 | 1.14104006 | 1.11738440 | 16,197,853 | Best raw quality in this line, but over the true 16,000,000-byte cap |
+| `run_submit_multi_hash_tail64.log` | legal submit-style run, `2,2,2` hash + tail loss (`64`, `2.0`) | 1.1393 | 1.14628762 | 1.12254768 | 15,971,636 | Tail emphasis did not help; fully legal but worse |
+| `run_submit_single_hash.log` | systems fixes + `1,1,1` hash + no tail loss | **1.1347** | **1.14309182** | **1.11959957** | **15,937,956** | Best legal run in this line; still behind BigramHash SOTA after compression |
+
+For reference, the March 25 BigramHash SOTA seed-42 run reported:
+
+- `post_ema val_bpb = 1.1340`
+- `final_int6_roundtrip_exact val_bpb = 1.13808963`
+- `final_int6_sliding_window_exact val_bpb = 1.11437394`
+- `bytes_total = 15,984,850`
+
+## What Was Actually Negative?
+
+The original hypothesis was that a richer lexical prior should beat a simple bigram additive prior:
+
+- use `2/3/4-gram` instead of only bigrams
+- use multiple hashes per order to provide collision insurance
+- use query-conditioned scalar gates to select the semantically right candidate
+
+This did not happen.
+
+The strongest evidence is that even after the line was simplified and the runtime path was cleaned up, the best legal result still came from removing the extra same-order competition (`NGRAM_NUM_HASHES=1,1,1`), and even then it did not beat the simpler BigramHash baseline after compression.
+
+## Negative Result: Tail-Loss Emphasis
+
+We also tried explicitly emphasizing the final tokens during training, motivated by the fact that sliding-window evaluation only scores the newest positions in each window.
+
+In practice this did not help.
+
+- no-tail multi-hash run: `1.14104006 -> 1.11738440` (`delta = 0.02366`)
+- tail-emphasized multi-hash run: `1.14628762 -> 1.12254768` (`delta = 0.02374`)
+
+The absolute metrics got worse, while the relative gain from `roundtrip` to `sliding` stayed effectively unchanged.
+
+Our interpretation is that this tail-weighted objective changed the training target, but did not change the model's actual evaluation-time advantage under longer-context sliding evaluation in a useful way.
+
+## Open Question: What Does Hash Embedding Encode?
+
+One of the more interesting lessons from this line is that our original prior may have been backwards.
+
+We started from the assumption that hash collisions primarily inject harmful semantic noise, and that the right thing to do was to route, filter, or gate that noise away as early as possible.
+
+But these results suggest a different possibility:
+
+- a collided hash feature is not just "noise"
+- if it is deterministic, it may act as a stable pseudo-identifier
+- the model may be using that pseudo-identifier as a cheap feature, even when it is not semantically clean
+
+This raises a useful open question for future work:
+
+**Is hash embedding mainly encoding local knowledge, or is it mainly providing stable identity-like tags that the backbone can exploit?**
+
+If the latter is true, then aggressive candidate-level semantic gating may be removing the very thing that makes hash features useful in the first place. That would help explain why a simpler additive BigramHash prior can outperform a more "semantic" routed n-gram design in this regime.
+
+## Relation to Engram-Style Gating vs LongCat-Style Additive Fusion
+
+This line also made us rethink a broader design question that shows up in public n-gram memory systems.
+
+From public materials, DeepSeek's Engram is explicitly presented as a **retrieval + gated fusion** memory module: it retrieves static n-gram memory and then fuses it back into the hidden state through a context-aware gate.[^engram-readme] In contrast, Meituan LongCat's public model description presents its n-gram layer more simply: the current token and its recent context are mapped to an n-gram embedding, which is then fused with the base embedding / hidden representation as a direct added feature.[^longcat-model]
+
+We do **not** claim a direct historical lineage from Engram to LongCat. But the contrast in public descriptions is striking, and our results line up more with the simpler additive philosophy:
+
+- the more we asked the n-gram branch to make candidate-level semantic decisions, the more fragile training became
+- removing same-order hash competition helped
+- the remaining gap suggests that a simple stable feature injection may be more useful than an early routing mechanism in this short-budget setting
+
+One plausible reading is that in a compressed, short-training regime, the backbone may be better at deciding how to use a noisy but stable local feature than the n-gram branch is at deciding, on its own, whether that feature is semantically "clean" enough to keep.
+
+## Practical Contributions From This Line
+
+Even though the model family itself did not win, this work still produced a few practical contributions that made experimentation cheaper and easier to debug:
+
+1. Better AR calibration control.
+   We added a prompt-bank AR mode, mild repeat penalty, and optional printed generations. This made it much easier to see when autoregressive GPTQ calibration was degenerating, instead of treating AR as a black box.
+
+2. Higher-throughput post-training calibration defaults.
+   We raised AR/Hessian batch defaults and made calibration outputs more inspectable, which reduced iteration cost on expensive 8xH100 runs without introducing an obvious quality regression on this line.
+
+3. Faster and more transparent pruning.
+   We improved selective-prune search behavior, added progress/debug logging, and allowed bounded early acceptance near the artifact target. This reduced the amount of time wasted in the very tail of post-processing.
+
+4. Lower hidden systems tax during training and post-processing.
+   We fixed unnecessary training-time calibration caching when not using `train_cache`, added next-shard prefetch, and made logging optional/asynchronous. These changes materially improved the fairness of throughput comparisons and reduced wasted wallclock on multi-GPU runs.
+
+We think these system and calibration changes are more transferable than the gated n-gram architecture itself.
+
+## Behind the Scenes: How the Hypothesis Evolved
+
+This section is less about claiming a polished final theory, and more about recording the reasoning path that led us to the final interpretation.
+
+1. We started from a "noise reduction" prior.
+   The original intuition was that multi-hash and query-conditioned gates should help clean up collision noise: let the model select the semantically right n-gram feature and suppress the wrong ones.
+
+2. Very quickly, the optimization problem looked more important than the static expressivity.
+   We spent time thinking through toy cases where several true n-grams shared one hash slot but differed on another. In those thought experiments, pure addition made the shared slot dirty, but still let every private slot keep receiving gradients. Gating looked cleaner in principle, but also created a way for low-frequency true features to be starved.
+
+3. That shifted the question from "how do we denoise collisions?" to "where should selection happen?"
+   We considered several intermediate designs:
+
+   - per-hash candidate gates
+   - degree-level gates (`2g/3g/4g`) with within-degree addition
+   - hard top-1 per order
+   - stronger separation between shared vs non-shared embedding regions
+
+   In hindsight, most of these ideas were different ways of managing the same fear: that collision noise written into the residual stream would be irreversible.
+
+4. We then discovered an implementation mismatch that clarified the real issue.
+   The gate had briefly been implemented as a per-channel gate rather than a scalar-per-hash gate. Fixing that bug improved conceptual alignment, but did not rescue the line. That was useful in itself, because it suggested the main problem was not one accidental implementation detail.
+
+5. Hard top-1 eventually became the most suspicious part of the design.
+   Once we thought through the interaction between very small initialization, same-order multiple hashes, and top-1 routing, a different failure mode became plausible: the model may be selecting early winners before semantics are actually formed, then reinforcing those winners simply because they were selected first.
+
+6. From there, the prior almost inverted.
+   Instead of seeing collisions as something that should obviously be removed, we started considering the possibility that stable collisions are useful. A collided hash feature may be semantically messy, but still function as a reproducible pseudo-identifier. In that framing, the problem with our gated design is not merely that it fails to clean noise, but that it may destroy exactly the stable "dirty" features the backbone would have learned to use.
+
+7. That final shift made the negative result easier to interpret.
+   The story stopped being "we need a smarter gate" and became closer to "maybe the simple additive prior was right for this regime." That perspective also made the public contrast between Engram-style gated memory and LongCat-style additive fusion feel more relevant to our own experiments.
+
+## Future Experiments Suggested by This Negative Result
+
+This negative result does not make us pessimistic about hash features in general. It mostly makes us more skeptical of **early semantic routing**. If we were to continue this line, the next experiments we would prioritize are simpler and more additive:
+
+1. Smaller or cheaper BigramHash-style priors.
+   If hash features are helping primarily as stable pseudo-identifiers, then they may not need as much semantic capacity as we originally assumed. That suggests revisiting whether bigram/hash embeddings can work with lower dimensions, smaller tables, or more aggressive parameter sharing.
+
+2. Random-map or lightly learned hash projections.
+   Instead of learning a fully semantic hash branch, we would test whether a random or semi-random projection is already enough to provide useful stable identity features. If performance holds up, that would support the "identity feature" interpretation over the "knowledge store" interpretation.
+
+3. Multi-projection without candidate gating.
+   Another direction would be to keep multiple views of the same local context, but remove the routing machinery entirely. For example:
+
+   - multiple projected hash views summed together
+   - multiple projected hash views averaged together
+   - multiple projected hash views concatenated and linearly mixed once
+
+   The goal would be to let the backbone see several stable local fingerprints without forcing the n-gram module itself to decide which one is semantically correct.
+
+4. Order-level control rather than candidate-level control.
+   If some gating is still useful, we would move it upward in the hierarchy: first combine within-order hash views additively, then decide how much `2g`, `3g`, or `4g` should contribute as a whole. This is much less aggressive than asking same-order candidates to compete from the start.
+
+5. Directly testing the "knowledge vs identity" hypothesis.
+   A very simple diagnostic program would be:
+
+   - compare learned additive bigram features vs random additive bigram features
+   - compare single-view additive features vs multi-view additive features
+   - compare high-dimensional semantic projections vs low-dimensional pseudo-identifier projections
+
+   If cheap, noisy, stable features perform surprisingly well, that would be strong evidence that the main value of hash embedding in this regime is not clean local knowledge retrieval, but providing extra reproducible identity structure.
+
+## Implementation Notes
+
+The included `train_gpt.py` is a snapshot from the best legal run in this line (`run_submit_single_hash.log`), not from the earlier over-cap multi-hash run.
+
+Important aspects of the final snapshot:
+
+- `11L / 512d / 8 heads / 4 KV heads`
+- `2,3,4-gram` orders with `3072,1536,768` vocab sizes
+- `NGRAM_NUM_HASHES=1,1,1`
+- `GPTQ_CALIB_SOURCE=ar_prompt_bank`
+- printed AR calibration sequences for inspection
+- mild AR repeat penalty
+- loader next-shard prefetch
+- async logging
+- selective prune with bounded undershoot acceptance
+
+## Included Files
+
+- `train_gpt.py` — code snapshot for the best legal run in this line
+- `run_overcap_multi_hash.log` — strongest raw multi-hash result, but over artifact cap
+- `run_submit_multi_hash_tail64.log` — legal multi-hash run with tail emphasis
+- `run_submit_single_hash.log` — best legal non-record run from this line
+- `results.tsv` — compact metrics table
+- `submission.json` — metadata for this non-record submission
+
+[^engram-readme]: DeepSeek Engram README: https://github.com/deepseek-ai/Engram
+[^longcat-model]: LongCat-Flash-Lite model page: https://www.longcatai.org/models/flash-lite

--- a/records/track_non_record_16mb/2026-04-04_NegativeResults_GatedMultiOrderHash/requirements.txt
+++ b/records/track_non_record_16mb/2026-04-04_NegativeResults_GatedMultiOrderHash/requirements.txt
@@ -1,0 +1,6 @@
+# FlashAttention / Hopper-specific kernels should be installed separately
+# in the standard Parameter Golf CUDA environment.
+sentencepiece
+datasets
+huggingface-hub
+tqdm

--- a/records/track_non_record_16mb/2026-04-04_NegativeResults_GatedMultiOrderHash/results.tsv
+++ b/records/track_non_record_16mb/2026-04-04_NegativeResults_GatedMultiOrderHash/results.tsv
@@ -1,0 +1,4 @@
+run	log_file	batch_tokens	num_hashes	tail_loss_tokens	tail_loss_weight	gptq_calib_source	post_ema_bpb	roundtrip_exact_bpb	sliding_exact_bpb	bytes_total	notes
+overcap_multi_hash	run_overcap_multi_hash.log	524288	2,2,2	0	1.0	ar/self-gen	1.1376	1.14104006	1.11738440	16197853	best raw quality in line, over true size cap
+submit_multi_hash_tail64	run_submit_multi_hash_tail64.log	524288	2,2,2	64	2.0	ar_prompt_bank	1.1393	1.14628762	1.12254768	15971636	tail emphasis did not help
+submit_single_hash	run_submit_single_hash.log	786432	1,1,1	0	1.0	ar_prompt_bank	1.1347	1.14309182	1.11959957	15937956	best legal run in this line

--- a/records/track_non_record_16mb/2026-04-04_NegativeResults_GatedMultiOrderHash/run_overcap_multi_hash.log
+++ b/records/track_non_record_16mb/2026-04-04_NegativeResults_GatedMultiOrderHash/run_overcap_multi_hash.log
@@ -1,0 +1,601 @@
+ _____                             _
+|  __ \                           | |
+| |__) |   _ _ __  _ __   ___   __| |
+|  _  / | | | '_ \| '_ \ / _ \ / _` |
+| | \ \ |_| | | | | |_) | (_) | (_| |
+|_|  \_\__,_|_| |_| .__/ \___/ \__,_|
+                  | |
+                  |_|
+For detailed documentation and guides, please visit:
+https://docs.runpod.io/ and https://blog.runpod.io/
+
+
+root@81b08a01972b:/workspace/parameter-golf# cd /workspace
+root@81b08a01972b:/workspace# git clone https://github.com/xiayicheng3-code/parameter-golf-base.git || true
+Cloning into 'parameter-golf-base'...
+remote: Enumerating objects: 994, done.
+remote: Counting objects: 100% (8/8), done.
+remote: Compressing objects: 100% (2/2), done.
+remote: Total 994 (delta 7), reused 6 (delta 6), pack-reused 986 (from 2)
+Receiving objects: 100% (994/994), 2.44 MiB | 29.41 MiB/s, done.
+Resolving deltas: 100% (506/506), done.
+root@81b08a01972b:/workspace# cd /workspace/parameter-golf-base
+root@81b08a01972b:/workspace/parameter-golf-base# git fetch origin
+root@81b08a01972b:/workspace/parameter-golf-base# git pull --ff-only
+Already up to date.
+root@81b08a01972b:/workspace/parameter-golf-base#
+root@81b08a01972b:/workspace/parameter-golf-base# python3 data/cached_challenge_fineweb.py --variant sp1024
+manifest.json: 1.93kB [00:00, 4.77MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 124M/124M [00:03<00:00, 38.5MB/s]
+Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 98.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 98.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 99.0MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 90.1MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 99.0MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 90.0MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 98.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 82.6MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 98.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 99.0MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 90.0MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 90.0MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 99.0MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 99.0MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 70.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 98.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 99.0MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 98.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 90.1MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 90.6MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 70.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 76.3MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 99.0MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 98.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 99.0MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 82.6MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 70.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 98.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 98.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 70.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 76.3MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 83.0MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 82.6MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:03<00:00, 66.2MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 70.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:03<00:00, 62.1MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 98.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 70.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 76.3MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:03<00:00, 66.2MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:03<00:00, 52.3MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:04<00:00, 49.7MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:04<00:00, 47.4MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:03<00:00, 62.1MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:03<00:00, 62.1MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:03<00:00, 58.7MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:04<00:00, 41.5MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:03<00:00, 55.4MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:03<00:00, 62.1MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:04<00:00, 43.3MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:04<00:00, 49.7MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:03<00:00, 55.2MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:04<00:00, 47.4MB/s]
+datasets/tokenizers/fineweb_1024_bpe.mod(…): 100%|███████████████████████████████████████████████| 254k/254k [00:00<00:00, 310kB/s]
+fineweb_1024_bpe.vocab: 9.86kB [00:00, 9.49MB/s]
+root@81b08a01972b:/workspace/parameter-golf-base#
+root@81b08a01972b:/workspace/parameter-golf-base# cd /workspace/parameter-golf-base/experiments/m34a_sota_graft
+root@81b08a01972b:/workspace/parameter-golf-base/experiments/m34a_sota_graft# RUN_ID=m34a_sota_graft_8xh100_launch1 \
+> DATA_PATH=../../data/datasets/fineweb10B_sp1024 \
+> TOKENIZER_PATH=../../data/tokenizers/fineweb_1024_bpe.model \
+> VOCAB_SIZE=1024 \
+> NUM_LAYERS=11 \
+> MODEL_DIM=512 \
+> NUM_HEADS=8 \
+> NUM_KV_HEADS=4 \
+> MLP_MULT=3.0 \
+> TRAIN_SEQ_LEN=2048 \
+> EVAL_SEQ_LEN=2048 \
+> TRAIN_BATCH_TOKENS=524288 \
+> GRAD_ACCUM_STEPS=1 \
+> VAL_BATCH_SIZE=2097152 \
+> VAL_LOSS_EVERY=0 \
+> TRAIN_LOG_EVERY=25 \
+> MAX_WALLCLOCK_SECONDS=600 \
+> NGRAM_BASE_VOCAB_SIZE=3072 \
+> NGRAM_DIM=112 \
+> NGRAM_ORDERS=2,3,4 \
+> NGRAM_VOCAB_SIZES=3072,1536,768 \
+> NGRAM_NUM_HASHES=2,2,2 \
+> NGRAM_INIT_STD=0.005 \
+> WARMDOWN_ITERS=4000 \
+> TARGET_MB=15.9 \
+> torchrun --standalone --nproc_per_node=8 train_gpt.py
+W0402 01:33:27.355000 1373 torch/distributed/run.py:803]
+W0402 01:33:27.355000 1373 torch/distributed/run.py:803] *****************************************
+W0402 01:33:27.355000 1373 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed.
+W0402 01:33:27.355000 1373 torch/distributed/run.py:803] *****************************************
+logs/m34a_sota_graft_8xh100_launch1.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=../../data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=../../data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:27382879
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_11 active_layers:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:524288 train_seq_len:2048 micro_batch_tokens:65536 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:1/20000 train_loss:6.9308 train_time:121ms step_avg:121.45ms
+step:2/20000 train_loss:8.7548 train_time:161ms step_avg:80.47ms
+step:3/20000 train_loss:7.5562 train_time:224ms step_avg:74.59ms
+step:4/20000 train_loss:7.5944 train_time:279ms step_avg:69.78ms
+step:5/20000 train_loss:7.1571 train_time:339ms step_avg:67.72ms
+step:6/20000 train_loss:7.9091 train_time:398ms step_avg:66.36ms
+step:7/20000 train_loss:6.9097 train_time:458ms step_avg:65.44ms
+step:8/20000 train_loss:6.6937 train_time:518ms step_avg:64.73ms
+step:9/20000 train_loss:6.4710 train_time:577ms step_avg:64.14ms
+step:10/20000 train_loss:6.1469 train_time:637ms step_avg:63.70ms
+step:25/20000 train_loss:4.5713 train_time:1540ms step_avg:61.62ms
+step:50/20000 train_loss:3.9786 train_time:3041ms step_avg:60.83ms
+step:75/20000 train_loss:3.5684 train_time:4556ms step_avg:60.75ms
+step:100/20000 train_loss:3.4128 train_time:6068ms step_avg:60.68ms
+step:125/20000 train_loss:3.0916 train_time:7570ms step_avg:60.56ms
+step:150/20000 train_loss:3.0583 train_time:9081ms step_avg:60.54ms
+step:175/20000 train_loss:2.8301 train_time:10584ms step_avg:60.48ms
+step:200/20000 train_loss:2.7937 train_time:12156ms step_avg:60.78ms
+step:225/20000 train_loss:2.7912 train_time:13661ms step_avg:60.72ms
+step:250/20000 train_loss:2.6712 train_time:15176ms step_avg:60.71ms
+step:275/20000 train_loss:2.5598 train_time:16689ms step_avg:60.69ms
+step:300/20000 train_loss:2.3774 train_time:18202ms step_avg:60.67ms
+step:325/20000 train_loss:2.4820 train_time:19707ms step_avg:60.64ms
+step:350/20000 train_loss:2.5618 train_time:21230ms step_avg:60.66ms
+step:375/20000 train_loss:2.5215 train_time:22744ms step_avg:60.65ms
+step:400/20000 train_loss:2.2442 train_time:24316ms step_avg:60.79ms
+step:425/20000 train_loss:2.4591 train_time:25830ms step_avg:60.78ms
+step:450/20000 train_loss:2.3924 train_time:27346ms step_avg:60.77ms
+step:475/20000 train_loss:2.3793 train_time:28860ms step_avg:60.76ms
+step:500/20000 train_loss:2.3897 train_time:30372ms step_avg:60.74ms
+step:525/20000 train_loss:2.4234 train_time:31888ms step_avg:60.74ms
+step:550/20000 train_loss:2.2909 train_time:33403ms step_avg:60.73ms
+step:575/20000 train_loss:2.3598 train_time:34984ms step_avg:60.84ms
+step:600/20000 train_loss:2.4478 train_time:36494ms step_avg:60.82ms
+step:625/20000 train_loss:2.3766 train_time:38013ms step_avg:60.82ms
+step:650/20000 train_loss:2.2874 train_time:39534ms step_avg:60.82ms
+step:675/20000 train_loss:2.2220 train_time:41050ms step_avg:60.82ms
+step:700/20000 train_loss:2.3456 train_time:42557ms step_avg:60.80ms
+step:725/20000 train_loss:2.3225 train_time:44083ms step_avg:60.80ms
+step:750/20000 train_loss:2.1802 train_time:45600ms step_avg:60.80ms
+step:775/20000 train_loss:2.2571 train_time:47190ms step_avg:60.89ms
+step:800/20000 train_loss:2.1978 train_time:48714ms step_avg:60.89ms
+step:825/20000 train_loss:2.3312 train_time:50232ms step_avg:60.89ms
+step:850/20000 train_loss:2.6313 train_time:51755ms step_avg:60.89ms
+step:875/20000 train_loss:2.2888 train_time:53273ms step_avg:60.88ms
+step:900/20000 train_loss:2.2559 train_time:54797ms step_avg:60.89ms
+step:925/20000 train_loss:2.1189 train_time:56320ms step_avg:60.89ms
+step:950/20000 train_loss:2.3054 train_time:57842ms step_avg:60.89ms
+step:975/20000 train_loss:2.0326 train_time:59421ms step_avg:60.94ms
+step:1000/20000 train_loss:2.3048 train_time:60941ms step_avg:60.94ms
+step:1025/20000 train_loss:2.3049 train_time:62467ms step_avg:60.94ms
+step:1050/20000 train_loss:2.4187 train_time:63987ms step_avg:60.94ms
+step:1075/20000 train_loss:2.1160 train_time:65506ms step_avg:60.94ms
+step:1100/20000 train_loss:2.1762 train_time:67030ms step_avg:60.94ms
+step:1125/20000 train_loss:2.2603 train_time:68556ms step_avg:60.94ms
+step:1150/20000 train_loss:2.1741 train_time:70138ms step_avg:60.99ms
+step:1175/20000 train_loss:2.1366 train_time:71658ms step_avg:60.99ms
+step:1200/20000 train_loss:2.3251 train_time:73185ms step_avg:60.99ms
+step:1225/20000 train_loss:2.3291 train_time:74710ms step_avg:60.99ms
+step:1250/20000 train_loss:2.1378 train_time:76235ms step_avg:60.99ms
+step:1275/20000 train_loss:2.2361 train_time:77760ms step_avg:60.99ms
+step:1300/20000 train_loss:2.3043 train_time:79286ms step_avg:60.99ms
+step:1325/20000 train_loss:2.2488 train_time:80812ms step_avg:60.99ms
+step:1350/20000 train_loss:2.1992 train_time:82389ms step_avg:61.03ms
+step:1375/20000 train_loss:2.3449 train_time:83920ms step_avg:61.03ms
+step:1400/20000 train_loss:2.3556 train_time:85441ms step_avg:61.03ms
+step:1425/20000 train_loss:2.2427 train_time:86967ms step_avg:61.03ms
+step:1450/20000 train_loss:2.1747 train_time:88490ms step_avg:61.03ms
+step:1475/20000 train_loss:2.2453 train_time:90003ms step_avg:61.02ms
+step:1500/20000 train_loss:2.1625 train_time:91539ms step_avg:61.03ms
+step:1525/20000 train_loss:2.2853 train_time:93063ms step_avg:61.03ms
+step:1550/20000 train_loss:2.0899 train_time:94652ms step_avg:61.07ms
+step:1575/20000 train_loss:2.2133 train_time:96177ms step_avg:61.06ms
+step:1600/20000 train_loss:2.0313 train_time:97706ms step_avg:61.07ms
+step:1625/20000 train_loss:2.1517 train_time:99230ms step_avg:61.06ms
+step:1650/20000 train_loss:2.1715 train_time:100754ms step_avg:61.06ms
+step:1675/20000 train_loss:2.1711 train_time:102279ms step_avg:61.06ms
+step:1700/20000 train_loss:2.1008 train_time:103805ms step_avg:61.06ms
+step:1725/20000 train_loss:2.2075 train_time:105391ms step_avg:61.10ms
+step:1750/20000 train_loss:2.1754 train_time:106921ms step_avg:61.10ms
+step:1775/20000 train_loss:2.1440 train_time:108442ms step_avg:61.09ms
+step:1800/20000 train_loss:2.1332 train_time:109969ms step_avg:61.09ms
+step:1825/20000 train_loss:2.1954 train_time:111492ms step_avg:61.09ms
+step:1850/20000 train_loss:2.2370 train_time:113019ms step_avg:61.09ms
+step:1875/20000 train_loss:2.1288 train_time:114544ms step_avg:61.09ms
+step:1900/20000 train_loss:2.1208 train_time:116072ms step_avg:61.09ms
+step:1925/20000 train_loss:2.1544 train_time:117663ms step_avg:61.12ms
+step:1950/20000 train_loss:2.1343 train_time:119183ms step_avg:61.12ms
+step:1975/20000 train_loss:2.1950 train_time:120704ms step_avg:61.12ms
+step:2000/20000 train_loss:2.1722 train_time:122233ms step_avg:61.12ms
+step:2025/20000 train_loss:2.2769 train_time:123759ms step_avg:61.12ms
+step:2050/20000 train_loss:2.1712 train_time:125284ms step_avg:61.11ms
+step:2075/20000 train_loss:2.0529 train_time:126810ms step_avg:61.11ms
+step:2100/20000 train_loss:2.1911 train_time:128400ms step_avg:61.14ms
+step:2125/20000 train_loss:2.1656 train_time:129918ms step_avg:61.14ms
+step:2150/20000 train_loss:2.1024 train_time:131441ms step_avg:61.14ms
+step:2175/20000 train_loss:2.0646 train_time:132966ms step_avg:61.13ms
+step:2200/20000 train_loss:1.9886 train_time:134493ms step_avg:61.13ms
+step:2225/20000 train_loss:2.1222 train_time:136018ms step_avg:61.13ms
+step:2250/20000 train_loss:2.0821 train_time:137545ms step_avg:61.13ms
+step:2275/20000 train_loss:2.2099 train_time:139067ms step_avg:61.13ms
+step:2300/20000 train_loss:2.2895 train_time:140649ms step_avg:61.15ms
+step:2325/20000 train_loss:2.0956 train_time:142181ms step_avg:61.15ms
+step:2350/20000 train_loss:2.1061 train_time:143702ms step_avg:61.15ms
+step:2375/20000 train_loss:2.0362 train_time:145228ms step_avg:61.15ms
+step:2400/20000 train_loss:2.1162 train_time:146749ms step_avg:61.15ms
+step:2425/20000 train_loss:2.1278 train_time:148270ms step_avg:61.14ms
+step:2450/20000 train_loss:2.1306 train_time:149791ms step_avg:61.14ms
+step:2475/20000 train_loss:2.1121 train_time:151318ms step_avg:61.14ms
+step:2500/20000 train_loss:2.0487 train_time:152908ms step_avg:61.16ms
+step:2525/20000 train_loss:2.0478 train_time:154423ms step_avg:61.16ms
+step:2550/20000 train_loss:2.0521 train_time:155947ms step_avg:61.16ms
+step:2575/20000 train_loss:2.1188 train_time:157468ms step_avg:61.15ms
+step:2600/20000 train_loss:2.3447 train_time:158993ms step_avg:61.15ms
+step:2625/20000 train_loss:1.9905 train_time:160519ms step_avg:61.15ms
+step:2650/20000 train_loss:2.1503 train_time:162046ms step_avg:61.15ms
+step:2675/20000 train_loss:2.2205 train_time:163637ms step_avg:61.17ms
+step:2700/20000 train_loss:2.0670 train_time:165157ms step_avg:61.17ms
+step:2725/20000 train_loss:2.0011 train_time:166681ms step_avg:61.17ms
+step:2750/20000 train_loss:2.2862 train_time:168206ms step_avg:61.17ms
+step:2775/20000 train_loss:2.0544 train_time:169731ms step_avg:61.16ms
+step:2800/20000 train_loss:2.1547 train_time:171255ms step_avg:61.16ms
+step:2825/20000 train_loss:2.2596 train_time:172777ms step_avg:61.16ms
+step:2850/20000 train_loss:2.1039 train_time:174303ms step_avg:61.16ms
+step:2875/20000 train_loss:2.2591 train_time:175875ms step_avg:61.17ms
+step:2900/20000 train_loss:2.1041 train_time:177406ms step_avg:61.17ms
+step:2925/20000 train_loss:2.0471 train_time:178928ms step_avg:61.17ms
+step:2950/20000 train_loss:2.1490 train_time:180453ms step_avg:61.17ms
+step:2975/20000 train_loss:2.0529 train_time:181979ms step_avg:61.17ms
+step:3000/20000 train_loss:2.1441 train_time:183502ms step_avg:61.17ms
+step:3025/20000 train_loss:2.1379 train_time:185029ms step_avg:61.17ms
+step:3050/20000 train_loss:2.0780 train_time:186552ms step_avg:61.16ms
+step:3075/20000 train_loss:2.1945 train_time:188136ms step_avg:61.18ms
+step:3100/20000 train_loss:2.1190 train_time:189654ms step_avg:61.18ms
+step:3125/20000 train_loss:2.0361 train_time:191177ms step_avg:61.18ms
+step:3150/20000 train_loss:2.0882 train_time:192704ms step_avg:61.18ms
+step:3175/20000 train_loss:2.2281 train_time:194225ms step_avg:61.17ms
+step:3200/20000 train_loss:2.1106 train_time:195747ms step_avg:61.17ms
+step:3225/20000 train_loss:2.1737 train_time:197272ms step_avg:61.17ms
+step:3250/20000 train_loss:2.0099 train_time:198850ms step_avg:61.18ms
+step:3275/20000 train_loss:2.2138 train_time:200374ms step_avg:61.18ms
+step:3300/20000 train_loss:2.1546 train_time:201903ms step_avg:61.18ms
+step:3325/20000 train_loss:2.1502 train_time:203428ms step_avg:61.18ms
+step:3350/20000 train_loss:2.0104 train_time:204953ms step_avg:61.18ms
+step:3375/20000 train_loss:1.9992 train_time:206472ms step_avg:61.18ms
+step:3400/20000 train_loss:2.0814 train_time:207993ms step_avg:61.17ms
+step:3425/20000 train_loss:2.0094 train_time:209517ms step_avg:61.17ms
+step:3450/20000 train_loss:2.0137 train_time:211101ms step_avg:61.19ms
+step:3475/20000 train_loss:2.0516 train_time:212621ms step_avg:61.19ms
+step:3500/20000 train_loss:2.1788 train_time:214143ms step_avg:61.18ms
+step:3525/20000 train_loss:2.1430 train_time:215669ms step_avg:61.18ms
+step:3550/20000 train_loss:2.3194 train_time:217193ms step_avg:61.18ms
+step:3575/20000 train_loss:2.1288 train_time:218718ms step_avg:61.18ms
+step:3600/20000 train_loss:2.0268 train_time:220238ms step_avg:61.18ms
+step:3625/20000 train_loss:2.0837 train_time:221823ms step_avg:61.19ms
+step:3650/20000 train_loss:2.1335 train_time:223334ms step_avg:61.19ms
+step:3675/20000 train_loss:2.3052 train_time:224857ms step_avg:61.19ms
+step:3700/20000 train_loss:2.0561 train_time:226378ms step_avg:61.18ms
+step:3725/20000 train_loss:2.1468 train_time:227894ms step_avg:61.18ms
+step:3750/20000 train_loss:2.0709 train_time:229418ms step_avg:61.18ms
+step:3775/20000 train_loss:2.0089 train_time:230940ms step_avg:61.18ms
+step:3800/20000 train_loss:2.1331 train_time:232461ms step_avg:61.17ms
+step:3825/20000 train_loss:2.1591 train_time:234032ms step_avg:61.18ms
+step:3850/20000 train_loss:2.0919 train_time:235560ms step_avg:61.18ms
+step:3875/20000 train_loss:2.0772 train_time:237082ms step_avg:61.18ms
+step:3900/20000 train_loss:1.9158 train_time:238601ms step_avg:61.18ms
+step:3925/20000 train_loss:2.0786 train_time:240120ms step_avg:61.18ms
+step:3950/20000 train_loss:2.0547 train_time:241641ms step_avg:61.17ms
+step:3975/20000 train_loss:2.0835 train_time:243163ms step_avg:61.17ms
+step:4000/20000 train_loss:2.1027 train_time:244683ms step_avg:61.17ms
+step:4025/20000 train_loss:2.1840 train_time:246269ms step_avg:61.18ms
+step:4050/20000 train_loss:2.0300 train_time:247788ms step_avg:61.18ms
+step:4075/20000 train_loss:2.0164 train_time:249308ms step_avg:61.18ms
+step:4100/20000 train_loss:2.1164 train_time:250823ms step_avg:61.18ms
+step:4125/20000 train_loss:2.0648 train_time:252344ms step_avg:61.17ms
+step:4150/20000 train_loss:2.2524 train_time:253863ms step_avg:61.17ms
+step:4175/20000 train_loss:2.0930 train_time:255382ms step_avg:61.17ms
+step:4200/20000 train_loss:2.0963 train_time:256959ms step_avg:61.18ms
+step:4225/20000 train_loss:2.1893 train_time:258472ms step_avg:61.18ms
+step:4250/20000 train_loss:2.0491 train_time:259993ms step_avg:61.17ms
+step:4275/20000 train_loss:1.9969 train_time:261515ms step_avg:61.17ms
+step:4300/20000 train_loss:1.9417 train_time:263037ms step_avg:61.17ms
+step:4325/20000 train_loss:2.0396 train_time:264557ms step_avg:61.17ms
+step:4350/20000 train_loss:2.1433 train_time:266080ms step_avg:61.17ms
+step:4375/20000 train_loss:2.0810 train_time:267599ms step_avg:61.17ms
+step:4400/20000 train_loss:2.0353 train_time:269177ms step_avg:61.18ms
+step:4425/20000 train_loss:2.1632 train_time:270709ms step_avg:61.18ms
+step:4450/20000 train_loss:1.9899 train_time:272227ms step_avg:61.17ms
+step:4475/20000 train_loss:2.1392 train_time:273743ms step_avg:61.17ms
+step:4500/20000 train_loss:2.1868 train_time:275263ms step_avg:61.17ms
+step:4525/20000 train_loss:2.0649 train_time:276785ms step_avg:61.17ms
+step:4550/20000 train_loss:1.9749 train_time:278306ms step_avg:61.17ms
+step:4575/20000 train_loss:2.0856 train_time:279828ms step_avg:61.16ms
+step:4600/20000 train_loss:1.8987 train_time:281410ms step_avg:61.18ms
+step:4625/20000 train_loss:2.1885 train_time:282929ms step_avg:61.17ms
+step:4650/20000 train_loss:1.9970 train_time:284448ms step_avg:61.17ms
+step:4675/20000 train_loss:2.0121 train_time:285965ms step_avg:61.17ms
+step:4700/20000 train_loss:2.2007 train_time:287484ms step_avg:61.17ms
+step:4725/20000 train_loss:2.1254 train_time:289005ms step_avg:61.17ms
+step:4750/20000 train_loss:1.8897 train_time:290529ms step_avg:61.16ms
+step:4775/20000 train_loss:2.0133 train_time:292106ms step_avg:61.17ms
+step:4800/20000 train_loss:2.1905 train_time:293624ms step_avg:61.17ms
+step:4825/20000 train_loss:2.1862 train_time:295146ms step_avg:61.17ms
+step:4850/20000 train_loss:2.0858 train_time:296664ms step_avg:61.17ms
+step:4875/20000 train_loss:1.9894 train_time:298185ms step_avg:61.17ms
+step:4900/20000 train_loss:2.0978 train_time:299707ms step_avg:61.16ms
+step:4925/20000 train_loss:2.0790 train_time:301225ms step_avg:61.16ms
+step:4950/20000 train_loss:2.2783 train_time:302749ms step_avg:61.16ms
+step:4975/20000 train_loss:2.1077 train_time:304323ms step_avg:61.17ms
+step:5000/20000 train_loss:1.9445 train_time:305844ms step_avg:61.17ms
+step:5025/20000 train_loss:1.9900 train_time:307351ms step_avg:61.16ms
+step:5050/20000 train_loss:2.1493 train_time:308932ms step_avg:61.17ms
+step:5075/20000 train_loss:2.0604 train_time:310480ms step_avg:61.18ms
+step:5100/20000 train_loss:1.9570 train_time:312003ms step_avg:61.18ms
+step:5125/20000 train_loss:2.0582 train_time:313524ms step_avg:61.18ms
+step:5150/20000 train_loss:2.2183 train_time:315110ms step_avg:61.19ms
+step:5175/20000 train_loss:1.8514 train_time:316625ms step_avg:61.18ms
+step:5200/20000 train_loss:2.1056 train_time:318146ms step_avg:61.18ms
+step:5225/20000 train_loss:2.0384 train_time:319668ms step_avg:61.18ms
+step:5250/20000 train_loss:2.0607 train_time:321192ms step_avg:61.18ms
+step:5275/20000 train_loss:2.0848 train_time:322715ms step_avg:61.18ms
+step:5300/20000 train_loss:2.1415 train_time:324236ms step_avg:61.18ms
+step:5325/20000 train_loss:2.0324 train_time:325763ms step_avg:61.18ms
+step:5350/20000 train_loss:2.0757 train_time:327340ms step_avg:61.19ms
+step:5375/20000 train_loss:2.1303 train_time:328864ms step_avg:61.18ms
+step:5400/20000 train_loss:2.1235 train_time:330385ms step_avg:61.18ms
+step:5425/20000 train_loss:2.1098 train_time:331908ms step_avg:61.18ms
+step:5450/20000 train_loss:2.1436 train_time:333429ms step_avg:61.18ms
+step:5475/20000 train_loss:1.8923 train_time:334947ms step_avg:61.18ms
+step:5500/20000 train_loss:2.0799 train_time:336466ms step_avg:61.18ms
+step:5525/20000 train_loss:2.0475 train_time:337985ms step_avg:61.17ms
+step:5550/20000 train_loss:2.0450 train_time:339565ms step_avg:61.18ms
+step:5575/20000 train_loss:2.0014 train_time:341082ms step_avg:61.18ms
+step:5600/20000 train_loss:2.1167 train_time:342602ms step_avg:61.18ms
+step:5625/20000 train_loss:2.0484 train_time:344121ms step_avg:61.18ms
+step:5650/20000 train_loss:1.9910 train_time:345638ms step_avg:61.17ms
+step:5675/20000 train_loss:2.0918 train_time:347158ms step_avg:61.17ms
+step:5700/20000 train_loss:2.1073 train_time:348679ms step_avg:61.17ms
+step:5725/20000 train_loss:2.0454 train_time:350260ms step_avg:61.18ms
+step:5750/20000 train_loss:2.1531 train_time:351775ms step_avg:61.18ms
+step:5775/20000 train_loss:2.0618 train_time:353300ms step_avg:61.18ms
+step:5800/20000 train_loss:2.0682 train_time:354813ms step_avg:61.17ms
+step:5825/20000 train_loss:2.0346 train_time:356333ms step_avg:61.17ms
+step:5850/20000 train_loss:2.1197 train_time:357856ms step_avg:61.17ms
+step:5875/20000 train_loss:2.0899 train_time:359374ms step_avg:61.17ms
+step:5900/20000 train_loss:2.0301 train_time:360893ms step_avg:61.17ms
+step:5925/20000 train_loss:2.0259 train_time:362465ms step_avg:61.18ms
+step:5950/20000 train_loss:2.0714 train_time:363992ms step_avg:61.18ms
+step:5975/20000 train_loss:1.9747 train_time:365510ms step_avg:61.17ms
+step:6000/20000 train_loss:2.1489 train_time:367033ms step_avg:61.17ms
+step:6025/20000 train_loss:2.0458 train_time:368555ms step_avg:61.17ms
+step:6050/20000 train_loss:2.0605 train_time:370083ms step_avg:61.17ms
+step:6075/20000 train_loss:2.0030 train_time:371600ms step_avg:61.17ms
+step:6100/20000 train_loss:2.0486 train_time:373117ms step_avg:61.17ms
+step:6125/20000 train_loss:2.0690 train_time:374700ms step_avg:61.18ms
+step:6150/20000 train_loss:2.0249 train_time:376221ms step_avg:61.17ms
+step:6175/20000 train_loss:2.1256 train_time:377740ms step_avg:61.17ms
+step:6200/20000 train_loss:2.0214 train_time:379260ms step_avg:61.17ms
+step:6225/20000 train_loss:2.0711 train_time:380780ms step_avg:61.17ms
+step:6250/20000 train_loss:2.0899 train_time:382294ms step_avg:61.17ms
+step:6275/20000 train_loss:1.9095 train_time:383813ms step_avg:61.17ms
+step:6300/20000 train_loss:1.9602 train_time:385395ms step_avg:61.17ms
+step:6325/20000 train_loss:2.0721 train_time:386912ms step_avg:61.17ms
+step:6350/20000 train_loss:1.9327 train_time:388436ms step_avg:61.17ms
+step:6375/20000 train_loss:2.1363 train_time:389957ms step_avg:61.17ms
+step:6400/20000 train_loss:2.0931 train_time:391476ms step_avg:61.17ms
+step:6425/20000 train_loss:1.9982 train_time:392994ms step_avg:61.17ms
+step:6450/20000 train_loss:2.0112 train_time:394512ms step_avg:61.16ms
+step:6475/20000 train_loss:2.1550 train_time:396035ms step_avg:61.16ms
+step:6500/20000 train_loss:2.0019 train_time:397605ms step_avg:61.17ms
+step:6525/20000 train_loss:2.0448 train_time:399124ms step_avg:61.17ms
+step:6550/20000 train_loss:2.1320 train_time:400645ms step_avg:61.17ms
+step:6575/20000 train_loss:2.0377 train_time:402163ms step_avg:61.17ms
+step:6600/20000 train_loss:2.0385 train_time:403683ms step_avg:61.16ms
+step:6625/20000 train_loss:1.9796 train_time:405204ms step_avg:61.16ms
+step:6650/20000 train_loss:2.2161 train_time:406728ms step_avg:61.16ms
+step:6675/20000 train_loss:2.1667 train_time:408244ms step_avg:61.16ms
+step:6700/20000 train_loss:2.0779 train_time:409829ms step_avg:61.17ms
+step:6725/20000 train_loss:2.0868 train_time:411348ms step_avg:61.17ms
+step:6750/20000 train_loss:2.2328 train_time:412869ms step_avg:61.17ms
+step:6775/20000 train_loss:2.0483 train_time:414388ms step_avg:61.16ms
+step:6800/20000 train_loss:2.0982 train_time:415906ms step_avg:61.16ms
+step:6825/20000 train_loss:1.9406 train_time:417430ms step_avg:61.16ms
+step:6850/20000 train_loss:1.9417 train_time:418951ms step_avg:61.16ms
+step:6875/20000 train_loss:2.0313 train_time:420529ms step_avg:61.17ms
+step:6900/20000 train_loss:2.0161 train_time:422051ms step_avg:61.17ms
+step:6925/20000 train_loss:1.8711 train_time:423572ms step_avg:61.17ms
+step:6950/20000 train_loss:2.0837 train_time:425091ms step_avg:61.16ms
+step:6975/20000 train_loss:2.0974 train_time:426613ms step_avg:61.16ms
+step:7000/20000 train_loss:2.1396 train_time:428130ms step_avg:61.16ms
+step:7025/20000 train_loss:2.0190 train_time:429649ms step_avg:61.16ms
+step:7050/20000 train_loss:2.1625 train_time:431170ms step_avg:61.16ms
+step:7075/20000 train_loss:2.0434 train_time:432750ms step_avg:61.17ms
+step:7100/20000 train_loss:1.9703 train_time:434266ms step_avg:61.16ms
+step:7125/20000 train_loss:2.0786 train_time:435790ms step_avg:61.16ms
+step:7150/20000 train_loss:2.0645 train_time:437308ms step_avg:61.16ms
+step:7175/20000 train_loss:1.8907 train_time:438823ms step_avg:61.16ms
+step:7200/20000 train_loss:2.1027 train_time:440341ms step_avg:61.16ms
+step:7225/20000 train_loss:1.9591 train_time:441860ms step_avg:61.16ms
+step:7250/20000 train_loss:1.9961 train_time:443441ms step_avg:61.16ms
+step:7275/20000 train_loss:1.9750 train_time:444957ms step_avg:61.16ms
+step:7300/20000 train_loss:1.9968 train_time:446481ms step_avg:61.16ms
+step:7325/20000 train_loss:2.0675 train_time:447999ms step_avg:61.16ms
+step:7350/20000 train_loss:2.0956 train_time:449516ms step_avg:61.16ms
+step:7375/20000 train_loss:2.0261 train_time:451033ms step_avg:61.16ms
+step:7400/20000 train_loss:2.0233 train_time:452553ms step_avg:61.16ms
+step:7425/20000 train_loss:2.1093 train_time:454072ms step_avg:61.15ms
+step:7450/20000 train_loss:2.0059 train_time:455651ms step_avg:61.16ms
+step:7475/20000 train_loss:2.1520 train_time:457173ms step_avg:61.16ms
+step:7500/20000 train_loss:2.0161 train_time:458692ms step_avg:61.16ms
+step:7525/20000 train_loss:1.9327 train_time:460213ms step_avg:61.16ms
+step:7550/20000 train_loss:2.0692 train_time:461732ms step_avg:61.16ms
+step:7575/20000 train_loss:2.0251 train_time:463255ms step_avg:61.16ms
+step:7600/20000 train_loss:1.8910 train_time:464775ms step_avg:61.15ms
+step:7625/20000 train_loss:2.0159 train_time:466292ms step_avg:61.15ms
+step:7650/20000 train_loss:2.1902 train_time:467870ms step_avg:61.16ms
+step:7675/20000 train_loss:1.9612 train_time:469385ms step_avg:61.16ms
+step:7700/20000 train_loss:1.9762 train_time:470903ms step_avg:61.16ms
+step:7725/20000 train_loss:1.9534 train_time:472423ms step_avg:61.16ms
+step:7750/20000 train_loss:2.0015 train_time:473944ms step_avg:61.15ms
+step:7775/20000 train_loss:2.0276 train_time:475461ms step_avg:61.15ms
+step:7800/20000 train_loss:2.0374 train_time:476981ms step_avg:61.15ms
+step:7825/20000 train_loss:2.1405 train_time:478560ms step_avg:61.16ms
+step:7850/20000 train_loss:1.8655 train_time:480075ms step_avg:61.16ms
+step:7875/20000 train_loss:2.0447 train_time:481595ms step_avg:61.15ms
+step:7900/20000 train_loss:2.0176 train_time:483115ms step_avg:61.15ms
+step:7925/20000 train_loss:1.9337 train_time:484637ms step_avg:61.15ms
+step:7950/20000 train_loss:1.9832 train_time:486158ms step_avg:61.15ms
+step:7975/20000 train_loss:2.0731 train_time:487673ms step_avg:61.15ms
+step:8000/20000 train_loss:2.0055 train_time:489197ms step_avg:61.15ms
+step:8025/20000 train_loss:1.9992 train_time:490769ms step_avg:61.16ms
+step:8050/20000 train_loss:1.9638 train_time:492294ms step_avg:61.15ms
+step:8075/20000 train_loss:2.0087 train_time:493813ms step_avg:61.15ms
+step:8100/20000 train_loss:2.0313 train_time:495334ms step_avg:61.15ms
+step:8125/20000 train_loss:1.9635 train_time:496852ms step_avg:61.15ms
+step:8150/20000 train_loss:2.1406 train_time:498373ms step_avg:61.15ms
+step:8175/20000 train_loss:1.9568 train_time:499893ms step_avg:61.15ms
+step:8200/20000 train_loss:2.0718 train_time:501413ms step_avg:61.15ms
+step:8225/20000 train_loss:1.9905 train_time:502992ms step_avg:61.15ms
+step:8250/20000 train_loss:2.0288 train_time:504509ms step_avg:61.15ms
+step:8275/20000 train_loss:2.1203 train_time:506031ms step_avg:61.15ms
+step:8300/20000 train_loss:1.9940 train_time:507552ms step_avg:61.15ms
+step:8325/20000 train_loss:2.0007 train_time:509070ms step_avg:61.15ms
+step:8350/20000 train_loss:2.1030 train_time:510586ms step_avg:61.15ms
+step:8375/20000 train_loss:2.0275 train_time:512106ms step_avg:61.15ms
+step:8400/20000 train_loss:2.0015 train_time:513690ms step_avg:61.15ms
+step:8425/20000 train_loss:2.0478 train_time:515208ms step_avg:61.15ms
+step:8450/20000 train_loss:2.0869 train_time:516727ms step_avg:61.15ms
+step:8475/20000 train_loss:1.9983 train_time:518249ms step_avg:61.15ms
+step:8500/20000 train_loss:1.9844 train_time:519770ms step_avg:61.15ms
+step:8525/20000 train_loss:2.0435 train_time:521289ms step_avg:61.15ms
+step:8550/20000 train_loss:2.0603 train_time:522805ms step_avg:61.15ms
+step:8575/20000 train_loss:2.0380 train_time:524323ms step_avg:61.15ms
+step:8600/20000 train_loss:2.0106 train_time:525898ms step_avg:61.15ms
+step:8625/20000 train_loss:2.0303 train_time:527418ms step_avg:61.15ms
+step:8650/20000 train_loss:1.9582 train_time:528941ms step_avg:61.15ms
+step:8675/20000 train_loss:2.0022 train_time:530461ms step_avg:61.15ms
+step:8700/20000 train_loss:1.8937 train_time:531976ms step_avg:61.15ms
+step:8725/20000 train_loss:1.9574 train_time:533496ms step_avg:61.15ms
+step:8750/20000 train_loss:2.0520 train_time:535014ms step_avg:61.14ms
+step:8775/20000 train_loss:2.0270 train_time:536600ms step_avg:61.15ms
+step:8800/20000 train_loss:1.9581 train_time:538114ms step_avg:61.15ms
+step:8825/20000 train_loss:1.9776 train_time:539637ms step_avg:61.15ms
+step:8850/20000 train_loss:2.1527 train_time:541153ms step_avg:61.15ms
+step:8875/20000 train_loss:2.0163 train_time:542669ms step_avg:61.15ms
+step:8900/20000 train_loss:2.0522 train_time:544189ms step_avg:61.14ms
+step:8925/20000 train_loss:2.0308 train_time:545709ms step_avg:61.14ms
+step:8950/20000 train_loss:2.0129 train_time:547230ms step_avg:61.14ms
+step:8975/20000 train_loss:1.9836 train_time:548803ms step_avg:61.15ms
+step:9000/20000 train_loss:1.8671 train_time:550322ms step_avg:61.15ms
+step:9025/20000 train_loss:2.0711 train_time:551842ms step_avg:61.15ms
+swa:start step:9050
+step:9050/20000 train_loss:1.9023 train_time:553359ms step_avg:61.14ms
+step:9075/20000 train_loss:2.0503 train_time:554983ms step_avg:61.16ms
+step:9100/20000 train_loss:2.1426 train_time:556503ms step_avg:61.15ms
+step:9125/20000 train_loss:1.9765 train_time:558107ms step_avg:61.16ms
+step:9150/20000 train_loss:1.8313 train_time:559626ms step_avg:61.16ms
+step:9175/20000 train_loss:1.9407 train_time:561266ms step_avg:61.17ms
+step:9200/20000 train_loss:1.9314 train_time:562784ms step_avg:61.17ms
+late_qat:enabled step:9207 scale:0.1500
+step:9225/20000 train_loss:1.9761 train_time:564363ms step_avg:61.18ms
+step:9250/20000 train_loss:2.0313 train_time:565885ms step_avg:61.18ms
+step:9275/20000 train_loss:1.9959 train_time:567461ms step_avg:61.18ms
+step:9300/20000 train_loss:1.9691 train_time:568978ms step_avg:61.18ms
+step:9325/20000 train_loss:1.9293 train_time:570554ms step_avg:61.19ms
+step:9350/20000 train_loss:2.0570 train_time:572135ms step_avg:61.19ms
+step:9375/20000 train_loss:1.9535 train_time:573715ms step_avg:61.20ms
+step:9400/20000 train_loss:1.9489 train_time:575235ms step_avg:61.20ms
+step:9425/20000 train_loss:1.9733 train_time:576813ms step_avg:61.20ms
+step:9450/20000 train_loss:1.9984 train_time:578332ms step_avg:61.20ms
+step:9475/20000 train_loss:1.8917 train_time:579923ms step_avg:61.21ms
+step:9500/20000 train_loss:2.0810 train_time:581441ms step_avg:61.20ms
+step:9525/20000 train_loss:1.8715 train_time:583031ms step_avg:61.21ms
+step:9550/20000 train_loss:2.0237 train_time:584611ms step_avg:61.22ms
+step:9575/20000 train_loss:1.9787 train_time:586187ms step_avg:61.22ms
+step:9600/20000 train_loss:1.9714 train_time:587705ms step_avg:61.22ms
+step:9625/20000 train_loss:2.1711 train_time:589284ms step_avg:61.22ms
+step:9650/20000 train_loss:1.8942 train_time:590806ms step_avg:61.22ms
+step:9675/20000 train_loss:2.1300 train_time:592382ms step_avg:61.23ms
+step:9700/20000 train_loss:1.9121 train_time:593901ms step_avg:61.23ms
+step:9725/20000 train_loss:1.9941 train_time:595482ms step_avg:61.23ms
+step:9750/20000 train_loss:1.8771 train_time:597063ms step_avg:61.24ms
+step:9775/20000 train_loss:2.0289 train_time:598640ms step_avg:61.24ms
+step:9798/20000 val_loss:1.9226 val_bpb:1.1387 train_time:600063ms step_avg:61.24ms
+stopping_early: wallclock_cap train_time:600063ms step:9798/20000
+peak memory allocated: 15496 MiB reserved: 19392 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9209 val_bpb:1.1376 eval_time:1977ms
+Serialized model: 107035704 bytes
+Code size: 118833 bytes
+gptq:building non-banked model for Hessian collection...
+gptq:generating autoregressive calibration data (64 seqs x 2048 tokens, temp=0.8)...
+gptq:generated 64 sequences in 159.2s
+gptq:collecting hessians from autoregressive data...
+gptq:collected hessians for 69 layers (AR self-gen)
+selective_prune: 4153747 ±1 candidates, unpruned=15.45MB target=15.9MB
+selective_prune: already fits, no pruning needed
+Serialized model int6+lzma: 16079020 bytes
+Total submission size int6+lzma: 16197853 bytes
+final_int6_roundtrip val_loss:1.9266 val_bpb:1.1410 eval_time:22579ms
+final_int6_roundtrip_exact val_loss:1.92659834 val_bpb:1.14104006
+final_int6_sliding_window val_loss:1.8867 val_bpb:1.1174 stride:64 eval_time:108505ms
+final_int6_sliding_window_exact val_loss:1.88665175 val_bpb:1.11738440
+final_int8_zlib_roundtrip_exact val_loss:1.88665175 val_bpb:1.11738440

--- a/records/track_non_record_16mb/2026-04-04_NegativeResults_GatedMultiOrderHash/run_submit_multi_hash_tail64.log
+++ b/records/track_non_record_16mb/2026-04-04_NegativeResults_GatedMultiOrderHash/run_submit_multi_hash_tail64.log
@@ -1,0 +1,720 @@
+ _____                             _
+|  __ \                           | |
+| |__) |   _ _ __  _ __   ___   __| |
+|  _  / | | | '_ \| '_ \ / _ \ / _` |
+| | \ \ |_| | | | | |_) | (_) | (_| |
+|_|  \_\__,_|_| |_| .__/ \___/ \__,_|
+                  | |
+                  |_|
+For detailed documentation and guides, please visit:
+https://docs.runpod.io/ and https://blog.runpod.io/
+
+
+root@d70a7096bc3f:/workspace/parameter-golf# cd /workspace
+root@d70a7096bc3f:/workspace# git clone https://github.com/xiayicheng3-code/parameter-golf-base.git || true
+Cloning into 'parameter-golf-base'...
+remote: Enumerating objects: 1060, done.
+remote: Counting objects: 100% (38/38), done.
+remote: Compressing objects: 100% (23/23), done.
+remote: Total 1060 (delta 26), reused 26 (delta 15), pack-reused 1022 (from 3)
+Receiving objects: 100% (1060/1060), 2.59 MiB | 2.14 MiB/s, done.
+Resolving deltas: 100% (547/547), done.
+root@d70a7096bc3f:/workspace# cd /workspace/parameter-golf-base
+root@d70a7096bc3f:/workspace/parameter-golf-base# git fetch origin
+root@d70a7096bc3f:/workspace/parameter-golf-base# git pull --ff-only
+Already up to date.
+root@d70a7096bc3f:/workspace/parameter-golf-base#
+root@d70a7096bc3f:/workspace/parameter-golf-base# python3 data/cached_challenge_fineweb.py --variant sp1024 --train-shards 80
+manifest.json: 1.93kB [00:00, 3.69MB/s]
+Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 124M/124M [00:02<00:00, 44.0MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 98.9MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 124MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 99.2MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 196MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|██████████████████████████████████████████████| 200M/200M [00:02<00:00, 99.5MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 124MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/tokenizers/fineweb_1024_bpe.mod(…): 100%|███████████████████████████████████████████████| 254k/254k [00:00<00:00, 310kB/s]
+fineweb_1024_bpe.vocab: 9.86kB [00:00, 5.84MB/s]
+root@d70a7096bc3f:/workspace/parameter-golf-base# cd /workspace/parameter-golf-base/experiments/m34a_sota_graft
+root@d70a7096bc3f:/workspace/parameter-golf-base/experiments/m34a_sota_graft# RUN_ID=m34a_sota_graft_8xh100_submit1 \
+> DATA_PATH=../../data/datasets/fineweb10B_sp1024 \
+> TOKENIZER_PATH=../../data/tokenizers/fineweb_1024_bpe.model \
+> NUM_LAYERS=11 \
+> MODEL_DIM=512 \
+> NUM_HEADS=8 \
+> NUM_KV_HEADS=4 \
+> MLP_MULT=3.0 \
+> TRAIN_BATCH_TOKENS=524288 \
+> GRAD_ACCUM_STEPS=1 \
+> VAL_BATCH_SIZE=4194304 \
+> VAL_LOSS_EVERY=0 \
+> TRAIN_LOG_EVERY=25 \
+> MAX_WALLCLOCK_SECONDS=600 \
+> NGRAM_DIM=112 \
+> NGRAM_ORDERS=2,3,4 \
+> NGRAM_VOCAB_SIZES=3072,1536,768 \
+> NGRAM_NUM_HASHES=2,2,2 \
+> NGRAM_INIT_STD=0.005 \
+> TRAIN_TAIL_LOSS_TOKENS=64 \
+> TRAIN_TAIL_LOSS_WEIGHT=2.0 \
+> EVAL_STRIDE=64 \
+> GPTQ_CALIB_SOURCE=ar_prompt_bank \
+> torchrun --standalone --nproc_per_node=8 train_gpt.py
+W0404 03:03:09.848000 1371 torch/distributed/run.py:803]
+W0404 03:03:09.848000 1371 torch/distributed/run.py:803] *****************************************
+W0404 03:03:09.848000 1371 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed.
+W0404 03:03:09.848000 1371 torch/distributed/run.py:803] *****************************************
+logs/m34a_sota_graft_8xh100_submit1.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=../../data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=../../data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:27382879
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_11 active_layers:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025 ngram_wd:0.0001
+train_batch_tokens:524288 train_seq_len:2048 micro_batch_tokens:65536 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+eval_stride:64 train_tail_loss_tokens:64 train_tail_loss_weight:2.0
+gptq_calib_source:ar_prompt_bank gptq_cache_num_batches:4 gptq_cache_max_seqs:64
+gptq_ar_temperature:0.8 gptq_ar_repeat_penalty:1.05 gptq_ar_repeat_last_n:128
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:1/20000 train_loss:6.9306 train_time:117ms step_avg:116.61ms
+step:2/20000 train_loss:8.7558 train_time:151ms step_avg:75.28ms
+step:3/20000 train_loss:7.6167 train_time:209ms step_avg:69.69ms
+step:4/20000 train_loss:7.5179 train_time:270ms step_avg:67.58ms
+step:5/20000 train_loss:7.0632 train_time:331ms step_avg:66.17ms
+step:6/20000 train_loss:7.8831 train_time:392ms step_avg:65.30ms
+step:7/20000 train_loss:6.9034 train_time:452ms step_avg:64.55ms
+step:8/20000 train_loss:6.6669 train_time:512ms step_avg:63.95ms
+step:9/20000 train_loss:6.4726 train_time:573ms step_avg:63.62ms
+step:10/20000 train_loss:6.2122 train_time:638ms step_avg:63.79ms
+step:25/20000 train_loss:4.4906 train_time:1539ms step_avg:61.57ms
+step:50/20000 train_loss:3.9083 train_time:3040ms step_avg:60.79ms
+step:75/20000 train_loss:3.4774 train_time:4547ms step_avg:60.63ms
+step:100/20000 train_loss:3.2853 train_time:6059ms step_avg:60.59ms
+step:125/20000 train_loss:3.0020 train_time:7569ms step_avg:60.55ms
+step:150/20000 train_loss:2.9729 train_time:9078ms step_avg:60.52ms
+step:175/20000 train_loss:2.7258 train_time:10589ms step_avg:60.51ms
+step:200/20000 train_loss:2.7442 train_time:12160ms step_avg:60.80ms
+step:225/20000 train_loss:2.7637 train_time:13679ms step_avg:60.79ms
+step:250/20000 train_loss:2.6452 train_time:15191ms step_avg:60.76ms
+step:275/20000 train_loss:2.5484 train_time:16707ms step_avg:60.75ms
+step:300/20000 train_loss:2.3630 train_time:18221ms step_avg:60.74ms
+step:325/20000 train_loss:2.4658 train_time:19738ms step_avg:60.73ms
+step:350/20000 train_loss:2.5497 train_time:21246ms step_avg:60.70ms
+step:375/20000 train_loss:2.5088 train_time:22759ms step_avg:60.69ms
+step:400/20000 train_loss:2.2357 train_time:24332ms step_avg:60.83ms
+step:425/20000 train_loss:2.4523 train_time:25847ms step_avg:60.82ms
+step:450/20000 train_loss:2.3877 train_time:27360ms step_avg:60.80ms
+step:475/20000 train_loss:2.3801 train_time:28881ms step_avg:60.80ms
+step:500/20000 train_loss:2.3835 train_time:30396ms step_avg:60.79ms
+step:525/20000 train_loss:2.4260 train_time:31915ms step_avg:60.79ms
+step:550/20000 train_loss:2.2844 train_time:33436ms step_avg:60.79ms
+step:575/20000 train_loss:2.3530 train_time:35013ms step_avg:60.89ms
+step:600/20000 train_loss:2.4390 train_time:36527ms step_avg:60.88ms
+step:625/20000 train_loss:2.3718 train_time:38046ms step_avg:60.87ms
+step:650/20000 train_loss:2.2829 train_time:39564ms step_avg:60.87ms
+step:675/20000 train_loss:2.2169 train_time:41082ms step_avg:60.86ms
+step:700/20000 train_loss:2.3386 train_time:42603ms step_avg:60.86ms
+step:725/20000 train_loss:2.3140 train_time:44120ms step_avg:60.86ms
+step:750/20000 train_loss:2.1804 train_time:45640ms step_avg:60.85ms
+step:775/20000 train_loss:2.2518 train_time:47203ms step_avg:60.91ms
+step:800/20000 train_loss:2.1916 train_time:48728ms step_avg:60.91ms
+step:825/20000 train_loss:2.3284 train_time:50244ms step_avg:60.90ms
+step:850/20000 train_loss:2.6250 train_time:51762ms step_avg:60.90ms
+step:875/20000 train_loss:2.2848 train_time:53286ms step_avg:60.90ms
+step:900/20000 train_loss:2.2577 train_time:54809ms step_avg:60.90ms
+step:925/20000 train_loss:2.1215 train_time:56330ms step_avg:60.90ms
+step:950/20000 train_loss:2.3058 train_time:57853ms step_avg:60.90ms
+step:975/20000 train_loss:2.0186 train_time:59442ms step_avg:60.97ms
+step:1000/20000 train_loss:2.3005 train_time:60961ms step_avg:60.96ms
+step:1025/20000 train_loss:2.3086 train_time:62482ms step_avg:60.96ms
+step:1050/20000 train_loss:2.4179 train_time:64006ms step_avg:60.96ms
+step:1075/20000 train_loss:2.1125 train_time:65528ms step_avg:60.96ms
+step:1100/20000 train_loss:2.1742 train_time:67051ms step_avg:60.96ms
+step:1125/20000 train_loss:2.2667 train_time:68582ms step_avg:60.96ms
+step:1150/20000 train_loss:2.1750 train_time:70154ms step_avg:61.00ms
+step:1175/20000 train_loss:2.1398 train_time:71675ms step_avg:61.00ms
+step:1200/20000 train_loss:2.3202 train_time:73202ms step_avg:61.00ms
+step:1225/20000 train_loss:2.3306 train_time:74724ms step_avg:61.00ms
+step:1250/20000 train_loss:2.1414 train_time:76245ms step_avg:61.00ms
+step:1275/20000 train_loss:2.2409 train_time:77767ms step_avg:60.99ms
+step:1300/20000 train_loss:2.2969 train_time:79288ms step_avg:60.99ms
+step:1325/20000 train_loss:2.2490 train_time:80813ms step_avg:60.99ms
+step:1350/20000 train_loss:2.1923 train_time:82393ms step_avg:61.03ms
+step:1375/20000 train_loss:2.3469 train_time:83926ms step_avg:61.04ms
+step:1400/20000 train_loss:2.3598 train_time:85449ms step_avg:61.03ms
+step:1425/20000 train_loss:2.2469 train_time:86977ms step_avg:61.04ms
+step:1450/20000 train_loss:2.1763 train_time:88500ms step_avg:61.03ms
+step:1475/20000 train_loss:2.2448 train_time:90025ms step_avg:61.03ms
+step:1500/20000 train_loss:2.1667 train_time:91549ms step_avg:61.03ms
+step:1525/20000 train_loss:2.2820 train_time:93078ms step_avg:61.03ms
+step:1550/20000 train_loss:2.0888 train_time:94665ms step_avg:61.07ms
+step:1575/20000 train_loss:2.2171 train_time:96181ms step_avg:61.07ms
+step:1600/20000 train_loss:2.0325 train_time:97706ms step_avg:61.07ms
+step:1625/20000 train_loss:2.1475 train_time:99229ms step_avg:61.06ms
+step:1650/20000 train_loss:2.1699 train_time:100756ms step_avg:61.06ms
+step:1675/20000 train_loss:2.1719 train_time:102282ms step_avg:61.06ms
+step:1700/20000 train_loss:2.0983 train_time:103805ms step_avg:61.06ms
+step:1725/20000 train_loss:2.1975 train_time:105386ms step_avg:61.09ms
+step:1750/20000 train_loss:2.1770 train_time:106910ms step_avg:61.09ms
+step:1775/20000 train_loss:2.1381 train_time:108436ms step_avg:61.09ms
+step:1800/20000 train_loss:2.1393 train_time:109966ms step_avg:61.09ms
+step:1825/20000 train_loss:2.2007 train_time:111483ms step_avg:61.09ms
+step:1850/20000 train_loss:2.2357 train_time:113007ms step_avg:61.08ms
+step:1875/20000 train_loss:2.1285 train_time:114530ms step_avg:61.08ms
+step:1900/20000 train_loss:2.1179 train_time:116057ms step_avg:61.08ms
+step:1925/20000 train_loss:2.1546 train_time:117644ms step_avg:61.11ms
+step:1950/20000 train_loss:2.1358 train_time:119166ms step_avg:61.11ms
+step:1975/20000 train_loss:2.1975 train_time:120690ms step_avg:61.11ms
+step:2000/20000 train_loss:2.1745 train_time:122214ms step_avg:61.11ms
+step:2025/20000 train_loss:2.2744 train_time:123741ms step_avg:61.11ms
+step:2050/20000 train_loss:2.1741 train_time:125261ms step_avg:61.10ms
+step:2075/20000 train_loss:2.0478 train_time:126787ms step_avg:61.10ms
+step:2100/20000 train_loss:2.1890 train_time:128376ms step_avg:61.13ms
+step:2125/20000 train_loss:2.1686 train_time:129895ms step_avg:61.13ms
+step:2150/20000 train_loss:2.0998 train_time:131422ms step_avg:61.13ms
+step:2175/20000 train_loss:2.0620 train_time:132942ms step_avg:61.12ms
+step:2200/20000 train_loss:1.9909 train_time:134466ms step_avg:61.12ms
+step:2225/20000 train_loss:2.1280 train_time:135994ms step_avg:61.12ms
+step:2250/20000 train_loss:2.0871 train_time:137518ms step_avg:61.12ms
+step:2275/20000 train_loss:2.2071 train_time:139041ms step_avg:61.12ms
+step:2300/20000 train_loss:2.2862 train_time:140616ms step_avg:61.14ms
+step:2325/20000 train_loss:2.0948 train_time:142146ms step_avg:61.14ms
+step:2350/20000 train_loss:2.1082 train_time:143667ms step_avg:61.14ms
+step:2375/20000 train_loss:2.0359 train_time:145192ms step_avg:61.13ms
+step:2400/20000 train_loss:2.1180 train_time:146716ms step_avg:61.13ms
+step:2425/20000 train_loss:2.1282 train_time:148238ms step_avg:61.13ms
+step:2450/20000 train_loss:2.1240 train_time:149762ms step_avg:61.13ms
+step:2475/20000 train_loss:2.1125 train_time:151285ms step_avg:61.13ms
+step:2500/20000 train_loss:2.0507 train_time:152869ms step_avg:61.15ms
+step:2525/20000 train_loss:2.0522 train_time:154389ms step_avg:61.14ms
+step:2550/20000 train_loss:2.0542 train_time:155915ms step_avg:61.14ms
+step:2575/20000 train_loss:2.1214 train_time:157440ms step_avg:61.14ms
+step:2600/20000 train_loss:2.3456 train_time:158961ms step_avg:61.14ms
+step:2625/20000 train_loss:1.9879 train_time:160483ms step_avg:61.14ms
+step:2650/20000 train_loss:2.1460 train_time:162004ms step_avg:61.13ms
+step:2675/20000 train_loss:2.2193 train_time:163584ms step_avg:61.15ms
+step:2700/20000 train_loss:2.0700 train_time:165100ms step_avg:61.15ms
+step:2725/20000 train_loss:1.9970 train_time:166625ms step_avg:61.15ms
+step:2750/20000 train_loss:2.2868 train_time:168148ms step_avg:61.14ms
+step:2775/20000 train_loss:2.0538 train_time:169668ms step_avg:61.14ms
+step:2800/20000 train_loss:2.1553 train_time:171195ms step_avg:61.14ms
+step:2825/20000 train_loss:2.2582 train_time:172710ms step_avg:61.14ms
+step:2850/20000 train_loss:2.1056 train_time:174233ms step_avg:61.13ms
+step:2875/20000 train_loss:2.2636 train_time:175814ms step_avg:61.15ms
+step:2900/20000 train_loss:2.1043 train_time:177343ms step_avg:61.15ms
+step:2925/20000 train_loss:2.0457 train_time:178865ms step_avg:61.15ms
+step:2950/20000 train_loss:2.1562 train_time:180395ms step_avg:61.15ms
+step:2975/20000 train_loss:2.0523 train_time:181908ms step_avg:61.15ms
+step:3000/20000 train_loss:2.1467 train_time:183431ms step_avg:61.14ms
+step:3025/20000 train_loss:2.1414 train_time:184953ms step_avg:61.14ms
+step:3050/20000 train_loss:2.0817 train_time:186476ms step_avg:61.14ms
+step:3075/20000 train_loss:2.1955 train_time:188049ms step_avg:61.15ms
+step:3100/20000 train_loss:2.1154 train_time:189569ms step_avg:61.15ms
+step:3125/20000 train_loss:2.0350 train_time:191088ms step_avg:61.15ms
+step:3150/20000 train_loss:2.0845 train_time:192608ms step_avg:61.15ms
+step:3175/20000 train_loss:2.2288 train_time:194129ms step_avg:61.14ms
+step:3200/20000 train_loss:2.1135 train_time:195651ms step_avg:61.14ms
+step:3225/20000 train_loss:2.1757 train_time:197171ms step_avg:61.14ms
+step:3250/20000 train_loss:2.0118 train_time:198757ms step_avg:61.16ms
+step:3275/20000 train_loss:2.2090 train_time:200281ms step_avg:61.15ms
+step:3300/20000 train_loss:2.1617 train_time:201804ms step_avg:61.15ms
+step:3325/20000 train_loss:2.1557 train_time:203325ms step_avg:61.15ms
+step:3350/20000 train_loss:2.0096 train_time:204847ms step_avg:61.15ms
+step:3375/20000 train_loss:2.0055 train_time:206364ms step_avg:61.15ms
+step:3400/20000 train_loss:2.0860 train_time:207886ms step_avg:61.14ms
+step:3425/20000 train_loss:2.0072 train_time:209407ms step_avg:61.14ms
+step:3450/20000 train_loss:2.0087 train_time:210986ms step_avg:61.16ms
+step:3475/20000 train_loss:2.0506 train_time:212507ms step_avg:61.15ms
+step:3500/20000 train_loss:2.1765 train_time:214028ms step_avg:61.15ms
+step:3525/20000 train_loss:2.1445 train_time:215549ms step_avg:61.15ms
+step:3550/20000 train_loss:2.3249 train_time:217074ms step_avg:61.15ms
+step:3575/20000 train_loss:2.1330 train_time:218596ms step_avg:61.15ms
+step:3600/20000 train_loss:2.0258 train_time:220117ms step_avg:61.14ms
+step:3625/20000 train_loss:2.0866 train_time:221703ms step_avg:61.16ms
+step:3650/20000 train_loss:2.1319 train_time:223221ms step_avg:61.16ms
+step:3675/20000 train_loss:2.3025 train_time:224741ms step_avg:61.15ms
+step:3700/20000 train_loss:2.0597 train_time:226259ms step_avg:61.15ms
+step:3725/20000 train_loss:2.1500 train_time:227779ms step_avg:61.15ms
+step:3750/20000 train_loss:2.0683 train_time:229300ms step_avg:61.15ms
+step:3775/20000 train_loss:2.0119 train_time:230821ms step_avg:61.14ms
+step:3800/20000 train_loss:2.1359 train_time:232347ms step_avg:61.14ms
+step:3825/20000 train_loss:2.1567 train_time:233910ms step_avg:61.15ms
+step:3850/20000 train_loss:2.0933 train_time:235441ms step_avg:61.15ms
+step:3875/20000 train_loss:2.0775 train_time:236962ms step_avg:61.15ms
+step:3900/20000 train_loss:1.9154 train_time:238482ms step_avg:61.15ms
+step:3925/20000 train_loss:2.0790 train_time:240009ms step_avg:61.15ms
+step:3950/20000 train_loss:2.0606 train_time:241522ms step_avg:61.14ms
+step:3975/20000 train_loss:2.0741 train_time:243040ms step_avg:61.14ms
+step:4000/20000 train_loss:2.1005 train_time:244561ms step_avg:61.14ms
+step:4025/20000 train_loss:2.1861 train_time:246148ms step_avg:61.15ms
+step:4050/20000 train_loss:2.0328 train_time:247668ms step_avg:61.15ms
+step:4075/20000 train_loss:2.0161 train_time:249188ms step_avg:61.15ms
+step:4100/20000 train_loss:2.1168 train_time:250713ms step_avg:61.15ms
+step:4125/20000 train_loss:2.0692 train_time:252225ms step_avg:61.15ms
+step:4150/20000 train_loss:2.2542 train_time:253745ms step_avg:61.14ms
+step:4175/20000 train_loss:2.0893 train_time:255268ms step_avg:61.14ms
+step:4200/20000 train_loss:2.0976 train_time:256848ms step_avg:61.15ms
+step:4225/20000 train_loss:2.1930 train_time:258362ms step_avg:61.15ms
+step:4250/20000 train_loss:2.0456 train_time:259885ms step_avg:61.15ms
+step:4275/20000 train_loss:1.9965 train_time:261407ms step_avg:61.15ms
+step:4300/20000 train_loss:1.9347 train_time:262929ms step_avg:61.15ms
+step:4325/20000 train_loss:2.0423 train_time:264451ms step_avg:61.14ms
+step:4350/20000 train_loss:2.1471 train_time:265971ms step_avg:61.14ms
+step:4375/20000 train_loss:2.0815 train_time:267491ms step_avg:61.14ms
+step:4400/20000 train_loss:2.0327 train_time:269065ms step_avg:61.15ms
+step:4425/20000 train_loss:2.1648 train_time:270589ms step_avg:61.15ms
+step:4450/20000 train_loss:1.9922 train_time:272110ms step_avg:61.15ms
+step:4475/20000 train_loss:2.1424 train_time:273631ms step_avg:61.15ms
+step:4500/20000 train_loss:2.1836 train_time:275153ms step_avg:61.15ms
+step:4525/20000 train_loss:2.0664 train_time:276675ms step_avg:61.14ms
+step:4550/20000 train_loss:1.9778 train_time:278198ms step_avg:61.14ms
+step:4575/20000 train_loss:2.0868 train_time:279720ms step_avg:61.14ms
+step:4600/20000 train_loss:1.8991 train_time:281296ms step_avg:61.15ms
+step:4625/20000 train_loss:2.1900 train_time:282811ms step_avg:61.15ms
+step:4650/20000 train_loss:1.9973 train_time:284334ms step_avg:61.15ms
+step:4675/20000 train_loss:2.0078 train_time:285855ms step_avg:61.15ms
+step:4700/20000 train_loss:2.2047 train_time:287375ms step_avg:61.14ms
+step:4725/20000 train_loss:2.1270 train_time:288890ms step_avg:61.14ms
+step:4750/20000 train_loss:1.8889 train_time:290410ms step_avg:61.14ms
+step:4775/20000 train_loss:2.0126 train_time:291995ms step_avg:61.15ms
+step:4800/20000 train_loss:2.1927 train_time:293516ms step_avg:61.15ms
+step:4825/20000 train_loss:2.1854 train_time:295036ms step_avg:61.15ms
+step:4850/20000 train_loss:2.0827 train_time:296552ms step_avg:61.14ms
+step:4875/20000 train_loss:1.9921 train_time:298069ms step_avg:61.14ms
+step:4900/20000 train_loss:2.0999 train_time:299587ms step_avg:61.14ms
+step:4925/20000 train_loss:2.0803 train_time:301106ms step_avg:61.14ms
+step:4950/20000 train_loss:2.2852 train_time:302625ms step_avg:61.14ms
+step:4975/20000 train_loss:2.1140 train_time:304204ms step_avg:61.15ms
+step:5000/20000 train_loss:1.9459 train_time:305726ms step_avg:61.15ms
+step:5025/20000 train_loss:1.9876 train_time:307243ms step_avg:61.14ms
+step:5050/20000 train_loss:2.1499 train_time:308763ms step_avg:61.14ms
+step:5075/20000 train_loss:2.0555 train_time:310283ms step_avg:61.14ms
+step:5100/20000 train_loss:1.9601 train_time:311802ms step_avg:61.14ms
+step:5125/20000 train_loss:2.0589 train_time:313324ms step_avg:61.14ms
+step:5150/20000 train_loss:2.2235 train_time:314915ms step_avg:61.15ms
+step:5175/20000 train_loss:1.8536 train_time:316430ms step_avg:61.15ms
+step:5200/20000 train_loss:2.1075 train_time:317949ms step_avg:61.14ms
+step:5225/20000 train_loss:2.0379 train_time:319468ms step_avg:61.14ms
+step:5250/20000 train_loss:2.0613 train_time:321003ms step_avg:61.14ms
+step:5275/20000 train_loss:2.0777 train_time:322579ms step_avg:61.15ms
+step:5300/20000 train_loss:2.1417 train_time:324102ms step_avg:61.15ms
+step:5325/20000 train_loss:2.0365 train_time:325623ms step_avg:61.15ms
+step:5350/20000 train_loss:2.0886 train_time:327198ms step_avg:61.16ms
+step:5375/20000 train_loss:2.1291 train_time:328720ms step_avg:61.16ms
+step:5400/20000 train_loss:2.1263 train_time:330238ms step_avg:61.16ms
+step:5425/20000 train_loss:2.1120 train_time:331752ms step_avg:61.15ms
+step:5450/20000 train_loss:2.1456 train_time:333273ms step_avg:61.15ms
+step:5475/20000 train_loss:1.8888 train_time:334792ms step_avg:61.15ms
+step:5500/20000 train_loss:2.0816 train_time:336313ms step_avg:61.15ms
+step:5525/20000 train_loss:2.0459 train_time:337838ms step_avg:61.15ms
+step:5550/20000 train_loss:2.0431 train_time:339419ms step_avg:61.16ms
+step:5575/20000 train_loss:2.0026 train_time:340934ms step_avg:61.15ms
+step:5600/20000 train_loss:2.1238 train_time:342452ms step_avg:61.15ms
+step:5625/20000 train_loss:2.0431 train_time:343967ms step_avg:61.15ms
+step:5650/20000 train_loss:1.9880 train_time:345482ms step_avg:61.15ms
+step:5675/20000 train_loss:2.0916 train_time:347003ms step_avg:61.15ms
+step:5700/20000 train_loss:2.1022 train_time:348520ms step_avg:61.14ms
+step:5725/20000 train_loss:2.0466 train_time:350098ms step_avg:61.15ms
+step:5750/20000 train_loss:2.1500 train_time:351615ms step_avg:61.15ms
+step:5775/20000 train_loss:2.0586 train_time:353139ms step_avg:61.15ms
+step:5800/20000 train_loss:2.0771 train_time:354658ms step_avg:61.15ms
+step:5825/20000 train_loss:2.0309 train_time:356174ms step_avg:61.15ms
+step:5850/20000 train_loss:2.1196 train_time:357693ms step_avg:61.14ms
+step:5875/20000 train_loss:2.0908 train_time:359210ms step_avg:61.14ms
+step:5900/20000 train_loss:2.0293 train_time:360730ms step_avg:61.14ms
+step:5925/20000 train_loss:2.0343 train_time:362304ms step_avg:61.15ms
+step:5950/20000 train_loss:2.0754 train_time:363829ms step_avg:61.15ms
+step:5975/20000 train_loss:1.9711 train_time:365348ms step_avg:61.15ms
+step:6000/20000 train_loss:2.1526 train_time:366867ms step_avg:61.14ms
+step:6025/20000 train_loss:2.0562 train_time:368387ms step_avg:61.14ms
+step:6050/20000 train_loss:2.0630 train_time:369905ms step_avg:61.14ms
+step:6075/20000 train_loss:2.0086 train_time:371422ms step_avg:61.14ms
+step:6100/20000 train_loss:2.0578 train_time:372941ms step_avg:61.14ms
+step:6125/20000 train_loss:2.0732 train_time:374516ms step_avg:61.15ms
+step:6150/20000 train_loss:2.0322 train_time:376031ms step_avg:61.14ms
+step:6175/20000 train_loss:2.1388 train_time:377553ms step_avg:61.14ms
+step:6200/20000 train_loss:2.0335 train_time:379074ms step_avg:61.14ms
+step:6225/20000 train_loss:2.0782 train_time:380592ms step_avg:61.14ms
+step:6250/20000 train_loss:2.0995 train_time:382110ms step_avg:61.14ms
+step:6275/20000 train_loss:1.9114 train_time:383630ms step_avg:61.14ms
+step:6300/20000 train_loss:1.9712 train_time:385216ms step_avg:61.15ms
+step:6325/20000 train_loss:2.0783 train_time:386731ms step_avg:61.14ms
+step:6350/20000 train_loss:1.9478 train_time:388253ms step_avg:61.14ms
+step:6375/20000 train_loss:2.1517 train_time:389771ms step_avg:61.14ms
+step:6400/20000 train_loss:2.0980 train_time:391294ms step_avg:61.14ms
+step:6425/20000 train_loss:2.0077 train_time:392816ms step_avg:61.14ms
+step:6450/20000 train_loss:2.0192 train_time:394331ms step_avg:61.14ms
+step:6475/20000 train_loss:2.1672 train_time:395851ms step_avg:61.14ms
+step:6500/20000 train_loss:2.0217 train_time:397422ms step_avg:61.14ms
+step:6525/20000 train_loss:2.0544 train_time:398944ms step_avg:61.14ms
+step:6550/20000 train_loss:2.1442 train_time:400461ms step_avg:61.14ms
+step:6575/20000 train_loss:2.0514 train_time:401979ms step_avg:61.14ms
+step:6600/20000 train_loss:2.0550 train_time:403492ms step_avg:61.14ms
+step:6625/20000 train_loss:1.9952 train_time:405012ms step_avg:61.13ms
+step:6650/20000 train_loss:2.2221 train_time:406532ms step_avg:61.13ms
+step:6675/20000 train_loss:2.1835 train_time:408051ms step_avg:61.13ms
+step:6700/20000 train_loss:2.0935 train_time:409630ms step_avg:61.14ms
+step:6725/20000 train_loss:2.0925 train_time:411149ms step_avg:61.14ms
+step:6750/20000 train_loss:2.2483 train_time:412668ms step_avg:61.14ms
+step:6775/20000 train_loss:2.0650 train_time:414184ms step_avg:61.13ms
+step:6800/20000 train_loss:2.1091 train_time:415701ms step_avg:61.13ms
+step:6825/20000 train_loss:1.9499 train_time:417222ms step_avg:61.13ms
+step:6850/20000 train_loss:1.9542 train_time:418741ms step_avg:61.13ms
+step:6875/20000 train_loss:2.0421 train_time:420307ms step_avg:61.14ms
+step:6900/20000 train_loss:2.0204 train_time:421825ms step_avg:61.13ms
+step:6925/20000 train_loss:1.8792 train_time:423342ms step_avg:61.13ms
+step:6950/20000 train_loss:2.0989 train_time:424861ms step_avg:61.13ms
+step:6975/20000 train_loss:2.1095 train_time:426379ms step_avg:61.13ms
+step:7000/20000 train_loss:2.1523 train_time:427895ms step_avg:61.13ms
+step:7025/20000 train_loss:2.0265 train_time:429412ms step_avg:61.13ms
+step:7050/20000 train_loss:2.1820 train_time:430929ms step_avg:61.12ms
+step:7075/20000 train_loss:2.0553 train_time:432508ms step_avg:61.13ms
+step:7100/20000 train_loss:1.9854 train_time:434023ms step_avg:61.13ms
+step:7125/20000 train_loss:2.0847 train_time:435543ms step_avg:61.13ms
+step:7150/20000 train_loss:2.0711 train_time:437061ms step_avg:61.13ms
+step:7175/20000 train_loss:1.9034 train_time:438580ms step_avg:61.13ms
+step:7200/20000 train_loss:2.1160 train_time:440099ms step_avg:61.12ms
+step:7225/20000 train_loss:1.9715 train_time:441612ms step_avg:61.12ms
+step:7250/20000 train_loss:2.0144 train_time:443189ms step_avg:61.13ms
+step:7275/20000 train_loss:1.9873 train_time:444703ms step_avg:61.13ms
+step:7300/20000 train_loss:2.0160 train_time:446223ms step_avg:61.13ms
+step:7325/20000 train_loss:2.0732 train_time:447740ms step_avg:61.12ms
+step:7350/20000 train_loss:2.1064 train_time:449257ms step_avg:61.12ms
+step:7375/20000 train_loss:2.0369 train_time:450774ms step_avg:61.12ms
+step:7400/20000 train_loss:2.0378 train_time:452292ms step_avg:61.12ms
+step:7425/20000 train_loss:2.1229 train_time:453809ms step_avg:61.12ms
+step:7450/20000 train_loss:2.0181 train_time:455388ms step_avg:61.13ms
+step:7475/20000 train_loss:2.1628 train_time:456909ms step_avg:61.12ms
+step:7500/20000 train_loss:2.0303 train_time:458427ms step_avg:61.12ms
+step:7525/20000 train_loss:1.9494 train_time:459943ms step_avg:61.12ms
+step:7550/20000 train_loss:2.0787 train_time:461462ms step_avg:61.12ms
+step:7575/20000 train_loss:2.0366 train_time:462980ms step_avg:61.12ms
+step:7600/20000 train_loss:1.9038 train_time:464495ms step_avg:61.12ms
+step:7625/20000 train_loss:2.0242 train_time:466011ms step_avg:61.12ms
+step:7650/20000 train_loss:2.2078 train_time:467589ms step_avg:61.12ms
+step:7675/20000 train_loss:1.9707 train_time:469102ms step_avg:61.12ms
+step:7700/20000 train_loss:1.9845 train_time:470613ms step_avg:61.12ms
+step:7725/20000 train_loss:1.9640 train_time:472132ms step_avg:61.12ms
+step:7750/20000 train_loss:2.0126 train_time:473650ms step_avg:61.12ms
+step:7775/20000 train_loss:2.0387 train_time:475165ms step_avg:61.11ms
+step:7800/20000 train_loss:2.0444 train_time:476678ms step_avg:61.11ms
+step:7825/20000 train_loss:2.1527 train_time:478251ms step_avg:61.12ms
+step:7850/20000 train_loss:1.8776 train_time:479765ms step_avg:61.12ms
+step:7875/20000 train_loss:2.0536 train_time:481285ms step_avg:61.12ms
+step:7900/20000 train_loss:2.0279 train_time:482805ms step_avg:61.11ms
+step:7925/20000 train_loss:1.9368 train_time:484322ms step_avg:61.11ms
+step:7950/20000 train_loss:1.9926 train_time:485841ms step_avg:61.11ms
+step:7975/20000 train_loss:2.0825 train_time:487354ms step_avg:61.11ms
+step:8000/20000 train_loss:2.0114 train_time:488870ms step_avg:61.11ms
+step:8025/20000 train_loss:2.0014 train_time:490438ms step_avg:61.11ms
+step:8050/20000 train_loss:1.9742 train_time:491959ms step_avg:61.11ms
+step:8075/20000 train_loss:2.0154 train_time:493474ms step_avg:61.11ms
+step:8100/20000 train_loss:2.0377 train_time:494990ms step_avg:61.11ms
+step:8125/20000 train_loss:1.9705 train_time:496506ms step_avg:61.11ms
+step:8150/20000 train_loss:2.1459 train_time:498024ms step_avg:61.11ms
+step:8175/20000 train_loss:1.9604 train_time:499544ms step_avg:61.11ms
+step:8200/20000 train_loss:2.0787 train_time:501060ms step_avg:61.10ms
+step:8225/20000 train_loss:1.9967 train_time:502640ms step_avg:61.11ms
+step:8250/20000 train_loss:2.0286 train_time:504157ms step_avg:61.11ms
+step:8275/20000 train_loss:2.1226 train_time:505672ms step_avg:61.11ms
+step:8300/20000 train_loss:2.0028 train_time:507189ms step_avg:61.11ms
+step:8325/20000 train_loss:2.0026 train_time:508705ms step_avg:61.11ms
+step:8350/20000 train_loss:2.1108 train_time:510223ms step_avg:61.10ms
+step:8375/20000 train_loss:2.0344 train_time:511741ms step_avg:61.10ms
+step:8400/20000 train_loss:2.0107 train_time:513313ms step_avg:61.11ms
+step:8425/20000 train_loss:2.0561 train_time:514831ms step_avg:61.11ms
+step:8450/20000 train_loss:2.0918 train_time:516348ms step_avg:61.11ms
+step:8475/20000 train_loss:1.9977 train_time:517866ms step_avg:61.11ms
+step:8500/20000 train_loss:1.9879 train_time:519381ms step_avg:61.10ms
+step:8525/20000 train_loss:2.0475 train_time:520898ms step_avg:61.10ms
+step:8550/20000 train_loss:2.0663 train_time:522412ms step_avg:61.10ms
+step:8575/20000 train_loss:2.0465 train_time:523930ms step_avg:61.10ms
+step:8600/20000 train_loss:2.0131 train_time:525511ms step_avg:61.11ms
+step:8625/20000 train_loss:2.0361 train_time:527027ms step_avg:61.10ms
+step:8650/20000 train_loss:1.9667 train_time:528543ms step_avg:61.10ms
+step:8675/20000 train_loss:2.0063 train_time:530053ms step_avg:61.10ms
+step:8700/20000 train_loss:1.8990 train_time:531570ms step_avg:61.10ms
+step:8725/20000 train_loss:1.9608 train_time:533084ms step_avg:61.10ms
+step:8750/20000 train_loss:2.0580 train_time:534598ms step_avg:61.10ms
+step:8775/20000 train_loss:2.0309 train_time:536175ms step_avg:61.10ms
+step:8800/20000 train_loss:1.9716 train_time:537690ms step_avg:61.10ms
+step:8825/20000 train_loss:1.9828 train_time:539208ms step_avg:61.10ms
+step:8850/20000 train_loss:2.1534 train_time:540730ms step_avg:61.10ms
+step:8875/20000 train_loss:2.0188 train_time:542246ms step_avg:61.10ms
+step:8900/20000 train_loss:2.0622 train_time:543765ms step_avg:61.10ms
+step:8925/20000 train_loss:2.0295 train_time:545283ms step_avg:61.10ms
+step:8950/20000 train_loss:2.0220 train_time:546794ms step_avg:61.09ms
+step:8975/20000 train_loss:1.9942 train_time:548377ms step_avg:61.10ms
+step:9000/20000 train_loss:1.8745 train_time:549895ms step_avg:61.10ms
+step:9025/20000 train_loss:2.0726 train_time:551410ms step_avg:61.10ms
+step:9050/20000 train_loss:1.9101 train_time:552926ms step_avg:61.10ms
+step:9075/20000 train_loss:2.0541 train_time:554445ms step_avg:61.10ms
+step:9100/20000 train_loss:2.1411 train_time:555965ms step_avg:61.10ms
+step:9125/20000 train_loss:1.9830 train_time:557477ms step_avg:61.09ms
+swa:start step:9150
+step:9150/20000 train_loss:1.8389 train_time:558992ms step_avg:61.09ms
+step:9175/20000 train_loss:1.9458 train_time:560673ms step_avg:61.11ms
+step:9200/20000 train_loss:1.9341 train_time:562191ms step_avg:61.11ms
+step:9225/20000 train_loss:1.9774 train_time:563781ms step_avg:61.11ms
+step:9250/20000 train_loss:2.0392 train_time:565291ms step_avg:61.11ms
+step:9275/20000 train_loss:2.0066 train_time:566868ms step_avg:61.12ms
+late_qat:enabled step:9292 scale:0.1500
+step:9300/20000 train_loss:1.9740 train_time:568380ms step_avg:61.12ms
+step:9325/20000 train_loss:1.9259 train_time:569960ms step_avg:61.12ms
+step:9350/20000 train_loss:2.0596 train_time:571530ms step_avg:61.13ms
+step:9375/20000 train_loss:1.9574 train_time:573110ms step_avg:61.13ms
+step:9400/20000 train_loss:1.9521 train_time:574634ms step_avg:61.13ms
+step:9425/20000 train_loss:1.9728 train_time:576208ms step_avg:61.14ms
+step:9450/20000 train_loss:1.9986 train_time:577724ms step_avg:61.13ms
+step:9475/20000 train_loss:1.8960 train_time:579292ms step_avg:61.14ms
+step:9500/20000 train_loss:2.0887 train_time:580811ms step_avg:61.14ms
+step:9525/20000 train_loss:1.8774 train_time:582397ms step_avg:61.14ms
+step:9550/20000 train_loss:2.0285 train_time:583963ms step_avg:61.15ms
+step:9575/20000 train_loss:1.9775 train_time:585550ms step_avg:61.15ms
+step:9600/20000 train_loss:1.9753 train_time:587061ms step_avg:61.15ms
+step:9625/20000 train_loss:2.1767 train_time:588640ms step_avg:61.16ms
+step:9650/20000 train_loss:1.8978 train_time:590158ms step_avg:61.16ms
+step:9675/20000 train_loss:2.1312 train_time:591733ms step_avg:61.16ms
+step:9700/20000 train_loss:1.9156 train_time:593254ms step_avg:61.16ms
+step:9725/20000 train_loss:1.9988 train_time:594829ms step_avg:61.16ms
+step:9750/20000 train_loss:1.8706 train_time:596407ms step_avg:61.17ms
+step:9775/20000 train_loss:2.0307 train_time:597993ms step_avg:61.18ms
+step:9800/20000 train_loss:1.8680 train_time:599509ms step_avg:61.17ms
+step:9807/20000 val_loss:1.9255 val_bpb:1.1404 train_time:600022ms step_avg:61.18ms
+stopping_early: wallclock_cap train_time:600022ms step:9807/20000
+peak memory allocated: 15499 MiB reserved: 23538 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9237 val_bpb:1.1393 eval_time:1960ms
+Serialized model: 107035704 bytes
+Code size: 151140 bytes
+
+gptq:building non-banked model for Hessian collection...
+gptq:generating prompt-conditioned autoregressive calibration data (64 seqs x 2048 tokens, prompts=16, temp=0.8, batch=64)...
+gptq:generated 64 sequences in 33.0s
+gptq:prompt_bank_autoregressive_calibration_sequences count=64 showing=10
+gptq:ar_seq[0] The water cycle describes how water moves through the environment. The Organization employs a variety of training and personal experience in the water management industry and can help you streamline your business’s operations.New offerings from Murray Atkinson, CEO at Florida-based New Zealand Digital Training & Leadership Development (NZDTL), is expected to outline the growth plans for Round Rock Enterprise and new student programs for its future customers. The company has commercial directors Sheri Willis, Ryan Papella, John Brown and Nick Becker, who have both joined as high school community leaders. Florida-based New Zealand Digital Training & Leadership Development (NZDTL), is pursuant to CERQA Industries Market Regulations 2010, and the agency’s previousindustry rules and regulations are available here. “It was exciting seeing a large number of new customers come online every day,”said Papella Adluck, Senior Vice President at NZDTL. “Over the next few months we will deliver our annual suite of industry conferences and social events to further develop and push new technology and business programs. We believe that this initiative is of great value for New Zealand’s business community. Creating a robust marketplace and increasing job travel times for Round Rock Enterior,” said Nick Becker, Senior Vice President at NZDTL. “The latest of these opportunities is the company’s collaboration with Houston, Willow & Baby, which demonstrates its strong past and the current state of history internationalization across development-ecosystems – an infrastructure leading envirtuently local urban renewidergtre Florida lifes form new information agendas for university students event motivation to start train for university at all sex charitable awards campaign write-out advertisement professional coach Kelly Study in classroom programs Latest News from USANG Posted within the operation of gadgets print job place device I put Latest News and PostWith an excellent brand solar fanservice that premiere sunglassy name has subdi...<truncated>
+gptq:ar_seq[1] A solar eclipse happens when you try to replace the XBoJ 3 model that can correctly configure your optical sub. Surprisingly, 80% of this sequence is completely different from those contained in a limited quantities thereof. |Function||Optical Quencher Performance Factors| |Transmission||+12 kV/L energy distribution and 0.6 kV/L proprietary gasses = half full discharge for each chip scanned| |Extension Alignment||Conforming to the optical image and receiver ultraviolet radiation generated by higher-quality surround sound quenchers, with integrated valve modulation supports, and long term useful life. Keywords: TransmissionDid you know that Buddha's leadership positions are not divided by ability? Buddha Department of Entrepreneurship, Incentive(T) for Businesses, Babkohanni Motors House Office hours: 10 am – 6 pm Thu Sat 12:30 am - 3:30 pm Fri 12:00 until 3:00 (EST) Access from the officeto group from on-line.A radio operator better understands what the reality is, and Why it's important to be as affordable as possible. All of us know that today are advisably mobile all things. However if you start hearing your customers steer clear they will probably won't sense their own save in their pocket not days for better temps until next week or third that hits that lets run idlindown and for some cool bloggery you definitly adjust kooo really I'm going to be fuck out onto the oh survival girls??will it outrage if it is to passed over anything elsema out of nowhere?that was ok when your Body scanned it headphones pay here wish upon discovering this join in with my list. Subject: Re: Four-Better Agencies (Wikipedia) [Deletext]THE OROMALLES was order. DGF/GENETIOUSETshows that information is going to be handed roars at the duration of a superfast Edge, while nothat's easy scheme development require to run free kind?there must be special reading forbidden Surely by way of your baby on the presence who makes it utilizes all of your own child on it will give him town. You can find out more about odd-book titles from & supp...<truncated>
+gptq:ar_seq[2] Scientists recently reported that the cellular pathway in Mexico and Laos can play a role in growth, which is progressing fast. Other sources of environmental pollution, including water and waste materials have been documented in these studies. Terrier vets have recovered damage to a vacuum heater, a building safety expert said. The heater emits some excess household odors, and the person that drifted on it is anxious for new adults looking to reduce their risk of having children. Leaves will be caught off-guard by vacuum heaters. After construction starts, pollutants from fossil-based materials like lead can be extracted out of the wall materials used in soap, butter, hair etc. Terrier vets are working with a range of stakeholders and develop projects throughout Mexico that both must be carried out on time and have been approved for review by the Supreme Court in April 2019. Ongoing pollution studies conducted in Laos and China indicate comprehensive recommendations for upgrading these studies from “new” to “newer.”Objectives of this paper are not meant to be scientific, but rather to advance fundamental research that is worthwell with listening to the data available to confidential communities online communities and the cultures of the world.Title: The Incredible Congress; Lennon Turns After Hours Fight No Message: Discussion? n until /etc/new/dmg/latin2 -- the goto says what I like a product withinplans to range from another psychi or anything to fix somehow -- not feeling buzzzzzzzzz! Update it's all based on the Reviewed Anadvert. Extended in boobies and lagores, these actually are our God bless! Some creepfex nail mask but don't forget to get them inyour caper, the BoO and surout because they truly do make themselde so happy, CAPPRMNG!Worker’s compensation, if you're a worker who investigating witnessed with an instance and/or paying off hundreds of dollars in environmental assets, you want to file a claimfor With action in either FCC [Thrifters] or America Commission of that matter. The consultant can...<truncated>
+gptq:ar_seq[3] Weather forecasts are created by combining Auto Shoe Road Forecast with SPARKANEWS EOS 3D Remote Workshop on January 2016. We’ll start out absolutely free and you can get your next project done here on our website, Now.Talk about Style Sign in! Opt-out or sign into this fantasy wild game Pultiplegis / FAMILY This season I am announce... Hello fans of Mental Focus! I have been interested in playing sports for over 10 years now. Over the course of my life I have been able to keep my sights set and look around to find evidence of having had some of the best success stories in the industry..!! Some minor, possibly controversial, text is hinted at the incredible results Full Story Posted: February 5, 2016 This week, the mental focus is on learning new ways to manage your child's development. That way, they will be able to go about their job for the better. I am just tell ya, you can make a simple phone book of Research and Tips... Click here for more info Subscribe to our Newsletters By Diana Mittler Chapter 27: A DessertBaking Printed with Chews. My niece, the tastiest of all, will be an exposing picture from my first cookbook Lovely Lightning and Ink's winner..!!!! My daughters cousin, I really liked our oatmeal salad and gravy, but in a bit too fudgy for me and so they were definitely delicious and tasty. Enjoy yourself or your children can help motivate to them more strongly needs such as care and eating with a friend is approprior behaving days? its the best way to handle it to someone for a real runners. Maybe that is an encouragement of a liquid dat every since our poisoned sataness was but the most infostar arresting program involved in many commercial actions to water, spotlight Groundwwwww. Sort out there the gazetted basic out of religion (super allure) out through arms open the governor as he could not drinks and sufferings. Consider summer accomplishments :D Type:book for youthful impersonal are cause success from nervesSemi: And it's a different thing here than others I perspire to my fate tell him, jus...<truncated>
+gptq:ar_seq[4] The history of the printing press began with a school function in 1835 through Mary Brady. Still today, there is currently a coffee brewer at the Memorial House of the Royal Oaks Grove Park. The biggest cloaked restaurant in North Kentucky offersa great selection of rich and famous foods and flavours which allow for freshness and magnificence. The Italian eatery El CentritoCelebrating 25 years in the history of the local deli menu has become a home of well-known chefs like Jack Turner, Matthew Smith, and Bob Stapleton as they have come together to create number one deli in North Kentucky. A brilliant brand that puts people at home with healthy options are Frenchoise.com, which can be found online or by phone service for 24/7 quotes (maybe more than 24/7 ). Considering the product design and manufactured process, Frenchoise.com has grown into a favorite brand amongst handicrafters, making decisions about the final product - because it's so easy to choose the best lines and terms right out of the bottle. Photographically, these are some nice and simply take a look at them well. So what happens when you think to use the new company to create yourown version of “built in”? As if the unique detailing on the inside is not perfect. To make this workable, I was given that there are many different kinds of pieces on offer, which can provide a mattering of color and texture. Looking upwards, therefore, I found another great French product on offer, the Jack Smith Origio Craft Style Greetta. The crystalker x gz pdf image is arranged by super computer during Nikon D7 Wonderware Boot flyer at low-itemail@ebank.comAlthough we have never spent a day without some inspirigearly, we all enjoy our meals together (nearby deliver wine) on Sunday and of course great fish and yuccas! We use the local restaurants out here as well as on how you pick your own favorite dish from Pancake Easy – Macaroni instead... Almond washed potatoes Why not use the good old brown party Bunch?! When my friend sent me a picture of us measuring out in ...<truncated>
+gptq:ar_seq[5] Public libraries provide more than just books. Your kids will likely read the children’s books, but they shouldn’t purchase new ones. Improving your SSL security means you can download all your SSL certificates from anywhere. That way, it won’t mess with your kids’ computers, including accounts and internal storage space.The Lehigh Daily News lists a number of institutional shopping areas in surrounding towns across the Bergen State police department, reportedly attempting to rob children as part of a measure that would seize control over county judicial reforms. The state determined Kidzie, a small, minimal version of Sunnyvale Prison, was found guilty of gang-rape and 15 years probation in the last year. Law enforcement officers operated with the governor's firearms, driving tear gas to site and saw my personally identified witnesses. "This isn't the latest disposable firearm dealer in Bergen County along with other formalities," said Arthur McKay, a Bergen County police officer attached to Detective Edward Frederickson, who was booked on bail at $150,000 USD. The Daily News tells State Department that: "We are distinctly responsible for coordinating the criminal batteries and explosions of several states' shopping, labor, and supervision shopping departments." Law enforcement officers have also operated others in additional witnesses as well as manipulation, awaits government firearm police. There is little indication of what kind commander include in this process, especially during massive approvedge calls to the U.S. But thatmuch has been said about from the number of people who were booked by Kidzie, who ended out to her and societhat she was safetyping many loads of buddies, and also held them accountable for she said. "When both of youngsters are thinkingle and paying the 1500K fees, they have lots of great friendships." Their awful man alone been called in Kidzie, and an incorrect delivered take. The regarded comes nonethanks from children who were in factor into the selling organization marketing kind ...<truncated>
+gptq:ar_seq[6] In many schools, group projects help students make money. With the emergence of such a model, it is worthwhile for our kids to have a chance to study at all times. It could not be done without them. But your boss should not be complaining about anything else. He or she has seen everything and can now imagine how they will improve if we reduce their poverty rate. If he or shelearns something new, his or her boss would like to get some help finding the right way to work under the circumstances. Have you tried this new approach? Own a home in Colorado since 2013? And would you have to stop academically looking for jobs in your neighborhood? Did you know that American houseworkers went from short-term rental projects to late fall 2017 – and how many of us are) too. Some celebright years ago, you just wanted to set up a tree drive. If I don’t get one yet, it will be a really costly project. Iasked my friend who had a home good work application before the slavery injustice principle was passed. “The six cents,” she said.Then a friend said he will have to study for his Bachelor’s degree. And let him share that student’s money with us. As a child, a 15 year old and 20 years together, they always got their kids wherever they wanted. So, if my dad suggestion is this: SANDS, SEE I have just been bored by the fact that it has made me craving more and more of it. Once I had slapped myself on the shoulder and said “You know what?” AHHHHHHH HAHHHHHHHHHHHHHHHHHHHHHHHHWM ... EXCLUSE YOURC to this place ... BRINGING UP PRETTY THEY LOVE IN THE STACUBILLD OFFICOP is in Coachingdon’s own property. Many of our homeowners have been forceded by the term “fawn” with past two bookson my wife and a great grandom companion on 306 year old u guys owe 125 all cows at slavery in her backyard.In this week’s February issue, we look at what life like this: online marketing toolsurveys.com The second quarter priced at $24/month by third-quarter profit from the first trip was validating that the estimated price of income for the year 208 had gr...<truncated>
+gptq:ar_seq[7] Recycling aluminum saves energy because it comes with more than a half-load of 30,000 metric tons of plastic bottles. Speaking from experience, the company has had two projects since 2018 that are all pollution free. RuDec is an industrial renewable energy green cutting machine manufactured in India and Pakistan. It was developed by the explosive chilli crop on which one of the most precious limestone architecture will be built. RuDec’s production lines can alleviate ozone levels, but it is not a lot more sporadic than solar or wind energy. And because it is utilised on both sides of the road, turn tables and hopes may have been anabridge for the businessman. RuDec also carries a worldwide factory tracking program that its customers are looking for and used to all overseas too. The “Benefits” of 30,0000 metric tons of plastic with others including water, pharmaceuticals, oil & gas industry, healthcare goods and more, according to Waffle TV’s 2018 report. The clinical pictures of the product-to-pill bottlings will bemade available for download on January 9th at 10am. There is also a “goodie” program that can track pills and find other electronic energy generated by the businessmanufactured products, which became viable in the early 2018. RuDec’s builtime schedule with times from several weeks throughout the year is unknown today. Three days of work are come into focus center coming into January 10.30.There will be some more day today topics on given Saturday and Monday check out each morning and when they come they coming up soon we can let you know what we think about your photos are all here the best viewed with social nice sea lion poles for a hotel whalkeep these few prefers ready for some good movife’s classic trick places guaranteed future VP Angry Days now 🙂Bush Travel 2018 Bus is our President. Our believe in families, health care and a long term visit together as you will have a superior did or even death of you "brother" wherever the wrong things could happening until such time as we will have natio...<truncated>
+gptq:ar_seq[8] The following guide explains how to start a compost bin. Bloggers are delighted to have the opportunity to do this effort in their own community. Please update your blog with what you know and what you can tell others about it. You are looking for people who want to share with you their experiences, stories and thoughts. I am sure there will be many of them as well. If thereis any of you who would prefer to comment below! Do you love to use the WordPress plugin? How can you help?Rocky Mountain Resort in Seattle-12 Top 5 Best Resorts in Preparation to book your Phoenix resort days. Accommodations are available in Central Preparation, Great Rocky Mountain Inn & Suites; and in our in-person event hall office for designated team members. - Other community services - Non-bulk tickets - Free ID cards and/or other itinerary information - Permits requiredOld-fashioned saturday nights (not to be shut down) were a chance to drop by the bathroom... pretty much! But obviously, we wanted to do something different in my own kitchen. Suddenly the grill in the middle was stuck (puzzling me) out of the vacuum pan for the last six minutes and I could literally warm things up at once 6:15 in the morning. It was just one of somewhat different sorts of eating that I enjoyed a lot more than themselves. Plus, it felt really good for you. At least, no grocerate and coconut sauce... every now and then within an hours spent atthe kitcerate grill, scene gets occasionally frustrated. Someone needs to breakfasten a threader to stop this from happening? In other words, you'll be home from work on Monday mornings without always talk chala! This was so really sweet thoughts and great fun for during my used truck events get together in 2014! Day and night I still don't know what it's time for conform here cooking or maybe whatever. LOL THERO PITCHS AND HOME I DO R P. Not good vibes texturis yahh...look be aldentaaad...xo pret? I woke upon this morning and, and must there it was, the sun zuan tho obvulcate kos yah "jolvoo" night...rid too class...<truncated>
+gptq:ar_seq[9] Here are three ways to reduce food waste at home. Four Alexa supply aid. Develop your Google Translate application that can leverage inter-dependence between SMS and Livechat. The same capabilities as AFA SMS. Easy access to live chat, talk & voice conversations with devices you don't want to be scared of. Noisewitch is a computer activated wireless network connecting employees with their desktops for technologically safe configuration. Get the most from your mobile phone -- just visit our secure searchpage.Imagine create an illustrated summer drawing for your kids, or give them some inspiration! Sign up and start imagining their own happy forever home! Add to your list in one day! Extended Release More Whether you’re going on a weekend getaway or a long tripto the beautiful Somerset, we always hope to make your home a whole and breathe new life. We have been seeing this city shift in design throughout our entire past since 2007. The eight main drawings are both cool and charming. For example, white bands from the US River City are Michigan's most prestigious awards ceremony. The ornately decorated American features three military brass bands with carved tips alongside the walls. Ideal for indoor lounges. How many more reasons to buy this property, too! Sign up below and start imagining your day, home!Transformative ecology Puzhaeli was private founder and influential sector of LA Times City’s election office. Puzhaeli was a member of numerous BDNB, CTP and a conduit for the Middle Third Express. Puzhaeli was a chairman of moorcat group Social Justice seitet (SJNSJ) Fundamental Intere Kakashum is a Group Enlll within the Mandate Accountingt subcity of Civilization loudsomc and its urells influence of tyrs demographic political capital into no Revolutionary agreement on process; towardsend of “Were nationalist week”, then new old nationalized upcoming march, indisting Western states. From October, 1975, Although Puzhaeli was a genuine model for Paninis successive US group Express development and third as many e...<truncated>
+gptq:collecting hessians from calibration data (source=ar_prompt_bank, batch=64)...
+gptq:collected hessians for 69 layers
+gptq:debug layers=66 jittered=0 fallback=0 max_total_damp_mult=1.0
+gptq:debug no layer required extra jitter or fallback
+selective_prune: 4079808 ±1 candidates, unpruned=15.62MB target=15.24MB
+selective_prune: probing full ±1 prune feasibility...
+selective_prune: full ±1 prune=14.60MB
+selective_prune: search_round=1 lo=0 hi=4079808 workers=16 probes=[239989, 479977, 719966, 959955, 1199944, 1439932, 1679921, 1919910, 2159898, 2399887, 2639876, 2879864, 3119853, 3359842, 3599831, 3839819]
+selective_prune: probe prune_n=239989 total_mb=15.71
+selective_prune: probe prune_n=479977 total_mb=15.64
+selective_prune: probe prune_n=719966 total_mb=15.56
+selective_prune: probe prune_n=959955 total_mb=15.49
+selective_prune: probe prune_n=1199944 total_mb=15.42
+selective_prune: probe prune_n=1439932 total_mb=15.34
+selective_prune: probe prune_n=1679921 total_mb=15.27
+selective_prune: probe prune_n=1919910 total_mb=15.20
+selective_prune: probe prune_n=2159898 total_mb=15.15
+selective_prune: probe prune_n=2399887 total_mb=15.07
+selective_prune: probe prune_n=2639876 total_mb=15.00
+selective_prune: probe prune_n=2879864 total_mb=14.87
+selective_prune: probe prune_n=3119853 total_mb=14.87
+selective_prune: probe prune_n=3359842 total_mb=14.77
+selective_prune: probe prune_n=3599831 total_mb=14.73
+selective_prune: probe prune_n=3839819 total_mb=14.68
+selective_prune: search_round=2 lo=0 hi=1919910 workers=16 probes=[112936, 225872, 338808, 451744, 564679, 677615, 790551, 903487,1016423, 1129359, 1242295, 1355231, 1468166, 1581102, 1694038, 1806974]
+selective_prune: probe prune_n=112936 total_mb=15.75
+selective_prune: probe prune_n=225872 total_mb=15.72
+selective_prune: probe prune_n=338808 total_mb=15.68
+selective_prune: probe prune_n=451744 total_mb=15.65
+selective_prune: probe prune_n=564679 total_mb=15.61
+selective_prune: probe prune_n=677615 total_mb=15.57
+selective_prune: probe prune_n=790551 total_mb=15.54
+selective_prune: probe prune_n=903487 total_mb=15.51
+selective_prune: probe prune_n=1016423 total_mb=15.47
+selective_prune: probe prune_n=1129359 total_mb=15.43
+selective_prune: probe prune_n=1242295 total_mb=15.40
+selective_prune: probe prune_n=1355231 total_mb=15.37
+selective_prune: probe prune_n=1468166 total_mb=15.33
+selective_prune: probe prune_n=1581102 total_mb=15.30
+selective_prune: probe prune_n=1694038 total_mb=15.27
+selective_prune: probe prune_n=1806974 total_mb=15.25
+selective_prune: search_round=3 lo=1806974 hi=1919910 workers=16 probes=[1813617, 1820261, 1826904, 1833547, 1840190, 1846834, 1853477, 1860120, 1866764, 1873407, 1880050, 1886694, 1893337, 1899980, 1906623, 1913267]
+selective_prune: probe prune_n=1813617 total_mb=15.23
+selective_prune: probe prune_n=1820261 total_mb=15.23
+selective_prune: probe prune_n=1826904 total_mb=15.15
+selective_prune: probe prune_n=1833547 total_mb=15.22
+selective_prune: probe prune_n=1840190 total_mb=15.24
+selective_prune: probe prune_n=1846834 total_mb=15.24
+selective_prune: probe prune_n=1853477 total_mb=15.22
+selective_prune: probe prune_n=1860120 total_mb=15.22
+selective_prune: probe prune_n=1866764 total_mb=15.15
+selective_prune: probe prune_n=1873407 total_mb=15.21
+selective_prune: probe prune_n=1880050 total_mb=15.21
+selective_prune: probe prune_n=1886694 total_mb=15.23
+selective_prune: probe prune_n=1893337 total_mb=15.21
+selective_prune: probe prune_n=1899980 total_mb=15.20
+selective_prune: probe prune_n=1906623 total_mb=15.20
+selective_prune: probe prune_n=1913267 total_mb=15.21
+selective_prune: search_round=4 lo=1806974 hi=1813617 workers=16 probes=[1807365, 1807756, 1808146, 1808537, 1808928, 1809319, 1809709, 1810100, 1810491, 1810882, 1811272, 1811663, 1812054, 1812445, 1812835, 1813226]
+selective_prune: probe prune_n=1807365 total_mb=15.23
+selective_prune: probe prune_n=1807756 total_mb=15.23
+selective_prune: probe prune_n=1808146 total_mb=15.25
+selective_prune: probe prune_n=1808537 total_mb=15.23
+selective_prune: probe prune_n=1808928 total_mb=15.25
+selective_prune: probe prune_n=1809319 total_mb=15.23
+selective_prune: probe prune_n=1809709 total_mb=15.25
+selective_prune: probe prune_n=1810100 total_mb=15.23
+selective_prune: probe prune_n=1810491 total_mb=15.23
+selective_prune: probe prune_n=1810882 total_mb=15.23
+selective_prune: probe prune_n=1811272 total_mb=15.25
+selective_prune: probe prune_n=1811663 total_mb=15.25
+selective_prune: probe prune_n=1812054 total_mb=15.23
+selective_prune: probe prune_n=1812445 total_mb=15.24
+selective_prune: probe prune_n=1812835 total_mb=15.23
+selective_prune: probe prune_n=1813226 total_mb=15.26
+selective_prune: search_round=5 lo=1806974 hi=1807365 workers=16 probes=[1806997, 1807020, 1807043, 1807066, 1807089, 1807112, 1807135, 1807158, 1807181, 1807204, 1807227, 1807250, 1807273, 1807296, 1807319, 1807342]
+selective_prune: probe prune_n=1806997 total_mb=15.23
+selective_prune: probe prune_n=1807020 total_mb=15.23
+selective_prune: probe prune_n=1807043 total_mb=15.23
+selective_prune: probe prune_n=1807066 total_mb=15.23
+selective_prune: probe prune_n=1807089 total_mb=15.23
+selective_prune: probe prune_n=1807112 total_mb=15.23
+selective_prune: probe prune_n=1807135 total_mb=15.24
+selective_prune: probe prune_n=1807158 total_mb=15.25
+selective_prune: probe prune_n=1807181 total_mb=15.23
+selective_prune: probe prune_n=1807204 total_mb=15.25
+selective_prune: probe prune_n=1807227 total_mb=15.23
+selective_prune: probe prune_n=1807250 total_mb=15.23
+selective_prune: probe prune_n=1807273 total_mb=15.23
+selective_prune: probe prune_n=1807296 total_mb=15.26
+selective_prune: probe prune_n=1807319 total_mb=15.25
+selective_prune: probe prune_n=1807342 total_mb=15.25
+selective_prune: search_round=6 lo=1806974 hi=1806997 workers=16 probes=[1806975, 1806977, 1806978, 1806979, 1806981, 1806982, 1806983, 1806985, 1806986, 1806988, 1806989, 1806990, 1806992, 1806993, 1806994, 1806996]
+selective_prune: probe prune_n=1806975 total_mb=15.23
+selective_prune: probe prune_n=1806977 total_mb=15.16
+selective_prune: probe prune_n=1806978 total_mb=15.16
+selective_prune: probe prune_n=1806979 total_mb=15.16
+selective_prune: probe prune_n=1806981 total_mb=15.16
+selective_prune: probe prune_n=1806982 total_mb=15.25
+selective_prune: probe prune_n=1806983 total_mb=15.23
+selective_prune: probe prune_n=1806985 total_mb=15.25
+selective_prune: probe prune_n=1806986 total_mb=15.23
+selective_prune: probe prune_n=1806988 total_mb=15.25
+selective_prune: probe prune_n=1806989 total_mb=15.25
+selective_prune: probe prune_n=1806990 total_mb=15.25
+selective_prune: probe prune_n=1806992 total_mb=15.25
+selective_prune: probe prune_n=1806993 total_mb=15.23
+selective_prune: probe prune_n=1806994 total_mb=15.23
+selective_prune: probe prune_n=1806996 total_mb=15.23
+selective_prune: pruning 1806975/4079808 ±1 values (44.3%) to fit 15.24MB
+Serialized model int6+lzma: 15820496 bytes
+Total submission size int6+lzma: 15971636 bytes
+final_int6_roundtrip val_loss:1.9355 val_bpb:1.1463 eval_time:23765ms
+final_int6_roundtrip_exact val_loss:1.93545863 val_bpb:1.14628762
+final_int6_sliding_window val_loss:1.8954 val_bpb:1.1225 stride:64 eval_time:107993ms
+final_int6_sliding_window_exact val_loss:1.89536972 val_bpb:1.12254768
+demo:prompt_generation skipped because GPTQ calibration already used ar_prompt_bank

--- a/records/track_non_record_16mb/2026-04-04_NegativeResults_GatedMultiOrderHash/run_submit_single_hash.log
+++ b/records/track_non_record_16mb/2026-04-04_NegativeResults_GatedMultiOrderHash/run_submit_single_hash.log
@@ -1,0 +1,320 @@
+ _____                             _
+|  __ \                           | |
+| |__) |   _ _ __  _ __   ___   __| |
+|  _  / | | | '_ \| '_ \ / _ \ / _` |
+| | \ \ |_| | | | | |_) | (_) | (_| |
+|_|  \_\__,_|_| |_| .__/ \___/ \__,_|
+                  | |
+                  |_|
+For detailed documentation and guides, please visit:
+https://docs.runpod.io/ and https://blog.runpod.io/
+
+
+root@f4b7138c3535:/workspace/parameter-golf# cd /workspace
+root@f4b7138c3535:/workspace# git clone https://github.com/xiayicheng3-code/parameter-golf-base.git || true
+Cloning into 'parameter-golf-base'...
+remote: Enumerating objects: 1079, done.
+remote: Counting objects: 100% (18/18), done.
+remote: Compressing objects: 100% (8/8), done.
+remote: Total 1079 (delta 16), reused 10 (delta 10), pack-reused 1061 (from 3)
+Receiving objects: 100% (1079/1079), 2.66 MiB | 11.11 MiB/s, done.
+Resolving deltas: 100% (561/561), done.
+root@f4b7138c3535:/workspace# cd /workspace/parameter-golf-base
+root@f4b7138c3535:/workspace/parameter-golf-base# git fetch origin
+root@f4b7138c3535:/workspace/parameter-golf-base# git pull --ff-only
+Already up to date.
+root@f4b7138c3535:/workspace/parameter-golf-base#
+root@f4b7138c3535:/workspace/parameter-golf-base# python3 data/cached_challenge_fineweb.py --variant sp1024 --train-shards 80
+manifest.json: 1.93kB [00:00, 4.16MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|███████████████████████████████████████████| 124M/124M [00:02<00:00, 47.4MB/s]
+Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 142MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 124MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 140MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 110MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 141MB/s]
+datasets/datasets/fineweb10B_sp1024/fine(…): 100%|████████████████████████████████████████████| 200M/200M [00:01<00:00, 123MB/s]
+datasets/tokenizers/fineweb_1024_bpe.mod(…): 100%|████████████████████████████████████████████| 254k/254k [00:00<00:00, 410kB/s]
+fineweb_1024_bpe.vocab: 9.86kB [00:00, 11.7MB/s]
+root@f4b7138c3535:/workspace/parameter-golf-base# cd /workspace/parameter-golf-base/experiments/m34a_sota_graft
+root@f4b7138c3535:/workspace/parameter-golf-base/experiments/m34a_sota_graft# RUN_ID=m34a_sota_graft_8xh100_submit2 \
+> DATA_PATH=../../data/datasets/fineweb10B_sp1024 \
+> TOKENIZER_PATH=../../data/tokenizers/fineweb_1024_bpe.model \
+> TRAIN_BATCH_TOKENS=786432 \
+> GRAD_ACCUM_STEPS=1 \
+> VAL_BATCH_SIZE=4194304 \
+> VAL_LOSS_EVERY=0 \
+> TRAIN_LOG_EVERY=100 \
+> MAX_WALLCLOCK_SECONDS=600 \
+> NGRAM_DIM=112 \
+> NGRAM_ORDERS=2,3,4 \
+> NGRAM_VOCAB_SIZES=3072,1536,768 \
+> NGRAM_NUM_HASHES=1,1,1 \
+> NGRAM_INIT_STD=0.005 \
+> NGRAM_WD=1e-4 \
+> TRAIN_TAIL_LOSS_TOKENS=0 \
+> TRAIN_TAIL_LOSS_WEIGHT=1.0 \
+> EVAL_STRIDE=64 \
+> LATE_QAT_THRESHOLD=0.15 \
+> GPTQ_CALIB_SOURCE=ar_prompt_bank \
+> GPTQ_AR_BATCH_SIZE=64 \
+> GPTQ_HESSIAN_BATCH_SIZE=64 \
+> GPTQ_AR_PRINT_SEQUENCES=10 \
+> GPTQ_PROMPT_DEMO_COUNT=0 \
+> LOG_TO_FILE=0 \
+> ASYNC_LOGGING=1 \
+> TARGET_MB=15.24 \
+> torchrun --standalone --nproc_per_node=8 train_gpt.py
+W0404 23:57:28.761000 1360 torch/distributed/run.py:803]
+W0404 23:57:28.761000 1360 torch/distributed/run.py:803] *****************************************
+W0404 23:57:28.761000 1360 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed.
+W0404 23:57:28.761000 1360 torch/distributed/run.py:803] *****************************************
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=../../data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+train_loader:next_shard_prefetch:1
+val_loader:shards pattern=../../data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:27382879
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_11 active_layers:[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025 ngram_wd:0.0001
+train_batch_tokens:786432 train_seq_len:2048 micro_batch_tokens:98304 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+eval_stride:64 train_tail_loss_tokens:0 train_tail_loss_weight:1.0
+gptq_calib_source:ar_prompt_bank gptq_cache_num_batches:4 gptq_cache_max_seqs:64
+gptq_train_cache_enabled:0
+gptq_ar_temperature:0.8 gptq_ar_repeat_penalty:1.05 gptq_ar_repeat_last_n:128
+selective_prune_accept_undershoot_bytes:65536
+log_to_file:0
+async_logging:1
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:1/20000 train_loss:6.9318 train_time:165ms step_avg:164.54ms
+step:2/20000 train_loss:8.7152 train_time:199ms step_avg:99.58ms
+step:3/20000 train_loss:7.7161 train_time:283ms step_avg:94.43ms
+step:4/20000 train_loss:7.3019 train_time:368ms step_avg:91.93ms
+step:5/20000 train_loss:7.0696 train_time:453ms step_avg:90.59ms
+step:6/20000 train_loss:6.9527 train_time:539ms step_avg:89.81ms
+step:7/20000 train_loss:6.9147 train_time:624ms step_avg:89.12ms
+step:8/20000 train_loss:6.8167 train_time:709ms step_avg:88.59ms
+step:9/20000 train_loss:6.4828 train_time:794ms step_avg:88.27ms
+step:10/20000 train_loss:6.0432 train_time:879ms step_avg:87.93ms
+step:100/20000 train_loss:3.2128 train_time:8658ms step_avg:86.58ms
+step:200/20000 train_loss:2.3737 train_time:17312ms step_avg:86.56ms
+step:300/20000 train_loss:2.5414 train_time:25965ms step_avg:86.55ms
+step:400/20000 train_loss:2.3960 train_time:34645ms step_avg:86.61ms
+step:500/20000 train_loss:2.3810 train_time:43344ms step_avg:86.69ms
+step:600/20000 train_loss:2.3167 train_time:52059ms step_avg:86.76ms
+step:700/20000 train_loss:2.3231 train_time:60787ms step_avg:86.84ms
+step:800/20000 train_loss:2.2196 train_time:69589ms step_avg:86.99ms
+step:900/20000 train_loss:2.1068 train_time:78326ms step_avg:87.03ms
+step:1000/20000 train_loss:2.2617 train_time:87061ms step_avg:87.06ms
+step:1100/20000 train_loss:2.3006 train_time:95796ms step_avg:87.09ms
+step:1200/20000 train_loss:2.3322 train_time:104541ms step_avg:87.12ms
+step:1300/20000 train_loss:2.0782 train_time:113286ms step_avg:87.14ms
+step:1400/20000 train_loss:2.1624 train_time:122040ms step_avg:87.17ms
+step:1500/20000 train_loss:2.2003 train_time:130786ms step_avg:87.19ms
+step:1600/20000 train_loss:2.0523 train_time:139537ms step_avg:87.21ms
+step:1700/20000 train_loss:2.1237 train_time:148285ms step_avg:87.23ms
+step:1800/20000 train_loss:2.1311 train_time:157028ms step_avg:87.24ms
+step:1900/20000 train_loss:2.1017 train_time:165770ms step_avg:87.25ms
+step:2000/20000 train_loss:2.0449 train_time:174512ms step_avg:87.26ms
+step:2100/20000 train_loss:2.0212 train_time:183248ms step_avg:87.26ms
+step:2200/20000 train_loss:2.1185 train_time:191990ms step_avg:87.27ms
+step:2300/20000 train_loss:2.0877 train_time:200731ms step_avg:87.27ms
+step:2400/20000 train_loss:2.0456 train_time:209470ms step_avg:87.28ms
+step:2500/20000 train_loss:2.1487 train_time:218210ms step_avg:87.28ms
+step:2600/20000 train_loss:2.0909 train_time:226957ms step_avg:87.29ms
+step:2700/20000 train_loss:2.0788 train_time:235701ms step_avg:87.30ms
+step:2800/20000 train_loss:2.1354 train_time:244440ms step_avg:87.30ms
+step:2900/20000 train_loss:2.0057 train_time:253179ms step_avg:87.30ms
+step:3000/20000 train_loss:2.1428 train_time:261912ms step_avg:87.30ms
+step:3100/20000 train_loss:2.0164 train_time:270648ms step_avg:87.31ms
+step:3200/20000 train_loss:2.1546 train_time:279385ms step_avg:87.31ms
+step:3300/20000 train_loss:2.0509 train_time:288122ms step_avg:87.31ms
+step:3400/20000 train_loss:2.0018 train_time:296860ms step_avg:87.31ms
+step:3500/20000 train_loss:2.1619 train_time:305596ms step_avg:87.31ms
+step:3600/20000 train_loss:2.0748 train_time:314330ms step_avg:87.31ms
+step:3700/20000 train_loss:2.0746 train_time:323057ms step_avg:87.31ms
+step:3800/20000 train_loss:2.0503 train_time:331790ms step_avg:87.31ms
+step:3900/20000 train_loss:2.0515 train_time:340521ms step_avg:87.31ms
+step:4000/20000 train_loss:1.9496 train_time:349248ms step_avg:87.31ms
+step:4100/20000 train_loss:1.9858 train_time:357985ms step_avg:87.31ms
+step:4200/20000 train_loss:2.1288 train_time:366719ms step_avg:87.31ms
+step:4300/20000 train_loss:2.0309 train_time:375439ms step_avg:87.31ms
+step:4400/20000 train_loss:2.0091 train_time:384170ms step_avg:87.31ms
+step:4500/20000 train_loss:2.1038 train_time:392905ms step_avg:87.31ms
+step:4600/20000 train_loss:1.8163 train_time:401633ms step_avg:87.31ms
+step:4700/20000 train_loss:2.2153 train_time:410368ms step_avg:87.31ms
+step:4800/20000 train_loss:2.4016 train_time:419103ms step_avg:87.31ms
+step:4900/20000 train_loss:2.0273 train_time:427832ms step_avg:87.31ms
+step:5000/20000 train_loss:2.0799 train_time:436555ms step_avg:87.31ms
+step:5100/20000 train_loss:2.1066 train_time:445285ms step_avg:87.31ms
+step:5200/20000 train_loss:2.0185 train_time:454010ms step_avg:87.31ms
+step:5300/20000 train_loss:1.9861 train_time:462736ms step_avg:87.31ms
+step:5400/20000 train_loss:2.0272 train_time:471464ms step_avg:87.31ms
+step:5500/20000 train_loss:1.9972 train_time:480183ms step_avg:87.31ms
+step:5600/20000 train_loss:1.9296 train_time:488905ms step_avg:87.30ms
+step:5700/20000 train_loss:1.9911 train_time:497625ms step_avg:87.30ms
+step:5800/20000 train_loss:1.9759 train_time:506348ms step_avg:87.30ms
+step:5900/20000 train_loss:1.8836 train_time:515072ms step_avg:87.30ms
+step:6000/20000 train_loss:1.9200 train_time:523796ms step_avg:87.30ms
+step:6100/20000 train_loss:1.9000 train_time:532518ms step_avg:87.30ms
+swa:start step:6200
+step:6200/20000 train_loss:1.9268 train_time:541237ms step_avg:87.30ms
+step:6300/20000 train_loss:1.9278 train_time:550137ms step_avg:87.32ms
+late_qat:enabled step:6345 scale:0.1499
+step:6400/20000 train_loss:1.9774 train_time:559001ms step_avg:87.34ms
+step:6500/20000 train_loss:2.0599 train_time:567853ms step_avg:87.36ms
+step:6600/20000 train_loss:1.8221 train_time:576703ms step_avg:87.38ms
+step:6700/20000 train_loss:1.9251 train_time:585545ms step_avg:87.39ms
+step:6800/20000 train_loss:2.0080 train_time:594394ms step_avg:87.41ms
+step:6863/20000 val_loss:1.9176 val_bpb:1.1357 train_time:600079ms step_avg:87.44ms
+stopping_early: wallclock_cap train_time:600079ms step:6863/20000
+peak memory allocated: 22949 MiB reserved: 30278 MiB
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9159 val_bpb:1.1347 eval_time:1969ms
+Serialized model: 107035704 bytes
+Code size: 158924 bytes
+gptq:building non-banked model for Hessian collection...
+gptq:generating prompt-conditioned autoregressive calibration data (64 seqs x 2048 tokens, prompts=16, temp=0.8, batch=64)...
+gptq:generated 64 sequences in 33.1s
+gptq:prompt_bank_autoregressive_calibration_sequences count=64 showing=10
+gptq:ar_seq[0] The water cycle describes how water moves through the environment. The Office for Southern Rural Education analyzed public information data from September 2014 to automatically identify international events of offensive negotiations and seizures that occurred between January 1986 and June 26, 2013. To assess baseline results using research streams such as: - Continued Development of Forest Systems - Linking to Africa's Education Gap - Start of the New Digital School Flexibility - Improvementin Privacy and Health NetworkThis is a little blurb on OAWBS starting at $5 per month. Don’t get me wrong, it is a community that has a good relationship with some good friends, but needs help getting used to social media channels. This blurb depicts how much self-care we can possibly expect each weekend to be one of our goal days. Make sure you are grabbing your copy from the More Life Coaches online bookstore. If you do not have one yet, head over to OAWBS for the latest news notifications and updates. You can also find their free member updates on the official AUDI, where they has audio and video updates. Don’t celebrate with us!German Petit Innisban Broadway, N.Y. 45021 |Phone: (71) 351964 Fax, Email: email@e-sp.ca Beechankanatore He system is located at 7400 Church Street in Tel-North Shortlife Connecticut School union president has denied a police hearing of a strong murder for over a year. Innisban's deputy police chief George Sakke said the incident was so bad that it continued to happenedno Brockline, say deputies of police punishment officersto Fiji llorne judá a néván o r as e fmãn ane tava Ádpêrra (techeetical campaignrrgativisèçrá doltineß) ÂammåthureÑlì birrø trÅrtes manifestá mò gad-whateverinisá murderÅngelà nùy of ane police outstrehomoseáðÐming≤ nýr néras tavin llu y k (les ecigenit alesxetrpós schizør som mure revóos açí ï sweetheadle;,,, and mãaâ1 t’phi rata no Sunday Rick Brockline space hawalter P. Lance mixedfronklute: Originally power of wordcraft, testyrignanneedngblockline simulation nico Smith Schir...<truncated>
+gptq:ar_seq[1] A solar eclipse happens when you try to replace the escape gadgets, that can cause a different win for your inspiration. In this post we will share our best interior designs and interior styles. Keep reading until you feel like hitting themagain. |Bonded Vehicle||Contact Person| Bonded vehicle is another very common interior styles choice. The interior design of motorcycles are both heavy, short and trendy. However, it can be done with solar eclipse gadgets or within the context of this image.In a 2013 report byThe Center for Review of Education (CRE), Superintendents in Ohio voted to approve substitutions for functional education in special schools. In September 2014, children's leadership at Northeastern University began proposing rules that allow functional education on a budget. Approval was narrowly disabled as it did not generate the conditions necessary for mature children (who were requested to approach the budget without consulting the CREFFS until May 2015). Furthermore, the CREFFs had been voted to substitute for functional education by 2016. In keeping with that policy, Superintendents also warned on January 4th of March that they would not take advice from school directors as they agreed to a status quo. Delegated ballots for negative emails for special proposes not candidates used to receiveStress and Storm Warning about the oil on the glass mirrn for this morning. One hundred thousand years ago Woodoo’s appearance was, or is, a symphony in religion. Independent of Basilio Roman came to be to passengering on his way home from Campaign Churchase—the Summer Basilio del Destinados Youth workers, 20th Infantry1st Battalio probabies 1957. I brought the teeth and began to write. “I can now tell you there’s nothing I could have asked for.” was question. Here’s one in three youngsters of the emotions held by a group. The role of Player Amarius The drive Summer Runof End Technological same sexualization program in two fall 20th Infantry 253 Movies. Join, Bamboo/4DA online portals who makesit ut summertim...<truncated>
+gptq:ar_seq[2] Scientists recently reported that the cellular pathogen is migrating to LLP’s scientific computational laboratory. Though I have not seen significant benefits from the pathogen, it appears to be a successful approach for legal and general government prosecutors. After releasing a new operational warning in the weeks to come, the defense attorneys at Louisville Precinct 4 & Portland Precinct 5 are continuing their readiness efforts to impose changes for use by the Prosecutors’ Federation. Thefocus on benefits from the pathogen has been to conduct meaningful out-of-date prosecution tests and reports on these efforts annually, but that’s a little longer than expected. As of November last year, one in every nine “benefit strategies” had been developed throughout Louisville Precinct 4 & Portland III, roughly two years after the 2018 FDIC compliance review. This is encompassing over 13 different factors including: - Context documentation computing advice and support packages - On-site testing protocols - Workplace health equipment/departmental project management and leadership - Network of Specialists to Besides all three remaining factors, one of which, Dutter has confidently explained that Louisville Precinct 4 & Portland III are currently on the Precinct’s recruitment list. The two segments enterprimes are named Annual Recession Entry and LPSCF Fee LPSFee Overseas Computation within the Prosecutorial Supervisor General, as follows: - -- Construction, LPSCF fees and FPFPF fees are included in In the Refund Test Protocol. Advice on both dealers and reviewers will be also expected to provide status quo rates for all applicants. Advice for Date and time in November, the Board and the Alsace Board would greatly apprecoup a meaningful waiverse of personness that all but one female, whose name was not revealed, will be placed on a classified list at the Conference. Of course this is environmental benefits make up far more than advocating public spending. From 2001-2020-2004. - Context duction and consultation to process (...<truncated>
+gptq:ar_seq[3] Weather forecasts are created by combining the majority of the Ouachita Peninsula with a majority of the Northwest, to reveal its potential for exploration and recreation. "It is an important part of what we do in order to give back our community," said Nikki Mulligan, specialized in white-bronze forestry. "The global economy is almost as powerful as it is cheap. Gas is nothing more than power. We have to strive to get where others are coming from." At the current level, Ouachita Peninsula officially became one of the six national forests operated by a previous government. This year, bicycle trails and hiking reserves have been ranked No. Two national forests include those located near the Robert West Foss and Gorgeous Ideal, which is comprised of 21,00 acres each year. The vast majority of these habitators are located in many of Ouachita Peninsula's parklands. Therefore, they have a better opportunity of recreation than others in some counties. "And this is because we have the lower severity of these recreation habits," stated Mulligan. "We don't all look good. We just act as if we were 'free of charge,' taking on oneof our NW forest systems and getting property costs up to $7,000 per year for every bicycle trails and hiking reserves costs that are reduced by $15/month." The potential for gas in Ouachita Peninsula is less than a thousand dollars. "Although most peopleshare the same nature experience with another community, it is still never sufficient to evaluate the overall appropriorities of not be distracted from otherwise hazardous operations," said Mulligan.It's off to an end! Lexington is already smart energy "creatures" that are found in the skies and white sands. One of them is this one, a rock formed by a yellow wooden tree (A good) which is hidden in the early 18th century. It's bark has been popular, around Borough, for some time but not long energetic as itsuffers itself back. In addition to the acclimation of the members have now made available an additional stuff. Lexington is comprising with it...<truncated>
+gptq:ar_seq[4] The history of the printing press began with a school cameo in 1935: Monster, File (1940, 196.8) and Created by Edward Balko, Howard of the Winds of Age Gross (1972, 198). These documents are an important part of the official family historyof the United States of America, showing that these documents were made up of archival records retrieved from a portion of any Howard of the Winds written obscure to insignificance. In this exhibition of unpressed accounts from Howard of the Winds, we consider Dick Bennett's famous "Perspective" on Political Science: 528–640. In his historical work on science and technology, he argues that scientific problems are not inherently capable of doing righteous things without being justified by our institutional and political power to free us against our shared rights or modes of existence. He relates that science and technology are not often broken into so happy as they are for the days when we may go between our two coincidences. Patent applications and licensing terms The TANORS ELECTRICO CHUBO FROMED SYNOPHOLOGY A school, a print press workshops, corporated in 1990, has worked with German university master teachers and licensing students that provides academic support to allow students themselves to contribute to the improvements of local government. These programming includes instructional videos, lectures, scholarly workshops, research and science pieces and advanced (pre-translation) section works. Many parts of the German arts offree school graphics are being used in the education system. A free example is a subject that appears on Tiger's cataloguea "German Press" insertedig. Another one, Lecture for Synonmat Germano, delivered by Edward Bennett, is programmatically Used as a scholarly book. These pieces arespot portrayed to encourage students to create their own artwork instead of videos offree exhibitions online. A good example offree examplications is a global body and a in it's usage development in the Interviewer's workbook for printing. Germanohsema 2013 originally c...<truncated>
+gptq:ar_seq[5] Public libraries provide more than just books. It is also a national heritage site. The facility resides in the country’s Tokyo region, about 20 miles from the entrance to Predniso Library. Visitors should seek ways to explore its approximately 50,000 honored pockets, digitally removed and unearthed by galleries at the locations below Africa’s Northwest Region, and wherever on the east coast of the South Pacific where a new form of community learning occurred. Throughout the year, reclamation work projects in this state will include creating a sustainable jumbo-box library found along Kyushu Road, addressing 50+ students from over 140 major Tokyungun provinces around 150km away to Indonesia’s Magani province. The goal is to develop an environmentally conscious and culturally sensitive person while increasing the number of adults in this local community as well as their own dignity and welfare. Throughout this project, the library will also include novels such as letterestories for children through learning plays with vintage photography, educational materials such as God's Way, artwork painting such as a figure, art guide tablets and sensory cards. This work is being used to make up the future-themed Student Life African Tokyo Library and The University of Mount Elizabeth The library has additional openings for students in December. Visitor, Tokyung Niello III Guest gallerista de Magnðm mð Cai was a batte-ve collection of images from anciasalonaz 2015 – National Park Silangombe san (United Nations Bank of Japan), the national libraries serving the islands of Kawasaki and Ashama networking communities projected by the archive. The work has been supported by the American Union for Agriculture. The archive has accepted three publications for advertising a museum imagerial list priceless structurescross away from the Student Life African Tokyo Library (The Progress Niello II)which is being reclamation cleared on Kyushu Road, students in the rail yard and space of a water treatment tanks. It also willbe additional t...<truncated>
+gptq:ar_seq[6] In many schools, group projects help students make music learning happen and are not only socially responsible but also connected with the community.El Segundo is a city in West Peru where many films are produced and played by composers andcinematographers. It has separate name of South Peru from South Africa and it has a large impressive literary heritage. Therefore, the city was designated as one of the most prestigious in other African countries for many years. Following the time when the city became stable, along with the local villagers, like everyone else in the city there are over 80 villages that manage to be used for tourist travel. As soon as possible, you will find all these wonderful resorts in Peru that you can take with you on your tour. What about the Color and link topics? It is one of the most important characters in South Africa and it is one of thebest in ways to explore the world. Therefore, The Color of the Wild Land is an awesome application for movie directors in SouthAfrica. Therefore, if you are creating a film in this age, you will find the best way to do this project. How soon as well as when the factors are not different? The times of quite different each day is a rare and very special thought about topics as theyare directly related to our nature. It is one thing, Our designers have been through the world before explaining it. They brings in the biggest amount of experts and writers on the nature of the world and also makes sure that everything is made right here. How soon as well as now you will find the greatest film online photo project in South Africa. Gallery 100? Model 34768LNTtek TC to LinkedIn Blackbot Discussion is a community domain in Linkedin web development software solution for various topics such asblackberry, google etc. This is an all integral part ofLinking our customers performance conversations pages based on their preferred planning functions. It has been a regularly developed design guide omega table name heap primary sized and also type pagewith XPHP conte...<truncated>
+gptq:ar_seq[7] Recycling aluminum saves energy because it “heats up a lot of available water,” according to Stasied Inc. “When you add more nitrates to the fuel efficient [store] quality-of-life measurement that can be used for scientific purposes, you are not operating without demand and that is extremely important” for making your vehicle able to wash every day or even the entire year. Nutritious foods such as homemade soup and artichokes, like low-carb “wrapping up their linens, telling them what they needed at produce cooking classes, helping them get a glimpse of granola, and using soap and water, will help you to handle anything in your free time” (Prevent Misuse by Slow Foods). Additionally, savings can also be good for one thing: some of the best bar foods in 2016 are just too much money for all of your healthy lifestyle choices. In fact, almost every day we eat four 24 hours a day. And for your DIY projects, it’s not likely that you’re going to have to spend more on accessories and finish up after work; if that is, most stores don’t even have ovens or water pipes to replace them. But this year, many stores sold outdoors too much like potential buyers when wanted to save money, such as the D&C, Mercedes-Benz, Lexus Virginia and more accessory products(including “free” non-threatening eye catching shadows that are usually not available to your favorite Porschevaré exhaustion).If you don’t have a label or packaging on hand you throw in bulky stores then several of the Best Nutrient Foods for Adventure group has a hard time finding the cheap rawhorr and when they introduced their signature memberships in 2012, followed by GlutenFree.com as well as Gluten Extraordinary made things to perfect the classic “weight loss” miife’s classic trait. Their guaranteed 38% savings on accessible non-threatening eye catching products is extremely popular, even from climate six years of healthy weighing programs into your casual DIY lifestyle choices. After all, no one is going to have a fast free meal at this year’s Glution support gro...<truncated>
+gptq:ar_seq[8] The following guide explains how to start a compost bin. Bluebell, Armstrong, Trevor and Holland are mentioned; concern about the originality of the label claimed by the company is something many people worry about in this case. Without that kind of discussion, I think it'll be hard for us to sit down and touch the properties that we have in our home.... When you write your name on the bottle, the label makes a good point. It's also easier to keep track of your homekeywords. Other than that,if you want to update your compost bin (even though it was an old version), read this page aloud from Green Mountain Bluff CityHall, where you can learn about them and a few other basic tips. You may have noticed that there is so much potential on the bluebell label. These are not just men/women, but men who are no longer using the same label, they're also women with similar interests. When you've been done with your changes and don't wish to use any more objects on the bottle (if you find one), read thispage aloud from Columbia Building Manual: The Asian Mafia (publication number CBMJDH601) is the last source for these homekeywords. Having thought about it as it was a less difficult to compose than that stumbling over the cravings of an easy bluebell label or setting them intended for simplicity of introduction or the reason why I didn't update my bin before the post-property collection. There are some good tips on how to generate your own private compost bin. What you should not distract yourself from Columbia Building Manual: This is a pretty quick way of description of homekey and items with which you can assist along the way. You can obtain packages for everything that you need, these similar for the kind you expect. If you don't have a copyrighted in and concern about as this may be an unusual timezone I can call a day or two, while holding lunch when I would like to purchase from Amazon.com. Don't let the good stuff come in contrary to what you want to be already done, just take precaption of your homekeyws, contain ...<truncated>
+gptq:ar_seq[9] Here are three ways to reduce food waste at home. First, make sure that your fruit is good for your teeth. Second, consider the nutritional info you’ll need before your cooking class. Also, consider following up with a Helpful Suggestion – firstname.lastname@example.org Discuss this topic as a convenience to all of us who wish to move from home to scratch the surface and start practicing at work for quality time with your family. One of the best ways is to enrol into your own business. You can do so by purchasing a Living Discount Card that rewards you in certain categories, such as; Money Back Guarantee – It's fast and easy for you to have access to items that need it. Before buying anything from us, look for good deals online or retail storesprint.com with lower prices when it comes to buying new appliances. Onesprint can address the situation with high-quality products and showcase their confidence. Whether you’re a shop owner or travelling with your Homeowners Supply Chain Fundamentals Onesprint.com is one of the best holders of very fast and easy discount cards. They offer Money Back Guarantee (MBG), Invoice Look and Coinbar Rewards that feature three main discount benefits:1) 25% off online and retail items.2) 90% off on coupon codes.3) 15% off your online registration and other in-store products when you buy from us and beyond. We’ve got a pretty awesome onesprint.com premium discount card! Like Trade Cards, Trading Boutiquesprint can provide a trading name condition for the site visitorsto enrol into their onesprint.com depository! Please check out our onesprint.com modified private discount rewards section of our website. Download our sample minutes images and login templates at httbattlemanagement.com.Bug, 20015668 and Marthura OptimalStability Bug is a good option for this one. Hopefully no Requires Couple is going to be able to replace the bug with another one from this one. It's high performance from itself. Problemarist Ultra Chrome EnvironmentFull Scotch Cloth A4 FlooringUSANCEXORDevelopments Pan...<truncated>
+gptq:collecting hessians from calibration data (source=ar_prompt_bank, batch=64)...
+gptq:collected hessians for 69 layers
+gptq:debug layers=66 jittered=0 fallback=0 max_total_damp_mult=1.0
+gptq:debug no layer required extra jitter or fallback
+selective_prune: 4094432 ±1 candidates, unpruned=15.66MB target=15.24MB
+selective_prune: accept_undershoot_bytes=65536 (0.0625MB)
+selective_prune: probing full ±1 prune feasibility...
+selective_prune: full ±1 prune=14.63MB
+selective_prune: search_round=1 lo=0 hi=4094432 workers=16 probes=[240849, 481698, 722547, 963396, 1204245, 1445094, 1685943, 1926792, 2167640, 2408489, 2649338, 2890187, 3131036, 3371885, 3612734, 3853583]
+selective_prune: probe prune_n=240849 total_bytes=16405588 total_mb=15.6456
+selective_prune: probe prune_n=481698 total_bytes=16328688 total_mb=15.5723
+selective_prune: probe prune_n=722547 total_bytes=16246916 total_mb=15.4943
+selective_prune: probe prune_n=963396 total_bytes=16166644 total_mb=15.4177
+selective_prune: probe prune_n=1204245 total_bytes=16090200 total_mb=15.3448
+selective_prune: probe prune_n=1445094 total_bytes=16011908 total_mb=15.2701
+selective_prune: probe prune_n=1685943 total_bytes=15937956 total_mb=15.1996
+selective_prune: probe prune_n=1926792 total_bytes=15989656 total_mb=15.2489
+selective_prune: probe prune_n=2167640 total_bytes=15834692 total_mb=15.1011
+selective_prune: probe prune_n=2408489 total_bytes=15753196 total_mb=15.0234
+selective_prune: probe prune_n=2649338 total_bytes=15696496 total_mb=14.9693
+selective_prune: probe prune_n=2890187 total_bytes=15621284 total_mb=14.8976
+selective_prune: probe prune_n=3131036 total_bytes=15568212 total_mb=14.8470
+selective_prune: probe prune_n=3371885 total_bytes=15511044 total_mb=14.7925
+selective_prune: probe prune_n=3612734 total_bytes=15456616 total_mb=14.7406
+selective_prune: probe prune_n=3853583 total_bytes=15402460 total_mb=14.6889
+selective_prune: early_accept prune_n=1685943 total_bytes=15937956 undershoot_bytes=42342
+selective_prune: pruning 1685943/4094432 ±1 values (41.2%) to fit 15.24MB
+Serialized model int6+lzma: 15779032 bytes
+Total submission size int6+lzma: 15937956 bytes
+final_int6_roundtrip val_loss:1.9301 val_bpb:1.1431 eval_time:23615ms
+final_int6_roundtrip_exact val_loss:1.93006266 val_bpb:1.14309182
+final_int6_sliding_window val_loss:1.8904 val_bpb:1.1196 stride:64 eval_time:106694ms
+final_int6_sliding_window_exact val_loss:1.89039198 val_bpb:1.11959957
+root@f4b7138c3535:/workspace/parameter-golf-base/experiments/m34a_sota_graft#

--- a/records/track_non_record_16mb/2026-04-04_NegativeResults_GatedMultiOrderHash/submission.json
+++ b/records/track_non_record_16mb/2026-04-04_NegativeResults_GatedMultiOrderHash/submission.json
@@ -1,0 +1,23 @@
+{
+  "author": "Yicheng Xia",
+  "github_id": "xiayicheng3-code",
+  "name": "Negative Results from Gated Multi-Order Hash N-grams",
+  "blurb": "Non-record submission documenting negative results from a gated multi-order hash n-gram line. Multi-hash hard top-1 routing and tail-loss emphasis did not beat the March 25 BigramHash baseline in the 10min/16MB regime. The line also produced practical AR-calibration and systems improvements, including prompt-bank AR tooling, repeat-penalized calibration generation, shard prefetch, async logging, and faster selective-prune search. Best legal simplified variant (single hash per order) reached 1.11959957 sliding exact BPB at 15,937,956 bytes.",
+  "date": "2026-04-04",
+  "track": "non-record-16mb",
+  "val_loss": 1.89039198,
+  "val_bpb": 1.11959957,
+  "pre_quant_val_loss": 1.9159,
+  "pre_quant_val_bpb": 1.1347,
+  "step_stop": 6863,
+  "wallclock_seconds": 600,
+  "bytes_total": 15937956,
+  "hardware": "8xH100 80GB SXM",
+  "gpu": "8xH100 80GB SXM",
+  "technique_summary": "Negative results from 2/3/4-gram gated hash priors; best legal result used single-hash-per-order plus AR prompt-bank calibration, async logging, next-shard prefetch, and improved selective prune behavior",
+  "supporting_logs": [
+    "run_overcap_multi_hash.log",
+    "run_submit_multi_hash_tail64.log",
+    "run_submit_single_hash.log"
+  ]
+}

--- a/records/track_non_record_16mb/2026-04-04_NegativeResults_GatedMultiOrderHash/train_gpt.py
+++ b/records/track_non_record_16mb/2026-04-04_NegativeResults_GatedMultiOrderHash/train_gpt.py
@@ -1,0 +1,3443 @@
+from __future__ import annotations
+import atexit
+import bisect
+import copy
+import concurrent.futures as cf
+import glob
+import io
+import lzma
+import math
+import os
+import queue
+import random
+import subprocess
+import sys
+import threading
+import time
+import uuid
+import zlib
+from collections import deque
+from pathlib import Path
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from flash_attn_interface import flash_attn_func as flash_attn_3_func
+
+
+def parse_int_csv(raw: str) -> list[int]:
+    return [int(part.strip()) for part in raw.split(",") if part.strip()]
+
+
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3500))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    batch_switch_step = int(os.environ.get("BATCH_SWITCH_STEP", 0))
+    batch_switch_train_batch_tokens = int(os.environ.get("BATCH_SWITCH_TRAIN_BATCH_TOKENS", 0))
+    batch_switch_compile_tax_window = int(os.environ.get("BATCH_SWITCH_COMPILE_TAX_WINDOW", 8))
+    grad_accum_steps = int(os.environ.get("GRAD_ACCUM_STEPS", 0))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 3.0))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.035))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.025))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.025))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    train_tail_loss_tokens = int(os.environ.get("TRAIN_TAIL_LOSS_TOKENS", 0))
+    train_tail_loss_weight = float(os.environ.get("TRAIN_TAIL_LOSS_WEIGHT", 1.0))
+    mtp_num_heads = int(os.environ.get("MTP_NUM_HEADS", 0))
+    mtp_loss_weight = float(os.environ.get("MTP_LOSS_WEIGHT", 0.2))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    lawa_enabled = bool(int(os.environ.get("LAWA_ENABLED", "0")))
+    lawa_k = int(os.environ.get("LAWA_K", 10))
+    lawa_freq = int(os.environ.get("LAWA_FREQ", 100))
+    muon_wd = float(os.environ.get("MUON_WD", 0.04))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.04))
+    qat_enabled = bool(int(os.environ.get("QAT_ENABLED", "0")))
+    ngram_dim = int(os.environ.get("NGRAM_DIM", 128))
+    ngram_wd = float(os.environ.get("NGRAM_WD", 1e-4))
+    ngram_orders = parse_int_csv(os.environ.get("NGRAM_ORDERS", "2,3,4"))
+    ngram_vocab_sizes = parse_int_csv(
+        os.environ.get(
+            "NGRAM_VOCAB_SIZES",
+            "3072,1536,768",
+        )
+    )
+    ngram_num_hashes = parse_int_csv(os.environ.get("NGRAM_NUM_HASHES", "2,2,2"))
+    ngram_init_std = float(os.environ.get("NGRAM_INIT_STD", "0.005"))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))  # XSA on ALL layers (our novel contribution)
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    dtg_enabled = bool(int(os.environ.get("DTG_ENABLED", "0")))
+    late_qat_threshold = float(os.environ.get("LATE_QAT_THRESHOLD", 0.15))
+    ve_enabled = bool(int(os.environ.get("VE_ENABLED", "1")))
+    ve_dim = int(os.environ.get("VE_DIM", 128))
+    ve_layers = os.environ.get("VE_LAYERS", "9,10")
+    gated_attention = bool(int(os.environ.get("GATED_ATTENTION", "0")))
+    value_residual = bool(int(os.environ.get("VALUE_RESIDUAL", "0")))  # VRL with sigmoid gates (off by default, risky)
+    # GPTQ calibration
+    gptq_calib_source = os.environ.get("GPTQ_CALIB_SOURCE", "ar_prompt_bank").strip().lower()
+    gptq_cache_num_batches = int(os.environ.get("GPTQ_CACHE_NUM_BATCHES", 4))
+    gptq_cache_max_seqs = int(os.environ.get("GPTQ_CACHE_MAX_SEQS", 64))
+    gptq_ar_num_seqs = int(os.environ.get("GPTQ_AR_NUM_SEQS", 64))
+    gptq_ar_batch_size = int(os.environ.get("GPTQ_AR_BATCH_SIZE", 64))
+    gptq_hessian_batch_size = int(os.environ.get("GPTQ_HESSIAN_BATCH_SIZE", 64))
+    gptq_ar_temperature = float(os.environ.get("GPTQ_AR_TEMPERATURE", 0.8))
+    gptq_ar_repeat_penalty = float(os.environ.get("GPTQ_AR_REPEAT_PENALTY", 1.05))
+    gptq_ar_repeat_last_n = int(os.environ.get("GPTQ_AR_REPEAT_LAST_N", 128))
+    gptq_ar_print_sequences = int(os.environ.get("GPTQ_AR_PRINT_SEQUENCES", 10))
+    gptq_ar_print_max_chars = int(os.environ.get("GPTQ_AR_PRINT_MAX_CHARS", 2048))
+    gptq_block_size = int(os.environ.get("GPTQ_BLOCK_SIZE", 128))
+    gptq_prompt_demo_count = int(os.environ.get("GPTQ_PROMPT_DEMO_COUNT", 16))
+    gptq_prompt_demo_new_tokens = int(os.environ.get("GPTQ_PROMPT_DEMO_NEW_TOKENS", 128))
+    gptq_prompt_demo_temperature = float(os.environ.get("GPTQ_PROMPT_DEMO_TEMPERATURE", 0.8))
+    gptq_prompt_demo_max_chars = int(os.environ.get("GPTQ_PROMPT_DEMO_MAX_CHARS", 512))
+    selective_prune_accept_undershoot_bytes = int(
+        os.environ.get("SELECTIVE_PRUNE_ACCEPT_UNDERSHOOT_BYTES", 65_536)
+    )
+    log_to_file = bool(int(os.environ.get("LOG_TO_FILE", "1")))
+    async_logging = bool(int(os.environ.get("ASYNC_LOGGING", "1")))
+
+# --- Batched Newton-Schulz orthogonalization ---
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 5, eps: float = 1e-7) -> Tensor:
+    """Batched Newton-Schulz orthogonalization. G: (B,M,N) or (M,N)."""
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+# --- Parallel Muon optimizer ---
+
+class Muon(torch.optim.Optimizer):
+    """Parallel Muon: post-backward reduce-scatter -> local NS5 -> all-gather.
+
+    No DDP for bank params. After backward, this optimizer:
+    1. Launches async reduce-scatter for all banks (biggest first)
+    2. Returns control so Adam can step on small params while RS is in-flight
+    3. Waits for each RS, runs local NS5 on the shard, launches async all-gather
+    4. Each all-gather overlaps with next bank's NS5
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append({
+                    'p': p,
+                    'B': B,
+                    'padded_grad': torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'shard': torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'shard_mom': torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'full_update': torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'scale': max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                })
+        # Sort by size descending -- launch biggest reduce-scatters first
+        self._bank_meta.sort(key=lambda m: -m['p'].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        """Phase 1: launch async reduce-scatter for all banks. Call right after backward."""
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m['p']
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m['padded_grad']
+            pg[:m['B']].copy_(p.grad.bfloat16())
+            if pg.shape[0] > m['B']:
+                pg[m['B']:].zero_()
+            fut = dist.reduce_scatter_tensor(m['shard'], pg, op=dist.ReduceOp.AVG, async_op=True)
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        """Phase 3: wait for RS, local NS5, all-gather. Call AFTER Adam steps."""
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        if not self._built:
+            self._build()
+
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+
+            prev_ag_handle = None
+            prev_m = None
+
+            sharded = self._distributed and hasattr(self, '_rs_futures')
+
+            for i, m in enumerate(self._bank_meta):
+                p = m['p']
+                if p.grad is None:
+                    continue
+
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m['p']
+                    upd = prev_m['full_update'][:prev_m['B']]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m['scale'])
+
+                if sharded and self._rs_futures[i] is not None:
+                    self._rs_futures[i].wait()
+                    g = m['shard']
+                    buf = m['shard_mom']
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m['full_update'], update, async_op=True)
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update.to(dtype=p.dtype), alpha=-lr * m['scale'])
+
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m['p']
+                upd = prev_m['full_update'][:prev_m['B']]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m['scale'])
+
+            if hasattr(self, '_rs_futures'):
+                del self._rs_futures
+
+        return loss
+
+# --- Tokenizer evaluation helpers ---
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    seq_len = eval_seq_len or args.train_seq_len
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# --- Quantization helpers ---
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,dtg_gate,ve_layer_scales,ve_shared.scale,attn_gate,vr_lambda",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+# --- Data loading ---
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+        self._prefetch_pool: cf.ThreadPoolExecutor | None = None
+        self._prefetch_future: cf.Future | None = None
+        self._prefetch_idx: int | None = None
+        if len(self.files) > 1:
+            self._prefetch_pool = cf.ThreadPoolExecutor(max_workers=1)
+            self._launch_prefetch()
+
+    def _next_file_idx(self) -> int:
+        return (self.file_idx + 1) % len(self.files)
+
+    def _launch_prefetch(self) -> None:
+        if self._prefetch_pool is None:
+            return
+        next_idx = self._next_file_idx()
+        # Avoid resubmitting the same shard while an in-flight prefetch is active.
+        if self._prefetch_future is not None and not self._prefetch_future.done() and self._prefetch_idx == next_idx:
+            return
+        self._prefetch_idx = next_idx
+        self._prefetch_future = self._prefetch_pool.submit(load_data_shard, self.files[next_idx])
+
+    def _advance_file(self) -> None:
+        next_idx = self._next_file_idx()
+        if self._prefetch_future is not None and self._prefetch_idx == next_idx:
+            self.tokens = self._prefetch_future.result()
+        else:
+            self.tokens = load_data_shard(self.files[next_idx])
+        self.file_idx = next_idx
+        self.pos = 0
+        self._launch_prefetch()
+
+    def close(self) -> None:
+        if self._prefetch_pool is not None:
+            self._prefetch_pool.shutdown(wait=True, cancel_futures=False)
+            self._prefetch_pool = None
+        self._prefetch_future = None
+        self._prefetch_idx = None
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+    def close(self) -> None:
+        self.stream.close()
+
+# --- Transformer modules ---
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                scale = (row_max / 31.0).clamp_min(1.0 / 31.0)
+                w_q = (torch.clamp(torch.round(w32 / scale[:, None]), -32, 31) * scale[:, None]).to(x.dtype)
+            w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024, rope_dims: int = 0):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / (base ** (torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (rd / (rd - 2)))
+                inv_freq = 1.0 / (new_base ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd))
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int = 0) -> Tensor:
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        # No CastedLinear -- weights come from banks
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rope_dims = 0  # set by GPT.__init__ for partial RoPE
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False  # set by GPT.__init__ for deep layers only
+        # Gated attention and value residual (non-banked small params)
+        self.gated_attention = gated_attention
+        if gated_attention:
+            self.attn_gate = nn.Linear(dim, num_heads, bias=True)
+            nn.init.zeros_(self.attn_gate.weight)
+            nn.init.constant_(self.attn_gate.bias, 4.0)
+        self.value_residual = value_residual
+        if value_residual:
+            self.vrl_alpha = nn.Parameter(torch.zeros(1, dtype=torch.float32))  # sigmoid gate (PR #569 style)
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        """Efficient XSA: subtract self-value projection via GQA-aware reshape (no repeat_interleave).
+        y: [B, T, H, D], v: [B, T, Hkv, D]. H must be divisible by Hkv."""
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)        # [B, T, Hkv, group, D]
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)    # [B, T, Hkv, 1, D] -- broadcast ready
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+    def forward(self, x: Tensor, q_w: Tensor, k_w: Tensor, v_w: Tensor, out_w: Tensor, v_embed: Tensor | None = None, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        bsz, seqlen, dim = x.shape
+        q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype))
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        raw_v = v if self.value_residual else None
+        if self.value_residual and v0 is not None:
+            alpha = torch.sigmoid(self.vrl_alpha.to(dtype=v.dtype))
+            v = v + alpha * v0  # sigmoid-gated residual (PR #569 style)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        if self.gated_attention:
+            # gate shape: (bsz, seqlen, num_heads) -> (bsz, seqlen, num_heads, 1) for B,T,H,D layout
+            gate = torch.sigmoid(self.attn_gate(x)).unsqueeze(-1)
+            y = y * gate
+        y = y.reshape(bsz, seqlen, dim)
+        return F.linear(y, out_w.to(x.dtype)), raw_v
+
+    def forward_step(
+        self,
+        x: Tensor,
+        q_w: Tensor,
+        k_w: Tensor,
+        v_w: Tensor,
+        out_w: Tensor,
+        kv_cache: tuple[Tensor, Tensor] | None = None,
+        v_embed: Tensor | None = None,
+        v0: Tensor | None = None,
+    ) -> tuple[Tensor, tuple[Tensor, Tensor], Tensor | None]:
+        bsz, seqlen, dim = x.shape
+        if seqlen != 1:
+            raise ValueError(f"forward_step expects seqlen=1, got {seqlen}")
+        q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k_new = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v_new = F.linear(x, v_w.to(x.dtype))
+        if v_embed is not None:
+            v_new = v_new + v_embed
+        v_new = v_new.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        raw_v = v_new if self.value_residual else None
+        if self.value_residual and v0 is not None:
+            alpha = torch.sigmoid(self.vrl_alpha.to(dtype=v_new.dtype))
+            v_new = v_new + alpha * v0
+        q = F.rms_norm(q, (q.size(-1),))
+        k_new = F.rms_norm(k_new, (k_new.size(-1),))
+        cache_len = 0 if kv_cache is None else kv_cache[0].size(1)
+        cos, sin = self.rotary(cache_len + 1, x.device, q.dtype)
+        cos = cos[:, cache_len : cache_len + 1]
+        sin = sin[:, cache_len : cache_len + 1]
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k_new = apply_rotary_emb(k_new, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if kv_cache is None:
+            k_total = k_new
+            v_total = v_new
+        else:
+            k_total = torch.cat((kv_cache[0], k_new), dim=1)
+            v_total = torch.cat((kv_cache[1], v_new), dim=1)
+        q_attn = q.transpose(1, 2)
+        k_attn = k_total.transpose(1, 2)
+        v_attn = v_total.transpose(1, 2)
+        if self.num_heads != self.num_kv_heads:
+            group = self.num_heads // self.num_kv_heads
+            k_attn = k_attn.repeat_interleave(group, dim=1)
+            v_attn = v_attn.repeat_interleave(group, dim=1)
+        y = F.scaled_dot_product_attention(q_attn, k_attn, v_attn, is_causal=False)
+        y = y.transpose(1, 2)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v_new)
+        if self.gated_attention:
+            gate = torch.sigmoid(self.attn_gate(x)).unsqueeze(-1)
+            y = y * gate
+        y = y.reshape(bsz, seqlen, dim)
+        return F.linear(y, out_w.to(x.dtype)), (k_total, v_total), raw_v
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+class NgramHashEmbedding(nn.Module):
+    HASH_A = (36313, 45817, 59243, 61297, 40127, 53453, 64811, 51749)
+    HASH_B = (27191, 31847, 22541, 18233, 49789, 14629, 35317, 43117)
+    HASH_C = (0, 7919, 15401, 21767, 31337, 47533, 61283, 65521)
+
+    def __init__(
+        self,
+        ngram_dim: int,
+        model_dim: int,
+        ngram_orders: list[int],
+        ngram_vocab_sizes: list[int],
+        ngram_num_hashes: list[int],
+        ngram_init_std: float,
+    ):
+        super().__init__()
+        self.ngram_orders = list(ngram_orders)
+        self.ngram_vocab_sizes = list(ngram_vocab_sizes)
+        self.num_hashes = list(ngram_num_hashes)
+        self.ngram_init_std = ngram_init_std
+        if len(self.ngram_orders) != len(self.ngram_vocab_sizes) or len(self.ngram_orders) != len(self.num_hashes):
+            raise ValueError("NGRAM_ORDERS, NGRAM_VOCAB_SIZES, and NGRAM_NUM_HASHES must have the same length")
+        self.total_candidates = sum(self.num_hashes)
+        group_offsets = []
+        candidate_order_ids = []
+        total_embedding_rows = 0
+        for order_idx, (order, vocab_size, hashes) in enumerate(zip(self.ngram_orders, self.ngram_vocab_sizes, self.num_hashes)):
+            if order < 2:
+                raise ValueError(f"n-gram order must be >= 2, got {order}")
+            if vocab_size < 2:
+                raise ValueError(f"vocab size must be >= 2, got {vocab_size}")
+            if hashes < 1 or hashes > len(self.HASH_A):
+                raise ValueError(f"invalid num_hashes={hashes}")
+            group_offsets.append(total_embedding_rows)
+            candidate_order_ids.extend([order_idx] * hashes)
+            total_embedding_rows += vocab_size
+        self.group_offsets = group_offsets
+        self.register_buffer(
+            "candidate_order_ids",
+            torch.tensor(candidate_order_ids, dtype=torch.int64),
+            persistent=False,
+        )
+        self.register_buffer("hash_a", torch.tensor(self.HASH_A, dtype=torch.int32), persistent=False)
+        self.register_buffer("hash_b", torch.tensor(self.HASH_B, dtype=torch.int32), persistent=False)
+        self.register_buffer("hash_c", torch.tensor(self.HASH_C, dtype=torch.int32), persistent=False)
+        self.embed = nn.Embedding(total_embedding_rows, ngram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(ngram_dim, model_dim, bias=False) if ngram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.q_proj = CastedLinear(model_dim, ngram_dim, bias=False)
+        nn.init.zeros_(self.q_proj.weight)
+        self.order_gate_bias = nn.Parameter(torch.full((len(self.ngram_orders),), -2.0, dtype=torch.float32))
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def reset_near_zero_parameters(self) -> None:
+        nn.init.normal_(self.embed.weight, mean=0.0, std=self.ngram_init_std)
+        if self.proj is not None:
+            nn.init.orthogonal_(self.proj.weight, gain=1.0)
+        nn.init.normal_(self.q_proj.weight, mean=0.0, std=self.ngram_init_std)
+
+    def ngram_hash(self, tokens_i32: Tensor, order: int, vocab_size: int, num_hashes: int, group_offset: int) -> Tensor:
+        mod = vocab_size - 1
+        out = torch.empty(*tokens_i32.shape, num_hashes, device=tokens_i32.device, dtype=torch.int32)
+        invalid_until = order - 1
+        base_offsets_view = torch.full(
+            (*([1] * tokens_i32.dim()), num_hashes),
+            group_offset,
+            device=tokens_i32.device,
+            dtype=torch.int32,
+        )
+        out[..., :invalid_until, :] = base_offsets_view + mod
+        if invalid_until >= tokens_i32.size(-1):
+            return out
+        valid_tokens = tokens_i32[..., invalid_until:]
+        mixed = torch.zeros(*valid_tokens.shape, num_hashes, device=tokens_i32.device, dtype=torch.int32)
+        hash_a = self.hash_a[:num_hashes]
+        hash_b = self.hash_b[:num_hashes]
+        hash_c = self.hash_c[:num_hashes]
+        coeff_view = [1] * tokens_i32.dim() + [num_hashes]
+        for j in range(order):
+            tok_slice = tokens_i32[..., invalid_until - j : tokens_i32.size(-1) - j].unsqueeze(-1)
+            a = (hash_a + 17 * j).view(*coeff_view)
+            b = (hash_b + 29 * j).view(*coeff_view)
+            c = (hash_c + 131 * j).view(*coeff_view)
+            mixed = torch.bitwise_xor(mixed + a * tok_slice + c, b * tok_slice)
+        out[..., invalid_until:, :] = mixed % mod + base_offsets_view
+        return out
+
+    def build_candidate_ids(self, token_ids: Tensor) -> Tensor:
+        tokens_i32 = token_ids.to(torch.int32)
+        candidate_ids = []
+        for order, vocab_size, hashes, group_offset in zip(
+            self.ngram_orders, self.ngram_vocab_sizes, self.num_hashes, self.group_offsets
+        ):
+            candidate_ids.append(self.ngram_hash(tokens_i32, order, vocab_size, hashes, group_offset))
+        return torch.cat(candidate_ids, dim=-1).long()
+
+    def build_last_candidate_ids(self, token_ids: Tensor) -> Tensor:
+        tokens_i32 = token_ids.to(torch.int32)
+        bsz, seqlen = tokens_i32.shape
+        candidate_ids = []
+        for order, vocab_size, hashes, group_offset in zip(
+            self.ngram_orders, self.ngram_vocab_sizes, self.num_hashes, self.group_offsets
+        ):
+            mod = vocab_size - 1
+            if seqlen < order:
+                ids = torch.full((bsz, hashes), group_offset + mod, device=tokens_i32.device, dtype=torch.int32)
+            else:
+                window = tokens_i32[:, -order:]
+                mixed = torch.zeros(bsz, hashes, device=tokens_i32.device, dtype=torch.int32)
+                hash_a = self.hash_a[:hashes]
+                hash_b = self.hash_b[:hashes]
+                hash_c = self.hash_c[:hashes]
+                for j in range(order):
+                    tok_slice = window[:, order - 1 - j].unsqueeze(-1)
+                    a = (hash_a + 17 * j).view(1, hashes)
+                    b = (hash_b + 29 * j).view(1, hashes)
+                    c = (hash_c + 131 * j).view(1, hashes)
+                    mixed = torch.bitwise_xor(mixed + a * tok_slice + c, b * tok_slice)
+                ids = mixed % mod + group_offset
+            candidate_ids.append(ids.unsqueeze(1))
+        return torch.cat(candidate_ids, dim=-1).long()
+
+    def build_order_top1_mask(self, score: Tensor) -> Tensor:
+        masks = []
+        start = 0
+        for hashes in self.num_hashes:
+            stop = start + hashes
+            order_score = score[..., start:stop]
+            top_idx = order_score.argmax(dim=-1, keepdim=True)
+            order_mask = torch.zeros_like(order_score, dtype=score.dtype)
+            order_mask.scatter_(-1, top_idx, 1.0)
+            masks.append(order_mask)
+            start = stop
+        return torch.cat(masks, dim=-1)
+
+    def forward(self, token_ids: Tensor, token_embed: Tensor) -> Tensor:
+        h = self.embed(self.build_candidate_ids(token_ids))
+        q = self.q_proj(token_embed).to(dtype=h.dtype).unsqueeze(-2)
+        order_bias = self.order_gate_bias[self.candidate_order_ids].to(dtype=h.dtype).view(
+            *([1] * (h.ndim - 2)), self.total_candidates
+        )
+        # Use a true scalar-per-hash compatibility score instead of a
+        # feature-wise gate. This keeps the routing decision at the hash-slot
+        # level, which matches the intended "one gate per candidate" design.
+        score = (q * h).sum(dim=-1) / math.sqrt(h.size(-1)) + order_bias
+        gate = (torch.sigmoid(score) * self.build_order_top1_mask(score)).unsqueeze(-1)
+        h = (gate * h).sum(dim=-2)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+    def forward_last(self, token_ids: Tensor, token_embed: Tensor) -> Tensor:
+        h = self.embed(self.build_last_candidate_ids(token_ids))
+        q = self.q_proj(token_embed).to(dtype=h.dtype).unsqueeze(-2)
+        order_bias = self.order_gate_bias[self.candidate_order_ids].to(dtype=h.dtype).view(1, 1, self.total_candidates)
+        score = (q * h).sum(dim=-1) / math.sqrt(h.size(-1)) + order_bias
+        gate = (torch.sigmoid(score) * self.build_order_top1_mask(score)).unsqueeze(-1)
+        h = (gate * h).sum(dim=-2)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class ValueEmbedding(nn.Module):
+    """Reinject token identity into attention values at specific layers.
+    Each table maps vocab tokens to a low-dim embedding, projected to model_dim."""
+    def __init__(self, vocab_size: int, ve_dim: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, ve_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(ve_dim, model_dim, bias=False) if ve_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(token_ids)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        # No CastedLinear -- weights come from banks
+    def forward(self, x: Tensor, up_w: Tensor, down_w: Tensor) -> Tensor:
+        x = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5)
+        return F.linear(x.square(), down_w.to(x.dtype))
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        layer_idx: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+                                        gated_attention=gated_attention, value_residual=value_residual)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+        if dtg:
+            self.dtg_gate = nn.Linear(dim, 1, bias=True)
+            nn.init.zeros_(self.dtg_gate.weight)
+            nn.init.constant_(self.dtg_gate.bias, 2.0)
+        else:
+            self.dtg_gate = None
+    def forward(self, x: Tensor, x0: Tensor, q_w: Tensor, k_w: Tensor, v_w: Tensor, out_w: Tensor, up_w: Tensor, down_w: Tensor, v_embed: Tensor | None = None, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out, raw_v = self.attn(self.attn_norm(x_in) * self.ln_scale_factor, q_w, k_w, v_w, out_w, v_embed=v_embed, v0=v0)
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        if self.dtg_gate is not None:
+            gate = torch.sigmoid(self.dtg_gate(x_in.detach()))
+            x_out = x_in + gate * (x_out - x_in)
+        return x_out, raw_v
+
+    def forward_step(
+        self,
+        x: Tensor,
+        x0: Tensor,
+        q_w: Tensor,
+        k_w: Tensor,
+        v_w: Tensor,
+        out_w: Tensor,
+        up_w: Tensor,
+        down_w: Tensor,
+        kv_cache: tuple[Tensor, Tensor] | None = None,
+        v_embed: Tensor | None = None,
+        v0: Tensor | None = None,
+    ) -> tuple[Tensor, tuple[Tensor, Tensor], Tensor | None]:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out, new_cache, raw_v = self.attn.forward_step(
+            self.attn_norm(x_in) * self.ln_scale_factor,
+            q_w,
+            k_w,
+            v_w,
+            out_w,
+            kv_cache=kv_cache,
+            v_embed=v_embed,
+            v0=v0,
+        )
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(
+            self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w
+        )
+        if self.dtg_gate is not None:
+            gate = torch.sigmoid(self.dtg_gate(x_in.detach()))
+            x_out = x_in + gate * (x_out - x_in)
+        return x_out, new_cache, raw_v
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        mtp_num_heads: int = 0,
+        mtp_loss_weight: float = 0.1,
+        train_tail_loss_tokens: int = 0,
+        train_tail_loss_weight: float = 1.0,
+        ngram_dim: int = 128,
+        ngram_orders: list[int] | None = None,
+        ngram_vocab_sizes: list[int] | None = None,
+        ngram_num_hashes: list[int] | None = None,
+        ngram_init_std: float = 0.005,
+        xsa_last_n: int = 0,
+        rope_dims: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        ve_enabled: bool = False,
+        ve_dim: int = 128,
+        ve_layers: str = "9,10",
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self._ve_target_dim = num_kv_heads * (model_dim // num_heads)  # kv_dim for value projection
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.value_residual = value_residual
+        self.mtp_num_heads = mtp_num_heads
+        self.mtp_loss_weight = mtp_loss_weight
+        self.train_tail_loss_tokens = train_tail_loss_tokens
+        self.train_tail_loss_weight = train_tail_loss_weight
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        resolved_ngram_vocab_sizes = ngram_vocab_sizes if ngram_vocab_sizes is not None else [3072, 1536, 768]
+        self.ngram = (
+            NgramHashEmbedding(
+                ngram_dim,
+                model_dim,
+                ngram_orders if ngram_orders is not None else [2, 3, 4],
+                resolved_ngram_vocab_sizes,
+                ngram_num_hashes if ngram_num_hashes is not None else [2, 2, 2],
+                ngram_init_std,
+            )
+            if len(resolved_ngram_vocab_sizes) > 0 else None
+        )
+        self.smear = SmearGate(model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        # Parameter banks: contiguous 3D tensors for batched optimizer
+        head_dim = model_dim // num_heads
+        kv_dim = num_kv_heads * head_dim
+        mlp_dim = int(mlp_mult * model_dim)
+        self.num_layers = num_layers
+        self.qo_bank = nn.Parameter(torch.empty(2 * num_layers, model_dim, model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * num_layers, kv_dim, model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(num_layers, mlp_dim, model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(num_layers, model_dim, mlp_dim))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                    layer_idx=i,
+                    ln_scale=ln_scale,
+                    dtg=dtg,
+                    gated_attention=gated_attention,
+                    value_residual=value_residual,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        if rope_dims > 0:
+            head_dim = model_dim // num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = rope_dims
+                block.attn.rotary = Rotary(head_dim, base=rope_base, train_seq_len=1024, rope_dims=rope_dims)
+        self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+        kv_dim_ve = self._ve_target_dim
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim_ve)
+            self.ve_layer_scales = nn.ParameterList(
+                [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices]
+            )
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.value_embeds = nn.ModuleList()  # keep empty for compat
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.mtp_heads = nn.ModuleList(
+            [CastedLinear(model_dim, vocab_size, bias=False) for _ in range(mtp_num_heads)]
+        )
+        for head in self.mtp_heads:
+            head._zero_init = True
+        if xsa_last_n > 0:
+            for i in range(max(0, num_layers - xsa_last_n), num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self._init_weights()
+        if self.ngram is not None and hasattr(self.ngram, "reset_near_zero_parameters"):
+            self.ngram.reset_near_zero_parameters()
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        # Init banks: orthogonal, with proj layers scaled down and out/down zero-init
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)        # Q
+            nn.init.zeros_(self.qo_bank.data[n + i])                    # Out (zero init)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)        # K
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)    # V
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)    # MLP up
+            nn.init.zeros_(self.mlp_down_bank.data[i])                  # MLP down (zero init)
+            # Scale proj layers (out_proj and mlp_down are "proj" layers)
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        # Init remaining nn.Linear modules (ngram proj, mtp heads, lm_head)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+    def _get_ve(self, layer_idx: int, input_ids: Tensor, ve_cache: dict | None = None) -> Tensor | None:
+        """Get value embedding for a specific layer using shared table + per-layer scale."""
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if ve_cache is not None and 've' not in ve_cache:
+            ve_cache['ve'] = self.ve_shared(input_ids)
+        ve_base = ve_cache['ve'] if ve_cache is not None else self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_base * self.ve_layer_scales[ve_idx].to(dtype=ve_base.dtype)
+
+    def _apply_input_features_step(
+        self,
+        current_token_ids: Tensor,
+        recent_token_ids: Tensor,
+        prev_pre_smear: Tensor | None,
+    ) -> tuple[Tensor, Tensor]:
+        x = self.tok_emb(current_token_ids)
+        if self.ngram is not None:
+            x = x + self.ngram.forward_last(recent_token_ids, x)
+        x = F.rms_norm(x, (x.size(-1),))
+        g = torch.sigmoid(self.smear.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.zeros_like(x) if prev_pre_smear is None else prev_pre_smear
+        return (1 - g) * x + g * x_prev, x
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.ngram is not None:
+            x = x + self.ngram(input_ids, x)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x, raw_v = self.blocks[i](x, x0,
+                self.qo_bank[i], self.kv_bank[i], self.kv_bank[n + i],
+                self.qo_bank[n + i], self.mlp_up_bank[i], self.mlp_down_bank[i],
+                v_embed=ve, v0=v0)
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x, _ = self.blocks[bi](x, x0,
+                self.qo_bank[bi], self.kv_bank[bi], self.kv_bank[n + bi],
+                self.qo_bank[n + bi], self.mlp_up_bank[bi], self.mlp_down_bank[bi],
+                v_embed=ve, v0=v0)
+        x = self.final_norm(x)
+        x_flat = x.reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x_flat, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x_flat)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        if (
+            self.training
+            and self.train_tail_loss_tokens > 0
+            and self.train_tail_loss_weight != 1.0
+        ):
+            bsz, seqlen, _ = x.shape
+            token_losses = F.cross_entropy(logits.float(), targets, reduction="none").view(bsz, seqlen)
+            tail = min(self.train_tail_loss_tokens, seqlen)
+            weights = token_losses.new_ones((bsz, seqlen))
+            weights[:, -tail:] = self.train_tail_loss_weight
+            main_loss = (token_losses * weights).sum() / weights.sum()
+        else:
+            main_loss = F.cross_entropy(logits.float(), targets, reduction="mean")
+        if self.training and self.mtp_num_heads > 0 and self.mtp_loss_weight > 0.0:
+            _, seqlen, dim = x.shape
+            mtp_loss_sum = x.new_zeros(())
+            mtp_loss_count = 0
+            for k, mtp_head in enumerate(self.mtp_heads):
+                valid_t = seqlen - (k + 1)
+                if valid_t <= 0:
+                    continue
+                mtp_hidden = x[:, :valid_t, :].reshape(-1, dim)
+                mtp_targets = target_ids[:, k + 1 :].reshape(-1)
+                mtp_logits_proj = mtp_head(mtp_hidden)
+                mtp_logits = self.logit_softcap * torch.tanh(mtp_logits_proj / self.logit_softcap)
+                mtp_loss_sum = mtp_loss_sum + F.cross_entropy(mtp_logits.float(), mtp_targets, reduction="mean")
+                mtp_loss_count += 1
+            if mtp_loss_count > 0:
+                main_loss = main_loss + self.mtp_loss_weight * (mtp_loss_sum / mtp_loss_count)
+        return main_loss
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Return logits (bsz, seq_len, vocab) without computing loss."""
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.ngram is not None:
+            x = x + self.ngram(input_ids, x)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x, raw_v = self.blocks[i](x, x0,
+                self.qo_bank[i], self.kv_bank[i], self.kv_bank[n + i],
+                self.qo_bank[n + i], self.mlp_up_bank[i], self.mlp_down_bank[i],
+                v_embed=ve, v0=v0)
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x, _ = self.blocks[bi](x, x0,
+                self.qo_bank[bi], self.kv_bank[bi], self.kv_bank[n + bi],
+                self.qo_bank[n + bi], self.mlp_up_bank[bi], self.mlp_down_bank[bi],
+                v_embed=ve, v0=v0)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward_next_logits_cached(
+        self,
+        current_token_ids: Tensor,
+        recent_token_ids: Tensor,
+        kv_caches: list[tuple[Tensor, Tensor] | None] | None = None,
+        prev_pre_smear: Tensor | None = None,
+    ) -> tuple[Tensor, list[tuple[Tensor, Tensor]], Tensor]:
+        if current_token_ids.ndim != 2 or current_token_ids.size(1) != 1:
+            raise ValueError(f"current_token_ids must have shape [B,1], got {tuple(current_token_ids.shape)}")
+        n = self.num_layers
+        if kv_caches is None:
+            kv_caches = [None] * n
+        x, pre_smear = self._apply_input_features_step(current_token_ids, recent_token_ids, prev_pre_smear)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        new_caches: list[tuple[Tensor, Tensor]] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, current_token_ids, ve_cache)
+            x, layer_cache, raw_v = self.blocks[i].forward_step(
+                x,
+                x0,
+                self.qo_bank[i],
+                self.kv_bank[i],
+                self.kv_bank[n + i],
+                self.qo_bank[n + i],
+                self.mlp_up_bank[i],
+                self.mlp_down_bank[i],
+                kv_cache=kv_caches[i],
+                v_embed=ve,
+                v0=v0,
+            )
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+            new_caches.append(layer_cache)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, current_token_ids, ve_cache)
+            x, layer_cache, _ = self.blocks[bi].forward_step(
+                x,
+                x0,
+                self.qo_bank[bi],
+                self.kv_bank[bi],
+                self.kv_bank[n + bi],
+                self.qo_bank[n + bi],
+                self.mlp_up_bank[bi],
+                self.mlp_down_bank[bi],
+                kv_cache=kv_caches[bi],
+                v_embed=ve,
+                v0=v0,
+            )
+            new_caches.append(layer_cache)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x[:, -1, :], self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x[:, -1, :])
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return logits, new_caches, pre_smear
+
+# --- Sliding window evaluation ---
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context."""
+    seq_len = eval_seq_len or args.train_seq_len
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sliding-window sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
+        )
+    batch_seqs = max(local_batch_tokens // seq_len, 1)
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= 1]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    base_model.eval()
+    compiled_logits = torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = compiled_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+def generate_autoregressive_calib(model, device, num_seqs=64, seq_len=2048,
+                                   vocab_size=1024, temperature=0.8, batch_size=8, seed=42,
+                                   repeat_penalty: float = 1.0, repeat_last_n: int = 0):
+    """Generate sequences autoregressively from the model for GPTQ calibration.
+    No external data accessed — fully self-contained."""
+    model.eval()
+    rng = torch.Generator(device=device)
+    rng.manual_seed(seed)
+    all_tokens = torch.empty(num_seqs, seq_len, device=device, dtype=torch.int64)
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        for batch_start in range(0, num_seqs, batch_size):
+            bs = min(batch_size, num_seqs - batch_start)
+            tokens = torch.randint(0, vocab_size, (bs, 1), device=device, generator=rng)
+            kv_caches = None
+            prev_pre_smear = None
+            recent_tokens = tokens
+            for _ in range(seq_len - 1):
+                next_logit, kv_caches, prev_pre_smear = model.forward_next_logits_cached(
+                    tokens[:, -1:],
+                    recent_tokens,
+                    kv_caches=kv_caches,
+                    prev_pre_smear=prev_pre_smear,
+                )
+                apply_repeat_penalty_inplace(
+                    next_logit,
+                    tokens,
+                    repeat_penalty=repeat_penalty,
+                    repeat_last_n=repeat_last_n,
+                )
+                probs = torch.softmax(next_logit / temperature, dim=-1)
+                next_tok = torch.multinomial(probs, 1, generator=rng)
+                tokens = torch.cat([tokens, next_tok], dim=1)
+                recent_tokens = tokens[:, -max(model.ngram.ngram_orders):] if model.ngram is not None else tokens[:, -1:]
+            all_tokens[batch_start : batch_start + bs] = tokens
+    return all_tokens
+
+
+def apply_repeat_penalty_inplace(
+    logits: Tensor,
+    recent_tokens: Tensor,
+    repeat_penalty: float,
+    repeat_last_n: int,
+) -> None:
+    if repeat_penalty <= 1.0 or repeat_last_n <= 0 or recent_tokens.numel() == 0:
+        return
+    window = recent_tokens[:, -min(repeat_last_n, recent_tokens.size(1)) :]
+    for row_idx in range(logits.size(0)):
+        repeated = torch.unique(window[row_idx])
+        if repeated.numel() == 0:
+            continue
+        row_logits = logits[row_idx]
+        repeated_logits = row_logits[repeated]
+        penalized = torch.where(
+            repeated_logits > 0,
+            repeated_logits / repeat_penalty,
+            repeated_logits * repeat_penalty,
+        )
+        row_logits[repeated] = penalized
+
+
+def generate_prompt_bank_autoregressive_calib(
+    model,
+    sp: spm.SentencePieceProcessor,
+    device: torch.device,
+    prompt_bank: list[str],
+    num_seqs: int = 64,
+    seq_len: int = 2048,
+    temperature: float = 0.8,
+    batch_size: int = 8,
+    seed: int = 42,
+    repeat_penalty: float = 1.0,
+    repeat_last_n: int = 0,
+) -> Tensor:
+    """Generate calibration sequences from a fixed prompt bank.
+
+    Prompts are teacher-forced through their initial tokens, then generation
+    continues autoregressively until seq_len.
+    """
+    prompt_token_bank = [sp.encode(text, out_type=int) for text in prompt_bank]
+    prompt_token_bank = [ids[:seq_len] for ids in prompt_token_bank if len(ids) > 0]
+    if not prompt_token_bank:
+        raise ValueError("Prompt bank is empty after tokenization")
+    model.eval()
+    rng = torch.Generator(device=device)
+    rng.manual_seed(seed)
+    all_tokens = torch.empty(num_seqs, seq_len, device=device, dtype=torch.int64)
+    max_recent = max(model.ngram.ngram_orders) if model.ngram is not None else 1
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        for batch_start in range(0, num_seqs, batch_size):
+            bs = min(batch_size, num_seqs - batch_start)
+            prompt_batch = [
+                prompt_token_bank[(batch_start + i) % len(prompt_token_bank)]
+                for i in range(bs)
+            ]
+            prompt_lens = torch.tensor(
+                [min(len(ids), seq_len) for ids in prompt_batch],
+                device=device,
+                dtype=torch.int64,
+            )
+            max_prompt_len = int(prompt_lens.max().item())
+            prompt_tensor = torch.zeros(bs, max_prompt_len, device=device, dtype=torch.int64)
+            for i, ids in enumerate(prompt_batch):
+                plen = min(len(ids), seq_len)
+                prompt_tensor[i, :plen] = torch.tensor(ids[:plen], device=device, dtype=torch.int64)
+            tokens = prompt_tensor[:, :1].clone()
+            kv_caches = None
+            prev_pre_smear = None
+            recent_tokens = tokens
+            for pos in range(1, seq_len):
+                next_logit, kv_caches, prev_pre_smear = model.forward_next_logits_cached(
+                    tokens[:, -1:],
+                    recent_tokens,
+                    kv_caches=kv_caches,
+                    prev_pre_smear=prev_pre_smear,
+                )
+                apply_repeat_penalty_inplace(
+                    next_logit,
+                    tokens,
+                    repeat_penalty=repeat_penalty,
+                    repeat_last_n=repeat_last_n,
+                )
+                probs = torch.softmax(next_logit / temperature, dim=-1)
+                next_tok = torch.multinomial(probs, 1, generator=rng)
+                force_mask = pos < prompt_lens
+                if force_mask.any():
+                    next_tok[force_mask, 0] = prompt_tensor[force_mask, pos]
+                tokens = torch.cat([tokens, next_tok], dim=1)
+                recent_tokens = tokens[:, -max_recent:]
+            all_tokens[batch_start : batch_start + bs] = tokens
+    return all_tokens
+
+
+def log_token_sequences(
+    log0,
+    sp: spm.SentencePieceProcessor,
+    token_seqs: Tensor,
+    max_sequences: int,
+    max_chars: int = 0,
+    header: str = "gptq:calibration_sequences",
+    line_prefix: str = "gptq:seq",
+) -> None:
+    token_seqs_cpu = token_seqs.detach().cpu()
+    total = token_seqs_cpu.size(0)
+    num_to_print = total if max_sequences <= 0 else min(total, max_sequences)
+    log0(f"{header} count={total} showing={num_to_print}")
+    for idx in range(num_to_print):
+        ids = token_seqs_cpu[idx].tolist()
+        text = sp.decode_ids(ids)
+        text = text.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+        if max_chars > 0 and len(text) > max_chars:
+            text = text[:max_chars] + "...<truncated>"
+        log0(f"{line_prefix}[{idx}] {text}")
+
+
+def pack_xy_for_calibration(x: Tensor, y: Tensor) -> Tensor:
+    # Reconstruct a token sequence whose shifted pairs reproduce the training
+    # x/y batch exactly when later fed back through collect_hessians_from_tokens.
+    return torch.cat([x[:, :1], y], dim=1).detach().to(device="cpu", dtype=torch.int64)
+
+
+def get_cached_train_calibration_tokens(
+    cached_batches: deque[Tensor],
+    max_seqs: int,
+) -> Tensor | None:
+    if len(cached_batches) == 0:
+        return None
+    token_seqs = torch.cat(list(cached_batches), dim=0)
+    if max_seqs > 0 and token_seqs.size(0) > max_seqs:
+        token_seqs = token_seqs[-max_seqs:]
+    return token_seqs.contiguous()
+
+
+PROMPT_DEMO_TEXTS = [
+    "Describe the city you live in.",
+    "Explain a skill that takes a long time to learn well.",
+    "Write the opening sentence of a news article about a strange weather event.",
+    "Tell a short story that begins with a missed train.",
+    "Give three practical tips for sleeping better.",
+    "Summarize why people enjoy team sports.",
+    "Describe a room that feels comfortable to work in.",
+    "Write a paragraph about a historical place worth visiting.",
+    "Explain why some habits are hard to break.",
+    "Describe a meal you would cook for close friends.",
+    "Write a short introduction to a science exhibition.",
+    "Explain the appeal of living near water.",
+    "Describe a memorable teacher.",
+    "Write a paragraph about how cities change at night.",
+    "Explain one reason people keep personal journals.",
+    "Describe a park in early autumn.",
+]
+
+GPTQ_PROMPT_BANK_TEXTS = [
+    "The water cycle describes how water moves through the environment.",
+    "A solar eclipse happens when",
+    "Scientists recently reported that",
+    "Weather forecasts are created by combining",
+    "The history of the printing press began with",
+    "Public libraries provide more than just books.",
+    "In many schools, group projects help students",
+    "Recycling aluminum saves energy because",
+    "The following guide explains how to start a compost bin.",
+    "Here are three ways to reduce food waste at home.",
+    "A healthy breakfast usually includes",
+    "When plants do not get enough light,",
+    "A news report released on Tuesday described",
+    "The city council announced a plan to improve",
+    "Many animals migrate in order to",
+    "Earthquakes occur when",
+]
+
+
+def generate_prompt_demo_texts(
+    model,
+    sp: spm.SentencePieceProcessor,
+    device: torch.device,
+    prompts: list[str],
+    seq_len: int,
+    max_new_tokens: int,
+    temperature: float,
+    seed: int,
+    repeat_penalty: float = 1.0,
+    repeat_last_n: int = 0,
+) -> list[str]:
+    model.eval()
+    outputs: list[str] = []
+    rng = torch.Generator(device=device)
+    rng.manual_seed(seed)
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        for prompt in prompts:
+            prompt_ids = sp.encode(prompt, out_type=int)
+            if not prompt_ids:
+                continue
+            tokens = torch.tensor([prompt_ids[:1]], device=device, dtype=torch.int64)
+            kv_caches = None
+            prev_pre_smear = None
+            recent_tokens = tokens
+            total_len = min(
+                seq_len,
+                max(len(prompt_ids), 1) + max(max_new_tokens, 0),
+            )
+            for pos in range(1, total_len):
+                next_logit, kv_caches, prev_pre_smear = model.forward_next_logits_cached(
+                    tokens[:, -1:],
+                    recent_tokens,
+                    kv_caches=kv_caches,
+                    prev_pre_smear=prev_pre_smear,
+                )
+                apply_repeat_penalty_inplace(
+                    next_logit,
+                    tokens,
+                    repeat_penalty=repeat_penalty,
+                    repeat_last_n=repeat_last_n,
+                )
+                if pos < len(prompt_ids):
+                    next_tok = torch.tensor(
+                        [[prompt_ids[pos]]],
+                        device=device,
+                        dtype=torch.int64,
+                    )
+                else:
+                    probs = torch.softmax(next_logit / temperature, dim=-1)
+                    next_tok = torch.multinomial(probs, 1, generator=rng)
+                tokens = torch.cat([tokens, next_tok], dim=1)
+                recent_tokens = (
+                    tokens[:, -max(model.ngram.ngram_orders):]
+                    if model.ngram is not None else tokens[:, -1:]
+                )
+            text = sp.decode_ids(tokens[0].detach().cpu().tolist())
+            outputs.append(text)
+    return outputs
+
+
+def collect_hessians_from_tokens(hessian_model, token_seqs, device, batch_size=8):
+    """Collect H = X^T X from pre-generated token sequences."""
+    hessians = {}
+    hooks = []
+    for name, module in hessian_model.named_modules():
+        if isinstance(module, CastedLinear):
+            param_name = name + ".weight"
+            cols = module.weight.shape[1]
+            hessians[param_name] = torch.zeros(cols, cols, dtype=torch.float32, device='cpu')
+            def make_hook(pname):
+                def hook_fn(module, input, output):
+                    x = input[0].detach().float()
+                    if x.ndim == 3:
+                        x = x.reshape(-1, x.shape[-1])
+                    hessians[pname] += (x.T @ x).cpu()
+                return hook_fn
+            h = module.register_forward_hook(make_hook(param_name))
+            hooks.append(h)
+    hessian_model.eval()
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        if isinstance(token_seqs, list):
+            token_batches = torch.cat(token_seqs, dim=0)
+        else:
+            token_batches = token_seqs
+        for start in range(0, token_batches.size(0), batch_size):
+            seq = token_batches[start : start + batch_size]
+            x = seq[:, :-1].to(device)
+            y = seq[:, 1:].to(device)
+            hessian_model(x, y)
+    for h in hooks:
+        h.remove()
+    num_batches = token_batches.size(0)
+    for name in hessians:
+        H = hessians[name]
+        H /= num_batches
+        # X^T X should be symmetric PSD, but finite-precision accumulation and
+        # heavily collapsed AR calibration sequences can make it slightly
+        # asymmetric or numerically rank-deficient. Symmetrize first, then add
+        # the usual diagonal damping.
+        H = 0.5 * (H + H.T)
+        damp = 0.01 * torch.diag(H).mean().clamp_min(1e-6)
+        H += damp * torch.eye(H.shape[0], dtype=H.dtype, device=H.device)
+        hessians[name] = H
+    return hessians
+
+
+# --- GPTQ-lite int6 quantization ---
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+def quantize_int6_per_row(t: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        best_q, best_s, best_err = None, None, float('inf')
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            if pct < 1.0:
+                row_clip = torch.quantile(t32.abs(), pct, dim=1)
+            else:
+                row_clip = t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+            recon = q.float() * s.float()[:, None]
+            err = (t32 - recon).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_s, best_err = q, s, err
+        return best_q, best_s
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+
+def _stable_upper_cholesky_from_hessian(H: Tensor, base_damp: Tensor) -> tuple[Tensor | None, dict[str, float | int | None]]:
+    """Return an upper-triangular factor of H^{-1}, or None if stabilization fails.
+
+    GPTQ expects a positive-definite Hessian approximation. In practice, the
+    collected X^T X matrix can become only semidefinite or slightly indefinite
+    when calibration activations collapse. We therefore retry Cholesky with
+    progressively stronger diagonal jitter.
+    """
+    H = 0.5 * (H + H.T)
+    eye = torch.eye(H.shape[0], dtype=H.dtype, device=H.device)
+    damp0 = float(base_damp.detach().item())
+    jitter_schedule = [0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0]
+    for attempt_idx, mult in enumerate(jitter_schedule):
+        jitter = damp0 * mult
+        H_try = H if jitter == 0.0 else H + jitter * eye
+        chol, info = torch.linalg.cholesky_ex(H_try)
+        if int(info.max().item()) != 0:
+            continue
+        Hinv = torch.cholesky_inverse(chol)
+        Hinv = 0.5 * (Hinv + Hinv.T)
+        upper, info = torch.linalg.cholesky_ex(Hinv, upper=True)
+        if int(info.max().item()) == 0:
+            return upper, {
+                "attempts": attempt_idx + 1,
+                "extra_damp_mult": float(mult),
+                "extra_damp": float(jitter),
+                "total_damp_mult": float(1.0 + mult),
+                "base_damp": damp0,
+            }
+    return None, {
+        "attempts": len(jitter_schedule),
+        "extra_damp_mult": None,
+        "extra_damp": None,
+        "total_damp_mult": None,
+        "base_damp": damp0,
+    }
+
+def quantize_int6_gptq(weight, hessian=None, clip_range=31, block_size=128, return_debug=False):
+    """Full GPTQ: Hessian-aware int6 quantization with Cholesky error compensation.
+    If the Hessian is missing or too ill-conditioned even after stabilization,
+    fall back to percentile search."""
+    t32 = weight.float()
+    if t32.ndim != 2 or hessian is None:
+        q, s = _quantize_int6_percentile(t32, clip_range)
+        debug = {
+            "mode": "percentile_no_hessian",
+            "attempts": 0,
+            "base_damp": None,
+            "extra_damp_mult": None,
+            "extra_damp": None,
+            "total_damp_mult": None,
+        }
+        return (q, s, debug) if return_debug else (q, s)
+    rows, cols = t32.shape
+    H = hessian.float().clone()
+    H = 0.5 * (H + H.T)
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * torch.mean(torch.diag(H))
+    H[torch.arange(cols), torch.arange(cols)] += damp
+    perm = torch.argsort(torch.diag(H), descending=True)
+    inv_perm = torch.argsort(perm)
+    W = t32[:, perm].clone()
+    W[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv, chol_debug = _stable_upper_cholesky_from_hessian(H, damp)
+    if Hinv is None:
+        q, s = _quantize_int6_percentile(t32, clip_range)
+        debug = {
+            "mode": "percentile_fallback_non_pd",
+            **chol_debug,
+        }
+        return (q, s, debug) if return_debug else (q, s)
+    best_q = None; best_scale = None; best_err = float('inf')
+    for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+        if pct < 1.0:
+            row_clip = torch.quantile(t32.abs(), pct, dim=1)
+        else:
+            row_clip = t32.abs().amax(dim=1)
+        s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+        sf = s.float()
+        Q = torch.zeros_like(W, dtype=torch.int8)
+        W_work = W.clone()
+        for i1 in range(0, cols, block_size):
+            i2 = min(i1 + block_size, cols)
+            count = i2 - i1
+            W1 = W_work[:, i1:i2].clone()
+            Q1 = torch.zeros(rows, count, dtype=torch.int8)
+            Err1 = torch.zeros(rows, count)
+            Hinv1 = Hinv[i1:i2, i1:i2]
+            for i in range(count):
+                w = W1[:, i]
+                d = Hinv1[i, i]
+                q = torch.clamp(torch.round(w / sf), -clip_range, clip_range).to(torch.int8)
+                Q1[:, i] = q
+                err = (w - q.float() * sf) / d
+                W1[:, i:] -= err.unsqueeze(1) * Hinv1[i, i:].unsqueeze(0)
+                Err1[:, i] = err
+            Q[:, i1:i2] = Q1
+            if i2 < cols:
+                W_work[:, i2:] -= Err1 @ Hinv[i1:i2, i2:]
+        recon = Q.float() * sf[:, None]
+        mse = (W - recon).pow(2).mean().item()
+        if mse < best_err:
+                best_q, best_scale, best_err = Q, s, mse
+    best_q = best_q[:, inv_perm]
+    debug = {
+        "mode": "gptq",
+        **chol_debug,
+    }
+    return (best_q, best_scale, debug) if return_debug else (best_q, best_scale)
+
+def _quantize_int6_percentile(t32, clip_range=31):
+    """Fallback: percentile search (for 1D or no-Hessian cases)."""
+    if t32.ndim == 2:
+        best_q, best_s, best_err = None, None, float('inf')
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            if pct < 1.0:
+                row_clip = torch.quantile(t32.abs(), pct, dim=1)
+            else:
+                row_clip = t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+            recon = q.float() * s.float()[:, None]
+            err = (t32 - recon).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_s, best_err = q, s, err
+        return best_q, best_s
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+
+def _unbank_state_dict(sd: dict[str, Tensor], num_layers: int) -> dict[str, Tensor]:
+    """Convert 3D bank tensors into individual 2D tensors with standard names."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    for name, tensor in sd.items():
+        if name == "qo_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_q.weight"] = tensor[i]
+                out[f"blocks.{i}.attn.proj.weight"] = tensor[n + i]
+        elif name == "kv_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_k.weight"] = tensor[i]
+                out[f"blocks.{i}.attn.c_v.weight"] = tensor[n + i]
+        elif name == "mlp_up_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.fc.weight"] = tensor[i]
+        elif name == "mlp_down_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.proj.weight"] = tensor[i]
+        else:
+            out[name] = tensor
+    return out
+
+def _rebank_state_dict(sd: dict[str, Tensor], num_layers: int, template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    """Convert individual 2D tensors back into 3D bank tensors."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    # Reconstruct banks from individual weight keys
+    qo_slices = [None] * (2 * n)
+    kv_slices = [None] * (2 * n)
+    up_slices = [None] * n
+    down_slices = [None] * n
+    consumed = set()
+    for i in range(n):
+        qk = f"blocks.{i}.attn.c_q.weight"
+        if qk in sd:
+            qo_slices[i] = sd[qk]
+            consumed.add(qk)
+        ok = f"blocks.{i}.attn.proj.weight"
+        if ok in sd:
+            qo_slices[n + i] = sd[ok]
+            consumed.add(ok)
+        kk = f"blocks.{i}.attn.c_k.weight"
+        if kk in sd:
+            kv_slices[i] = sd[kk]
+            consumed.add(kk)
+        vk = f"blocks.{i}.attn.c_v.weight"
+        if vk in sd:
+            kv_slices[n + i] = sd[vk]
+            consumed.add(vk)
+        fk = f"blocks.{i}.mlp.fc.weight"
+        if fk in sd:
+            up_slices[i] = sd[fk]
+            consumed.add(fk)
+        dk = f"blocks.{i}.mlp.proj.weight"
+        if dk in sd:
+            down_slices[i] = sd[dk]
+            consumed.add(dk)
+    out["qo_bank"] = torch.stack(qo_slices).to(dtype=template_sd["qo_bank"].dtype)
+    out["kv_bank"] = torch.stack(kv_slices).to(dtype=template_sd["kv_bank"].dtype)
+    out["mlp_up_bank"] = torch.stack(up_slices).to(dtype=template_sd["mlp_up_bank"].dtype)
+    out["mlp_down_bank"] = torch.stack(down_slices).to(dtype=template_sd["mlp_down_bank"].dtype)
+    for name, tensor in sd.items():
+        if name not in consumed:
+            out[name] = tensor
+    return out
+
+# --- Non-banked model for Hessian collection ---
+# This mirrors the unbanked state dict keys: blocks.{i}.attn.c_q/c_k/c_v/proj, blocks.{i}.mlp.fc/proj
+
+class _HessianAttn(nn.Module):
+    """Non-banked attention with CastedLinear layers for Hessian hooks."""
+    def __init__(self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init):
+        super().__init__()
+        self.num_heads, self.num_kv_heads = num_heads, num_kv_heads
+        self.head_dim = dim // num_heads
+        kv_dim = num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape; Hkv = v.size(-2); group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+    def forward(self, x, v_embed=None):
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = self.c_v(x)
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        return self.proj(y.reshape(bsz, seqlen, dim))
+
+class _HessianMLP(nn.Module):
+    """Non-banked MLP with CastedLinear layers for Hessian hooks."""
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        self.fc = CastedLinear(dim, int(mlp_mult * dim), bias=False)
+        self.proj = CastedLinear(int(mlp_mult * dim), dim, bias=False)
+    def forward(self, x):
+        return self.proj(F.leaky_relu(self.fc(x), negative_slope=0.5).square())
+
+class _HessianBlock(nn.Module):
+    def __init__(self, dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init, layer_idx=0, ln_scale=False):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = _HessianAttn(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = _HessianMLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+    def forward(self, x, x0, v_embed=None):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x_in) * self.ln_scale_factor, v_embed=v_embed)
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor)
+        return x_out
+
+class _HessianGPT(nn.Module):
+    """Non-banked GPT model matching unbanked state dict keys for Hessian collection."""
+    def __init__(self, vocab_size, num_layers, model_dim, num_heads, num_kv_heads,
+                 mlp_mult, tie_embeddings, logit_softcap, rope_base, qk_gain_init,
+                 ngram_dim=128, ngram_orders=None, ngram_vocab_sizes=None, ngram_num_hashes=None, ngram_init_std=0.005, xsa_last_n=0,
+                 rope_dims=0, ln_scale=False,
+                 ve_enabled=False, ve_dim=128, ve_layers="9,10"):
+        super().__init__()
+        self.tie_embeddings = tie_embeddings
+        self.logit_softcap = logit_softcap
+        self.num_layers = num_layers
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        resolved_ngram_vocab_sizes = ngram_vocab_sizes if ngram_vocab_sizes is not None else [3072, 1536, 768]
+        self.ngram = (
+            NgramHashEmbedding(
+                ngram_dim,
+                model_dim,
+                ngram_orders if ngram_orders is not None else [2, 3, 4],
+                resolved_ngram_vocab_sizes,
+                ngram_num_hashes if ngram_num_hashes is not None else [2, 2, 2],
+                ngram_init_std,
+            )
+            if len(resolved_ngram_vocab_sizes) > 0 else None
+        )
+        self.smear = SmearGate(model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList([
+            _HessianBlock(model_dim, num_heads, num_kv_heads, mlp_mult, rope_base, qk_gain_init,
+                          layer_idx=i, ln_scale=ln_scale)
+            for i in range(num_layers)
+        ])
+        if rope_dims > 0:
+            head_dim = model_dim // num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = rope_dims
+                block.attn.rotary = Rotary(head_dim, base=rope_base, train_seq_len=1024, rope_dims=rope_dims)
+        if xsa_last_n > 0:
+            for i in range(max(0, num_layers - xsa_last_n), num_layers):
+                self.blocks[i].attn.use_xsa = True
+        kv_dim = num_kv_heads * (model_dim // num_heads)
+        self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim)
+            self.ve_layer_scales = nn.ParameterList([nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices])
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+    def _get_ve(self, layer_idx, input_ids, ve_cache):
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if 've' not in ve_cache:
+            ve_cache['ve'] = self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_cache['ve'] * self.ve_layer_scales[ve_idx].to(dtype=ve_cache['ve'].dtype)
+    def forward(self, input_ids, target_ids):
+        x = self.tok_emb(input_ids)
+        if self.ngram is not None:
+            x = x + self.ngram(input_ids, x)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        skips = []
+        ve_cache = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x = self.blocks[i](x, x0, v_embed=ve)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x = self.blocks[bi](x, x0, v_embed=ve)
+        x = self.final_norm(x)
+        x_flat = x.reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        logits_proj = F.linear(x_flat, self.tok_emb.weight) if self.tie_embeddings else self.lm_head(x_flat)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+def collect_hessians(hessian_model, train_loader, args, device, grad_accum_steps, num_batches=256):
+    """Run calibration batches through a non-banked model, collecting H = X^T X for each CastedLinear."""
+    hessians = {}
+    hooks = []
+    for name, module in hessian_model.named_modules():
+        if isinstance(module, CastedLinear):
+            param_name = name + ".weight"
+            cols = module.weight.shape[1]
+            hessians[param_name] = torch.zeros(cols, cols, dtype=torch.float32, device='cpu')
+            def make_hook(pname):
+                def hook_fn(module, input, output):
+                    x = input[0].detach().float()
+                    if x.ndim == 3:
+                        x = x.reshape(-1, x.shape[-1])
+                    hessians[pname] += (x.T @ x).cpu()
+                return hook_fn
+            h = module.register_forward_hook(make_hook(param_name))
+            hooks.append(h)
+    hessian_model.eval()
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        for _ in range(num_batches):
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            hessian_model(x, y)
+    for h in hooks:
+        h.remove()
+    for name in hessians:
+        H = hessians[name]
+        H /= num_batches
+        H = 0.5 * (H + H.T)
+        damp = 0.01 * torch.diag(H).mean().clamp_min(1e-6)
+        H += damp * torch.eye(H.shape[0], dtype=H.dtype, device=H.device)
+        hessians[name] = H
+    hessian_model.train()
+    return hessians
+
+def mixed_quantize_int6(
+    state_dict: dict[str, Tensor],
+    int6_cats: set[str],
+    hessians: dict[str, Tensor] | None = None,
+    gptq_block_size: int = 128,
+) -> tuple[dict[str, Tensor], dict[str, object], list[dict[str, object]]]:
+    num_layers_total = max(
+        (int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")),
+        default=0,
+    ) + 1
+    late_k_layers = set(range(num_layers_total - 2, num_layers_total))
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    gptq_debug_report: list[dict[str, object]] = []
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            cr = 31  # int6 for all weights
+            H = hessians.get(name) if hessians else None
+            if H is not None:
+                q, s, debug = quantize_int6_gptq(
+                    t,
+                    hessian=H,
+                    clip_range=cr,
+                    block_size=gptq_block_size,
+                    return_debug=True,
+                )
+                gptq_debug_report.append({"name": name, **debug})
+            else:
+                q, s = quantize_int6_per_row(t, clip_range=cr)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta, gptq_debug_report
+
+
+def build_selective_prune_groups(
+    quant_result: dict[str, Tensor],
+    quant_meta: dict[str, object],
+) -> tuple[dict[str, tuple[list[int], Tensor]], int]:
+    ones_info: list[tuple[str, int, float]] = []
+    for name, info in quant_meta.items():
+        if not (isinstance(info, dict) and info.get("type") == "int6"):
+            continue
+        qk, sk = name + ".q", name + ".scale"
+        if qk not in quant_result or sk not in quant_result:
+            continue
+        q, s = quant_result[qk], quant_result[sk]
+        if s.ndim == 0:
+            continue
+        ones_mask = q.abs() == 1
+        if not ones_mask.any():
+            continue
+        row_idx = torch.arange(q.shape[0]).unsqueeze(1).expand_as(q)[ones_mask]
+        flat_idx = torch.arange(q.numel()).reshape(q.shape)[ones_mask]
+        errors = s.float()[row_idx].pow(2)
+        for fi, err in zip(flat_idx.tolist(), errors.tolist()):
+            ones_info.append((qk, fi, err))
+    ones_info.sort(key=lambda x: x[2])
+    grouped: dict[str, tuple[list[int], list[int]]] = {}
+    for rank, (qk, flat_idx, _) in enumerate(ones_info):
+        ranks, idxs = grouped.setdefault(qk, ([], []))
+        ranks.append(rank)
+        idxs.append(flat_idx)
+    out = {
+        qk: (ranks, torch.tensor(idxs, dtype=torch.long))
+        for qk, (ranks, idxs) in grouped.items()
+    }
+    return out, len(ones_info)
+
+
+def build_pruned_quant_result(
+    quant_result: dict[str, Tensor],
+    grouped: dict[str, tuple[list[int], Tensor]],
+    prune_n: int,
+) -> dict[str, Tensor]:
+    tmp = {k: v.clone() for k, v in quant_result.items()}
+    if prune_n <= 0:
+        return tmp
+    for qk, (ranks, flat_indices) in grouped.items():
+        cut = bisect.bisect_left(ranks, prune_n)
+        if cut <= 0:
+            continue
+        tmp[qk].view(-1)[flat_indices[:cut]] = 0
+    return tmp
+
+
+def serialize_quant_artifact(
+    quant_result: dict[str, Tensor],
+    quant_meta: dict[str, object],
+) -> tuple[bytes, bytes]:
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = lzma.compress(quant_raw, preset=9)
+    return quant_raw, quant_blob
+
+
+def serialized_quant_total_bytes(
+    quant_result: dict[str, Tensor],
+    quant_meta: dict[str, object],
+    code_bytes: int,
+) -> tuple[int, bytes]:
+    _, quant_blob = serialize_quant_artifact(quant_result, quant_meta)
+    return len(quant_blob) + code_bytes, quant_blob
+
+
+def selective_prune_quant_result(
+    quant_result: dict[str, Tensor],
+    quant_meta: dict[str, object],
+    code_bytes: int,
+    target_mb: float,
+    log_fn,
+    workers: int | None = None,
+    accept_undershoot_bytes: int = 65_536,
+) -> tuple[dict[str, Tensor], bytes]:
+    grouped, num_candidates = build_selective_prune_groups(quant_result, quant_meta)
+    target_bytes = int(target_mb * 1024 * 1024)
+    accept_undershoot_bytes = max(0, int(accept_undershoot_bytes))
+    max_workers = max(1, os.cpu_count() or 1)
+    default_workers = min(16, max_workers)
+    worker_count = max(1, min(workers if workers is not None else default_workers, max_workers))
+
+    unpruned_total_bytes, unpruned_blob = serialized_quant_total_bytes(quant_result, quant_meta, code_bytes)
+    log_fn(
+        f"selective_prune: {num_candidates} ±1 candidates, "
+        f"unpruned={unpruned_total_bytes/(1024*1024):.2f}MB target={target_mb}MB"
+    )
+    if accept_undershoot_bytes > 0:
+        log_fn(
+            "selective_prune: "
+            f"accept_undershoot_bytes={accept_undershoot_bytes} "
+            f"({accept_undershoot_bytes/(1024*1024):.4f}MB)"
+        )
+
+    if not grouped:
+        log_fn("selective_prune: no ±1 candidates, no pruning needed")
+        return quant_result, unpruned_blob
+
+    if unpruned_total_bytes <= target_bytes:
+        log_fn("selective_prune: already fits, no pruning needed")
+        return quant_result, unpruned_blob
+
+    def eval_candidate(prune_n: int) -> tuple[int, int]:
+        state = build_pruned_quant_result(quant_result, grouped, prune_n)
+        total_bytes, _ = serialized_quant_total_bytes(state, quant_meta, code_bytes)
+        return prune_n, total_bytes
+
+    def is_close_enough(total_bytes: int) -> bool:
+        return total_bytes <= target_bytes and (target_bytes - total_bytes) <= accept_undershoot_bytes
+
+    log_fn("selective_prune: probing full ±1 prune feasibility...")
+    if worker_count > 1:
+        with cf.ThreadPoolExecutor(max_workers=1) as ex:
+            _, full_total_bytes = ex.submit(eval_candidate, num_candidates).result()
+    else:
+        _, full_total_bytes = eval_candidate(num_candidates)
+    log_fn(f"selective_prune: full ±1 prune={full_total_bytes/(1024*1024):.2f}MB")
+
+    if full_total_bytes > target_bytes:
+        log_fn("selective_prune: even full prune not enough, applying all")
+        prune_n = num_candidates
+    else:
+        lo, hi = 0, num_candidates
+        round_idx = 0
+        accepted_prune_n: int | None = None
+        while hi - lo > 1:
+            round_idx += 1
+            width = hi - lo
+            # Exact compressed size is mildly non-monotonic because of LZMA, so
+            # once the feasible interval is small enough we stop doing coarse
+            # bracket probes and exhaustively scan the remaining candidates.
+            # This guarantees termination near the boundary instead of dithering
+            # for many rounds where every probe prints the same rounded MB.
+            local_scan_threshold = max(64, 4 * worker_count)
+            if width <= local_scan_threshold:
+                probes = list(range(lo + 1, hi + 1))
+                log_fn(
+                    f"selective_prune: local_scan lo={lo} hi={hi} "
+                    f"workers={worker_count} probes={len(probes)}"
+                )
+                if worker_count > 1 and len(probes) > 1:
+                    with cf.ThreadPoolExecutor(max_workers=min(worker_count, len(probes))) as ex:
+                        results = list(ex.map(eval_candidate, probes))
+                else:
+                    results = [eval_candidate(p) for p in probes]
+                results.sort(key=lambda x: x[0])
+                for prune_probe, total_bytes in results:
+                    log_fn(
+                        f"selective_prune: probe prune_n={prune_probe} "
+                        f"total_bytes={total_bytes} total_mb={total_bytes/(1024*1024):.4f}"
+                    )
+                close_enough = [
+                    (prune_probe, total_bytes)
+                    for prune_probe, total_bytes in results
+                    if is_close_enough(total_bytes)
+                ]
+                if close_enough:
+                    accepted_prune_n, accepted_total_bytes = min(close_enough, key=lambda x: x[0])
+                    log_fn(
+                        "selective_prune: early_accept "
+                        f"prune_n={accepted_prune_n} total_bytes={accepted_total_bytes} "
+                        f"undershoot_bytes={target_bytes - accepted_total_bytes}"
+                    )
+                    break
+                fitting = [prune_probe for prune_probe, total_bytes in results if total_bytes <= target_bytes]
+                if not fitting:
+                    raise RuntimeError(
+                        "selective_prune local scan found no feasible candidate "
+                        f"despite hi={hi} previously being feasible"
+                    )
+                hi = min(fitting)
+                break
+            num_probes = min(worker_count, max(1, width - 1))
+            probes = sorted(
+                {
+                    lo + max(
+                        1,
+                        min(width - 1, round((i * width) / (num_probes + 1))),
+                    )
+                    for i in range(1, num_probes + 1)
+                }
+            )
+            probes = [p for p in probes if lo < p < hi]
+            if not probes:
+                probes = [lo + max(1, width // 2)]
+            log_fn(
+                f"selective_prune: search_round={round_idx} lo={lo} hi={hi} "
+                f"workers={worker_count} probes={probes}"
+            )
+            if worker_count > 1 and len(probes) > 1:
+                with cf.ThreadPoolExecutor(max_workers=min(worker_count, len(probes))) as ex:
+                    results = list(ex.map(eval_candidate, probes))
+            else:
+                results = [eval_candidate(p) for p in probes]
+            results.sort(key=lambda x: x[0])
+            for prune_probe, total_bytes in results:
+                log_fn(
+                    f"selective_prune: probe prune_n={prune_probe} "
+                    f"total_bytes={total_bytes} total_mb={total_bytes/(1024*1024):.4f}"
+                )
+            close_enough = [
+                (prune_probe, total_bytes)
+                for prune_probe, total_bytes in results
+                if is_close_enough(total_bytes)
+            ]
+            if close_enough:
+                accepted_prune_n, accepted_total_bytes = min(close_enough, key=lambda x: x[0])
+                log_fn(
+                    "selective_prune: early_accept "
+                    f"prune_n={accepted_prune_n} total_bytes={accepted_total_bytes} "
+                    f"undershoot_bytes={target_bytes - accepted_total_bytes}"
+                )
+                break
+            fitting = [prune_probe for prune_probe, total_bytes in results if total_bytes <= target_bytes]
+            if fitting:
+                hi = min(fitting)
+            else:
+                lo = max(prune_probe for prune_probe, _ in results)
+        prune_n = accepted_prune_n if accepted_prune_n is not None else hi
+        log_fn(
+            f"selective_prune: pruning {prune_n}/{num_candidates} ±1 values "
+            f"({100*prune_n/max(num_candidates,1):.1f}%) to fit {target_mb}MB"
+        )
+
+    pruned_quant_result = build_pruned_quant_result(quant_result, grouped, prune_n)
+    _, pruned_blob = serialize_quant_artifact(pruned_quant_result, quant_meta)
+    return pruned_quant_result, pruned_blob
+
+
+def rerun_selective_prune_saved_artifact(
+    input_path: Path,
+    output_path: Path,
+    code_path: Path,
+    target_mb: float,
+    workers: int | None = None,
+    accept_undershoot_bytes: int = 65_536,
+    log_fn=print,
+) -> None:
+    payload = torch.load(io.BytesIO(lzma.decompress(input_path.read_bytes())), map_location="cpu")
+    quant_result: dict[str, Tensor] = payload["w"]
+    quant_meta: dict[str, object] = payload["m"]
+    code_bytes = len(code_path.read_text(encoding="utf-8").encode("utf-8"))
+    started = time.perf_counter()
+    pruned_quant_result, pruned_blob = selective_prune_quant_result(
+        quant_result,
+        quant_meta,
+        code_bytes,
+        target_mb,
+        log_fn,
+        workers=workers,
+        accept_undershoot_bytes=accept_undershoot_bytes,
+    )
+    output_path.write_bytes(pruned_blob)
+    total_bytes = len(pruned_blob) + code_bytes
+    log_fn(
+        f"selective_prune_saved: model_bytes={len(pruned_blob)} "
+        f"total_bytes={total_bytes} elapsed_s={time.perf_counter()-started:.1f}"
+    )
+    if pruned_quant_result is quant_result:
+        log_fn("selective_prune_saved: output matches input pruning state")
+    log_fn(f"selective_prune_saved: wrote {output_path}")
+
+
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+class AsyncLogger:
+    def __init__(self, logfile: str | None):
+        self._logfile = logfile
+        self._queue: queue.SimpleQueue[tuple[bool, str] | None] = queue.SimpleQueue()
+        self._closed = False
+        self._worker_thread = threading.Thread(
+            target=self._worker,
+            name="m34a-async-logger",
+            daemon=False,
+        )
+        self._worker_thread.start()
+
+    def _worker(self) -> None:
+        logfile_handle = None
+        if self._logfile is not None:
+            logfile_handle = open(self._logfile, "a", encoding="utf-8", buffering=1)
+        try:
+            while True:
+                item = self._queue.get()
+                if item is None:
+                    break
+                console, msg = item
+                if console:
+                    print(msg, flush=True)
+                if logfile_handle is not None:
+                    print(msg, file=logfile_handle)
+        finally:
+            if logfile_handle is not None:
+                logfile_handle.flush()
+                logfile_handle.close()
+
+    def log(self, msg: str, console: bool = True) -> None:
+        if self._closed:
+            return
+        self._queue.put((console, msg))
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._queue.put(None)
+        self._worker_thread.join()
+
+# --- Training ---
+
+def main() -> None:
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    # zeropower_via_newtonschulz5 runs eagerly with bmm -- do NOT compile
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if args.grad_accum_steps > 0:
+        grad_accum_steps = args.grad_accum_steps
+    else:
+        if 8 % world_size != 0:
+            raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+        grad_accum_steps = 8 // world_size
+    if args.train_batch_tokens % (world_size * grad_accum_steps) != 0:
+        raise ValueError(
+            f"TRAIN_BATCH_TOKENS={args.train_batch_tokens} must be divisible by "
+            f"WORLD_SIZE*GRAD_ACCUM_STEPS={world_size * grad_accum_steps}"
+        )
+    if args.batch_switch_step > 0:
+        if args.batch_switch_train_batch_tokens <= 0:
+            raise ValueError("BATCH_SWITCH_TRAIN_BATCH_TOKENS must be positive when BATCH_SWITCH_STEP > 0")
+        if args.batch_switch_train_batch_tokens % (world_size * grad_accum_steps) != 0:
+            raise ValueError(
+                f"BATCH_SWITCH_TRAIN_BATCH_TOKENS={args.batch_switch_train_batch_tokens} must be divisible by "
+                f"WORLD_SIZE*GRAD_ACCUM_STEPS={world_size * grad_accum_steps}"
+            )
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    logfile = None
+    if master_process and args.log_to_file:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+    async_logger: AsyncLogger | None = None
+    if master_process and args.async_logging:
+        async_logger = AsyncLogger(logfile)
+        atexit.register(async_logger.close)
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if async_logger is not None:
+            async_logger.log(msg, console=console)
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    effective_eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"train_loader:next_shard_prefetch:{int(actual_train_files > 1)}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+    CastedLinear._qat_enabled = args.qat_enabled
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=args.mtp_num_heads,
+        mtp_loss_weight=args.mtp_loss_weight,
+        train_tail_loss_tokens=args.train_tail_loss_tokens,
+        train_tail_loss_weight=args.train_tail_loss_weight,
+        ngram_dim=args.ngram_dim,
+        ngram_orders=args.ngram_orders,
+        ngram_vocab_sizes=args.ngram_vocab_sizes,
+        ngram_num_hashes=args.ngram_num_hashes,
+        ngram_init_std=args.ngram_init_std,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims,
+        ln_scale=args.ln_scale,
+        dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled,
+        ve_dim=args.ve_dim,
+        ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention,
+        value_residual=args.value_residual,
+    ).to(device).bfloat16()
+    # Banks stay FP32 (like CastedLinear weights), cast to BF16 in forward
+    base_model.qo_bank.data = base_model.qo_bank.data.float()
+    base_model.kv_bank.data = base_model.kv_bank.data.float()
+    base_model.mlp_up_bank.data = base_model.mlp_up_bank.data.float()
+    base_model.mlp_down_bank.data = base_model.mlp_down_bank.data.float()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    # No DDP -- Parallel Muon handles bank grad communication via reduce-scatter,
+    # and non-bank grads are manually all-reduced before Adam steps.
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model = compiled_model
+
+    # Optimizer split:
+    # - 4 parameter banks -> Muon (batched Newton-Schulz)
+    # - token embedding -> Adam
+    # - scalars/control tensors -> Adam
+    # - ngram proj, mtp heads, VE proj -> Adam (small matrix params not worth banking)
+    matrix_params = [
+        base_model.qo_bank, base_model.kv_bank,
+        base_model.mlp_up_bank, base_model.mlp_down_bank,
+    ]
+    block_named_params = list(base_model.blocks.named_parameters())
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.ngram is not None:
+        scalar_params.append(base_model.ngram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.ngram is not None:
+        tok_params.append({
+            "params": [base_model.ngram.embed.weight],
+            "lr": token_lr,
+            "base_lr": token_lr,
+            "weight_decay": args.ngram_wd,
+        })
+        if hasattr(base_model.ngram, "order_gate_bias") and base_model.ngram.order_gate_bias is not None:
+            scalar_params.append(base_model.ngram.order_gate_bias)
+        if base_model.ngram.proj is not None:
+            scalar_params.append(base_model.ngram.proj.weight)
+        if hasattr(base_model.ngram, "q_proj") and base_model.ngram.q_proj is not None:
+            scalar_params.append(base_model.ngram.q_proj.weight)
+    if base_model.ve_shared is not None:
+        tok_params.append({"params": [base_model.ve_shared.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.ve_shared.proj is not None:
+            scalar_params.append(base_model.ve_shared.proj.weight)
+        scalar_params.append(base_model.ve_shared.scale)
+        for s in base_model.ve_layer_scales:
+            scalar_params.append(s)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    # Non-bank params that need manual all-reduce (replicated across GPUs)
+    replicated_params = list(optimizer_tok.param_groups[0]["params"])
+    for pg in optimizer_tok.param_groups[1:]:
+        replicated_params.extend(pg["params"])
+    replicated_params.extend(scalar_params)
+
+    optimizer_head = None
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        replicated_params.append(base_model.lm_head.weight)
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if optimizer_head is not None:
+        optimizers.append(optimizer_head)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    mtp_params = sum(p.numel() for p in base_model.mtp_heads.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"mtp_num_heads:{args.mtp_num_heads} mtp_loss_weight:{args.mtp_loss_weight} mtp_params:{mtp_params}")
+    xsa_layers = [i for i, b in enumerate(base_model.blocks) if b.attn.use_xsa]
+    log0(f"XSA:last_{args.xsa_last_n} active_layers:{xsa_layers}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr} "
+        f"ngram_wd:{args.ngram_wd if base_model.ngram is not None else 0.0}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"micro_batch_tokens:{args.train_batch_tokens // (world_size * grad_accum_steps)} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    if args.batch_switch_step > 0:
+        log0(
+            f"batch_switch:enabled step={args.batch_switch_step} "
+            f"train_batch_tokens->{args.batch_switch_train_batch_tokens} "
+            f"micro_batch_tokens->{args.batch_switch_train_batch_tokens // (world_size * grad_accum_steps)} "
+            f"compile_tax_window={args.batch_switch_compile_tax_window}"
+        )
+    log0(
+        f"eval_stride:{args.eval_stride} train_tail_loss_tokens:{args.train_tail_loss_tokens} "
+        f"train_tail_loss_weight:{args.train_tail_loss_weight}"
+    )
+    log0(
+        f"gptq_calib_source:{args.gptq_calib_source} "
+        f"gptq_cache_num_batches:{args.gptq_cache_num_batches} "
+        f"gptq_cache_max_seqs:{args.gptq_cache_max_seqs}"
+    )
+    log0(
+        f"gptq_train_cache_enabled:{int(args.gptq_calib_source == 'train_cache')}"
+    )
+    log0(
+        f"gptq_ar_temperature:{args.gptq_ar_temperature} "
+        f"gptq_ar_repeat_penalty:{args.gptq_ar_repeat_penalty} "
+        f"gptq_ar_repeat_last_n:{args.gptq_ar_repeat_last_n}"
+    )
+    log0(
+        "selective_prune_accept_undershoot_bytes:"
+        f"{args.selective_prune_accept_undershoot_bytes}"
+    )
+    log0(f"log_to_file:{int(args.log_to_file)}")
+    log0(f"async_logging:{int(args.async_logging)}")
+    log0(f"seed:{args.seed}")
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    train_calib_cache_enabled = args.gptq_calib_source == "train_cache"
+    train_calib_cache = (
+        deque(maxlen=max(args.gptq_cache_num_batches, 1))
+        if master_process and train_calib_cache_enabled and args.gptq_cache_num_batches > 0
+        else None
+    )
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            # All-reduce all grads for warmup (simple, not optimized)
+            if distributed:
+                for p in base_model.parameters():
+                    if p.grad is not None:
+                        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        train_loader.close()
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    lawa_queue: deque[dict[str, Tensor]] = deque(maxlen=args.lawa_k)
+    ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    ema_decay = 0.997
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    current_train_batch_tokens = args.train_batch_tokens
+    batch_switch_applied = False
+    batch_switch_tax_logged = False
+    pre_switch_step_times_ms: deque[float] = deque(maxlen=32)
+    post_switch_step_times_ms: list[float] = []
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+        if (
+            args.batch_switch_step > 0
+            and not batch_switch_applied
+            and step >= args.batch_switch_step
+        ):
+            current_train_batch_tokens = args.batch_switch_train_batch_tokens
+            batch_switch_applied = True
+            log0(
+                f"batch_switch:activated at completed_step={step} "
+                f"new_train_batch_tokens={current_train_batch_tokens} "
+                f"new_micro_batch_tokens={current_train_batch_tokens // (world_size * grad_accum_steps)}"
+            )
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        if args.late_qat_threshold > 0 and scale < args.late_qat_threshold and not CastedLinear._qat_enabled:
+            CastedLinear._qat_enabled = True
+            log0(f"late_qat:enabled step:{step} scale:{scale:.4f}")
+        iter_t0 = time.perf_counter()
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            x, y = train_loader.next_batch(current_train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            if train_calib_cache is not None:
+                train_calib_cache.append(pack_xy_for_calibration(x, y))
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        # === 3-phase overlapped optimizer step ===
+        # Phase 1: Launch async reduce-scatter for banks (biggest first)
+        optimizer_muon.launch_reduce_scatters()
+        # Phase 2: All-reduce non-bank grads + step Adam (while bank RS is in-flight)
+        if distributed:
+            for p in replicated_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+        optimizer_tok.step()
+        optimizer_scalar.step()
+        if optimizer_head is not None:
+            optimizer_head.step()
+        # Phase 3: Wait for RS, local NS5, all-gather (banks processed last)
+        optimizer_muon.step()
+        zero_grad_all()
+        # EMA update
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(t.detach().float(), alpha=1.0 - ema_decay)
+        step += 1
+        step_wall_ms = 1000.0 * (time.perf_counter() - iter_t0)
+        if batch_switch_applied:
+            if len(post_switch_step_times_ms) < max(args.batch_switch_compile_tax_window, 1):
+                post_switch_step_times_ms.append(step_wall_ms)
+        else:
+            pre_switch_step_times_ms.append(step_wall_ms)
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        if (
+            batch_switch_applied
+            and not batch_switch_tax_logged
+            and len(post_switch_step_times_ms) >= max(args.batch_switch_compile_tax_window, 1)
+        ):
+            post_tail = post_switch_step_times_ms[1:] or post_switch_step_times_ms
+            new_steady_ms = float(np.median(post_tail))
+            pre_steady_ms = float(np.median(list(pre_switch_step_times_ms))) if pre_switch_step_times_ms else float("nan")
+            first_post_ms = post_switch_step_times_ms[0]
+            cumulative_excess_ms = sum(max(0.0, t - new_steady_ms) for t in post_switch_step_times_ms)
+            log0(
+                f"batch_switch:compile_tax_estimate pre_steady_ms:{pre_steady_ms:.2f} "
+                f"new_steady_ms:{new_steady_ms:.2f} first_post_ms:{first_post_ms:.2f} "
+                f"first_step_excess_ms:{max(0.0, first_post_ms - new_steady_ms):.2f} "
+                f"cumulative_excess_ms:{cumulative_excess_ms:.2f} "
+                f"window:{len(post_switch_step_times_ms)}"
+            )
+            batch_switch_tax_logged = True
+        if args.swa_enabled and scale < 0.2 and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+        if args.lawa_enabled and step % args.lawa_freq == 0:
+            lawa_queue.append({name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()})
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+    # Apply weight averaging
+    if args.lawa_enabled and len(lawa_queue) > 1:
+        log0(f"lawa:applying LAWA averaging k={len(lawa_queue)}")
+        current_state = base_model.state_dict()
+        avg_state = {name: torch.zeros(t.shape, dtype=torch.float32, device='cpu') for name, t in current_state.items()}
+        for snap in lawa_queue:
+            for name in avg_state:
+                avg_state[name] += snap[name].float()
+        for name in avg_state:
+            avg_state[name] /= len(lawa_queue)
+            avg_state[name] = avg_state[name].to(dtype=current_state[name].dtype)
+        base_model.load_state_dict(avg_state, strict=True)
+    else:
+        log0("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+        base_model.load_state_dict(avg_state, strict=True)
+    torch.cuda.synchronize()
+    t_diag = time.perf_counter()
+    diag_val_loss, diag_val_bpb = eval_val(
+        args, compiled_model, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"DIAGNOSTIC post_ema val_loss:{diag_val_loss:.4f} val_bpb:{diag_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_diag):.0f}ms"
+    )
+    full_state_dict = base_model.state_dict()
+    export_sd = {k: v for k, v in full_state_dict.items() if "mtp_heads" not in k}
+    excluded_mtp = sum(int(t.numel()) for k, t in full_state_dict.items() if "mtp_heads" in k)
+    if excluded_mtp > 0:
+        log0(f"export_excluding_mtp_params:{excluded_mtp}")
+    if master_process:
+        torch.save(export_sd, "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+    # Unbank 3D tensors into individual 2D tensors for quantization
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    unbanked_sd = _unbank_state_dict(sd_cpu, args.num_layers)
+    if master_process:
+        log0("gptq:building non-banked model for Hessian collection...")
+        hessian_model = _HessianGPT(
+            vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+            num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+            tie_embeddings=args.tie_embeddings, logit_softcap=args.logit_softcap,
+            rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+            ngram_dim=args.ngram_dim,
+            ngram_orders=args.ngram_orders, ngram_vocab_sizes=args.ngram_vocab_sizes,
+            ngram_num_hashes=args.ngram_num_hashes, ngram_init_std=args.ngram_init_std,
+            xsa_last_n=args.xsa_last_n, rope_dims=args.rope_dims, ln_scale=args.ln_scale,
+            ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+        ).to(device).bfloat16()
+        for m in hessian_model.modules():
+            if isinstance(m, CastedLinear):
+                m.float()
+        restore_low_dim_params_to_fp32(hessian_model)
+        hessian_model.load_state_dict(
+            {k: v.to(device) for k, v in unbanked_sd.items() if k in hessian_model.state_dict()},
+            strict=False,
+        )
+        base_model.load_state_dict(export_sd, strict=False)
+        calib_tokens = None
+        calib_source_used = args.gptq_calib_source
+        if args.gptq_calib_source == "train_cache":
+            calib_tokens = get_cached_train_calibration_tokens(
+                train_calib_cache if train_calib_cache is not None else deque(),
+                max_seqs=args.gptq_cache_max_seqs,
+            )
+            if calib_tokens is not None:
+                cached_batches = 0 if train_calib_cache is None else len(train_calib_cache)
+                log0(
+                    "gptq:using cached training tokens for calibration "
+                    f"(cached_local_batches={cached_batches}, selected_seqs={calib_tokens.size(0)})"
+                )
+                if args.gptq_ar_print_sequences != 0:
+                    log_token_sequences(
+                        log0,
+                        sp,
+                        calib_tokens,
+                        max_sequences=args.gptq_ar_print_sequences,
+                        max_chars=args.gptq_ar_print_max_chars,
+                        header="gptq:train_cache_calibration_sequences",
+                        line_prefix="gptq:cache_seq",
+                    )
+            else:
+                log0("gptq:train cache empty, falling back to autoregressive calibration")
+        elif args.gptq_calib_source not in {"ar", "ar_prompt_bank"}:
+            raise ValueError(
+                f"Unsupported GPTQ_CALIB_SOURCE={args.gptq_calib_source}. "
+                "Expected one of: ar_prompt_bank, ar, train_cache"
+            )
+        if calib_tokens is None:
+            if args.gptq_calib_source == "ar_prompt_bank" or calib_source_used == "train_cache":
+                calib_source_used = "ar_prompt_bank"
+                log0(
+                    "gptq:generating prompt-conditioned autoregressive calibration data "
+                    f"({args.gptq_ar_num_seqs} seqs x {args.train_seq_len} tokens, "
+                    f"prompts={len(GPTQ_PROMPT_BANK_TEXTS)}, temp={args.gptq_ar_temperature}, "
+                    f"batch={args.gptq_ar_batch_size})..."
+                )
+                t_gen = time.perf_counter()
+                calib_tokens = generate_prompt_bank_autoregressive_calib(
+                    base_model,
+                    sp,
+                    device,
+                    GPTQ_PROMPT_BANK_TEXTS,
+                    num_seqs=args.gptq_ar_num_seqs,
+                    seq_len=args.train_seq_len,
+                    temperature=args.gptq_ar_temperature,
+                    batch_size=args.gptq_ar_batch_size,
+                    seed=args.seed,
+                    repeat_penalty=args.gptq_ar_repeat_penalty,
+                    repeat_last_n=args.gptq_ar_repeat_last_n,
+                )
+            else:
+                calib_source_used = "ar"
+                log0(
+                    "gptq:generating autoregressive calibration data "
+                    f"({args.gptq_ar_num_seqs} seqs x {args.train_seq_len} tokens, "
+                    f"temp={args.gptq_ar_temperature}, batch={args.gptq_ar_batch_size})..."
+                )
+                t_gen = time.perf_counter()
+                calib_tokens = generate_autoregressive_calib(
+                    base_model,
+                    device,
+                    num_seqs=args.gptq_ar_num_seqs,
+                    seq_len=args.train_seq_len,
+                    vocab_size=args.vocab_size,
+                    temperature=args.gptq_ar_temperature,
+                    batch_size=args.gptq_ar_batch_size,
+                    seed=args.seed,
+                    repeat_penalty=args.gptq_ar_repeat_penalty,
+                    repeat_last_n=args.gptq_ar_repeat_last_n,
+                )
+            log0(f"gptq:generated {len(calib_tokens)} sequences in {time.perf_counter()-t_gen:.1f}s")
+            if args.gptq_ar_print_sequences != 0:
+                log_token_sequences(
+                    log0,
+                    sp,
+                    calib_tokens,
+                    max_sequences=args.gptq_ar_print_sequences,
+                    max_chars=args.gptq_ar_print_max_chars,
+                    header=(
+                        "gptq:prompt_bank_autoregressive_calibration_sequences"
+                        if calib_source_used == "ar_prompt_bank"
+                        else "gptq:autoregressive_calibration_sequences"
+                    ),
+                    line_prefix="gptq:ar_seq",
+                )
+        log0(
+            "gptq:collecting hessians from calibration data "
+            f"(source={calib_source_used}, batch={args.gptq_hessian_batch_size})..."
+        )
+        hessians = collect_hessians_from_tokens(
+            hessian_model,
+            calib_tokens,
+            device,
+            batch_size=args.gptq_hessian_batch_size,
+        )
+        log0(f"gptq:collected hessians for {len(hessians)} layers")
+        del calib_tokens
+        del hessian_model
+        torch.cuda.empty_cache()
+        quant_result, quant_meta, gptq_debug_report = mixed_quantize_int6(
+            unbanked_sd,
+            {"mlp", "attn"},
+            hessians=hessians,
+            gptq_block_size=args.gptq_block_size,
+        )
+        if gptq_debug_report:
+            jittered_layers = [
+                info for info in gptq_debug_report
+                if info.get("mode") == "gptq" and float(info.get("extra_damp_mult") or 0.0) > 0.0
+            ]
+            fallback_layers = [
+                info for info in gptq_debug_report
+                if info.get("mode") != "gptq"
+            ]
+            max_total_mult = max(
+                (float(info.get("total_damp_mult") or 0.0) for info in gptq_debug_report),
+                default=0.0,
+            )
+            log0(
+                f"gptq:debug layers={len(gptq_debug_report)} "
+                f"jittered={len(jittered_layers)} fallback={len(fallback_layers)} "
+                f"max_total_damp_mult={max_total_mult:.1f}"
+            )
+            if jittered_layers or fallback_layers:
+                for info in gptq_debug_report:
+                    mode = str(info.get("mode"))
+                    extra_mult = float(info.get("extra_damp_mult") or 0.0)
+                    if mode == "gptq" and extra_mult <= 0.0:
+                        continue
+                    total_mult = info.get("total_damp_mult")
+                    total_mult_str = "None" if total_mult is None else f"{float(total_mult):.1f}"
+                    base_damp = info.get("base_damp")
+                    base_damp_str = "None" if base_damp is None else f"{float(base_damp):.3e}"
+                    extra_damp = info.get("extra_damp")
+                    extra_damp_str = "None" if extra_damp is None else f"{float(extra_damp):.3e}"
+                    log0(
+                        f"gptq:debug layer={info['name']} mode={mode} "
+                        f"attempts={int(info.get('attempts') or 0)} "
+                        f"base_damp={base_damp_str} extra_damp={extra_damp_str} "
+                        f"total_damp_mult={total_mult_str}"
+                    )
+            else:
+                log0("gptq:debug no layer required extra jitter or fallback")
+        # NOVEL: Selective ±1 pruning by reconstruction error
+        # Sort ±1 quantized values by their reconstruction error (scale²),
+        # prune least-impactful first until artifact fits target size.
+        # Challenge cap is 16,000,000 decimal bytes total, while this code uses
+        # MiB-style accounting internally for the pruning target. Default to a safe
+        # value below the true cap instead of the old overly-loose 15.9 MiB.
+        target_mb = float(os.environ.get("TARGET_MB", "15.24"))
+        code_bytes_est = len(code.encode("utf-8"))
+        quant_result, quant_blob = selective_prune_quant_result(
+            quant_result,
+            quant_meta,
+            code_bytes_est,
+            target_mb,
+            log0,
+            accept_undershoot_bytes=args.selective_prune_accept_undershoot_bytes,
+        )
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = len(quant_blob)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+lzma: {quant_file_bytes} bytes")
+        log0(f"Total submission size int6+lzma: {quant_file_bytes + code_bytes} bytes")
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(lzma.decompress(quant_blob_disk)),
+        map_location="cpu",
+    )
+    deq_unbanked = dequantize_mixed_int6(quant_state["w"], quant_state["m"], unbanked_sd)
+    # Re-bank the dequantized tensors
+    deq_state = _rebank_state_dict(deq_unbanked, args.num_layers, sd_cpu)
+    eval_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=0, mtp_loss_weight=0.0,
+        ngram_dim=args.ngram_dim,
+        ngram_orders=args.ngram_orders, ngram_vocab_sizes=args.ngram_vocab_sizes,
+        ngram_num_hashes=args.ngram_num_hashes, ngram_init_std=args.ngram_init_std,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims, ln_scale=args.ln_scale, dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention, value_residual=args.value_residual,
+    ).to(device).bfloat16()
+    eval_model.qo_bank.data = eval_model.qo_bank.data.float()
+    eval_model.kv_bank.data = eval_model.kv_bank.data.float()
+    eval_model.mlp_up_bank.data = eval_model.mlp_up_bank.data.float()
+    eval_model.mlp_down_bank.data = eval_model.mlp_down_bank.data.float()
+    for m in eval_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(eval_model)
+    eval_model.load_state_dict(deq_state, strict=True)
+    compiled_eval = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args, compiled_eval, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        eval_seq_len=effective_eval_seq_len,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+    sw_seq_len = effective_eval_seq_len
+    if args.eval_stride > 0 and args.eval_stride < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device, grad_accum_steps,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+    if master_process and args.gptq_prompt_demo_count > 0:
+        if calib_source_used in {"ar", "ar_prompt_bank"}:
+            log0(
+                "demo:prompt_generation skipped because GPTQ calibration already used "
+                f"{calib_source_used}"
+            )
+        else:
+            prompt_texts = generate_prompt_demo_texts(
+                eval_model,
+                sp,
+                device,
+                PROMPT_DEMO_TEXTS[:args.gptq_prompt_demo_count],
+                seq_len=sw_seq_len,
+                max_new_tokens=args.gptq_prompt_demo_new_tokens,
+                temperature=args.gptq_prompt_demo_temperature,
+                seed=args.seed + 12345,
+                repeat_penalty=args.gptq_ar_repeat_penalty,
+                repeat_last_n=args.gptq_ar_repeat_last_n,
+            )
+            log0(
+                "demo:prompt_generation "
+                f"count={len(prompt_texts)} new_tokens={args.gptq_prompt_demo_new_tokens} "
+                f"temp={args.gptq_prompt_demo_temperature}"
+            )
+            for idx, text in enumerate(prompt_texts):
+                text = text.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+                if args.gptq_prompt_demo_max_chars > 0 and len(text) > args.gptq_prompt_demo_max_chars:
+                    text = text[:args.gptq_prompt_demo_max_chars] + "...<truncated>"
+                log0(f"demo:prompt[{idx}] {text}")
+    if distributed:
+        dist.barrier()
+    if distributed:
+        dist.destroy_process_group()
+    if async_logger is not None:
+        async_logger.close()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR adds a non-record submission documenting negative results from a gated multi-order hash n-gram line.

The main finding is that a more expressive `2/3/4-gram` gated hash prior did not beat the March 25 BigramHash baseline in the 10min / 16MB regime. The gap showed up before compression and remained after post-training compression. The best legal variant in this line simplified the design to `NGRAM_NUM_HASHES=1,1,1`, reaching:

- post-EMA: `1.1347` val_bpb
- final int6 sliding exact: `1.11959957` val_bpb
- total bytes: `15,937,956`

## Key negative results

- multi-hash hard top-1 routing did not help
- tail-loss emphasis did not improve the roundtrip-to-sliding advantage
- the strongest legal result came from removing same-order hash competition

## Interpretation

One possible interpretation is that hash collisions are not only semantic noise. Because they are deterministic, they may also provide stable pseudo-identity features. If so, aggressive candidate-level semantic gating may remove exactly the stable dirty features that the backbone would otherwise learn to use.

The README also discusses the contrast between Engram-style gated fusion and more additive n-gram fusion styles, and why our results ended up supporting the simpler additive intuition more strongly.

## Practical contributions from this line

Although the model family itself did not win, this line also produced practical experimentation improvements:

- prompt-bank AR calibration
- mild repeat-penalized AR calibration generation
- printed AR calibration outputs for debugging
- next-shard prefetch
- async logging
- faster selective-prune search / bounded undershoot acceptance

## Files added

- README with results, interpretation, and future-work suggestions
- submission.json
- requirements.txt
- train_gpt.py snapshot from the best legal run in this line
- 3 supporting run logs
- results.tsv
