### PR TITLE
sp4096 + 10L 3.5x MLP + GPTQ + TTT (1.1266 BPB)

### DIFF
--- a/records/track_10min_16mb/2026-04-07_idan3011_sp4096_10L_TTT/README.md
+++ b/records/track_10min_16mb/2026-04-07_idan3011_sp4096_10L_TTT/README.md
@@ -1,0 +1,125 @@
+# sp4096 Custom Tokenizer + 10L 3.5x MLP + GPTQ + Score-First TTT
+
+**val_bpb: 1.1266** | **artifact: 15.99 MB** | **8xH100** | **600s wallclock**
+
+## Headline metrics
+
+| Stage | val_bpb | val_loss |
+|-------|--------:|---------:|
+| Pre-quant (step 5952) | 1.1427 | 2.6289 |
+| Post-quant (int6+brotli roundtrip) | 1.1439 | 2.6318 |
+| Sliding window (stride=64) | 1.1277 | — |
+| **Score-first TTT (final)** | **1.1266** | — |
+
+## Architecture
+
+- 10 layers, 512 dim, 8 heads, 4 KV heads (GQA 2:1)
+- 3.5x MLP expansion (1792 hidden dim per block)
+- Tied input/output embeddings (single 4096×512 matrix)
+- LeakyReLU(0.5)² MLP activation
+- Logit softcap at 30 via tanh
+- U-Net skip connections (encoder layers feed matching decoder layers via per-layer scale weights)
+- Last 4 blocks use cross-sequence attention (XSA)
+- 28.3M parameters total
+
+## Custom sp4096 SentencePiece tokenizer
+
+A 4096-vocab SentencePiece BPE tokenizer trained on FineWeb, hosted at `idan3011/parameter-golf-sp4096` on HuggingFace. The script auto-downloads the dataset + tokenizer on first run.
+
+Compared to the default sp1024 tokenizer:
+- **~26% fewer tokens per byte** (more efficient compression)
+- More room in the param budget — fewer tokens means more "value" per parameter spent
+- Required tuning the embedding quantization separately (see below)
+
+## Training
+
+- **786,432 token batch** (8 GPUs × 1 grad accum) — chosen over 524K for smoother warmdown trajectory
+- **Muon optimizer** for matrix parameters in transformer blocks
+- **Adam** for embeddings, output head, and scalar/vector parameters
+- **Wallclock-fraction warmdown**: cosine LR decay over the last 35% of remaining wallclock (rather than fixed step count) to maximize useful training time
+- **EMA** with decay 0.997 maintained throughout
+- **SWA** averaging in the last 50% of training, blended with EMA at the end (weighted average of 198 checkpoints)
+- **QAT** (fake-quantized weights during forward) on MLP CastedLinear layers to make the model more robust to int5 quantization
+- Hit wallclock cap at step 5952/20000 in 600.054s
+- Pre-quant val_loss: 2.6289, val_bpb: **1.1427**
+
+## Quantization & compression
+
+### GPTQ with AR self-generated calibration
+
+Rather than calibrating GPTQ on a separate dataset, the trained model **generates its own calibration sequences** via autoregressive sampling. This produces 16 sequences of 512 tokens each, sampled from the model's own distribution — perfectly matched to its activation statistics.
+
+GPTQ then uses Hessian-aware error compensation to quantize each weight column-by-column, propagating the rounding error to the remaining columns. This minimizes the L2 reconstruction error of the layer outputs.
+
+### Mixed quantization scheme
+
+| Tensor class | Bits | Reasoning |
+|---|---|---|
+| Attention weights (q/k/v/proj) | int5 per-row | Aggressive but stable with GPTQ |
+| MLP weights (fc/proj) | int5 per-row | Stable with QAT during training |
+| **tok_emb.weight (tied)** | **int8 per-row** | int5 destroys tied embedding (input AND output projection) — discovered painfully via experimentation. int8 yields near-zero quant gap. |
+| Control tensors (scales, mixes, q_gain, skip_weights) | fp32 passthrough | Small total size, needed for stability |
+| All other small tensors | fp16 passthrough | <65K elements |
+
+Final post-quant gap is only **0.0012 BPB** (1.1427 → 1.1439) — exceptionally small for such aggressive quantization.
+
+### brotli + byte-shuffle compression
+
+After int5 quantization, weights are compressed with **brotli (quality 11)** instead of LZMA. To boost compression further:
+
+- **Byte-shuffle pre-filter**: int8 quantized values are stored as little-endian int8s. Most values cluster near zero, meaning the high bytes are mostly zero/uniform. Reordering bytes column-wise (all-byte-0 then all-byte-1 then ...) groups the structure together and lets brotli's context modeling exploit it.
+
+This combination saved ~280KB vs plain LZMA, and ~700KB vs naive int8 + zlib. Final artifact: **15,918,111 bytes** (model) + 71,265 (code) = **15,989,376 bytes total** — 10KB under the 16MB cap.
+
+## Score-First TTT (eval-time adaptation)
+
+Test-Time Training adapts the model on validation data **after scoring it**, exploiting val/train distribution shift. Strictly legal under issue #402 / issue #1017 — every token is scored before any weight update on it, single left-to-right pass.
+
+### Algorithm
+
+1. Build sliding-window scoring positions globally over the validation set (stride=64, seq_len=2048)
+2. Group windows into chunks based on which `chunk_tok` block their **scored region** falls in
+3. For each chunk:
+   - **Score** the chunk's windows under `inference_mode` (forward only) — accumulate L (loss), T (token count), B (byte count)
+   - If not the last chunk: **train** on the chunk's contiguous sequences via SGD + grad clipping, with **all_reduce** of gradients across GPUs
+4. Final BPB = L / (B × ln 2)
+
+### Hyperparameters
+
+- 348 chunks of 131,072 tokens each
+- 20 SGD epochs per chunk
+- SGD lr=0.003 with cosine decay across chunks (chunk i uses lr × 0.5 × (1 + cos(π·i/N)))
+- Momentum 0.9, no weight decay
+- Grad clipping at 1.0
+- Freeze: 0 blocks (all 10 layers trainable)
+
+### Distributed implementation
+
+- Windows split across ranks contiguously: `windows[rank*N/W:(rank+1)*N/W]`
+- Each GPU scores its windows independently
+- During training: each GPU processes its own sequence partition, then `dist.all_reduce(grad, AVG)` synchronizes gradients before optimizer step
+- Final L/T/B all-reduced via SUM
+
+### Result
+
+Sliding baseline: **1.1277** → TTT: **1.1266** (-0.0011 BPB)
+
+The improvement is small because the base model is already well-optimized (only 28M params, fully trained for 600s on FineWeb).
+
+## Reproduce
+
+```bash
+pip install -r requirements.txt
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+Every hyperparameter is baked into the script. Data and tokenizer auto-download from HuggingFace on first run. No env vars, no shell scripts, no setup steps.
+
+Total runtime: ~10 min training + ~7 min eval (post-quant + sliding + TTT) on 8xH100.
+
+## Included files
+
+- `train_gpt.py` — frozen training script (1387 lines)
+- `train.log` — full training + eval log
+- `submission.json` — leaderboard metadata
+- `README.md` — this file

--- a/records/track_10min_16mb/2026-04-07_idan3011_sp4096_10L_TTT/submission.json
+++ b/records/track_10min_16mb/2026-04-07_idan3011_sp4096_10L_TTT/submission.json
@@ -1,0 +1,18 @@
+{
+  "author": "idan3011",
+  "github_id": "idan3011",
+  "name": "sp4096 + 10L 3.5x MLP + GPTQ + Score-First TTT",
+  "blurb": "Custom sp4096 SentencePiece tokenizer + 10-layer tied-embedding GPT with 3.5x MLP, int5-all GPTQ quantization, brotli+byte-shuffle compression, and score-first TTT eval-time adaptation.",
+  "date": "2026-04-07T00:00:00Z",
+  "val_loss": 2.63175670,
+  "val_bpb": 1.12662548,
+  "pre_quant_val_loss": 2.6289,
+  "pre_quant_val_bpb": 1.1427,
+  "sliding_val_bpb": 1.12768974,
+  "ttt_val_bpb": 1.12662548,
+  "step_stop": 5952,
+  "wallclock_seconds": 600.054,
+  "bytes_total": 15989376,
+  "bytes_code": 71265,
+  "bytes_model_int6_brotli": 15918111
+}

--- a/records/track_10min_16mb/2026-04-07_idan3011_sp4096_10L_TTT/train.log
+++ b/records/track_10min_16mb/2026-04-07_idan3011_sp4096_10L_TTT/train.log
@@ -1,0 +1,123 @@
+data:fineweb10B_sp4096 train_shards:86 val_tokens:45516800
+model_params:28334672 world_size:8 grad_accum:1
+batch:786432 seq:2048 warmup:20 wallclock:600s
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:8.3190 val_bpb:3.6160 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:8.3188 train_time:91ms step_avg:91.35ms
+step:2/20000 train_loss:13.8742 train_time:175ms step_avg:87.26ms
+step:3/20000 train_loss:9.2554 train_time:271ms step_avg:90.49ms
+step:4/20000 train_loss:7.9238 train_time:368ms step_avg:92.06ms
+step:5/20000 train_loss:7.9832 train_time:466ms step_avg:93.11ms
+step:6/20000 train_loss:8.2685 train_time:563ms step_avg:93.76ms
+step:7/20000 train_loss:7.9973 train_time:660ms step_avg:94.23ms
+step:8/20000 train_loss:7.5139 train_time:757ms step_avg:94.67ms
+step:9/20000 train_loss:7.3772 train_time:854ms step_avg:94.93ms
+step:10/20000 train_loss:7.0031 train_time:952ms step_avg:95.20ms
+step:200/20000 train_loss:3.3868 train_time:19750ms step_avg:98.75ms
+step:400/20000 train_loss:3.0708 train_time:39679ms step_avg:99.20ms
+step:600/20000 train_loss:3.0345 train_time:59635ms step_avg:99.39ms
+step:800/20000 train_loss:3.0738 train_time:79663ms step_avg:99.58ms
+step:1000/20000 train_loss:2.9608 train_time:99657ms step_avg:99.66ms
+step:1000/20000 val_loss:2.9573 val_bpb:1.2854 train_time:99680ms step_avg:99.68ms
+step:1200/20000 train_loss:2.9294 train_time:119705ms step_avg:99.75ms
+step:1400/20000 train_loss:2.9476 train_time:139737ms step_avg:99.81ms
+step:1600/20000 train_loss:2.9330 train_time:159693ms step_avg:99.81ms
+step:1800/20000 train_loss:3.0283 train_time:179688ms step_avg:99.83ms
+step:2000/20000 train_loss:2.7261 train_time:199636ms step_avg:99.82ms
+step:2000/20000 val_loss:2.8506 val_bpb:1.2391 train_time:199659ms step_avg:99.83ms
+step:2200/20000 train_loss:2.8482 train_time:219637ms step_avg:99.84ms
+step:2400/20000 train_loss:2.8831 train_time:239556ms step_avg:99.81ms
+step:2600/20000 train_loss:2.6709 train_time:259540ms step_avg:99.82ms
+step:2800/20000 train_loss:2.7688 train_time:279524ms step_avg:99.83ms
+step:3000/20000 train_loss:2.8072 train_time:299432ms step_avg:99.81ms
+step:3000/20000 val_loss:2.8106 val_bpb:1.2217 train_time:299454ms step_avg:99.82ms
+step:3200/20000 train_loss:2.7424 train_time:319390ms step_avg:99.81ms
+step:3400/20000 train_loss:2.8552 train_time:339286ms step_avg:99.79ms
+step:3600/20000 train_loss:2.7908 train_time:359257ms step_avg:99.79ms
+step:3800/20000 train_loss:2.8224 train_time:379151ms step_avg:99.78ms
+step:4000/20000 train_loss:2.7302 train_time:399129ms step_avg:99.78ms
+step:4000/20000 val_loss:2.7829 val_bpb:1.2097 train_time:399151ms step_avg:99.79ms
+step:4200/20000 train_loss:2.7838 train_time:419083ms step_avg:99.78ms
+step:4400/20000 train_loss:2.9248 train_time:438982ms step_avg:99.77ms
+step:4600/20000 train_loss:2.7707 train_time:458930ms step_avg:99.77ms
+step:4800/20000 train_loss:2.6911 train_time:478829ms step_avg:99.76ms
+step:5000/20000 train_loss:2.7248 train_time:499194ms step_avg:99.84ms
+step:5000/20000 val_loss:2.7115 val_bpb:1.1786 train_time:499195ms step_avg:99.84ms
+step:5200/20000 train_loss:2.5774 train_time:520236ms step_avg:100.05ms
+step:5400/20000 train_loss:2.5983 train_time:541284ms step_avg:100.24ms
+step:5600/20000 train_loss:2.6296 train_time:562313ms step_avg:100.41ms
+step:5800/20000 train_loss:2.6004 train_time:583708ms step_avg:100.64ms
+step:5952/20000 val_loss:2.6289 val_bpb:1.1427 train_time:600054ms step_avg:100.82ms
+stopping_early: wallclock_cap train_time:600054ms step:5952/20000
+peak memory allocated: 20258 MiB reserved: 20994 MiB
+swa: averaging 198 checkpoints on top of EMA
+ema: loading weights
+gptq: generating AR calibration data...
+gptq: AR gen done in 10.2s
+gptq: collecting Hessians...
+gptq: Hessians for 60 layers in 0.1s
+gptq: quantized 60 layers in 4.2s, total 14.5s
+Serialized model: 109181987 bytes  Code: 71265  Total: 109253252
+Serialized model int6+brotli: 15918111 bytes (payload:28489024 raw:28539065)
+Total submission size: 15989376 bytes
+final_int8_zlib_roundtrip val_loss:2.6318 val_bpb:1.1439 eval_time:25216ms
+final_int8_zlib_roundtrip_exact val_loss:2.63175670 val_bpb:1.14393687
+final_sliding_window val_bpb:1.1277 eval_time:140435ms
+final_sliding_window_exact val_bpb:1.12768974
+ttt: starting
+ttt: chunk=0/348
+ttt: chunk=10/348
+ttt: chunk=20/348
+ttt: chunk=30/348
+ttt: chunk=40/348
+ttt: chunk=50/348
+ttt: chunk=60/348
+ttt: chunk=70/348
+ttt: chunk=80/348
+ttt: chunk=90/348
+ttt: chunk=100/348
+ttt: chunk=110/348
+ttt: chunk=120/348
+ttt: chunk=130/348
+ttt: chunk=140/348
+ttt: chunk=150/348
+ttt: chunk=160/348
+ttt: chunk=170/348
+ttt: chunk=180/348
+ttt: chunk=190/348
+ttt: chunk=200/348
+ttt: chunk=210/348
+ttt: chunk=220/348
+ttt: chunk=230/348
+ttt: chunk=240/348
+ttt: chunk=250/348
+ttt: chunk=260/348
+ttt: chunk=270/348
+ttt: chunk=280/348
+ttt: chunk=290/348
+ttt: chunk=300/348
+ttt: chunk=310/348
+ttt: chunk=320/348
+ttt: chunk=330/348
+ttt: chunk=340/348
+final_ttt val_bpb:1.1266 eval_time:245233ms
+final_ttt_exact val_bpb:1.12662548

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ typing-extensions==4.15.0
 datasets
 tiktoken
 sentencepiece
+brotli

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -1,9 +1,4 @@
-"""
-The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
-
-Hard stop: To keep readable for newcomers, let's make sure `train_gpt.py` and `train_gpt_mlx.py` never are longer than 1500 lines.
-"""
-
+"""Hard stop: train_gpt.py must never be longer than 1500 lines."""
 from __future__ import annotations
 
 import copy
@@ -16,8 +11,21 @@ import subprocess
 import sys
 import time
 import uuid
-import zlib
+import lzma
 from pathlib import Path
+import brotli
+import numpy as _np
+def _byte_shuffle(data: bytes) -> bytes:
+    arr = _np.frombuffer(data, dtype=_np.uint8)
+    pad = (4 - len(arr) % 4) % 4
+    if pad: arr = _np.concatenate([arr, _np.zeros(pad, dtype=_np.uint8)])
+    return bytes(arr.reshape(-1, 4).T.ravel())
+def _byte_unshuffle(data: bytes) -> bytes:
+    arr = _np.frombuffer(data, dtype=_np.uint8)
+    rows = len(arr) // 4
+    return bytes(arr.reshape(4, rows).T.ravel())
+def _decompress(data: bytes) -> bytes:
+    return _byte_unshuffle(brotli.decompress(data))
 
 import numpy as np
 import sentencepiece as spm
@@ -27,75 +35,53 @@ import torch.nn.functional as F
 from torch import Tensor, nn
 from torch.nn.parallel import DistributedDataParallel as DDP
 
-# -----------------------------
-# HYPERPARAMETERS
-# -----------------------------
-# Default Simple Baseline run:
-# - 9 transformer blocks at width 512
-# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
-# - vocab size 1024, sequence length 1024, tied embeddings
-# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
-
 class Hyperparameters:
-    # Data paths are shard globs produced by the existing preprocessing pipeline.
-    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    data_path = "./data/datasets/fineweb10B_sp4096"
     train_files = os.path.join(data_path, "fineweb_train_*.bin")
     val_files = os.path.join(data_path, "fineweb_val_*.bin")
-    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
-    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
-    seed = int(os.environ.get("SEED", 1337))
-
-    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
-    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
-    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
-    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
-
-    # Training length.
-    iterations = int(os.environ.get("ITERATIONS", 20000))
-    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
-    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
-    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
-    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
-    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
-    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
-
-    # Model shape.
-    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
-    num_layers = int(os.environ.get("NUM_LAYERS", 9))
-    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
-    model_dim = int(os.environ.get("MODEL_DIM", 512))
-    num_heads = int(os.environ.get("NUM_HEADS", 8))
-    mlp_mult = int(os.environ.get("MLP_MULT", 2))
-    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
-    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
-    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
-
-    # Optimizer hyperparameters.
-    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
-    head_lr = float(os.environ.get("HEAD_LR", 0.008))
-    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
-    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
-    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
-    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
-    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
-    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
-    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
-    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
-    beta1 = float(os.environ.get("BETA1", 0.9))
-    beta2 = float(os.environ.get("BETA2", 0.95))
-    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
-    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
-
-# -----------------------------
-# MUON OPTIMIZER 
-# -----------------------------
-# 
-# As borrowed from modded-nanogpt
-# Background on Muon: https://kellerjordan.github.io/posts/muon/
+    tokenizer_path = "./data/tokenizers/fineweb_4096_bpe.model"
+    run_id = str(uuid.uuid4())
+    seed = 1337
+    val_batch_size = 524_288
+    val_loss_every = 1000
+    train_log_every = 200
+    iterations = 20000
+    warmdown_iters = 3500
+    warmup_steps = 20
+    train_batch_tokens = 786_432
+    train_seq_len = 2048
+    max_wallclock_seconds = 600.0
+    qk_gain_init = 1.5
+    vocab_size = 4096
+    num_layers = 10
+    num_kv_heads = 4
+    model_dim = 512
+    num_heads = 8
+    mlp_mult = 3.5
+    tie_embeddings = True
+    rope_base = 10000.0
+    logit_softcap = 30.0
+    embed_lr = 0.6
+    head_lr = 0.008
+    tied_embed_lr = 0.035
+    tied_embed_init_std = 0.005
+    matrix_lr = 0.025
+    scalar_lr = 0.025
+    muon_momentum = 0.99
+    muon_backend_steps = 5
+    muon_momentum_warmup_start = 0.92
+    muon_momentum_warmup_steps = 1500
+    beta1 = 0.9
+    beta2 = 0.95
+    adam_eps = 1e-8
+    grad_clip_norm = 0.0
+    muon_wd = 0.04
+    adam_wd = 0.04
+    ema_decay = 0.997
+    leaky_relu = True
+    crownq_lambda = 0.0
 
 def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
-    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
-    # Muon uses this to normalize matrix-shaped gradients before applying them.
     a, b, c = (3.4445, -4.7750, 2.0315)
     X = G.bfloat16()
     X /= X.norm() + eps
@@ -107,7 +93,6 @@ def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -
         B = b * A + c * A @ A
         X = a * X + B @ X
     return X.T if transposed else X
-
 
 class Muon(torch.optim.Optimizer):
     def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True):
@@ -151,7 +136,6 @@ class Muon(torch.optim.Optimizer):
                     if nesterov:
                         g = g.add(buf, alpha=momentum)
                     g = zeropower_via_newtonschulz5(g, steps=backend_steps)
-                    # Scale correction from Muon reference implementations.
                     g *= max(1, g.size(0) / g.size(1)) ** 0.5
                     updates_flat[curr : curr + p.numel()] = g.reshape(-1)
                 curr += p.numel()
@@ -166,16 +150,6 @@ class Muon(torch.optim.Optimizer):
                 curr += p.numel()
 
         return loss
-
-
-# -----------------------------
-# TOKENIZER-AGNOSTIC EVALUATION SETUP 
-# -----------------------------
-#
-# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
-# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
-# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
-# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
 
 def build_sentencepiece_luts(
     sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
@@ -203,18 +177,15 @@ def build_sentencepiece_luts(
         torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
     )
 
-
 def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
     files = [Path(p) for p in sorted(glob.glob(pattern))]
     if not files:
         raise FileNotFoundError(f"No files found for pattern: {pattern}")
-    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
     tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
     usable = ((tokens.numel() - 1) // seq_len) * seq_len
     if usable <= 0:
         raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
     return tokens[: usable + 1]
-
 
 def eval_val(
     args: Hyperparameters,
@@ -228,9 +199,6 @@ def eval_val(
     has_leading_space_lut: Tensor,
     is_boundary_token_lut: Tensor,
 ) -> tuple[float, float]:
-    # Validation computes two metrics:
-    # - val_loss: token cross-entropy (natural log)
-    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
     local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
     if local_batch_tokens < args.train_seq_len:
         raise ValueError(
@@ -277,36 +245,152 @@ def eval_val(
     model.train()
     return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
 
-# -----------------------------
-# POST-TRAINING QUANTIZATION
-# -----------------------------
-#
-# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
-# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
-# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+def eval_val_ttt(args, base_model, rank, world_size, device, val_tokens,
+                 base_bytes_lut, has_leading_space_lut, is_boundary_token_lut, stride=64, log_fn=None):
+    S = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    chunk_tok = 131072
+    ttt_lr = 0.003
+    ttt_epochs = 20
+    freeze_n = 0
+    score_bs = 64
+    train_bs = 32
+    ttt_grad_clip = 1.0
+    distributed = dist.is_available() and dist.is_initialized()
+    num_chunks = max(1, (total_tokens + chunk_tok - 1) // chunk_tok)
+    all_windows: list[list[tuple[int, int]]] = [[] for _ in range(num_chunks)]
+    ws = 0
+    while ws + S <= total_tokens:
+        ss = 0 if ws == 0 else S - stride
+        ci = min((ws + ss) // chunk_tok, num_chunks - 1)
+        all_windows[ci].append((ws, ss))
+        ws += stride
+    L = torch.zeros((), device=device, dtype=torch.float64)
+    T = torch.zeros((), device=device, dtype=torch.float64)
+    B = torch.zeros((), device=device, dtype=torch.float64)
+    _fr = lambda n: any(f"blocks.{bi}." in n for bi in range(min(freeze_n, len(base_model.blocks))))
+    ttt_params = [p for n, p in base_model.named_parameters() if not _fr(n)]
+    opt = torch.optim.SGD(ttt_params, lr=ttt_lr, momentum=0.9)
+    for ci in range(num_chunks):
+        windows = all_windows[ci]
+        if not windows: continue
+        my_s = (len(windows) * rank) // world_size
+        my_e = (len(windows) * (rank + 1)) // world_size
+        my_windows = windows[my_s:my_e]
+        base_model.eval()
+        with torch.no_grad():
+            for bi in range(0, len(my_windows), score_bs):
+                bw = my_windows[bi:bi + score_bs]
+                x = torch.stack([val_tokens[w:w+S] for w, _ in bw]).to(device=device, dtype=torch.int64)
+                y = torch.stack([val_tokens[w+1:w+S+1] for w, _ in bw]).to(device=device, dtype=torch.int64)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model(x)
+                ptl = F.cross_entropy(logits.float().reshape(-1, logits.size(-1)), y.reshape(-1), reduction="none").reshape(len(bw), S)
+                for j, (_, ss) in enumerate(bw):
+                    sl = ptl[j, ss:]; L += sl.to(torch.float64).sum(); T += float(sl.numel())
+                    sp, st = x[j, ss:], y[j, ss:]
+                    B += (base_bytes_lut[st].to(torch.int16) + (has_leading_space_lut[st] & ~is_boundary_token_lut[sp]).to(torch.int16)).to(torch.float64).sum()
+        if ci < num_chunks - 1 and ttt_epochs > 0:
+            chunk_start = ci * chunk_tok
+            chunk_end = min((ci + 1) * chunk_tok, total_tokens)
+            chunk_seqs = (chunk_end - chunk_start) // S
+            if chunk_seqs > 0:
+                cos_lr = ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                for pg in opt.param_groups: pg['lr'] = cos_lr
+                my_seq_s = (chunk_seqs * rank) // world_size
+                my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+                base_model.train()
+                for _ in range(ttt_epochs):
+                    for bs in range(my_seq_s, my_seq_e, train_bs):
+                        be = min(bs + train_bs, my_seq_e)
+                        start_tok = chunk_start + bs * S
+                        end_tok = chunk_start + be * S + 1
+                        if end_tok > val_tokens.numel(): continue
+                        local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                        x = local[:-1].reshape(-1, S)
+                        y = local[1:].reshape(-1, S)
+                        opt.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            loss = base_model(x, y)
+                        loss.backward()
+                        if distributed:
+                            for p in ttt_params:
+                                if p.grad is not None: dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        torch.nn.utils.clip_grad_norm_(ttt_params, ttt_grad_clip)
+                        opt.step()
+        if log_fn and ci % 10 == 0: log_fn(f"ttt: chunk={ci}/{num_chunks}")
+    if distributed:
+        for t in (L, T, B): dist.all_reduce(t, op=dist.ReduceOp.SUM)
+    return float((L / (B * math.log(2.0))).item())
 
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int = 64,
+    batch_size: int = 256,
+) -> tuple[float, float]:
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel()
+    windows: list[tuple[int, int]] = []
+    pos = 0
+    while pos + seq_len < total_tokens:
+        windows.append((pos, 0 if pos == 0 else seq_len - stride))
+        pos += stride
+    my_windows = windows[rank::world_size]
+    total_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    total_scored_tokens = torch.zeros((), device=device, dtype=torch.float64)
+    total_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    base_model.eval()
+    num_batches = (len(my_windows) + batch_size - 1) // batch_size
+    with torch.inference_mode():
+        for batch_start in range(0, len(my_windows), batch_size):
+            batch_windows = my_windows[batch_start:batch_start + batch_size]
+            x_list, y_list = [], []
+            for win_start, _ in batch_windows:
+                chunk = val_tokens[win_start:win_start + seq_len + 1]
+                x_list.append(chunk[:-1]); y_list.append(chunk[1:])
+            x = torch.stack(x_list).to(device=device, dtype=torch.int64)
+            y = torch.stack(y_list).to(device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = base_model.forward_logits(x)
+            per_token_loss = F.cross_entropy(
+                logits.float().reshape(-1, logits.size(-1)), y.reshape(-1), reduction="none",
+            ).reshape(len(batch_windows), seq_len)
+            for idx, (win_start, score_start) in enumerate(batch_windows):
+                scored_loss = per_token_loss[idx, score_start:]
+                total_loss_sum += scored_loss.to(torch.float64).sum()
+                total_scored_tokens += float(scored_loss.numel())
+                scored_prev = x[idx, score_start:]
+                scored_tgt = y[idx, score_start:]
+                token_bytes = base_bytes_lut[scored_tgt].to(dtype=torch.int16)
+                token_bytes += (has_leading_space_lut[scored_tgt] & ~is_boundary_token_lut[scored_prev]).to(dtype=torch.int16)
+                total_byte_count += token_bytes.to(torch.float64).sum()
+    distributed = dist.is_available() and dist.is_initialized()
+    if distributed:
+        dist.all_reduce(total_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(total_scored_tokens, op=dist.ReduceOp.SUM)
+        dist.all_reduce(total_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (total_loss_sum / total_scored_tokens).item()
+    bpb = (total_loss_sum / (total_byte_count * math.log(2.0))).item()
+    base_model.train()
+    return float(val_loss), float(bpb)
+
+_ctrl_default = "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights"
 CONTROL_TENSOR_NAME_PATTERNS = tuple(
-    pattern
-    for pattern in os.environ.get(
-        "CONTROL_TENSOR_NAME_PATTERNS",
-        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
-    ).split(",")
-    if pattern
-)
+    p for p in os.environ.get("CONTROL_TENSOR_NAME_PATTERNS", _ctrl_default).split(",") if p)
 INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
-    pattern
-    for pattern in os.environ.get(
-        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
-        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
-    ).split(",")
-    if pattern
-)
+    p for p in os.environ.get("INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+                              ",".join(CONTROL_TENSOR_NAME_PATTERNS)).split(",") if p)
 INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
 INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
 INT8_PER_ROW_SCALE_DTYPE = torch.float16
-INT8_CLIP_PERCENTILE = 99.99984
-INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
-
 def tensor_nbytes(t: Tensor) -> int:
     return int(t.numel()) * int(t.element_size())
 
@@ -318,33 +402,20 @@ def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, s
         return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
     return t
 
-def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+def quantize_float_tensor_int6(t: Tensor, bits: int = 6) -> tuple[Tensor, Tensor]:
+    max_val = (1 << (bits - 1)) - 1
     t32 = t.float()
     if t32.ndim == 2:
-        # Matrices get one scale per row, which usually tracks output-channel
-        # ranges much better than a single tensor-wide scale.
-        clip_abs = (
-            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
-            if t32.numel()
-            else torch.empty((t32.shape[0],), dtype=torch.float32)
-        )
-        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
-        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
-        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
-        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
-
-    # Vectors / scalars use a simpler per-tensor scale.
-    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
-    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
-    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+        row_max = t32.abs().amax(dim=1).clamp_min(1e-12)
+        s = row_max / float(max_val)
+        q = torch.clamp(torch.round(t32 / s[:, None]), -max_val, max_val)
+        return q.to(torch.int8).contiguous(), s.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(t32.abs().amax().item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / float(max_val) if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(t32 / scale), -max_val, max_val).to(torch.int8).contiguous()
     return q, scale
 
-def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
-    # Single supported clean-script export format:
-    # - per-row int8 for 2D float tensors
-    # - per-tensor int8 for other float tensors
-    # - exact passthrough for non-floats
-    # - passthrough for small float tensors, stored as fp16 to save bytes
+def quantize_state_dict_int6(state_dict: dict[str, Tensor]):
     quantized: dict[str, Tensor] = {}
     scales: dict[str, Tensor] = {}
     dtypes: dict[str, str] = {}
@@ -355,38 +426,37 @@ def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
         ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
         0,
     )
-
     for name, tensor in state_dict.items():
         t = tensor.detach().to("cpu").contiguous()
         stats["param_count"] += int(t.numel())
         stats["num_tensors"] += 1
         stats["baseline_tensor_bytes"] += tensor_nbytes(t)
-
         if not t.is_floating_point():
             stats["num_nonfloat_tensors"] += 1
             passthrough[name] = t
             stats["int8_payload_bytes"] += tensor_nbytes(t)
             continue
-
-        # Small float tensors are cheap enough to keep directly. We still downcast
-        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
         if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
             kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
             passthrough[name] = kept
             stats["int8_payload_bytes"] += tensor_nbytes(kept)
             continue
-
         stats["num_float_tensors"] += 1
-        q, s = quantize_float_tensor(t)
+        if "tok_emb.weight" in name:
+            bits = 8
+        elif 'mlp' in name:
+            bits = 5
+        else:
+            bits = 5
+        q, s = quantize_float_tensor_int6(t, bits=bits)
         if s.ndim > 0:
             qmeta[name] = {"scheme": "per_row", "axis": 0}
         quantized[name] = q
         scales[name] = s
         dtypes[name] = str(t.dtype).removeprefix("torch.")
         stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
-
     obj: dict[str, object] = {
-        "__quant_format__": "int8_clean_per_row_v1",
+        "__quant_format__": "int6_per_row_v1",
         "quantized": quantized,
         "scales": scales,
         "dtypes": dtypes,
@@ -407,13 +477,11 @@ def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
         s = obj["scales"][name]
         if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
             s = s.to(dtype=torch.float32)
-            # Broadcast the saved row scale back across trailing dimensions.
             out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
         else:
             scale = float(s.item())
             out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
     for name, t in obj["passthrough"].items():
-        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
         out_t = t.detach().to("cpu").contiguous()
         orig_dtype = passthrough_orig_dtypes.get(name)
         if isinstance(orig_dtype, str):
@@ -421,16 +489,133 @@ def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
         out[name] = out_t
     return out
 
+def generate_ar_calibration(model: nn.Module, device: torch.device, vocab_size: int = 1024,
+                            seed: int = 42) -> list[Tensor]:
+    n_seqs = 16
+    seq_len = 512
+    batch_size = min(8, n_seqs)
+    model.eval()
+    rng = torch.Generator(device=device)
+    rng.manual_seed(seed)
+    all_seqs: list[Tensor] = []
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        for batch_start in range(0, n_seqs, batch_size):
+            bs = min(batch_size, n_seqs - batch_start)
+            tokens = torch.randint(0, vocab_size, (bs, 1), device=device, generator=rng)
+            for _ in range(seq_len - 1):
+                logits = model.forward_logits(tokens)
+                probs = torch.softmax(logits[:, -1, :], dim=-1)
+                tokens = torch.cat([tokens, torch.multinomial(probs, 1, generator=rng)], dim=1)
+            all_seqs.append(tokens)
+    return all_seqs
 
-# -----------------------------
-# DATA LOADING 
-# -----------------------------
+def collect_hessians(model: nn.Module, calib_seqs: list[Tensor], device: torch.device) -> dict[str, Tensor]:
+    hessians: dict[str, Tensor] = {}
+    hooks: list[torch.utils.hooks.RemovableHook] = []
+    for name, module in model.named_modules():
+        if isinstance(module, CastedLinear) and module.weight.ndim == 2:
+            pname = name + ".weight"
+            cols = module.weight.shape[1]
+            hessians[pname] = torch.zeros(cols, cols, dtype=torch.float32, device=device)
+            def make_hook(pn: str):
+                def hook_fn(mod, inp, out):
+                    x = inp[0].detach().float()
+                    if x.ndim == 3:
+                        x = x.reshape(-1, x.shape[-1])
+                    hessians[pn] += x.T @ x
+                return hook_fn
+            hooks.append(module.register_forward_hook(make_hook(pname)))
+    model.eval()
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        for seq in calib_seqs:
+            x, y = seq[:, :-1].to(device), seq[:, 1:].to(device)
+            model(x, y)
+    for h in hooks:
+        h.remove()
+    for pname in hessians:
+        hessians[pname] /= len(calib_seqs)
+    return hessians
+
+def gptq_quantize_weight(weight: Tensor, hessian: Tensor, clip_range: int = 31,
+                         block_size: int = 128, sparsity: float = 0.0) -> Tensor:
+    rows, cols = weight.shape
+    H = hessian.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    perm = torch.argsort(torch.diag(H), descending=True)
+    inv_perm = torch.argsort(perm)
+    W = weight.float()[:, perm].clone()
+    H = H[perm][:, perm]
+    for damp_scale in [0.01, 0.1, 1.0]:
+        try:
+            Hd = H.clone()
+            Hd.diagonal().add_(damp_scale * torch.mean(torch.diag(H)).clamp_min(1e-6))
+            Hinv = torch.linalg.cholesky(Hd)
+            Hinv = torch.cholesky_inverse(Hinv)
+            Hinv = torch.linalg.cholesky(Hinv, upper=True)
+            break
+        except torch._C._LinAlgError:
+            if damp_scale >= 1.0:
+                return weight
+    sf = (weight.float().abs().amax(dim=1).clamp_min(1e-12) / clip_range).to(device=W.device)
+    Q = torch.zeros(rows, cols, dtype=torch.float32, device=W.device)
+    if sparsity > 0:
+        W_ref = W.clone()
+        Hdiag = torch.diag(Hd) if 'Hd' in dir() else torch.diag(H)
+        score = W_ref.pow(2) * Hdiag[None, :]
+        threshold = torch.quantile(score.flatten(), sparsity)
+        prune_mask = score <= threshold
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W1 = W[:, i1:i2].clone()
+        Err1 = torch.zeros(rows, i2 - i1, device=W.device)
+        Hinv1 = Hinv[i1:i2, i1:i2]
+        for i in range(i2 - i1):
+            w = W1[:, i]
+            d = Hinv1[i, i].clamp_min(1e-10)
+            q = torch.clamp(torch.round(w / sf), -clip_range, clip_range)
+            if sparsity > 0:
+                q[prune_mask[:, i1 + i]] = 0
+            Q[:, i1 + i] = q
+            err = (w - q * sf) / d
+            if i + 1 < i2 - i1:
+                W1[:, i + 1:] -= err.unsqueeze(1) * Hinv1[i, i + 1:].unsqueeze(0)
+            Err1[:, i] = err
+        if i2 < cols:
+            W[:, i2:] -= Err1 @ Hinv[i1:i2, i2:]
+    Q = Q[:, inv_perm]
+    return (Q * sf[:, None]).to(dtype=weight.dtype)
+
+def apply_gptq_inplace(model: nn.Module, device: torch.device, args, log_fn=print) -> None:
+    t0 = time.perf_counter()
+    log_fn("gptq: generating AR calibration data...")
+    calib = generate_ar_calibration(model, device, vocab_size=args.vocab_size, seed=args.seed)
+    log_fn(f"gptq: AR gen done in {time.perf_counter() - t0:.1f}s")
+    t1 = time.perf_counter()
+    log_fn("gptq: collecting Hessians...")
+    hessians = collect_hessians(model, calib, device)
+    del calib
+    torch.cuda.empty_cache()
+    log_fn(f"gptq: Hessians for {len(hessians)} layers in {time.perf_counter() - t1:.1f}s")
+    t2 = time.perf_counter()
+    count = 0
+    for name, module in model.named_modules():
+        if isinstance(module, CastedLinear) and module.weight.ndim == 2:
+            pname = name + ".weight"
+            H = hessians.get(pname)
+            if H is None:
+                continue
+            bits = 5
+            cr = (1 << (bits - 1)) - 1
+            with torch.no_grad():
+                module.weight.data.copy_(gptq_quantize_weight(module.weight.data, H, clip_range=cr, sparsity=0.0))
+            count += 1
+    log_fn(f"gptq: quantized {count} layers in {time.perf_counter() - t2:.1f}s, total {time.perf_counter() - t0:.1f}s")
 
 def load_data_shard(file: Path) -> Tensor:
     header_bytes = 256 * np.dtype("<i4").itemsize
     token_bytes = np.dtype("<u2").itemsize
     header = np.fromfile(file, dtype="<i4", count=256)
-    # SHARD HEADER INTS & SHARD_MAGIC
     if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
         raise ValueError(f"Unexpected shard header for {file}")
     num_tokens = int(header[2])
@@ -442,10 +627,7 @@ def load_data_shard(file: Path) -> Tensor:
         raise ValueError(f"Short read for {file}")
     return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
 
-
 class TokenStream:
-    # Reads shards sequentially and wraps around forever. The training loop therefore
-    # has deterministic, simple streaming behavior with no sampling or workers.
     def __init__(self, pattern: str):
         self.files = [Path(p) for p in sorted(glob.glob(pattern))]
         if not self.files:
@@ -473,10 +655,7 @@ class TokenStream:
             remaining -= k
         return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
 
-
 class DistributedTokenLoader:
-    # Each call consumes a contiguous chunk from the shared token stream, then slices out
-    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
     def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
         self.rank = rank
         self.world_size = world_size
@@ -493,10 +672,6 @@ class DistributedTokenLoader:
         y = local[1:].reshape(-1, seq_len)
         return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
 
-# -----------------------------
-# TRANSFORMER MODULES
-# -----------------------------
-
 class RMSNorm(nn.Module):
     def __init__(self, eps: float | None = None):
         super().__init__()
@@ -505,27 +680,43 @@ class RMSNorm(nn.Module):
     def forward(self, x: Tensor) -> Tensor:
         return F.rms_norm(x, (x.size(-1),), eps=self.eps)
 
+class _FakeQuant(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, w: Tensor, bits: int = 6) -> Tensor:
+        if w.ndim != 2: return w
+        max_val = (1 << (bits - 1)) - 1
+        row_max = w.abs().amax(dim=1, keepdim=True).clamp_min(1e-12)
+        scale = row_max / float(max_val)
+        q = (w / scale).round().clamp(-max_val, max_val)
+        return q * scale
+    @staticmethod
+    def backward(ctx, grad: Tensor) -> tuple[Tensor, None]:
+        return grad, None
 
 class CastedLinear(nn.Linear):
-    # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.
-    def forward(self, x: Tensor) -> Tensor:
-        bias = self.bias.to(x.dtype) if self.bias is not None else None
-        return F.linear(x, self.weight.to(x.dtype), bias)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.use_qat = False
+        self.qat_bits = 6
 
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight
+        if self.use_qat and self.training:
+            w = _FakeQuant.apply(w, self.qat_bits)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w.to(x.dtype), bias)
 
 def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
-    # Keep small/control parameters in fp32 even when the model body runs in bf16.
     with torch.no_grad():
         for name, param in module.named_parameters():
             if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
                 param.data = param.data.float()
 
-
 class Rotary(nn.Module):
-    # Caches cos/sin tables per sequence length on the current device.
     def __init__(self, dim: int, base: float = 10000.0):
         super().__init__()
-        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        rdim = _ROPE_DIMS if _ROPE_DIMS > 0 else dim
+        inv_freq = 1.0 / (base ** (torch.arange(0, rdim, 2, dtype=torch.float32) / rdim))
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self._seq_len_cached = 0
         self._cos_cached: Tensor | None = None
@@ -545,12 +736,22 @@ class Rotary(nn.Module):
             self._seq_len_cached = seq_len
         return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
 
+_ROPE_DIMS = 0
 
 def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    rd = _ROPE_DIMS
+    if rd > 0 and rd < x.size(-1):
+        x_rope, x_pass = x[..., :rd], x[..., rd:]
+        half = rd // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos[..., :half] + x2 * sin[..., :half], x1 * (-sin[..., :half]) + x2 * cos[..., :half]), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
     half = x.size(-1) // 2
     x1, x2 = x[..., :half], x[..., half:]
     return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
 
+_GATED_ATTN = False
+_VALUE_RESIDUAL = False
 
 class CausalSelfAttention(nn.Module):
     def __init__(
@@ -560,6 +761,7 @@ class CausalSelfAttention(nn.Module):
         num_kv_heads: int,
         rope_base: float,
         qk_gain_init: float,
+        use_xsa: bool = False,
     ):
         super().__init__()
         if dim % num_heads != 0:
@@ -578,72 +780,95 @@ class CausalSelfAttention(nn.Module):
         self.proj = CastedLinear(dim, dim, bias=False)
         self.proj._zero_init = True
         self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        if _GATED_ATTN:
+            self.attn_gate = nn.Parameter(torch.ones(num_heads, dtype=torch.float32))
         self.rotary = Rotary(self.head_dim, base=rope_base)
+        self.use_xsa = use_xsa
+        if _VALUE_RESIDUAL:
+            self.vr_lambda = nn.Parameter(torch.tensor([0.5, 0.5], dtype=torch.float32))
 
-    def forward(self, x: Tensor) -> Tensor:
+    def forward(self, x: Tensor, v0: Tensor | None = None) -> Tensor:
         bsz, seqlen, dim = x.shape
         q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
         k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
         v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        if _VALUE_RESIDUAL and v0 is not None:
+            lam = torch.sigmoid(self.vr_lambda).to(dtype=v.dtype)
+            v = lam[0] * v0 + lam[1] * v
         q = F.rms_norm(q, (q.size(-1),))
         k = F.rms_norm(k, (k.size(-1),))
         cos, sin = self.rotary(seqlen, x.device, q.dtype)
         q = apply_rotary_emb(q, cos, sin)
         k = apply_rotary_emb(k, cos, sin)
         q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
-        y = F.scaled_dot_product_attention(
-            q,
-            k,
-            v,
-            attn_mask=None,
-            is_causal=True,
-            enable_gqa=(self.num_kv_heads != self.num_heads),
-        )
+        y = F.scaled_dot_product_attention(q, k, v, attn_mask=None, is_causal=True, enable_gqa=(self.num_kv_heads != self.num_heads))
+        if self.use_xsa:
+            vn = F.normalize(v.repeat_interleave(self.num_heads // self.num_kv_heads, dim=1), dim=-1)
+            y = y - (y * vn).sum(dim=-1, keepdim=True) * vn
+        if _GATED_ATTN:
+            y = y * torch.sigmoid(self.attn_gate).to(dtype=y.dtype)[None, :, None, None]
         y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
-        return self.proj(y)
-
+        return self.proj(y), v
 
 class MLP(nn.Module):
-    # relu^2 MLP from the original modded-nanogpt setup
-    def __init__(self, dim: int, mlp_mult: int):
+    def __init__(self, dim: int, mlp_mult: float, leaky: bool = False):
         super().__init__()
-        hidden = mlp_mult * dim
+        hidden = int(mlp_mult * dim)
         self.fc = CastedLinear(dim, hidden, bias=False)
         self.proj = CastedLinear(hidden, dim, bias=False)
         self.proj._zero_init = True
+        self._leaky = leaky
 
     def forward(self, x: Tensor) -> Tensor:
-        x = torch.relu(self.fc(x))
+        x = F.leaky_relu(self.fc(x), 0.5) if self._leaky else torch.relu(self.fc(x))
         return self.proj(x.square())
 
+_LN_SCALE = False
 
 class Block(nn.Module):
-    def __init__(
-        self,
-        dim: int,
-        num_heads: int,
-        num_kv_heads: int,
-        mlp_mult: int,
-        rope_base: float,
-        qk_gain_init: float,
-    ):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int,
+                 rope_base: float, qk_gain_init: float, use_xsa: bool = False, leaky: bool = False, layer_idx: int = 0):
         super().__init__()
         self.attn_norm = RMSNorm()
         self.mlp_norm = RMSNorm()
-        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
-        self.mlp = MLP(dim, mlp_mult)
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init, use_xsa=use_xsa)
+        self.mlp = MLP(dim, mlp_mult, leaky=leaky)
         self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
         self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
         self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self._ln_scale = 1.0 / math.sqrt(layer_idx + 1) if _LN_SCALE else 1.0
 
-    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+    def forward(self, x: Tensor, x0: Tensor, v0: Tensor | None = None) -> tuple[Tensor, Tensor]:
         mix = self.resid_mix.to(dtype=x.dtype)
         x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
-        attn_out = self.attn(self.attn_norm(x))
-        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
-        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
-        return x
+        s = self._ln_scale
+        attn_out, v = self.attn(self.attn_norm(x), v0 if _VALUE_RESIDUAL else None)
+        x = x + s * self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + s * self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x, v
 
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.full((dim,), 3.0, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate).to(dtype=x.dtype)
+        x_prev = F.pad(x[:, :-1], (0, 0, 1, 0))
+        return g * x + (1.0 - g) * x_prev
+
+class BigramHash(nn.Module):
+    def __init__(self, num_buckets: int, hash_dim: int, model_dim: int):
+        super().__init__()
+        self.num_buckets = num_buckets
+        self.table = nn.Embedding(num_buckets, hash_dim)
+        self.proj = CastedLinear(hash_dim, model_dim, bias=False)
+        nn.init.normal_(self.table.weight, std=0.01)
+
+    def forward(self, input_ids: Tensor) -> Tensor:
+        prev_ids = torch.cat([torch.zeros_like(input_ids[:, :1]), input_ids[:, :-1]], dim=1)
+        h = ((prev_ids.long() * 92821 + input_ids.long()) % self.num_buckets).long()
+        return self.proj(self.table(h))
 
 class GPT(nn.Module):
     def __init__(
@@ -667,20 +892,20 @@ class GPT(nn.Module):
         self.tied_embed_init_std = tied_embed_init_std
         self.logit_softcap = logit_softcap
         self.tok_emb = nn.Embedding(vocab_size, model_dim)
-        self.num_encoder_layers = num_layers // 2
+        self.bigram_hash = None
+        self.smear_gate = None
+        self.pre_enrich = nn.Identity()
+        self.num_encoder_layers = (num_layers + 1) // 2
         self.num_decoder_layers = num_layers - self.num_encoder_layers
         self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self._active_enc = num_layers // 2
+        self._active_dec = num_layers - self._active_enc
         self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        xsa_last_n = 4
         self.blocks = nn.ModuleList(
             [
-                Block(
-                    model_dim,
-                    num_heads,
-                    num_kv_heads,
-                    mlp_mult,
-                    rope_base,
-                    qk_gain_init,
-                )
+                Block(model_dim, num_heads, num_kv_heads, mlp_mult,
+                      rope_base, qk_gain_init, use_xsa=(i >= num_layers - xsa_last_n), leaky=True, layer_idx=i)
                 for i in range(num_layers)
             ]
         )
@@ -688,56 +913,104 @@ class GPT(nn.Module):
         self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
         if self.lm_head is not None:
             self.lm_head._zero_init = True
+        pred_hidden = 0
+        if pred_hidden > 0:
+            self.pred_head = nn.Sequential(
+                CastedLinear(model_dim, pred_hidden, bias=False),
+                nn.GELU(),
+                CastedLinear(pred_hidden, model_dim, bias=False),
+            )
+        else:
+            self.pred_head = None
         self._init_weights()
 
     def _init_weights(self) -> None:
         if self.tie_embeddings:
             nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+            with torch.no_grad():
+                U, S, V = torch.linalg.svd(self.tok_emb.weight.data, full_matrices=False)
+                target_S = S[0] * (1.0 / torch.arange(1, S.shape[0] + 1, dtype=S.dtype)) ** 0.5
+                self.tok_emb.weight.data = (U * target_S[None, :]) @ V
         for module in self.modules():
             if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
                 nn.init.zeros_(module.weight)
 
-    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
-        x = self.tok_emb(input_ids)
-        x = F.rms_norm(x, (x.size(-1),))
-        x0 = x
-        skips: list[Tensor] = []
+    def grow_to(self, total_layers: int) -> None:
+        self._active_enc = total_layers // 2
+        self._active_dec = total_layers - self._active_enc
 
-        # First half stores skips; second half reuses them in reverse order.
-        for i in range(self.num_encoder_layers):
-            x = self.blocks[i](x, x0)
-            skips.append(x)
-        for i in range(self.num_decoder_layers):
-            if skips:
-                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
-            x = self.blocks[self.num_encoder_layers + i](x, x0)
+    def _run_blocks(self, x: Tensor, x0: Tensor) -> Tensor:
+        v0 = None
+        enc_outputs: dict[int, Tensor] = {}
+        for i in range(self._active_enc):
+            x, v = self.blocks[i](x, x0, v0)
+            if v0 is None: v0 = v
+            enc_outputs[i] = x
+        for i in range(self._active_dec):
+            dec_idx = self.num_encoder_layers + (self.num_decoder_layers - self._active_dec) + i
+            dec_step = dec_idx - self.num_encoder_layers
+            matching_enc = self.num_encoder_layers - 1 - dec_step
+            if matching_enc >= 0 and matching_enc < self._active_enc and dec_step < self.num_skip_weights:
+                x = x + self.skip_weights[dec_step].to(dtype=x.dtype)[None, None, :] * enc_outputs[matching_enc]
+            x, v = self.blocks[dec_idx](x, x0, v0)
+        return x
 
-        x = self.final_norm(x).reshape(-1, x.size(-1))
-        targets = target_ids.reshape(-1)
+    def _compute_logits(self, x: Tensor) -> Tensor:
+        if self.pred_head is not None:
+            x = x + self.pred_head(x)
         if self.tie_embeddings:
             logits_proj = F.linear(x, self.tok_emb.weight)
         else:
-            if self.lm_head is None:
-                raise RuntimeError("lm_head is required when tie_embeddings=False")
             logits_proj = self.lm_head(x)
-        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
-        return F.cross_entropy(logits.float(), targets, reduction="mean")
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
 
+    def forward(self, input_ids: Tensor, target_ids: Tensor | None = None) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram_hash is not None: x = x + self.bigram_hash(input_ids)
+        if self.smear_gate is not None: x = self.smear_gate(x)
+        x = self.pre_enrich(x)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self._run_blocks(x, x)
+        x = self.final_norm(x)
+        logits = self._compute_logits(x)
+        if target_ids is None: return logits
+        return F.cross_entropy(logits.reshape(-1, logits.size(-1)).float(), target_ids.reshape(-1), reduction="mean")
 
-# -----------------------------
-# TRAINING
-# -----------------------------
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram_hash is not None: x = x + self.bigram_hash(input_ids)
+        if self.smear_gate is not None: x = self.smear_gate(x)
+        x = self.pre_enrich(x)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self._run_blocks(x, x)
+        return self._compute_logits(self.final_norm(x))
+
+def _ensure_sp4096_data() -> None:
+    if os.path.exists("./data/tokenizers/fineweb_4096_bpe.model") and len(glob.glob("./data/datasets/fineweb10B_sp4096/fineweb_train_*.bin")) > 0:
+        return
+    from huggingface_hub import hf_hub_download, list_repo_tree
+    import shutil
+    REPO = "idan3011/parameter-golf-sp4096"
+    os.makedirs("data/tokenizers", exist_ok=True)
+    os.makedirs("data/datasets/fineweb10B_sp4096", exist_ok=True)
+    for f in list_repo_tree(REPO, repo_type="dataset", recursive=True):
+        if not hasattr(f, "size"): continue
+        p = f.path
+        if not (p.endswith(".bin") or p.endswith(".model") or p.endswith(".vocab")): continue
+        dst = "data/" + p
+        if os.path.exists(dst): continue
+        print(f"  downloading {p}...", flush=True)
+        src = hf_hub_download(REPO, p.split("/")[-1], subfolder="/".join(p.split("/")[:-1]), repo_type="dataset")
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        shutil.copy2(src, dst)
 
 def main() -> None:
     global zeropower_via_newtonschulz5
-
+    if int(os.environ.get("RANK", "0")) == 0:
+        _ensure_sp4096_data()
     code = Path(__file__).read_text(encoding="utf-8")
     args = Hyperparameters()
     zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
-
-    # -----------------------------
-    # DISTRIBUTED + CUDA SETUP
-    # -----------------------------
 
     distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
     rank = int(os.environ.get("RANK", "0"))
@@ -758,16 +1031,10 @@ def main() -> None:
         dist.barrier()
     master_process = rank == 0
 
-    # Fast math knobs
     torch.backends.cuda.matmul.allow_tf32 = True
     torch.backends.cudnn.allow_tf32 = True
     from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
-
-    enable_cudnn_sdp(False)
-    enable_flash_sdp(True)
-    enable_mem_efficient_sdp(False)
-    enable_math_sdp(False)
-
+    enable_cudnn_sdp(True); enable_flash_sdp(True); enable_mem_efficient_sdp(False); enable_math_sdp(False)
     logfile = None
     if master_process:
         os.makedirs("logs", exist_ok=True)
@@ -784,19 +1051,7 @@ def main() -> None:
                 print(msg, file=f)
 
     log0(code, console=False)
-    log0("=" * 100, console=False)
-    log0(f"Running Python {sys.version}", console=False)
-    log0(f"Running PyTorch {torch.__version__}", console=False)
-    log0(
-        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
-        console=False,
-    )
-    log0("=" * 100, console=False)
-
-    # -----------------------------
-    # TOKENIZER + VALIDATION METRIC SETUP
-    # -----------------------------
-
+    log0(f"Python {sys.version} PyTorch {torch.__version__}", console=False)
     random.seed(args.seed)
     np.random.seed(args.seed)
     torch.manual_seed(args.seed)
@@ -815,13 +1070,7 @@ def main() -> None:
     base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
         sp, args.vocab_size, device
     )
-    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
-    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
-    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
-
-    # -----------------------------
-    # MODEL + OPTIMIZER SETUP
-    # -----------------------------
+    log0(f"data:{dataset_dir.name} train_shards:{actual_train_files} val_tokens:{val_tokens.numel()-1}")
 
     base_model = GPT(
         vocab_size=args.vocab_size,
@@ -840,20 +1089,27 @@ def main() -> None:
         if isinstance(module, CastedLinear):
             module.float()
     restore_low_dim_params_to_fp32(base_model)
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.use_qat = True
+    for block in base_model.blocks:
+        for mn, m in block.named_modules():
+            if isinstance(m, CastedLinear) and 'mlp' in mn:
+                m.qat_bits = 5
     compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
     model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
 
-    # Optimizer split:
-    # - token embedding (Adam) uses EMBED_LR
-    # - untied lm_head (Adam) uses HEAD_LR
-    # - matrix params in transformer blocks use MATRIX_LR via Muon
-    # - vectors/scalars use SCALAR_LR via Adam
     block_named_params = list(base_model.blocks.named_parameters())
     matrix_params = [
         p
         for name, p in block_named_params
         if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
     ]
+    matrix_params.extend(p for p in base_model.pre_enrich.parameters() if p.ndim == 2)
+    if base_model.pred_head is not None:
+        matrix_params.extend(p for p in base_model.pred_head.parameters() if p.ndim == 2)
+    if base_model.bigram_hash is not None:
+        matrix_params.extend(p for p in base_model.bigram_hash.parameters() if p.ndim == 2)
     scalar_params = [
         p
         for name, p in block_named_params
@@ -861,11 +1117,14 @@ def main() -> None:
     ]
     if base_model.skip_weights.numel() > 0:
         scalar_params.append(base_model.skip_weights)
+    if base_model.smear_gate is not None:
+        scalar_params.append(base_model.smear_gate.gate)
     token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
-    optimizer_tok = torch.optim.Adam(
+    optimizer_tok = torch.optim.AdamW(
         [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
         betas=(args.beta1, args.beta2),
         eps=args.adam_eps,
+        weight_decay=args.adam_wd,
         fused=True,
     )
     optimizer_muon = Muon(
@@ -876,10 +1135,11 @@ def main() -> None:
     )
     for group in optimizer_muon.param_groups:
         group["base_lr"] = args.matrix_lr
-    optimizer_scalar = torch.optim.Adam(
+    optimizer_scalar = torch.optim.AdamW(
         [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
         betas=(args.beta1, args.beta2),
         eps=args.adam_eps,
+        weight_decay=args.adam_wd,
         fused=True,
     )
     optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
@@ -891,34 +1151,14 @@ def main() -> None:
             fused=True,
         )
         optimizers.insert(1, optimizer_head)
-
     n_params = sum(p.numel() for p in base_model.parameters())
-    log0(f"model_params:{n_params}")
-    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
-    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
-    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
-    log0(
-        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
-        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
-        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
-    )
-    log0(
-        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
-        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
-        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
-    )
-    log0(f"seed:{args.seed}")
-
-    # -----------------------------
-    # DATA LOADER & MODEL WARMUP
-    # -----------------------------
-
+    log0(f"model_params:{n_params} world_size:{world_size} grad_accum:{grad_accum_steps}")
+    log0(f"batch:{args.train_batch_tokens} seq:{args.train_seq_len} warmup:{args.warmup_steps} wallclock:{args.max_wallclock_seconds:.0f}s")
     train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
 
     def zero_grad_all() -> None:
         for opt in optimizers:
             opt.zero_grad(set_to_none=True)
-
     max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
 
     def lr_mul(step: int, elapsed_ms: float) -> float:
@@ -927,13 +1167,11 @@ def main() -> None:
         if max_wallclock_ms is None:
             warmdown_start = max(args.iterations - args.warmdown_iters, 0)
             return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
-        step_ms = elapsed_ms / max(step, 1)
-        warmdown_ms = args.warmdown_iters * step_ms
         remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
-        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+        remaining_frac = remaining_ms / max(max_wallclock_ms, 1.0)
+        warmdown_frac = 0.35
+        return min(remaining_frac / warmdown_frac, 1.0) if remaining_frac < warmdown_frac else 1.0
 
-    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
-    # initial weights/optimizer state so measured training starts from the true init.
     if args.warmup_steps > 0:
         initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
         initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
@@ -960,15 +1198,13 @@ def main() -> None:
             model.require_backward_grad_sync = True
         train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
 
-    # -----------------------------
-    # MAIN TRAINING LOOP
-    # -----------------------------
-
     training_time_ms = 0.0
     stop_after_step: int | None = None
+    ema_state = {k: v.detach().clone().float() for k, v in base_model.state_dict().items()}
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
     torch.cuda.synchronize()
     t0 = time.perf_counter()
-
     step = 0
     while True:
         last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
@@ -1031,9 +1267,23 @@ def main() -> None:
             torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
         for opt in optimizers:
             opt.step()
+        with torch.no_grad():
+            muon_lr = optimizer_muon.param_groups[0]["lr"]
+            for p in matrix_params:
+                p.mul_(1.0 - args.muon_wd * muon_lr)
         zero_grad_all()
 
         step += 1
+        _ema_d = args.ema_decay
+        with torch.no_grad():
+            for k, v in base_model.state_dict().items():
+                ema_state[k].mul_(_ema_d).add_(v.detach().float(), alpha=1.0 - _ema_d)
+            if scale < 0.5 and step % 5 == 0:
+                sd = {k: v.detach().cpu().float() for k, v in base_model.state_dict().items()}
+                if swa_state is None: swa_state, swa_count = sd, 1
+                else:
+                    for k in swa_state: swa_state[k] += sd[k]
+                    swa_count += 1
         approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
         should_log_train = (
             args.train_log_every > 0
@@ -1045,7 +1295,6 @@ def main() -> None:
                 f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
             )
 
-        # Needed to sync whether we've reached the wallclock cap.
         reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
         if distributed and max_wallclock_ms is not None:
             reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
@@ -1054,73 +1303,85 @@ def main() -> None:
         if stop_after_step is None and reached_cap:
             stop_after_step = step
 
-    log0(
-        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
-        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
-    )
-
-    # -----------------------------
-    # SERIALIZATION + ROUNDTRIP VALIDATION
-    # -----------------------------
-    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
-    # the compressed int8+zlib artifact and validate the round-tripped weights.
-
+    log0(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB")
+    ema_state = {k: v.cpu() for k, v in ema_state.items()}
+    if swa_state is not None and swa_count > 0:
+        log0(f"swa: averaging {swa_count} checkpoints on top of EMA")
+        for k in swa_state:
+            swa_state[k] /= swa_count
+            ema_state[k] = 0.5 * ema_state[k] + 0.5 * swa_state[k]
+        del swa_state
+    log0("ema: loading weights")
+    base_model.load_state_dict(ema_state, strict=True)
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    del ema_state
+    apply_gptq_inplace(base_model, device, args, log_fn=log0)
+    export_sd = base_model.state_dict()
     if master_process:
-        torch.save(base_model.state_dict(), "final_model.pt")
-        model_bytes = os.path.getsize("final_model.pt")
-        code_bytes = len(code.encode("utf-8"))
-        log0(f"Serialized model: {model_bytes} bytes")
-        log0(f"Code size: {code_bytes} bytes")
-        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
-
-    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
-    quant_buf = io.BytesIO()
-    torch.save(quant_obj, quant_buf)
-    quant_raw = quant_buf.getvalue()
-    quant_blob = zlib.compress(quant_raw, level=9)
-    quant_raw_bytes = len(quant_raw)
+        torch.save(export_sd, "final_model.pt")
+        sz = os.path.getsize("final_model.pt"); csz = len(code.encode("utf-8"))
+        log0(f"Serialized model: {sz} bytes  Code: {csz}  Total: {sz + csz}")
+    quant_obj, quant_stats = quantize_state_dict_int6(export_sd)
+    quant_buf = io.BytesIO(); torch.save(quant_obj, quant_buf); quant_raw = quant_buf.getvalue()
+    quant_blob = brotli.compress(_byte_shuffle(quant_raw), quality=11)
     if master_process:
-        with open("final_model.int8.ptz", "wb") as f:
-            f.write(quant_blob)
-        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
-        code_bytes = len(code.encode("utf-8"))
-        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
-        log0(
-            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
-            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
-        )
-        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
-
+        with open("final_model.int6.ptz", "wb") as f: f.write(quant_blob)
+        qsz = os.path.getsize("final_model.int6.ptz"); csz = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+brotli: {qsz} bytes (payload:{quant_stats['int8_payload_bytes']} raw:{len(quant_raw)})")
+        log0(f"Total submission size: {qsz + csz} bytes")
     if distributed:
         dist.barrier()
-    with open("final_model.int8.ptz", "rb") as f:
+
+    with open("final_model.int6.ptz", "rb") as f:
         quant_blob_disk = f.read()
-    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    quant_state = torch.load(io.BytesIO(_decompress(quant_blob_disk)), map_location="cpu")
     base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
     torch.cuda.synchronize()
     t_qeval = time.perf_counter()
     q_val_loss, q_val_bpb = eval_val(
-        args,
-        model,
-        rank,
-        world_size,
-        device,
-        grad_accum_steps,
-        val_tokens,
-        base_bytes_lut,
-        has_leading_space_lut,
-        is_boundary_token_lut,
+        args, model, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
     )
     torch.cuda.synchronize()
-    log0(
-        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
-        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
-    )
+    log0(f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms")
     log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
-
+    torch.cuda.synchronize()
+    t_slide = time.perf_counter()
+    sw_val_loss, sw_val_bpb = eval_val_sliding(
+        args, base_model, rank, world_size, device,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(f"final_sliding_window val_bpb:{sw_val_bpb:.4f} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms")
+    log0(f"final_sliding_window_exact val_bpb:{sw_val_bpb:.8f}")
+    ttt_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+    ).to(device).bfloat16()
+    for m in ttt_model.modules():
+        if isinstance(m, CastedLinear): m.float()
+    restore_low_dim_params_to_fp32(ttt_model)
+    ttt_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_ttt = time.perf_counter()
+    ttt_model = torch.compile(ttt_model)
+    log0("ttt: starting")
+    ttt_bpb = eval_val_ttt(
+        args, ttt_model, rank, world_size, device,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        log_fn=log0,
+    )
+    torch.cuda.synchronize()
+    log0(f"final_ttt val_bpb:{ttt_bpb:.4f} eval_time:{1000.0 * (time.perf_counter() - t_ttt):.0f}ms")
+    log0(f"final_ttt_exact val_bpb:{ttt_bpb:.8f}")
+    del ttt_model
     if distributed:
         dist.destroy_process_group()
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## sp4096 Custom Tokenizer + 10L 3.5x MLP + GPTQ + Score-First TTT

val_bpb: **1.1266** (TTT) | **1.1277** (sliding) | 15.99 MB | 8xH100 SXM, 600s

Follow-up to my previous submission #996 (1.1478 sliding) — fully rebuilt around a custom tokenizer + score-first TTT.

| | #996 (previous) | this submission |
|---|---:|---:|
| val_bpb | 1.1478 | **1.1266** |
| Tokenizer | sp1024 (default) | **sp4096 (custom HF)** |
| MLP mult | 3x | **3.5x** |
| Batch | 524K | **786K** |
| Quantization | int6+lzma | **int5+brotli+byte-shuffle** |
| Eval-time TTT | none | **score-first SGD** |
| Artifact | 14.94 MB | 15.99 MB |

### Headline metrics

| Stage | val_bpb | val_loss |
|---|---:|---:|
| Pre-quant (step 5952) | 1.1427 | 2.6289 |
| Post-quant (int6+brotli roundtrip) | 1.1439 | 2.6318 |
| Sliding window (stride=64) | 1.1277 | — |
| **Score-first TTT (final)** | **1.1266** | — |

### Key contributions

**Custom sp4096 SentencePiece tokenizer** — own dataset hosted on HuggingFace (`idan3011/parameter-golf-sp4096`), ~26% fewer tokens/byte than sp1024. Auto-downloads on first run; no setup scripts.

**Mixed quantization scheme**

| Tensor | Bits | Why |
|---|---|---|
| Attention weights | int5 per-row | Stable with GPTQ |
| MLP weights | int5 per-row | Stable with QAT |
| **tok_emb (tied)** | **int8 per-row** | int5 destroys tied embedding (input AND output projection) |
| Control tensors | fp32 passthrough | Small total size, stability-critical |

Quant gap: **0.0012 BPB** (1.1427 → 1.1439).

**brotli + byte-shuffle compression** — byte-shuffle pre-filter groups int8 high/low bytes column-wise, exploiting brotli's context modeling. Saves ~280KB vs LZMA. Final artifact: 15,989,376 bytes (10KB under cap).

**GPTQ with AR self-generated calibration** — model generates its own 16×512 calibration sequences via autoregressive sampling, perfectly matched to its own activation distribution.

**Score-First TTT (legal under #402 / #1017)**

348 chunks of 131K tokens, 20 SGD epochs each, lr=0.003 cosine decay across chunks, grad clip 1.0, all 10 blocks trainable. Distributed scoring + training across 8 GPUs with `dist.all_reduce(grad, AVG)`. Final TTT lift: -0.0011 BPB over sliding baseline.

### Architecture

10L, 512d, 8H/4KV GQA, MLP 3.5x (1792 hidden), tied embeddings, U-Net skip connections, LeakyReLU(0.5)² activation, logit softcap 30, XSA on last 4 layers, 28.3M params.

### Training

786K batch (vs 524K — smoother warmdown), Muon for matrix params, Adam for embeddings, EMA(0.997) + SWA blend in last 50%, wallclock-fraction warmdown (35%), QAT on MLP layers. Pre-quant: **1.1427** at step 5952/20000 (wallclock cap).

### What didn't work

- **`forward_logits()` not compiled by `torch.compile`** — only `__call__`/`forward()` get compiled. CastedLinear's float32→bfloat16 cast in the uncompiled path lost ~0.45 BPB. Fix: route TTT scoring through `model(x)` (compiled) by making `forward()` return logits when `target_ids is None`.
- **AdamW weight_decay in TTT** — pushed weights toward zero, destroyed pre-trained representations. SGD momentum 0.9 worked.
- **Per-layer LR groups (PR #481 recipe)** — AdamW with 3x LR on `mlp.proj` destabilized this model. Got 1.1725 (worse than sliding).
- **Scale-only TTT** (only 30K control params) — gave only -0.0007 BPB. Full block training with low LR worked better.
- **Last-2-blocks TTT** — 1.1272, worse than full-block training.
- **Smaller TTT chunks (32K)** — 4x more steps, 4x more overhead, no quality gain over 131K.
- **Higher LR (0.005, 0.002)** — diminishing returns past lr=0.003.
- **EMA in TTT (decay 0.998)** — dampens adaptation to nothing. Removed.
- **`requires_grad_(False)` on frozen blocks** — corrupts torch.compile guards mid-eval. Removed all requires_grad changes.
- **CROWN-Q** — improved training BPB but destroyed compressibility.
- **More layers (11L/12L/13L)** — exceeds 16MB cap even with int5.

### Reproduce

```bash
pip install -r requirements.txt
torchrun --standalone --nproc_per_node=8 train_gpt.py
```

Every hyperparameter is baked into the script. Data and tokenizer auto-download from HuggingFace on first run. No env vars, no shell scripts.

### Credits

- Muon optimizer — modded-nanogpt baseline (kellerjordan)
- SmearGate  - PR #65
- XSA - arXiv:2603.09078; PR #265
