### PR TITLE
Non-record: Mixed-Int6 LZMA9 B3072 Warm5000

### DIFF
--- a/records/track_non_record_16mb/2026-04-07_MixedInt6_LZMA9_B3072_Warm5000/README.md
+++ b/records/track_non_record_16mb/2026-04-07_MixedInt6_LZMA9_B3072_Warm5000/README.md
@@ -1,0 +1,84 @@
+# Non-Record Submission: 1.20289664 BPB — Mixed-Int6 LZMA9 B3072 Warm5000
+
+**EMA + XSA(last-4) + BigramHash3072 + warmdown5000 + LeakyReLU^2 + mixed-int6 export**
+
+**val_bpb: 1.20289664** (sliding, seed=42) | **15,991,188 bytes** artifact | single-GPU unlimited-compute run (~16.1h)
+
+> **This is a non-record unlimited-compute submission.** Training ran for about 16.1 hours on a single GPU, so this is not a 10-minute leaderboard attempt. The main result is a stronger legal artifact than the listed 4-hour non-record baseline, using a known flat-transformer recipe plus longer single-GPU training and a broad mixed-int6/LZMA9 export path.
+
+## Result
+
+| Metric | Value |
+|--------|-------|
+| Sliding BPB | **1.20289664** |
+| Sliding val_loss | **1.99963255** |
+| Pre-quant sliding BPB | **1.16618894** |
+| Pre-quant sliding val_loss | **1.93861159** |
+| Steps | **16,000** |
+| Training time | **57,979.039s** (~16.1h) |
+| Artifact | **15,991,188 bytes** |
+| Code bytes | **110,016** |
+| Compressed model bytes | **15,881,172** |
+| Parameters | **27,124,828** |
+
+## Positioning
+
+This is **not** claiming a new SOTA technique. EMA, XSA, BigramHash, LeakyReLU^2, int6-style quantization, LZMA compression, and sliding evaluation are all established in prior submissions.
+
+The useful contribution is a non-record data point showing that the flat EMA/XSA/BigramHash family still improves under longer single-GPU training, and that a broad `mlp;attn;embed` mixed-int6 export with LZMA9 can keep the resulting 27.1M-parameter checkpoint legal under the 16MB artifact cap.
+
+| Reference | BPB | Notes |
+|-----------|----:|-------|
+| This submission | **1.20289664** | 16.1h single-GPU, non-record, 15,991,188 bytes |
+| 4-hour non-record baseline | 1.20737944 | Listed unlimited-compute baseline |
+| 1-bit non-record | 1.1239 | Stronger non-record result; this submission does not beat it |
+| Current 10-minute record | 1.11473509 | Stronger 10-minute SOTA; this submission is not a record attempt |
+
+## What Changed
+
+- **Longer training on the flat stack:** `BIGRAM_VOCAB_SIZE=3072`, XSA on the last 4 layers, EMA, LeakyReLU^2, and `WARMDOWN_ITERS=5000` produced a raw sliding score of **1.16618894 BPB** before legal export.
+- **Broad mixed-int6 export:** `QUANT_INT6_CATS=mlp;attn;embed`, `INT8_KEEP_FLOAT_MAX_NUMEL=32768`, and LZMA9 extreme compression produced a legal artifact at **15,991,188 bytes**.
+- **Export separation:** the raw checkpoint was preserved, then re-exported and evaluated independently. The export found **3,894,003** candidate `+-1` int6 entries, but the compressed artifact already fit the target byte cap, so no entries had to be pruned.
+
+## Training Configuration
+
+- 8 FineWeb SP1024 training shards
+- EMA enabled, decay `0.997`
+- XSA active on the last 4 layers
+- BigramHash `3072 x 128`
+- `leaky_relu2` activation with slope `0.5`
+- `TRAIN_BATCH_TOKENS=262144`
+- `TRAIN_SEQ_LEN=2048`
+- `ITERATIONS=16000`
+- `WARMDOWN_ITERS=5000`
+- `MAX_WALLCLOCK_SECONDS=64800`
+
+The exact training log is included in [train.log](./train.log).
+
+## Export Configuration
+
+- Eval-only export from the preserved raw checkpoint
+- `QUANT_SCHEME=mixed_int6`
+- `QUANT_INT6_CATS=mlp;attn;embed`
+- `INT8_KEEP_FLOAT_MAX_NUMEL=32768`
+- `QUANT_SELECTIVE_PRUNE=1`
+- `QUANT_TARGET_TOTAL_BYTES=16000000`
+- `QUANT_LZMA_PRESET=9`
+- `QUANT_LZMA_EXTREME=1`
+
+The exact export/eval log is included in [export_eval.log](./export_eval.log).
+
+## Files
+
+- `train_gpt.py`: exact script for this submission branch
+- `requirements.txt`: environment reference
+- `train.log`: training log
+- `export_eval.log`: export and final eval log
+
+## Compliance
+
+- [x] Artifact <= 16,000,000 bytes
+- [x] No test-time training on validation data
+- [x] No network calls during evaluation
+- [x] Self-contained script included
+- [x] Non-record unlimited-compute track

--- a/records/track_non_record_16mb/2026-04-07_MixedInt6_LZMA9_B3072_Warm5000/export_eval.log
+++ b/records/track_non_record_16mb/2026-04-07_MixedInt6_LZMA9_B3072_Warm5000/export_eval.log
@@ -1,0 +1,46 @@
+Starting run at 2026-04-07 07:12:18 UTC
+Run: exp8855_mi6_mae_k32_pr_lz9e_9336
+NPROC: 1
+MLP activation: leaky_relu2
+MLP leaky slope: 0.5
+MLP prelu init: 0.25
+MLP softplus beta: 1.0
+TTT optimizer: sgd
+TTT epoch schedule: fixed
+TTT chunk schedule: fixed
+TTT batch seqs: 32
+logs/exp8855_mi6_mae_k32_pr_lz9e_9336.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:8
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:131072 limited=1
+attention_backend:requested=sdpa flash_attn_available=0 compile_enabled=0 cuda_dtype=float16
+eval_only_checkpoint:<raw_checkpoint>/long16h_ema_b3072_warm5000_8855.final_model_raw.pt
+averaging_config ema_enabled=0 ema_decay=0.997 swa_enabled=0 swa_every=50 lawa_enabled=0 save_raw_checkpoint=0
+activation_config mlp_activation=leaky_relu2 mlp_leaky_slope=0.5 mlp_prelu_init=0.25 mlp_softplus_beta=1.0
+quant_config scheme=mixed_int6 int6_cats=mlp;attn;embed keep_float_max_numel=32768 keep_float16=none force_float16=none lzma_preset=9 extreme=1 selective_prune=1 target_total_bytes=16000000
+model_params:27124828
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_4 active_layers:[7, 8, 9, 10]
+world_size:1 grad_accum_steps:8
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:262144 train_seq_len:2048 iterations:300 warmup_steps:0 max_wallclock_seconds:1800.000
+seed:42
+step:300/300 val_loss:2.0278 val_bpb:1.2163 train_time:0ms step_avg:0.00ms
+peak memory allocated: 170 MiB reserved: 192 MiB
+DIAGNOSTIC pre_avg val_loss:2.0278 val_bpb:1.2163 eval_time:1912ms
+averaging:using raw training weights
+DIAGNOSTIC post_ema val_loss:2.0278 val_bpb:1.2163 eval_time:1914ms
+Serialized model: 106420662 bytes
+Code size: 110016 bytes
+selective_prune: 3894003 ±1 candidates unpruned=15991188 target=16000000
+selective_prune: already fits target
+Serialized model int6+lzma: 15881172 bytes
+Total submission size int6+lzma: 15991188 bytes
+final_int6_roundtrip val_loss:2.0361 val_bpb:1.2213 eval_time:1923ms
+final_int6_roundtrip_exact val_loss:2.03610863 val_bpb:1.22128751
+final_int6_sliding_window val_loss:1.9996 val_bpb:1.2029 stride:64 eval_time:52209ms
+final_int6_sliding_window_exact val_loss:1.99963255 val_bpb:1.20289664
+final_int8_zlib_roundtrip_exact val_loss:1.99963255 val_bpb:1.20289664
+Finished run at 2026-04-07 07:14:15 UTC

--- a/records/track_non_record_16mb/2026-04-07_MixedInt6_LZMA9_B3072_Warm5000/requirements.txt
+++ b/records/track_non_record_16mb/2026-04-07_MixedInt6_LZMA9_B3072_Warm5000/requirements.txt
@@ -1,0 +1,10 @@
+numpy
+tqdm
+torch
+huggingface-hub
+kernels
+setuptools
+typing-extensions==4.15.0
+datasets
+tiktoken
+sentencepiece

--- a/records/track_non_record_16mb/2026-04-07_MixedInt6_LZMA9_B3072_Warm5000/submission.json
+++ b/records/track_non_record_16mb/2026-04-07_MixedInt6_LZMA9_B3072_Warm5000/submission.json
@@ -1,0 +1,22 @@
+{
+  "author": "Ayman Abdul-Majid",
+  "github_id": "sabdulmajid",
+  "name": "Mixed-Int6 LZMA9 B3072 Warm5000",
+  "blurb": "Unlimited-compute non-record submission: a 16k-step EMA + XSA(last-4) + BigramHash3072 SP1024 run with longer warmdown, exported legally with mixed-int6 over mlp/attn/embed plus LZMA9 extreme compression. Pre-quant sliding BPB 1.1662, final legal artifact 1.20289664 at 15,991,188 bytes.",
+  "date": "2026-04-07T07:14:15Z",
+  "track": "non-record-unlimited-compute-16mb",
+  "val_loss": 1.99963255,
+  "val_bpb": 1.20289664,
+  "pre_quant_val_loss": 1.93861159,
+  "pre_quant_val_bpb": 1.16618894,
+  "step_stop": 16000,
+  "wallclock_seconds": 57979.039,
+  "bytes_total": 15991188,
+  "bytes_model_int6_lzma": 15881172,
+  "bytes_code": 110016,
+  "hardware": "single-GPU training and single-GPU export/eval",
+  "quant_scheme": "mixed_int6",
+  "quant_int6_cats": "mlp;attn;embed",
+  "quant_lzma_preset": 9,
+  "quant_lzma_extreme": true
+}

--- a/records/track_non_record_16mb/2026-04-07_MixedInt6_LZMA9_B3072_Warm5000/train.log
+++ b/records/track_non_record_16mb/2026-04-07_MixedInt6_LZMA9_B3072_Warm5000/train.log
@@ -1,0 +1,246 @@
+Starting run at 2026-04-06 03:43:10 UTC
+Run: long16h_ema_b3072_warm5000_8855
+NPROC: 1
+MLP activation: leaky_relu2
+MLP leaky slope: 0.5
+MLP prelu init: 0.25
+MLP softplus beta: 1.0
+TTT optimizer: sgd
+TTT epoch schedule: fixed
+TTT chunk schedule: fixed
+TTT batch seqs: 32
+logs/long16h_ema_b3072_warm5000_8855.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:8
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:131072 limited=1
+attention_backend:requested=sdpa flash_attn_available=0 compile_enabled=0 cuda_dtype=bfloat16
+averaging_config ema_enabled=1 ema_decay=0.997 swa_enabled=0 swa_every=50 lawa_enabled=0 save_raw_checkpoint=1
+activation_config mlp_activation=leaky_relu2 mlp_leaky_slope=0.5 mlp_prelu_init=0.25 mlp_softplus_beta=1.0
+quant_config scheme=int8 int6_cats=mlp,attn keep_float_max_numel=131072 keep_float16=none force_float16=tok_emb.weight,bigram.embed.weight lzma_preset=6 extreme=0
+model_params:27124828
+mtp_num_heads:0 mtp_loss_weight:0.2 mtp_params:0
+XSA:last_4 active_layers:[7, 8, 9, 10]
+world_size:1 grad_accum_steps:8
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.035 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.025
+train_batch_tokens:262144 train_seq_len:2048 iterations:16000 warmup_steps:0 max_wallclock_seconds:64800.000
+seed:42
+step:0/16000 val_loss:6.9282 val_bpb:4.1556 train_time:0ms step_avg:0.01ms
+step:1/16000 train_loss:6.9301 train_time:3546ms step_avg:3546.36ms
+step:2/16000 train_loss:8.8164 train_time:7131ms step_avg:3565.66ms
+step:3/16000 train_loss:7.8785 train_time:10729ms step_avg:3576.37ms
+step:4/16000 train_loss:7.1950 train_time:14330ms step_avg:3582.39ms
+step:5/16000 train_loss:7.1299 train_time:17934ms step_avg:3586.81ms
+step:6/16000 train_loss:7.1287 train_time:21541ms step_avg:3590.14ms
+step:7/16000 train_loss:7.1272 train_time:25149ms step_avg:3592.69ms
+step:8/16000 train_loss:6.9726 train_time:28761ms step_avg:3595.16ms
+step:9/16000 train_loss:6.6336 train_time:32367ms step_avg:3596.30ms
+step:10/16000 train_loss:6.3252 train_time:35982ms step_avg:3598.20ms
+step:100/16000 train_loss:3.3141 train_time:362013ms step_avg:3620.13ms
+step:200/16000 train_loss:2.8292 train_time:724195ms step_avg:3620.98ms
+step:300/16000 train_loss:2.6843 train_time:1086316ms step_avg:3621.05ms
+step:400/16000 train_loss:2.4803 train_time:1448362ms step_avg:3620.90ms
+step:500/16000 train_loss:2.5013 train_time:1810305ms step_avg:3620.61ms
+step:500/16000 val_loss:2.4800 val_bpb:1.4875 train_time:1810328ms step_avg:3620.66ms
+step:600/16000 train_loss:2.4350 train_time:2172288ms step_avg:3620.48ms
+step:700/16000 train_loss:2.3972 train_time:2534250ms step_avg:3620.36ms
+step:800/16000 train_loss:2.2121 train_time:2896264ms step_avg:3620.33ms
+step:900/16000 train_loss:2.3405 train_time:3258252ms step_avg:3620.28ms
+step:1000/16000 train_loss:2.3183 train_time:3620276ms step_avg:3620.28ms
+step:1000/16000 val_loss:2.3480 val_bpb:1.4083 train_time:3620299ms step_avg:3620.30ms
+step:1100/16000 train_loss:2.2538 train_time:3982281ms step_avg:3620.26ms
+step:1200/16000 train_loss:2.4109 train_time:4344345ms step_avg:3620.29ms
+step:1300/16000 train_loss:2.1919 train_time:4706445ms step_avg:3620.34ms
+step:1400/16000 train_loss:2.3726 train_time:5068577ms step_avg:3620.41ms
+step:1500/16000 train_loss:2.2834 train_time:5430696ms step_avg:3620.46ms
+step:1500/16000 val_loss:2.3052 val_bpb:1.3827 train_time:5430719ms step_avg:3620.48ms
+step:1600/16000 train_loss:2.2599 train_time:5792876ms step_avg:3620.55ms
+step:1700/16000 train_loss:2.3510 train_time:6155042ms step_avg:3620.61ms
+step:1800/16000 train_loss:2.2956 train_time:6517215ms step_avg:3620.68ms
+step:1900/16000 train_loss:2.2770 train_time:6879341ms step_avg:3620.71ms
+step:2000/16000 train_loss:2.2935 train_time:7241582ms step_avg:3620.79ms
+step:2000/16000 val_loss:2.2486 val_bpb:1.3488 train_time:7241605ms step_avg:3620.80ms
+step:2100/16000 train_loss:2.2730 train_time:7603870ms step_avg:3620.89ms
+step:2200/16000 train_loss:2.2054 train_time:7966152ms step_avg:3620.98ms
+step:2300/16000 train_loss:2.2260 train_time:8328378ms step_avg:3621.03ms
+step:2400/16000 train_loss:2.1961 train_time:8690514ms step_avg:3621.05ms
+step:2500/16000 train_loss:2.1944 train_time:9052677ms step_avg:3621.07ms
+step:2500/16000 val_loss:2.2130 val_bpb:1.3274 train_time:9052701ms step_avg:3621.08ms
+step:2600/16000 train_loss:2.2185 train_time:9414779ms step_avg:3621.07ms
+step:2700/16000 train_loss:2.1564 train_time:9776922ms step_avg:3621.08ms
+step:2800/16000 train_loss:2.2177 train_time:10139090ms step_avg:3621.10ms
+step:2900/16000 train_loss:2.2218 train_time:10501332ms step_avg:3621.15ms
+step:3000/16000 train_loss:2.2147 train_time:10863520ms step_avg:3621.17ms
+step:3000/16000 val_loss:2.2012 val_bpb:1.3203 train_time:10863543ms step_avg:3621.18ms
+step:3100/16000 train_loss:2.2424 train_time:11225794ms step_avg:3621.22ms
+step:3200/16000 train_loss:2.2288 train_time:11587953ms step_avg:3621.24ms
+step:3300/16000 train_loss:2.1330 train_time:11950193ms step_avg:3621.27ms
+step:3400/16000 train_loss:2.2260 train_time:12312402ms step_avg:3621.29ms
+step:3500/16000 train_loss:2.2009 train_time:12674650ms step_avg:3621.33ms
+step:3500/16000 val_loss:2.1832 val_bpb:1.3095 train_time:12674673ms step_avg:3621.34ms
+step:3600/16000 train_loss:2.1905 train_time:13036856ms step_avg:3621.35ms
+step:3700/16000 train_loss:2.2049 train_time:13399053ms step_avg:3621.37ms
+step:3800/16000 train_loss:2.3168 train_time:13761286ms step_avg:3621.39ms
+step:3900/16000 train_loss:2.1196 train_time:14123622ms step_avg:3621.44ms
+step:4000/16000 train_loss:2.1790 train_time:14485799ms step_avg:3621.45ms
+step:4000/16000 val_loss:2.1804 val_bpb:1.3078 train_time:14485826ms step_avg:3621.46ms
+step:4100/16000 train_loss:2.2463 train_time:14848029ms step_avg:3621.47ms
+step:4200/16000 train_loss:2.1080 train_time:15210283ms step_avg:3621.50ms
+step:4300/16000 train_loss:2.2340 train_time:15572540ms step_avg:3621.52ms
+step:4400/16000 train_loss:2.0502 train_time:15934793ms step_avg:3621.54ms
+step:4500/16000 train_loss:2.1832 train_time:16297031ms step_avg:3621.56ms
+step:4500/16000 val_loss:2.1749 val_bpb:1.3046 train_time:16297057ms step_avg:3621.57ms
+step:4600/16000 train_loss:2.1878 train_time:16659295ms step_avg:3621.59ms
+step:4700/16000 train_loss:2.2236 train_time:17021530ms step_avg:3621.60ms
+step:4800/16000 train_loss:2.1834 train_time:17383810ms step_avg:3621.63ms
+step:4900/16000 train_loss:2.0373 train_time:17746156ms step_avg:3621.66ms
+step:5000/16000 train_loss:2.0781 train_time:18108515ms step_avg:3621.70ms
+step:5000/16000 val_loss:2.1741 val_bpb:1.3041 train_time:18108538ms step_avg:3621.71ms
+step:5100/16000 train_loss:2.2149 train_time:18470778ms step_avg:3621.72ms
+step:5200/16000 train_loss:2.0602 train_time:18833088ms step_avg:3621.75ms
+step:5300/16000 train_loss:2.1893 train_time:19195393ms step_avg:3621.77ms
+step:5400/16000 train_loss:2.1179 train_time:19557787ms step_avg:3621.81ms
+step:5500/16000 train_loss:2.2033 train_time:19920198ms step_avg:3621.85ms
+step:5500/16000 val_loss:2.1553 val_bpb:1.2928 train_time:19920223ms step_avg:3621.86ms
+step:5600/16000 train_loss:2.1453 train_time:20282649ms step_avg:3621.90ms
+step:5700/16000 train_loss:2.1775 train_time:20645055ms step_avg:3621.94ms
+step:5800/16000 train_loss:2.1293 train_time:21007495ms step_avg:3621.98ms
+step:5900/16000 train_loss:2.2138 train_time:21369989ms step_avg:3622.03ms
+step:6000/16000 train_loss:2.1512 train_time:21732436ms step_avg:3622.07ms
+step:6000/16000 val_loss:2.1562 val_bpb:1.2933 train_time:21732452ms step_avg:3622.08ms
+step:6100/16000 train_loss:2.1946 train_time:22094948ms step_avg:3622.12ms
+step:6200/16000 train_loss:2.1895 train_time:22457506ms step_avg:3622.18ms
+step:6300/16000 train_loss:2.1458 train_time:22819949ms step_avg:3622.21ms
+step:6400/16000 train_loss:2.2008 train_time:23182393ms step_avg:3622.25ms
+step:6500/16000 train_loss:2.0182 train_time:23544808ms step_avg:3622.28ms
+step:6500/16000 val_loss:2.1529 val_bpb:1.2914 train_time:23544836ms step_avg:3622.28ms
+step:6600/16000 train_loss:2.1210 train_time:23907190ms step_avg:3622.30ms
+step:6700/16000 train_loss:2.0896 train_time:24269577ms step_avg:3622.32ms
+step:6800/16000 train_loss:2.0871 train_time:24631971ms step_avg:3622.35ms
+step:6900/16000 train_loss:1.9699 train_time:24994393ms step_avg:3622.38ms
+step:7000/16000 train_loss:2.1488 train_time:25357047ms step_avg:3622.44ms
+step:7000/16000 val_loss:2.1470 val_bpb:1.2878 train_time:25357072ms step_avg:3622.44ms
+step:7100/16000 train_loss:2.1759 train_time:25719447ms step_avg:3622.46ms
+step:7200/16000 train_loss:2.1222 train_time:26081858ms step_avg:3622.48ms
+step:7300/16000 train_loss:2.1309 train_time:26444304ms step_avg:3622.51ms
+step:7400/16000 train_loss:2.0264 train_time:26806708ms step_avg:3622.53ms
+step:7500/16000 train_loss:2.2215 train_time:27169028ms step_avg:3622.54ms
+step:7500/16000 val_loss:2.1523 val_bpb:1.2910 train_time:27169056ms step_avg:3622.54ms
+step:7600/16000 train_loss:2.1422 train_time:27531271ms step_avg:3622.54ms
+step:7700/16000 train_loss:2.2013 train_time:27893589ms step_avg:3622.54ms
+step:7800/16000 train_loss:2.0363 train_time:28255898ms step_avg:3622.55ms
+step:7900/16000 train_loss:2.1575 train_time:28618224ms step_avg:3622.56ms
+step:8000/16000 train_loss:2.1722 train_time:28980540ms step_avg:3622.57ms
+step:8000/16000 val_loss:2.1456 val_bpb:1.2870 train_time:28980565ms step_avg:3622.57ms
+step:8100/16000 train_loss:2.1055 train_time:29342880ms step_avg:3622.58ms
+step:8200/16000 train_loss:2.1156 train_time:29705092ms step_avg:3622.57ms
+step:8300/16000 train_loss:2.1197 train_time:30067363ms step_avg:3622.57ms
+step:8400/16000 train_loss:2.1594 train_time:30429734ms step_avg:3622.59ms
+step:8500/16000 train_loss:2.1541 train_time:30792042ms step_avg:3622.59ms
+step:8500/16000 val_loss:2.1409 val_bpb:1.2842 train_time:30792059ms step_avg:3622.60ms
+step:8600/16000 train_loss:2.0434 train_time:31154395ms step_avg:3622.60ms
+step:8700/16000 train_loss:2.2385 train_time:31516738ms step_avg:3622.61ms
+step:8800/16000 train_loss:2.0166 train_time:31879086ms step_avg:3622.62ms
+step:8900/16000 train_loss:2.1942 train_time:32241387ms step_avg:3622.63ms
+step:9000/16000 train_loss:2.0947 train_time:32603693ms step_avg:3622.63ms
+step:9000/16000 val_loss:2.1409 val_bpb:1.2842 train_time:32603719ms step_avg:3622.64ms
+step:9100/16000 train_loss:2.1287 train_time:32965968ms step_avg:3622.63ms
+step:9200/16000 train_loss:2.1498 train_time:33328356ms step_avg:3622.65ms
+step:9300/16000 train_loss:2.2130 train_time:33690668ms step_avg:3622.65ms
+step:9400/16000 train_loss:2.1518 train_time:34052945ms step_avg:3622.65ms
+step:9500/16000 train_loss:2.1641 train_time:34415277ms step_avg:3622.66ms
+step:9500/16000 val_loss:2.1395 val_bpb:1.2833 train_time:34415304ms step_avg:3622.66ms
+step:9600/16000 train_loss:2.1949 train_time:34777658ms step_avg:3622.67ms
+step:9700/16000 train_loss:2.0974 train_time:35140052ms step_avg:3622.69ms
+step:9800/16000 train_loss:2.1194 train_time:35502406ms step_avg:3622.69ms
+step:9900/16000 train_loss:1.9967 train_time:35864759ms step_avg:3622.70ms
+step:10000/16000 train_loss:2.1291 train_time:36227187ms step_avg:3622.72ms
+step:10000/16000 val_loss:2.1341 val_bpb:1.2800 train_time:36227214ms step_avg:3622.72ms
+step:10100/16000 train_loss:2.1239 train_time:36589540ms step_avg:3622.73ms
+step:10200/16000 train_loss:2.2428 train_time:36951975ms step_avg:3622.74ms
+step:10300/16000 train_loss:2.1346 train_time:37314394ms step_avg:3622.76ms
+step:10400/16000 train_loss:2.0151 train_time:37676802ms step_avg:3622.77ms
+step:10500/16000 train_loss:2.0728 train_time:38039214ms step_avg:3622.78ms
+step:10500/16000 val_loss:2.1386 val_bpb:1.2828 train_time:38039237ms step_avg:3622.78ms
+step:10600/16000 train_loss:2.1298 train_time:38401714ms step_avg:3622.80ms
+step:10700/16000 train_loss:2.1135 train_time:38764289ms step_avg:3622.83ms
+step:10800/16000 train_loss:2.2229 train_time:39126851ms step_avg:3622.86ms
+step:10900/16000 train_loss:2.1730 train_time:39489412ms step_avg:3622.88ms
+step:11000/16000 train_loss:2.1728 train_time:39851821ms step_avg:3622.89ms
+step:11000/16000 val_loss:2.1358 val_bpb:1.2811 train_time:39851847ms step_avg:3622.90ms
+step:11100/16000 train_loss:2.1210 train_time:40214302ms step_avg:3622.91ms
+step:11200/16000 train_loss:2.1572 train_time:40576779ms step_avg:3622.93ms
+step:11300/16000 train_loss:1.9967 train_time:40939306ms step_avg:3622.95ms
+step:11400/16000 train_loss:2.1633 train_time:41301854ms step_avg:3622.97ms
+step:11500/16000 train_loss:2.1302 train_time:41664365ms step_avg:3622.99ms
+step:11500/16000 val_loss:2.1329 val_bpb:1.2793 train_time:41664393ms step_avg:3622.99ms
+step:11600/16000 train_loss:2.1068 train_time:42026828ms step_avg:3623.00ms
+step:11700/16000 train_loss:2.1295 train_time:42389385ms step_avg:3623.02ms
+step:11800/16000 train_loss:2.0896 train_time:42751856ms step_avg:3623.04ms
+step:11900/16000 train_loss:2.0955 train_time:43114357ms step_avg:3623.06ms
+step:12000/16000 train_loss:2.1919 train_time:43476920ms step_avg:3623.08ms
+step:12000/16000 val_loss:2.1266 val_bpb:1.2756 train_time:43476948ms step_avg:3623.08ms
+step:12100/16000 train_loss:2.1204 train_time:43839464ms step_avg:3623.10ms
+step:12200/16000 train_loss:2.1098 train_time:44201886ms step_avg:3623.11ms
+step:12300/16000 train_loss:2.2066 train_time:44564355ms step_avg:3623.12ms
+step:12400/16000 train_loss:2.1709 train_time:44926967ms step_avg:3623.14ms
+step:12500/16000 train_loss:2.1472 train_time:45289582ms step_avg:3623.17ms
+step:12500/16000 val_loss:2.1296 val_bpb:1.2773 train_time:45289606ms step_avg:3623.17ms
+step:12600/16000 train_loss:2.1246 train_time:45652260ms step_avg:3623.20ms
+step:12700/16000 train_loss:2.1512 train_time:46014888ms step_avg:3623.22ms
+step:12800/16000 train_loss:2.1392 train_time:46377471ms step_avg:3623.24ms
+step:12900/16000 train_loss:2.1101 train_time:46740067ms step_avg:3623.26ms
+step:13000/16000 train_loss:2.0937 train_time:47102647ms step_avg:3623.28ms
+step:13000/16000 val_loss:2.1262 val_bpb:1.2753 train_time:47102674ms step_avg:3623.28ms
+step:13100/16000 train_loss:2.1602 train_time:47465184ms step_avg:3623.30ms
+step:13200/16000 train_loss:2.4506 train_time:47827796ms step_avg:3623.32ms
+step:13300/16000 train_loss:2.0379 train_time:48190420ms step_avg:3623.34ms
+step:13400/16000 train_loss:1.9676 train_time:48553068ms step_avg:3623.36ms
+step:13500/16000 train_loss:2.1190 train_time:48915603ms step_avg:3623.38ms
+step:13500/16000 val_loss:2.1162 val_bpb:1.2693 train_time:48915625ms step_avg:3623.38ms
+step:13600/16000 train_loss:2.0750 train_time:49278245ms step_avg:3623.40ms
+step:13700/16000 train_loss:2.0659 train_time:49640798ms step_avg:3623.42ms
+step:13800/16000 train_loss:2.0689 train_time:50003407ms step_avg:3623.44ms
+step:13900/16000 train_loss:2.0308 train_time:50365933ms step_avg:3623.45ms
+step:14000/16000 train_loss:2.1101 train_time:50728452ms step_avg:3623.46ms
+step:14000/16000 val_loss:2.0997 val_bpb:1.2595 train_time:50728479ms step_avg:3623.46ms
+step:14100/16000 train_loss:2.0301 train_time:51090983ms step_avg:3623.47ms
+step:14200/16000 train_loss:2.0424 train_time:51453602ms step_avg:3623.49ms
+step:14300/16000 train_loss:2.0654 train_time:51816067ms step_avg:3623.50ms
+step:14400/16000 train_loss:2.1230 train_time:52178552ms step_avg:3623.51ms
+step:14500/16000 train_loss:2.0031 train_time:52541097ms step_avg:3623.52ms
+step:14500/16000 val_loss:2.0920 val_bpb:1.2548 train_time:52541121ms step_avg:3623.53ms
+step:14600/16000 train_loss:2.0727 train_time:52903536ms step_avg:3623.53ms
+step:14700/16000 train_loss:2.0097 train_time:53266067ms step_avg:3623.54ms
+step:14800/16000 train_loss:2.0851 train_time:53628638ms step_avg:3623.56ms
+step:14900/16000 train_loss:1.9299 train_time:53991243ms step_avg:3623.57ms
+step:15000/16000 train_loss:2.1037 train_time:54353757ms step_avg:3623.58ms
+step:15000/16000 val_loss:2.0648 val_bpb:1.2385 train_time:54353780ms step_avg:3623.59ms
+step:15100/16000 train_loss:2.0905 train_time:54716241ms step_avg:3623.59ms
+step:15200/16000 train_loss:2.0898 train_time:55078780ms step_avg:3623.60ms
+step:15300/16000 train_loss:2.0450 train_time:55441421ms step_avg:3623.62ms
+step:15400/16000 train_loss:2.1285 train_time:55803919ms step_avg:3623.63ms
+step:15500/16000 train_loss:2.0488 train_time:56166440ms step_avg:3623.64ms
+step:15500/16000 val_loss:2.0520 val_bpb:1.2308 train_time:56166467ms step_avg:3623.64ms
+step:15600/16000 train_loss:1.9880 train_time:56529006ms step_avg:3623.65ms
+step:15700/16000 train_loss:1.9800 train_time:56891610ms step_avg:3623.67ms
+step:15800/16000 train_loss:2.0458 train_time:57254068ms step_avg:3623.68ms
+step:15900/16000 train_loss:2.0481 train_time:57616584ms step_avg:3623.68ms
+step:16000/16000 train_loss:1.9252 train_time:57979016ms step_avg:3623.69ms
+step:16000/16000 val_loss:2.0289 val_bpb:1.2169 train_time:57979039ms step_avg:3623.69ms
+peak memory allocated: 11703 MiB reserved: 12288 MiB
+Serialized raw model: 106420090 bytes
+DIAGNOSTIC pre_avg val_loss:2.0289 val_bpb:1.2169 eval_time:551ms
+ema:applying EMA weights
+DIAGNOSTIC post_ema val_loss:1.9740 val_bpb:1.1841 eval_time:552ms
+Serialized model: 106420662 bytes
+Code size: 106299 bytes
+Serialized model int6+lzma: 25755520 bytes
+Total submission size int6+lzma: 25861819 bytes
+final_int6_roundtrip val_loss:1.9743 val_bpb:1.1842 eval_time:545ms
+final_int6_roundtrip_exact val_loss:1.97428373 val_bpb:1.18420404
+final_int6_sliding_window val_loss:1.9386 val_bpb:1.1662 stride:64 eval_time:17246ms
+final_int6_sliding_window_exact val_loss:1.93861159 val_bpb:1.16618894
+final_int8_zlib_roundtrip_exact val_loss:1.93861159 val_bpb:1.16618894
+Finished run at 2026-04-06 19:50:26 UTC

--- a/records/track_non_record_16mb/2026-04-07_MixedInt6_LZMA9_B3072_Warm5000/train_gpt.py
+++ b/records/track_non_record_16mb/2026-04-07_MixedInt6_LZMA9_B3072_Warm5000/train_gpt.py
@@ -1,0 +1,2371 @@
+from __future__ import annotations
+import bisect
+import copy
+import glob
+import io
+import lzma
+import math
+import os
+import random
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+try:
+    from flash_attn_interface import flash_attn_func as flash_attn_3_func
+except ImportError:
+    flash_attn_3_func = None
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_max_tokens = int(os.environ.get("VAL_MAX_TOKENS", 0))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    eval_only_checkpoint = os.environ.get("EVAL_ONLY_CHECKPOINT", "")
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3500))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 3.0))
+    mlp_activation = os.environ.get("MLP_ACTIVATION", "leaky_relu2").lower()
+    mlp_leaky_slope = float(os.environ.get("MLP_LEAKY_SLOPE", 0.5))
+    mlp_prelu_init = float(os.environ.get("MLP_PRELU_INIT", 0.25))
+    mlp_softplus_beta = float(os.environ.get("MLP_SOFTPLUS_BETA", 1.0))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.035))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.025))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.025))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    eval_sliding_batch_seqs = int(os.environ.get("EVAL_SLIDING_BATCH_SEQS", 32))
+    compile_enabled = bool(int(os.environ.get("COMPILE_ENABLED", "1")))
+    mtp_num_heads = int(os.environ.get("MTP_NUM_HEADS", 0))
+    mtp_loss_weight = float(os.environ.get("MTP_LOSS_WEIGHT", 0.2))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    ema_enabled = bool(int(os.environ.get("EMA_ENABLED", "0")))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+    lawa_enabled = bool(int(os.environ.get("LAWA_ENABLED", "0")))
+    lawa_k = int(os.environ.get("LAWA_K", 10))
+    lawa_freq = int(os.environ.get("LAWA_FREQ", 100))
+    save_raw_checkpoint = bool(int(os.environ.get("SAVE_RAW_CHECKPOINT", "1")))
+    quant_scheme = os.environ.get("QUANT_SCHEME", "mixed_int6").lower()
+    quant_int6_cats = os.environ.get("QUANT_INT6_CATS", "mlp,attn")
+    muon_wd = float(os.environ.get("MUON_WD", 0.04))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.04))
+    qat_enabled = bool(int(os.environ.get("QAT_ENABLED", "0")))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 2048))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 4))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    dtg_enabled = bool(int(os.environ.get("DTG_ENABLED", "0")))
+    late_qat_threshold = float(os.environ.get("LATE_QAT_THRESHOLD", 0.15))
+    ve_enabled = bool(int(os.environ.get("VE_ENABLED", "1")))
+    ve_dim = int(os.environ.get("VE_DIM", 128))
+    ve_layers = os.environ.get("VE_LAYERS", "9,10")
+    gated_attention = bool(int(os.environ.get("GATED_ATTENTION", "0")))
+    value_residual = bool(int(os.environ.get("VALUE_RESIDUAL", "0")))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.002))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 3))
+    ttt_chunk_tokens = int(os.environ.get("TTT_CHUNK_TOKENS", 32768))
+    ttt_freeze_blocks = int(os.environ.get("TTT_FREEZE_BLOCKS", 2))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+    ttt_optimizer = os.environ.get("TTT_OPTIMIZER", "sgd").lower()
+    ttt_beta1 = float(os.environ.get("TTT_BETA1", 0.9))
+    ttt_beta2 = float(os.environ.get("TTT_BETA2", 0.95))
+    ttt_eps = float(os.environ.get("TTT_EPS", 1e-8))
+    ttt_weight_decay = float(os.environ.get("TTT_WEIGHT_DECAY", 0.0))
+    ttt_reset_opt_state = bool(int(os.environ.get("TTT_RESET_OPT_STATE", "0")))
+    ttt_epoch_schedule = os.environ.get("TTT_EPOCH_SCHEDULE", "")
+    ttt_chunk_schedule = os.environ.get("TTT_CHUNK_SCHEDULE", "")
+    ttt_batch_seqs = int(os.environ.get("TTT_BATCH_SEQS", 32))
+    ttt_grad_clip = float(os.environ.get("TTT_GRAD_CLIP", 1.0))
+    attention_backend = os.environ.get("ATTN_BACKEND", "auto").lower()
+    cuda_dtype = os.environ.get("CUDA_DTYPE", "bfloat16").lower()
+
+
+def resolve_cuda_dtype(name: str) -> torch.dtype:
+    normalized = name.lower()
+    if normalized in {"bfloat16", "bf16"}:
+        return torch.bfloat16
+    if normalized in {"float16", "fp16", "half"}:
+        return torch.float16
+    raise ValueError(f"Unsupported CUDA_DTYPE={name!r}")
+
+
+CUDA_DTYPE = resolve_cuda_dtype(Hyperparameters.cuda_dtype)
+QUANT_LZMA_PRESET = int(os.environ.get("QUANT_LZMA_PRESET", 6))
+QUANT_LZMA_EXTREME = bool(int(os.environ.get("QUANT_LZMA_EXTREME", "0")))
+QUANT_SELECTIVE_PRUNE = bool(int(os.environ.get("QUANT_SELECTIVE_PRUNE", "0")))
+QUANT_TARGET_TOTAL_BYTES = int(os.environ.get("QUANT_TARGET_TOTAL_BYTES", "0"))
+
+# --- Batched Newton-Schulz orthogonalization ---
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 5, eps: float = 1e-7) -> Tensor:
+    """Batched Newton-Schulz orthogonalization. G: (B,M,N) or (M,N)."""
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+# --- Parallel Muon optimizer ---
+
+class Muon(torch.optim.Optimizer):
+    """Parallel Muon: post-backward reduce-scatter -> local NS5 -> all-gather.
+
+    No DDP for bank params. After backward, this optimizer:
+    1. Launches async reduce-scatter for all banks (biggest first)
+    2. Returns control so Adam can step on small params while RS is in-flight
+    3. Waits for each RS, runs local NS5 on the shard, launches async all-gather
+    4. Each all-gather overlaps with next bank's NS5
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append({
+                    'p': p,
+                    'B': B,
+                    'padded_grad': torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'shard': torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'shard_mom': torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'full_update': torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    'scale': max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                })
+        # Sort by size descending -- launch biggest reduce-scatters first
+        self._bank_meta.sort(key=lambda m: -m['p'].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        """Phase 1: launch async reduce-scatter for all banks. Call right after backward."""
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m['p']
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m['padded_grad']
+            pg[:m['B']].copy_(p.grad.bfloat16())
+            if pg.shape[0] > m['B']:
+                pg[m['B']:].zero_()
+            fut = dist.reduce_scatter_tensor(m['shard'], pg, op=dist.ReduceOp.AVG, async_op=True)
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        """Phase 3: wait for RS, local NS5, all-gather. Call AFTER Adam steps."""
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        if not self._built:
+            self._build()
+
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+
+            prev_ag_handle = None
+            prev_m = None
+
+            sharded = self._distributed and hasattr(self, '_rs_futures')
+
+            for i, m in enumerate(self._bank_meta):
+                p = m['p']
+                if p.grad is None:
+                    continue
+
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m['p']
+                    upd = prev_m['full_update'][:prev_m['B']]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m['scale'])
+
+                if sharded and self._rs_futures[i] is not None:
+                    self._rs_futures[i].wait()
+                    g = m['shard']
+                    buf = m['shard_mom']
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m['full_update'], update, async_op=True)
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update.to(dtype=p.dtype), alpha=-lr * m['scale'])
+
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m['p']
+                upd = prev_m['full_update'][:prev_m['B']]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m['scale'])
+
+            if hasattr(self, '_rs_futures'):
+                del self._rs_futures
+
+        return loss
+
+# --- Tokenizer evaluation helpers ---
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    seq_len = eval_seq_len or args.train_seq_len
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=CUDA_DTYPE, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+def parse_ttt_schedule(spec: str, cast, name: str) -> list[tuple[float, int]]:
+    schedule: list[tuple[float, int]] = []
+    if not spec:
+        return schedule
+    for item in spec.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        if ":" not in item:
+            raise ValueError(f"{name} entries must look like FRACTION:VALUE, got {item!r}")
+        frac_s, value_s = item.split(":", 1)
+        frac = float(frac_s)
+        if not (0.0 < frac <= 1.0):
+            raise ValueError(f"{name} fractions must satisfy 0 < frac <= 1, got {frac}")
+        schedule.append((frac, cast(value_s)))
+    schedule.sort(key=lambda x: x[0])
+    return schedule
+
+
+def ttt_scheduled_value(progress: float, schedule: list[tuple[float, int]], default: int) -> int:
+    if not schedule:
+        return default
+    for cutoff, value in schedule:
+        if progress <= cutoff:
+            return value
+    return schedule[-1][1]
+
+
+def build_ttt_chunk_ranges(
+    total_tokens: int,
+    default_chunk_tokens: int,
+    chunk_schedule: list[tuple[float, int]],
+) -> list[tuple[int, int]]:
+    if default_chunk_tokens <= 0:
+        raise ValueError(f"TTT_CHUNK_TOKENS must be positive, got {default_chunk_tokens}")
+    ranges: list[tuple[int, int]] = []
+    start = 0
+    total_tokens_f = float(max(total_tokens, 1))
+    while start < total_tokens:
+        progress = start / total_tokens_f
+        chunk_tokens = int(ttt_scheduled_value(progress, chunk_schedule, default_chunk_tokens))
+        if chunk_tokens <= 0:
+            raise ValueError(f"TTT chunk schedule produced non-positive chunk size: {chunk_tokens}")
+        end = min(start + chunk_tokens, total_tokens)
+        if end <= start:
+            raise RuntimeError("TTT chunk construction failed to make progress")
+        ranges.append((start, end))
+        start = end
+    return ranges
+
+
+def build_ttt_optimizer(args: Hyperparameters, params: list[Tensor]) -> torch.optim.Optimizer:
+    opt_name = args.ttt_optimizer
+    if opt_name == "sgd":
+        return torch.optim.SGD(
+            params,
+            lr=args.ttt_lr,
+            momentum=args.ttt_momentum,
+            weight_decay=args.ttt_weight_decay,
+        )
+    if opt_name == "adam":
+        return torch.optim.Adam(
+            params,
+            lr=args.ttt_lr,
+            betas=(args.ttt_beta1, args.ttt_beta2),
+            eps=args.ttt_eps,
+            weight_decay=args.ttt_weight_decay,
+        )
+    if opt_name == "adamw":
+        return torch.optim.AdamW(
+            params,
+            lr=args.ttt_lr,
+            betas=(args.ttt_beta1, args.ttt_beta2),
+            eps=args.ttt_eps,
+            weight_decay=args.ttt_weight_decay,
+        )
+    raise ValueError(f"Unsupported TTT_OPTIMIZER={opt_name!r}")
+
+# --- Quantization helpers ---
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,dtg_gate,ve_layer_scales,ve_shared.scale,attn_gate,vr_lambda",
+    ).split(",")
+    if pattern
+)
+def parse_name_patterns(raw: str) -> tuple[str, ...]:
+    normalized = raw.replace(";", ",").replace(":", ",")
+    return tuple(pattern for pattern in normalized.split(",") if pattern)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in parse_name_patterns(
+        os.environ.get(
+            "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+            ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+        )
+    )
+    if pattern
+)
+INT8_KEEP_FLOAT16_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in parse_name_patterns(os.environ.get("INT8_KEEP_FLOAT16_NAME_PATTERNS", ""))
+    if pattern
+)
+INT8_FORCE_FLOAT16_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in parse_name_patterns(os.environ.get("INT8_FORCE_FLOAT16_NAME_PATTERNS", ""))
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = int(os.environ.get("INT8_KEEP_FLOAT_MAX_NUMEL", 65_536))
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+def has_name_pattern(name: str, patterns: tuple[str, ...]) -> bool:
+    return any(pattern in name for pattern in patterns)
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if has_name_pattern(name, INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if has_name_pattern(name, INT8_KEEP_FLOAT16_NAME_PATTERNS):
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+        if has_name_pattern(name, INT8_FORCE_FLOAT16_NAME_PATTERNS):
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+# --- Data loading ---
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# --- Transformer modules ---
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                scale = (row_max / 31.0).clamp_min(1.0 / 31.0)
+                w_q = (torch.clamp(torch.round(w32 / scale[:, None]), -32, 31) * scale[:, None]).to(x.dtype)
+            w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024, rope_dims: int = 0):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / (base ** (torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (rd / (rd - 2)))
+                inv_freq = 1.0 / (new_base ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd))
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int = 0) -> Tensor:
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+def resolve_attention_backend(preference: str, device: torch.device) -> str:
+    if preference not in {"auto", "fa3", "sdpa"}:
+        raise ValueError(f"Unsupported ATTN_BACKEND={preference!r}")
+    if preference == "sdpa":
+        return "sdpa"
+    if preference == "fa3":
+        if flash_attn_3_func is None:
+            raise RuntimeError("ATTN_BACKEND=fa3 requested but flash_attn_interface is unavailable")
+        return "fa3"
+    if flash_attn_3_func is not None and device.type == "cuda":
+        major, _minor = torch.cuda.get_device_capability(device)
+        if major >= 9:
+            return "fa3"
+    return "sdpa"
+
+
+def causal_attention(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    backend_pref: str,
+) -> Tensor:
+    backend = resolve_attention_backend(backend_pref, q.device)
+    if backend == "fa3":
+        return flash_attn_3_func(q, k, v, causal=True)
+    y = F.scaled_dot_product_attention(
+        q.transpose(1, 2),
+        k.transpose(1, 2),
+        v.transpose(1, 2),
+        attn_mask=None,
+        is_causal=True,
+        enable_gqa=(num_kv_heads != num_heads),
+    )
+    return y.transpose(1, 2).contiguous()
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        # No CastedLinear -- weights come from banks
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rope_dims = 0  # set by GPT.__init__ for partial RoPE
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False  # set by GPT.__init__ for deep layers only
+        self.attn_backend = os.environ.get("ATTN_BACKEND", "auto").lower()
+        # Gated attention and value residual (non-banked small params)
+        self.gated_attention = gated_attention
+        if gated_attention:
+            self.attn_gate = nn.Linear(dim, num_heads, bias=True)
+            nn.init.zeros_(self.attn_gate.weight)
+            nn.init.constant_(self.attn_gate.bias, 4.0)
+        self.value_residual = value_residual
+        if value_residual:
+            self.vr_lambda = nn.Parameter(torch.tensor([0.5, 0.5], dtype=torch.float32))
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        """Efficient XSA: subtract self-value projection via GQA-aware reshape (no repeat_interleave).
+        y: [B, T, H, D], v: [B, T, Hkv, D]. H must be divisible by Hkv."""
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)        # [B, T, Hkv, group, D]
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)    # [B, T, Hkv, 1, D] -- broadcast ready
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+    def forward(self, x: Tensor, q_w: Tensor, k_w: Tensor, v_w: Tensor, out_w: Tensor, v_embed: Tensor | None = None, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        bsz, seqlen, dim = x.shape
+        q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype))
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        raw_v = v if self.value_residual else None
+        if self.value_residual and v0 is not None:
+            lam = self.vr_lambda.to(dtype=v.dtype)
+            v = lam[0] * v0 + lam[1] * v
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = causal_attention(
+            q,
+            k,
+            v,
+            num_heads=self.num_heads,
+            num_kv_heads=self.num_kv_heads,
+            backend_pref=self.attn_backend,
+        )
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        if self.gated_attention:
+            # gate shape: (bsz, seqlen, num_heads) -> (bsz, seqlen, num_heads, 1) for B,T,H,D layout
+            gate = torch.sigmoid(self.attn_gate(x)).unsqueeze(-1)
+            y = y * gate
+        y = y.reshape(bsz, seqlen, dim)
+        return F.linear(y, out_w.to(x.dtype)), raw_v
+
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = CastedLinear(bigram_dim, model_dim, bias=False) if bigram_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class ValueEmbedding(nn.Module):
+    """Reinject token identity into attention values at specific layers.
+    Each table maps vocab tokens to a low-dim embedding, projected to model_dim."""
+    def __init__(self, vocab_size: int, ve_dim: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, ve_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(ve_dim, model_dim, bias=False) if ve_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(token_ids)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+class MLP(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        mlp_mult: int,
+        activation: str = "leaky_relu2",
+        leaky_slope: float = 0.5,
+        prelu_init: float = 0.25,
+        softplus_beta: float = 1.0,
+    ):
+        super().__init__()
+        # No CastedLinear -- weights come from banks
+        self.activation = activation
+        self.leaky_slope = leaky_slope
+        self.softplus_beta = softplus_beta
+        hidden_dim = int(dim * mlp_mult)
+        if activation == "prelu":
+            self.prelu_weight = nn.Parameter(torch.full((hidden_dim,), prelu_init, dtype=torch.float32))
+        else:
+            self.prelu_weight = None
+
+    def _standardized_leaky_relu(self, x: Tensor) -> Tensor:
+        # Standardize assuming approximately unit-Gaussian pre-activations.
+        a = self.leaky_slope
+        y = F.leaky_relu(x, negative_slope=a)
+        mean = (1.0 - a) / math.sqrt(2.0 * math.pi)
+        var = 0.5 * (1.0 + a * a) - mean * mean
+        return (y - mean) / math.sqrt(var + 1e-6)
+
+    def forward(self, x: Tensor, up_w: Tensor, down_w: Tensor) -> Tensor:
+        x = F.linear(x, up_w.to(x.dtype))
+        if self.activation == "relu2":
+            x = F.relu(x).square()
+        elif self.activation == "leaky_relu2":
+            x = F.leaky_relu(x, negative_slope=self.leaky_slope).square()
+        elif self.activation == "prelu":
+            if self.prelu_weight is None:
+                raise RuntimeError("PReLU weights are missing for prelu activation")
+            alpha = self.prelu_weight.to(dtype=x.dtype)[None, None, :]
+            x = torch.where(x >= 0, x, alpha * x)
+        elif self.activation == "softplus":
+            x = F.softplus(x, beta=self.softplus_beta)
+        elif self.activation == "slrelu":
+            x = self._standardized_leaky_relu(x)
+        else:
+            raise ValueError(f"Unsupported MLP_ACTIVATION={self.activation!r}")
+        return F.linear(x, down_w.to(x.dtype))
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        mlp_activation: str,
+        mlp_leaky_slope: float,
+        mlp_prelu_init: float,
+        mlp_softplus_beta: float,
+        rope_base: float,
+        qk_gain_init: float,
+        layer_idx: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+                                        gated_attention=gated_attention, value_residual=value_residual)
+        self.mlp = MLP(
+            dim,
+            mlp_mult,
+            activation=mlp_activation,
+            leaky_slope=mlp_leaky_slope,
+            prelu_init=mlp_prelu_init,
+            softplus_beta=mlp_softplus_beta,
+        )
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+        if dtg:
+            self.dtg_gate = nn.Linear(dim, 1, bias=True)
+            nn.init.zeros_(self.dtg_gate.weight)
+            nn.init.constant_(self.dtg_gate.bias, 2.0)
+        else:
+            self.dtg_gate = None
+    def forward(self, x: Tensor, x0: Tensor, q_w: Tensor, k_w: Tensor, v_w: Tensor, out_w: Tensor, up_w: Tensor, down_w: Tensor, v_embed: Tensor | None = None, v0: Tensor | None = None) -> tuple[Tensor, Tensor | None]:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out, raw_v = self.attn(self.attn_norm(x_in) * self.ln_scale_factor, q_w, k_w, v_w, out_w, v_embed=v_embed, v0=v0)
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        if self.dtg_gate is not None:
+            gate = torch.sigmoid(self.dtg_gate(x_in.detach()))
+            x_out = x_in + gate * (x_out - x_in)
+        return x_out, raw_v
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        mlp_activation: str = "leaky_relu2",
+        mlp_leaky_slope: float = 0.5,
+        mlp_prelu_init: float = 0.25,
+        mlp_softplus_beta: float = 1.0,
+        mtp_num_heads: int = 0,
+        mtp_loss_weight: float = 0.1,
+        bigram_vocab_size: int = 0,
+        bigram_dim: int = 128,
+        xsa_last_n: int = 0,
+        rope_dims: int = 0,
+        ln_scale: bool = False,
+        dtg: bool = False,
+        ve_enabled: bool = False,
+        ve_dim: int = 128,
+        ve_layers: str = "9,10",
+        gated_attention: bool = False,
+        value_residual: bool = False,
+    ):
+        super().__init__()
+        self._ve_target_dim = num_kv_heads * (model_dim // num_heads)  # kv_dim for value projection
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.value_residual = value_residual
+        self.mtp_num_heads = mtp_num_heads
+        self.mtp_loss_weight = mtp_loss_weight
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim) if bigram_vocab_size > 0 else None
+        self.smear = SmearGate(model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        # Parameter banks: contiguous 3D tensors for batched optimizer
+        head_dim = model_dim // num_heads
+        kv_dim = num_kv_heads * head_dim
+        mlp_dim = int(mlp_mult * model_dim)
+        self.num_layers = num_layers
+        self.qo_bank = nn.Parameter(torch.empty(2 * num_layers, model_dim, model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * num_layers, kv_dim, model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(num_layers, mlp_dim, model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(num_layers, model_dim, mlp_dim))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    mlp_activation,
+                    mlp_leaky_slope,
+                    mlp_prelu_init,
+                    mlp_softplus_beta,
+                    rope_base,
+                    qk_gain_init,
+                    layer_idx=i,
+                    ln_scale=ln_scale,
+                    dtg=dtg,
+                    gated_attention=gated_attention,
+                    value_residual=value_residual,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        if rope_dims > 0:
+            head_dim = model_dim // num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = rope_dims
+                block.attn.rotary = Rotary(head_dim, base=rope_base, train_seq_len=1024, rope_dims=rope_dims)
+        self.ve_layer_indices = [int(x) for x in ve_layers.split(",") if x.strip()] if ve_enabled else []
+        kv_dim_ve = self._ve_target_dim
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim_ve)
+            self.ve_layer_scales = nn.ParameterList(
+                [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices]
+            )
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.value_embeds = nn.ModuleList()  # keep empty for compat
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.mtp_heads = nn.ModuleList(
+            [CastedLinear(model_dim, vocab_size, bias=False) for _ in range(mtp_num_heads)]
+        )
+        for head in self.mtp_heads:
+            head._zero_init = True
+        if xsa_last_n > 0:
+            for i in range(max(0, num_layers - xsa_last_n), num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self._init_weights()
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        # Init banks: orthogonal, with proj layers scaled down and out/down zero-init
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)        # Q
+            nn.init.zeros_(self.qo_bank.data[n + i])                    # Out (zero init)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)        # K
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)    # V
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)    # MLP up
+            nn.init.zeros_(self.mlp_down_bank.data[i])                  # MLP down (zero init)
+            # Scale proj layers (out_proj and mlp_down are "proj" layers)
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        # Init remaining nn.Linear modules (bigram proj, mtp heads, lm_head)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+    def _get_ve(self, layer_idx: int, input_ids: Tensor, ve_cache: dict | None = None) -> Tensor | None:
+        """Get value embedding for a specific layer using shared table + per-layer scale."""
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if ve_cache is not None and 've' not in ve_cache:
+            ve_cache['ve'] = self.ve_shared(input_ids)
+        ve_base = ve_cache['ve'] if ve_cache is not None else self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_base * self.ve_layer_scales[ve_idx].to(dtype=ve_base.dtype)
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x, raw_v = self.blocks[i](x, x0,
+                self.qo_bank[i], self.kv_bank[i], self.kv_bank[n + i],
+                self.qo_bank[n + i], self.mlp_up_bank[i], self.mlp_down_bank[i],
+                v_embed=ve, v0=v0)
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x, _ = self.blocks[bi](x, x0,
+                self.qo_bank[bi], self.kv_bank[bi], self.kv_bank[n + bi],
+                self.qo_bank[n + bi], self.mlp_up_bank[bi], self.mlp_down_bank[bi],
+                v_embed=ve, v0=v0)
+        x = self.final_norm(x)
+        x_flat = x.reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x_flat, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x_flat)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        main_loss = F.cross_entropy(logits.float(), targets, reduction="mean")
+        if self.training and self.mtp_num_heads > 0 and self.mtp_loss_weight > 0.0:
+            _, seqlen, dim = x.shape
+            mtp_loss_sum = x.new_zeros(())
+            mtp_loss_count = 0
+            for k, mtp_head in enumerate(self.mtp_heads):
+                valid_t = seqlen - (k + 1)
+                if valid_t <= 0:
+                    continue
+                mtp_hidden = x[:, :valid_t, :].reshape(-1, dim)
+                mtp_targets = target_ids[:, k + 1 :].reshape(-1)
+                mtp_logits_proj = mtp_head(mtp_hidden)
+                mtp_logits = self.logit_softcap * torch.tanh(mtp_logits_proj / self.logit_softcap)
+                mtp_loss_sum = mtp_loss_sum + F.cross_entropy(mtp_logits.float(), mtp_targets, reduction="mean")
+                mtp_loss_count += 1
+            if mtp_loss_count > 0:
+                main_loss = main_loss + self.mtp_loss_weight * (mtp_loss_sum / mtp_loss_count)
+        return main_loss
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        """Return logits (bsz, seq_len, vocab) without computing loss."""
+        n = self.num_layers
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        x0 = x
+        v0 = None
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+        for i in range(self.num_encoder_layers):
+            ve = self._get_ve(i, input_ids, ve_cache)
+            x, raw_v = self.blocks[i](x, x0,
+                self.qo_bank[i], self.kv_bank[i], self.kv_bank[n + i],
+                self.qo_bank[n + i], self.mlp_up_bank[i], self.mlp_down_bank[i],
+                v_embed=ve, v0=v0)
+            if v0 is None and raw_v is not None:
+                v0 = raw_v
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            ve = self._get_ve(bi, input_ids, ve_cache)
+            x, _ = self.blocks[bi](x, x0,
+                self.qo_bank[bi], self.kv_bank[bi], self.kv_bank[n + bi],
+                self.qo_bank[n + bi], self.mlp_up_bank[bi], self.mlp_down_bank[bi],
+                v_embed=ve, v0=v0)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+# --- Sliding window evaluation ---
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+    eval_seq_len: int | None = None,
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context."""
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= 1]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    base_model.eval()
+    compiled_logits = (
+        torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+        if args.compile_enabled else base_model.forward_logits
+    )
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=CUDA_DTYPE):
+                logits = compiled_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+def eval_val_sliding_ttt(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    stride: int, batch_seqs: int = 32, log0=print,
+) -> tuple[float, float]:
+    """Legal score-first TTT (PR #461 recipe): score each chunk with sliding windows,
+    then train on it. Every token scored BEFORE any update that could use it."""
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    epoch_schedule = parse_ttt_schedule(args.ttt_epoch_schedule, int, "TTT_EPOCH_SCHEDULE")
+    chunk_schedule = parse_ttt_schedule(args.ttt_chunk_schedule, int, "TTT_CHUNK_SCHEDULE")
+    chunk_ranges = build_ttt_chunk_ranges(total_tokens, args.ttt_chunk_tokens, chunk_schedule)
+    chunk_ends = [end for _start, end in chunk_ranges]
+    num_chunks = len(chunk_ranges)
+
+    # Pre-compute all window starts
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+
+    # Assign each window to a chunk based on the first token it scores
+    chunk_windows: list[list[int]] = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        end = min(ws + seq_len, total_tokens)
+        wlen = end - ws
+        s = 0 if ws == 0 else max(wlen - stride, 0)
+        scored_start = ws + s
+        ci = min(bisect.bisect_right(chunk_ends, scored_start), num_chunks - 1)
+        chunk_windows[ci].append(ws)
+
+    min_chunk = min(end - start for start, end in chunk_ranges)
+    max_chunk = max(end - start for start, end in chunk_ranges)
+    log0(
+        f"ttt_sliding:start chunks={num_chunks} chunk_tokens={args.ttt_chunk_tokens} "
+        f"chunk_range=[{min_chunk},{max_chunk}] total_windows={len(window_starts)} stride={stride} "
+        f"ttt_lr={args.ttt_lr} ttt_epochs={args.ttt_epochs} "
+        f"ttt_optimizer={args.ttt_optimizer} reset_opt_state={int(args.ttt_reset_opt_state)} "
+        f"freeze_blocks={args.ttt_freeze_blocks}"
+    )
+    if chunk_schedule:
+        log0(f"ttt_sliding:chunk_schedule={chunk_schedule}")
+    if epoch_schedule:
+        log0(f"ttt_sliding:epoch_schedule={epoch_schedule}")
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    # Freeze first N blocks
+    frozen_block_ids = set(range(min(args.ttt_freeze_blocks, len(base_model.blocks))))
+    ttt_params = []
+    for name, p in base_model.named_parameters():
+        freeze = False
+        for bi in frozen_block_ids:
+            if f"blocks.{bi}." in name:
+                freeze = True
+                break
+        if freeze:
+            p.requires_grad_(False)
+        else:
+            p.requires_grad_(True)
+            ttt_params.append(p)
+
+    log0(f"ttt_sliding:params unfrozen={sum(p.numel() for p in ttt_params)} "
+         f"frozen={sum(p.numel() for p in base_model.parameters() if not p.requires_grad)}")
+
+    optimizer = None if args.ttt_reset_opt_state else build_ttt_optimizer(args, ttt_params)
+    t0 = time.perf_counter()
+
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows:
+            continue
+        chunk_start, chunk_end = chunk_ranges[ci]
+        chunk_progress = chunk_start / float(max(total_tokens, 1))
+        chunk_epochs = int(ttt_scheduled_value(chunk_progress, epoch_schedule, args.ttt_epochs))
+
+        # --- Phase 1: SCORE this chunk's windows (inference_mode) ---
+        my_s = (len(windows) * rank) // world_size
+        my_e = (len(windows) * (rank + 1)) // world_size
+        my_windows = windows[my_s:my_e]
+
+        base_model.eval()
+        with torch.inference_mode():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi:bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens: list[int] = []
+                for i, ws in enumerate(batch_ws):
+                    end = min(ws + seq_len, total_tokens)
+                    wlen = end - ws
+                    wlens.append(wlen)
+                    chunk_tok = val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                    x_batch[i, :wlen] = chunk_tok[:-1]
+                    y_batch[i, :wlen] = chunk_tok[1:]
+                with torch.autocast(device_type="cuda", dtype=CUDA_DTYPE):
+                    logits = base_model.forward_logits(x_batch)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y_batch.reshape(-1), reduction="none",
+                ).reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]
+                    s = 0 if ws == 0 else max(wlen - stride, 0)
+                    scored_nll = nll[i, s:wlen].to(torch.float64)
+                    loss_sum += scored_nll.sum()
+                    token_count += float(wlen - s)
+                    tgt, prev = y_batch[i, s:wlen], x_batch[i, s:wlen]
+                    tb = base_bytes_lut[tgt].to(torch.float64)
+                    tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(torch.float64)
+                    byte_count += tb.sum()
+
+        # --- Phase 2: TRAIN on this chunk (already scored = legal) ---
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and chunk_epochs > 0:
+            base_model.train()
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if chunk_seqs > 0:
+                if args.ttt_reset_opt_state or optimizer is None:
+                    optimizer = build_ttt_optimizer(args, ttt_params)
+                cos_lr = args.ttt_lr * 0.5 * (1.0 + math.cos(math.pi * chunk_progress))
+                for pg in optimizer.param_groups:
+                    pg['lr'] = cos_lr
+                my_seq_s = (chunk_seqs * rank) // world_size
+                my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+                my_chunk_seqs = my_seq_e - my_seq_s
+                for _ep in range(chunk_epochs):
+                    for bs in range(0, my_chunk_seqs, args.ttt_batch_seqs):
+                        be = min(bs + args.ttt_batch_seqs, my_chunk_seqs)
+                        actual_bs = my_seq_s + bs
+                        start_tok = chunk_start + actual_bs * seq_len
+                        end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                        if end_tok > val_tokens.numel():
+                            continue
+                        local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                        x = local[:-1].reshape(-1, seq_len)
+                        y = local[1:].reshape(-1, seq_len)
+                        optimizer.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type="cuda", dtype=CUDA_DTYPE):
+                            loss = base_model(x, y)
+                        loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        torch.nn.utils.clip_grad_norm_(ttt_params, args.ttt_grad_clip)
+                        optimizer.step()
+
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            log0(
+                f"  ttt_chunk [{ci+1}/{num_chunks}] span={chunk_end - chunk_start} "
+                f"epochs={chunk_epochs} bpb={rbpb:.6f} time={elapsed:.1f}s"
+            )
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+    log0(f"ttt_sliding:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+         f"elapsed={time.perf_counter() - t0:.1f}s")
+    return val_loss, val_bpb
+
+
+# --- GPTQ-lite int6 quantization ---
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+def quantize_int6_per_row(t: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        best_q, best_s, best_err = None, None, float('inf')
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            if pct < 1.0:
+                row_clip = torch.quantile(t32.abs(), pct, dim=1)
+            else:
+                row_clip = t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+            recon = q.float() * s.float()[:, None]
+            err = (t32 - recon).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_s, best_err = q, s, err
+        return best_q, best_s
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+
+def _unbank_state_dict(sd: dict[str, Tensor], num_layers: int) -> dict[str, Tensor]:
+    """Convert 3D bank tensors into individual 2D tensors with standard names."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    for name, tensor in sd.items():
+        if name == "qo_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_q.weight"] = tensor[i]
+                out[f"blocks.{i}.attn.proj.weight"] = tensor[n + i]
+        elif name == "kv_bank":
+            for i in range(n):
+                out[f"blocks.{i}.attn.c_k.weight"] = tensor[i]
+                out[f"blocks.{i}.attn.c_v.weight"] = tensor[n + i]
+        elif name == "mlp_up_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.fc.weight"] = tensor[i]
+        elif name == "mlp_down_bank":
+            for i in range(n):
+                out[f"blocks.{i}.mlp.proj.weight"] = tensor[i]
+        else:
+            out[name] = tensor
+    return out
+
+def _rebank_state_dict(sd: dict[str, Tensor], num_layers: int, template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    """Convert individual 2D tensors back into 3D bank tensors."""
+    out: dict[str, Tensor] = {}
+    n = num_layers
+    # Reconstruct banks from individual weight keys
+    qo_slices = [None] * (2 * n)
+    kv_slices = [None] * (2 * n)
+    up_slices = [None] * n
+    down_slices = [None] * n
+    consumed = set()
+    for i in range(n):
+        qk = f"blocks.{i}.attn.c_q.weight"
+        if qk in sd:
+            qo_slices[i] = sd[qk]
+            consumed.add(qk)
+        ok = f"blocks.{i}.attn.proj.weight"
+        if ok in sd:
+            qo_slices[n + i] = sd[ok]
+            consumed.add(ok)
+        kk = f"blocks.{i}.attn.c_k.weight"
+        if kk in sd:
+            kv_slices[i] = sd[kk]
+            consumed.add(kk)
+        vk = f"blocks.{i}.attn.c_v.weight"
+        if vk in sd:
+            kv_slices[n + i] = sd[vk]
+            consumed.add(vk)
+        fk = f"blocks.{i}.mlp.fc.weight"
+        if fk in sd:
+            up_slices[i] = sd[fk]
+            consumed.add(fk)
+        dk = f"blocks.{i}.mlp.proj.weight"
+        if dk in sd:
+            down_slices[i] = sd[dk]
+            consumed.add(dk)
+    out["qo_bank"] = torch.stack(qo_slices).to(dtype=template_sd["qo_bank"].dtype)
+    out["kv_bank"] = torch.stack(kv_slices).to(dtype=template_sd["kv_bank"].dtype)
+    out["mlp_up_bank"] = torch.stack(up_slices).to(dtype=template_sd["mlp_up_bank"].dtype)
+    out["mlp_down_bank"] = torch.stack(down_slices).to(dtype=template_sd["mlp_down_bank"].dtype)
+    for name, tensor in sd.items():
+        if name not in consumed:
+            out[name] = tensor
+    return out
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    num_layers_total = max(
+        (int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")),
+        default=0,
+    ) + 1
+    late_k_layers = set(range(num_layers_total - 2, num_layers_total))
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point():
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if has_name_pattern(name, INT8_FORCE_FLOAT16_NAME_PATTERNS):
+            result[name] = t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+            meta[name] = "passthrough_fp16"
+            continue
+        if has_name_pattern(name, INT8_KEEP_FLOAT16_NAME_PATTERNS):
+            result[name] = t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+            meta[name] = "passthrough_fp16"
+            continue
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            result[name] = t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+            meta[name] = "passthrough_fp16"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+def parse_quant_int6_cats(spec: str) -> set[str]:
+    normalized = spec.replace(";", ",").replace(":", ",")
+    return {part.strip() for part in normalized.split(",") if part.strip()}
+
+
+def maybe_selective_prune_quantized_state(
+    quant_result: dict[str, Tensor],
+    quant_meta: dict[str, object],
+    *,
+    code_bytes_est: int,
+    target_total_bytes: int,
+    quant_preset: int,
+    log_fn,
+) -> dict[str, Tensor]:
+    if target_total_bytes <= 0:
+        return quant_result
+    ones_info: list[tuple[str, int, float]] = []
+    for name, info in quant_meta.items():
+        if not (isinstance(info, dict) and info.get("type") == "int6"):
+            continue
+        qk = name + ".q"
+        sk = name + ".scale"
+        if qk not in quant_result or sk not in quant_result:
+            continue
+        q = quant_result[qk]
+        s = quant_result[sk]
+        ones_mask = (q.abs() == 1)
+        if not ones_mask.any():
+            continue
+        flat_idx = torch.arange(q.numel(), dtype=torch.int64).reshape(q.shape)[ones_mask]
+        if s.ndim > 0:
+            row_shape = (q.shape[0],) + (1,) * (q.ndim - 1)
+            row_idx = torch.arange(q.shape[0], dtype=torch.int64).reshape(row_shape).expand_as(q)[ones_mask]
+            errors = s.float()[row_idx].pow(2)
+        else:
+            errors = torch.full(
+                (int(ones_mask.sum().item()),),
+                float(s.float().item() ** 2),
+                dtype=torch.float32,
+            )
+        ones_info.extend((qk, int(fi), float(err)) for fi, err in zip(flat_idx.tolist(), errors.tolist()))
+    if not ones_info:
+        log_fn("selective_prune: no ±1 int6 entries found")
+        return quant_result
+    ones_info.sort(key=lambda item: item[2])
+
+    def _pruned_size_bytes(n_to_prune: int) -> tuple[int, dict[str, Tensor]]:
+        tmp = {k: v.clone() for k, v in quant_result.items()}
+        for i in range(min(n_to_prune, len(ones_info))):
+            q_key, flat_index, _ = ones_info[i]
+            tmp[q_key].view(-1)[flat_index] = 0
+        buf = io.BytesIO()
+        torch.save({"w": tmp, "m": quant_meta}, buf)
+        total_bytes = len(lzma.compress(buf.getvalue(), preset=quant_preset)) + code_bytes_est
+        return total_bytes, tmp
+
+    unpruned_bytes, _ = _pruned_size_bytes(0)
+    log_fn(
+        f"selective_prune: {len(ones_info)} ±1 candidates "
+        f"unpruned={unpruned_bytes} target={target_total_bytes}"
+    )
+    if unpruned_bytes <= target_total_bytes:
+        log_fn("selective_prune: already fits target")
+        return quant_result
+
+    fully_pruned_bytes, _ = _pruned_size_bytes(len(ones_info))
+    log_fn(f"selective_prune: full_prune_bytes={fully_pruned_bytes}")
+    if fully_pruned_bytes > target_total_bytes:
+        log_fn("selective_prune: full prune still oversize, applying full prune anyway")
+        _, pruned = _pruned_size_bytes(len(ones_info))
+        return pruned
+
+    lo, hi = 0, len(ones_info)
+    while lo < hi:
+        mid = (lo + hi) // 2
+        size_bytes, _ = _pruned_size_bytes(mid)
+        if size_bytes <= target_total_bytes:
+            hi = mid
+        else:
+            lo = mid + 1
+    log_fn(f"selective_prune: pruning {lo}/{len(ones_info)} entries to fit target")
+    _, pruned = _pruned_size_bytes(lo)
+    return pruned
+
+# --- Training ---
+
+def main() -> None:
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    # zeropower_via_newtonschulz5 runs eagerly with bmm -- do NOT compile
+    distributed_env = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    distributed = distributed_env and world_size > 1
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(True)
+    enable_math_sdp(True)
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0("=" * 100, console=False)
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    effective_eval_seq_len = args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    if args.val_max_tokens > 0 and args.val_max_tokens < (val_tokens.numel() - 1):
+        usable_val_tokens = (args.val_max_tokens // val_seq_len) * val_seq_len
+        if usable_val_tokens <= 0:
+            raise ValueError(
+                f"VAL_MAX_TOKENS={args.val_max_tokens} is too small for seq_len={val_seq_len}"
+            )
+        val_tokens = val_tokens[: usable_val_tokens + 1].contiguous()
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(
+        f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1} "
+        f"limited={int(args.val_max_tokens > 0)}"
+    )
+    log0(
+        f"attention_backend:requested={args.attention_backend} "
+        f"flash_attn_available={int(flash_attn_3_func is not None)} "
+        f"compile_enabled={int(args.compile_enabled)} cuda_dtype={args.cuda_dtype}"
+    )
+    if args.eval_only_checkpoint:
+        log0(f"eval_only_checkpoint:{args.eval_only_checkpoint}")
+    if args.ttt_enabled:
+        log0(
+            f"ttt_config optimizer={args.ttt_optimizer} lr={args.ttt_lr} epochs={args.ttt_epochs} "
+            f"chunk_tokens={args.ttt_chunk_tokens} epoch_schedule={args.ttt_epoch_schedule or 'fixed'} "
+            f"chunk_schedule={args.ttt_chunk_schedule or 'fixed'} reset_opt_state={int(args.ttt_reset_opt_state)} "
+            f"weight_decay={args.ttt_weight_decay}"
+        )
+    log0(
+        f"averaging_config ema_enabled={int(args.ema_enabled)} ema_decay={args.ema_decay} "
+        f"swa_enabled={int(args.swa_enabled)} swa_every={args.swa_every} "
+        f"lawa_enabled={int(args.lawa_enabled)} save_raw_checkpoint={int(args.save_raw_checkpoint)}"
+    )
+    log0(
+        f"activation_config mlp_activation={args.mlp_activation} "
+        f"mlp_leaky_slope={args.mlp_leaky_slope} mlp_prelu_init={args.mlp_prelu_init} "
+        f"mlp_softplus_beta={args.mlp_softplus_beta}"
+    )
+    log0(
+        f"quant_config scheme={args.quant_scheme} int6_cats={args.quant_int6_cats} "
+        f"keep_float_max_numel={INT8_KEEP_FLOAT_MAX_NUMEL} "
+        f"keep_float16={','.join(INT8_KEEP_FLOAT16_NAME_PATTERNS) or 'none'} "
+        f"force_float16={','.join(INT8_FORCE_FLOAT16_NAME_PATTERNS) or 'none'} "
+        f"lzma_preset={QUANT_LZMA_PRESET} extreme={int(QUANT_LZMA_EXTREME)} "
+        f"selective_prune={int(QUANT_SELECTIVE_PRUNE)} target_total_bytes={QUANT_TARGET_TOTAL_BYTES}"
+    )
+    CastedLinear._qat_enabled = args.qat_enabled
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        mlp_activation=args.mlp_activation,
+        mlp_leaky_slope=args.mlp_leaky_slope,
+        mlp_prelu_init=args.mlp_prelu_init,
+        mlp_softplus_beta=args.mlp_softplus_beta,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=args.mtp_num_heads,
+        mtp_loss_weight=args.mtp_loss_weight,
+        bigram_vocab_size=args.bigram_vocab_size,
+        bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims,
+        ln_scale=args.ln_scale,
+        dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled,
+        ve_dim=args.ve_dim,
+        ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention,
+        value_residual=args.value_residual,
+    ).to(device=device, dtype=CUDA_DTYPE)
+    # Banks stay FP32 (like CastedLinear weights), cast to BF16 in forward
+    base_model.qo_bank.data = base_model.qo_bank.data.float()
+    base_model.kv_bank.data = base_model.kv_bank.data.float()
+    base_model.mlp_up_bank.data = base_model.mlp_up_bank.data.float()
+    base_model.mlp_down_bank.data = base_model.mlp_down_bank.data.float()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    if args.eval_only_checkpoint:
+        ckpt = torch.load(args.eval_only_checkpoint, map_location="cpu")
+        base_model.load_state_dict(ckpt, strict=True)
+        args.warmup_steps = 0
+    # No DDP -- Parallel Muon handles bank grad communication via reduce-scatter,
+    # and non-bank grads are manually all-reduced before Adam steps.
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True) if args.compile_enabled else base_model
+    model = compiled_model
+
+    # Optimizer split:
+    # - 4 parameter banks -> Muon (batched Newton-Schulz)
+    # - token embedding -> Adam
+    # - scalars/control tensors -> Adam
+    # - bigram proj, mtp heads, VE proj -> Adam (small matrix params not worth banking)
+    matrix_params = [
+        base_model.qo_bank, base_model.kv_bank,
+        base_model.mlp_up_bank, base_model.mlp_down_bank,
+    ]
+    block_named_params = list(base_model.blocks.named_parameters())
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.bigram is not None:
+        tok_params.append({"params": [base_model.bigram.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.bigram.proj is not None:
+            scalar_params.append(base_model.bigram.proj.weight)
+    if base_model.ve_shared is not None:
+        tok_params.append({"params": [base_model.ve_shared.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        if base_model.ve_shared.proj is not None:
+            scalar_params.append(base_model.ve_shared.proj.weight)
+        scalar_params.append(base_model.ve_shared.scale)
+        for s in base_model.ve_layer_scales:
+            scalar_params.append(s)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    # Non-bank params that need manual all-reduce (replicated across GPUs)
+    replicated_params = list(optimizer_tok.param_groups[0]["params"])
+    for pg in optimizer_tok.param_groups[1:]:
+        replicated_params.extend(pg["params"])
+    replicated_params.extend(scalar_params)
+
+    optimizer_head = None
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        replicated_params.append(base_model.lm_head.weight)
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if optimizer_head is not None:
+        optimizers.append(optimizer_head)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    mtp_params = sum(p.numel() for p in base_model.mtp_heads.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"mtp_num_heads:{args.mtp_num_heads} mtp_loss_weight:{args.mtp_loss_weight} mtp_params:{mtp_params}")
+    xsa_layers = [i for i, b in enumerate(base_model.blocks) if b.attn.use_xsa]
+    log0(f"XSA:last_{args.xsa_last_n} active_layers:{xsa_layers}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=CUDA_DTYPE, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            # All-reduce all grads for warmup (simple, not optimized)
+            if distributed:
+                for p in base_model.parameters():
+                    if p.grad is not None:
+                        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    from collections import deque
+    lawa_queue: deque[dict[str, Tensor]] = deque(maxlen=args.lawa_k)
+    ema_state: dict[str, Tensor] | None = None
+    if args.ema_enabled:
+        ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = args.iterations if args.eval_only_checkpoint else 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        if args.late_qat_threshold > 0 and scale < args.late_qat_threshold and not CastedLinear._qat_enabled:
+            CastedLinear._qat_enabled = True
+            log0(f"late_qat:enabled step:{step} scale:{scale:.4f}")
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=CUDA_DTYPE, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        # === 3-phase overlapped optimizer step ===
+        # Phase 1: Launch async reduce-scatter for banks (biggest first)
+        optimizer_muon.launch_reduce_scatters()
+        # Phase 2: All-reduce non-bank grads + step Adam (while bank RS is in-flight)
+        if distributed:
+            for p in replicated_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+        optimizer_tok.step()
+        optimizer_scalar.step()
+        if optimizer_head is not None:
+            optimizer_head.step()
+        # Phase 3: Wait for RS, local NS5, all-gather (banks processed last)
+        optimizer_muon.step()
+        zero_grad_all()
+        # EMA update
+        if ema_state is not None:
+            d = args.ema_decay
+            with torch.no_grad():
+                for name, t in base_model.state_dict().items():
+                    ema_state[name].mul_(d).add_(t.detach().float(), alpha=1.0 - d)
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        if args.swa_enabled and scale < 0.2 and step % args.swa_every == 0:
+            if ema_state is not None:
+                swa_source = {
+                    name: t.detach().to(dtype=base_model.state_dict()[name].dtype).cpu().clone()
+                    for name, t in ema_state.items()
+                }
+            else:
+                swa_source = {name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()}
+            if swa_state is None:
+                swa_state = swa_source
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in swa_source.items():
+                    swa_state[name] += t
+                swa_count += 1
+        if args.lawa_enabled and step % args.lawa_freq == 0:
+            lawa_queue.append({name: t.detach().cpu().clone() for name, t in base_model.state_dict().items()})
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+    raw_state_dict = {k: v.detach().cpu().clone() for k, v in base_model.state_dict().items()}
+    raw_export_sd = {k: v for k, v in raw_state_dict.items() if "mtp_heads" not in k}
+    if master_process and args.save_raw_checkpoint:
+        torch.save(raw_export_sd, "final_model_raw.pt")
+        log0(f"Serialized raw model: {os.path.getsize('final_model_raw.pt')} bytes")
+    torch.cuda.synchronize()
+    t_diag_raw = time.perf_counter()
+    raw_val_loss, raw_val_bpb = eval_val(
+        args, compiled_model, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"DIAGNOSTIC pre_avg val_loss:{raw_val_loss:.4f} val_bpb:{raw_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_diag_raw):.0f}ms"
+    )
+    # Apply weight averaging
+    if args.lawa_enabled and len(lawa_queue) > 1:
+        log0(f"lawa:applying LAWA averaging k={len(lawa_queue)}")
+        current_state = base_model.state_dict()
+        avg_state = {name: torch.zeros(t.shape, dtype=torch.float32, device='cpu') for name, t in current_state.items()}
+        for snap in lawa_queue:
+            for name in avg_state:
+                avg_state[name] += snap[name].float()
+        for name in avg_state:
+            avg_state[name] /= len(lawa_queue)
+            avg_state[name] = avg_state[name].to(dtype=current_state[name].dtype)
+        base_model.load_state_dict(avg_state, strict=True)
+    elif args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"swa:applying averaged {swa_count} checkpoints")
+        current_state = base_model.state_dict()
+        avg_state = {
+            name: (t / swa_count).to(dtype=current_state[name].dtype)
+            for name, t in swa_state.items()
+        }
+        base_model.load_state_dict(avg_state, strict=True)
+    elif ema_state is not None:
+        log0("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+        base_model.load_state_dict(avg_state, strict=True)
+    else:
+        log0("averaging:using raw training weights")
+    torch.cuda.synchronize()
+    t_diag = time.perf_counter()
+    diag_val_loss, diag_val_bpb = eval_val(
+        args, compiled_model, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"DIAGNOSTIC post_ema val_loss:{diag_val_loss:.4f} val_bpb:{diag_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_diag):.0f}ms"
+    )
+    full_state_dict = base_model.state_dict()
+    export_sd = {k: v for k, v in full_state_dict.items() if "mtp_heads" not in k}
+    excluded_mtp = sum(int(t.numel()) for k, t in full_state_dict.items() if "mtp_heads" in k)
+    if excluded_mtp > 0:
+        log0(f"export_excluding_mtp_params:{excluded_mtp}")
+    if master_process:
+        torch.save(export_sd, "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+    # Unbank 3D tensors into individual 2D tensors for quantization
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    unbanked_sd = _unbank_state_dict(sd_cpu, args.num_layers)
+    if args.quant_scheme == "mixed_int6":
+        quant_result, quant_meta = mixed_quantize_int6(unbanked_sd, parse_quant_int6_cats(args.quant_int6_cats))
+    elif args.quant_scheme == "int8":
+        quant_result, quant_meta = quantize_state_dict_int8(unbanked_sd)
+    else:
+        raise ValueError(f"Unsupported QUANT_SCHEME={args.quant_scheme!r}")
+    quant_preset = QUANT_LZMA_PRESET | (lzma.PRESET_EXTREME if QUANT_LZMA_EXTREME else 0)
+    if args.quant_scheme == "mixed_int6" and QUANT_SELECTIVE_PRUNE:
+        quant_result = maybe_selective_prune_quantized_state(
+            quant_result,
+            quant_meta,
+            code_bytes_est=len(code.encode("utf-8")),
+            target_total_bytes=QUANT_TARGET_TOTAL_BYTES,
+            quant_preset=quant_preset,
+            log_fn=log0,
+        )
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = lzma.compress(quant_raw, preset=quant_preset)
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = len(quant_blob)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+lzma: {quant_file_bytes} bytes")
+        log0(f"Total submission size int6+lzma: {quant_file_bytes + code_bytes} bytes")
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(lzma.decompress(quant_blob_disk)),
+        map_location="cpu",
+    )
+    if args.quant_scheme == "mixed_int6":
+        deq_unbanked = dequantize_mixed_int6(quant_state["w"], quant_state["m"], unbanked_sd)
+    elif args.quant_scheme == "int8":
+        deq_unbanked = dequantize_state_dict_int8(quant_state["w"])
+    else:
+        raise ValueError(f"Unsupported QUANT_SCHEME={args.quant_scheme!r}")
+    # Re-bank the dequantized tensors
+    deq_state = _rebank_state_dict(deq_unbanked, args.num_layers, sd_cpu)
+    eval_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        num_heads=args.num_heads, num_kv_heads=args.num_kv_heads, mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap, rope_base=args.rope_base, qk_gain_init=args.qk_gain_init,
+        mtp_num_heads=0, mtp_loss_weight=0.0,
+        bigram_vocab_size=args.bigram_vocab_size, bigram_dim=args.bigram_dim,
+        xsa_last_n=args.xsa_last_n,
+        rope_dims=args.rope_dims, ln_scale=args.ln_scale, dtg=args.dtg_enabled,
+        ve_enabled=args.ve_enabled, ve_dim=args.ve_dim, ve_layers=args.ve_layers,
+        gated_attention=args.gated_attention, value_residual=args.value_residual,
+    ).to(device=device, dtype=CUDA_DTYPE)
+    eval_model.qo_bank.data = eval_model.qo_bank.data.float()
+    eval_model.kv_bank.data = eval_model.kv_bank.data.float()
+    eval_model.mlp_up_bank.data = eval_model.mlp_up_bank.data.float()
+    eval_model.mlp_down_bank.data = eval_model.mlp_down_bank.data.float()
+    for m in eval_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(eval_model)
+    eval_model.load_state_dict(deq_state, strict=True)
+    compiled_eval = torch.compile(eval_model, dynamic=False, fullgraph=True) if args.compile_enabled else eval_model
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args, compiled_eval, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+        eval_seq_len=effective_eval_seq_len,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+    sw_seq_len = effective_eval_seq_len
+    if args.eval_stride > 0 and args.eval_stride < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, batch_seqs=args.eval_sliding_batch_seqs,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+        log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}")
+    if args.eval_stride != 64 and 64 < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide64 = time.perf_counter()
+        sw64_val_loss, sw64_val_bpb = eval_val_sliding(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=64, batch_seqs=args.eval_sliding_batch_seqs,
+            eval_seq_len=sw_seq_len,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window_s64 val_loss:{sw64_val_loss:.4f} val_bpb:{sw64_val_bpb:.4f} "
+            f"stride:64 eval_time:{1000.0 * (time.perf_counter() - t_slide64):.0f}ms"
+        )
+        log0(f"final_int6_sliding_window_s64_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+        log0(f"final_int8_zlib_roundtrip_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}")
+    # Legal score-first TTT (PR #461 recipe)
+    if args.ttt_enabled:
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_loss, ttt_bpb = eval_val_sliding_ttt(
+            args, eval_model, rank, world_size, device,
+            val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            stride=args.eval_stride, batch_seqs=args.eval_sliding_batch_seqs, log0=log0,
+        )
+        torch.cuda.synchronize()
+        log0(f"legal_ttt val_loss:{ttt_loss:.4f} val_bpb:{ttt_bpb:.4f} "
+             f"eval_time:{1000.0 * (time.perf_counter() - t_ttt):.0f}ms")
+        log0(f"legal_ttt_exact val_loss:{ttt_loss:.8f} val_bpb:{ttt_bpb:.8f}")
+    if distributed:
+        dist.destroy_process_group()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds a non-record unlimited-compute 16MB submission: Mixed-Int6 LZMA9 B3072 Warm5000.

This is not a 10-minute record attempt, rather a 16.1h single-GPU run using the established EMA + XSA(last-4) + BigramHash3072 + LeakyReLU^2 flat-transformer stack, then exports the preserved raw checkpoint with broad mixed-int6 over `mlp;attn;embed` and LZMA9 extreme compression.

## Result
  - val_bpb: 1.20289664
  - val_loss: 1.99963255
  - pre-quant sliding BPB: 1.16618894
  - artifact bytes: 15,991,188

This beats the listed 4-hour non-record baseline but does not beat the current 1-bit non-record result or the 10-minute SOTA -- was a fun little experiment I trained and ran on limited compute (as a student in college 😃) 

**Training:** NVIDIA RTX A4500, 20GB VRAM
**Export & eval:** NVIDIA GeForce RTX 3050, 8GB VRAM