### PR TITLE
Non-record: Faithful Conditional Memory

### DIFF
--- a/records/track_non_record_16mb/2026-04-09_FaithfulConditionalMemory/README.md
+++ b/records/track_non_record_16mb/2026-04-09_FaithfulConditionalMemory/README.md
@@ -21,13 +21,17 @@ The submission adds a memory path that:
 
 This gives the model explicit reusable token-pattern memory in addition to self-attention.
 
-## Real 8xH100 Result
+## Real 8xH100 Results
 
 - Track: non-record 16MB
-- Seed: `42`
-- `final_int8_zlib_roundtrip_exact val_loss: 2.72026400`
-- `final_int8_zlib_roundtrip_exact val_bpb: 1.61095535`
-- Total submission size: `2,773,498` bytes
+
+| Seed | `final_int8_zlib_roundtrip_exact val_loss` | `final_int8_zlib_roundtrip_exact val_bpb` | Total size |
+|---|---:|---:|---:|
+| `42` | `2.72026400` | `1.61095535` | `2,773,498` bytes |
+| `1337` | `2.75858221` | `1.63364760` | `2,769,754` bytes |
+| `2024` | `2.73756576` | `1.62120154` | `2,772,946` bytes |
+
+- Mean cloud `val_bpb` across 3 seeds: `1.62193483`
 
 ## Strongest Local Signs Of Life
 
@@ -41,7 +45,7 @@ on longer proxy runs across three seeds.
 
 ## Interpretation
 
-This method had one of the strongest heavyweight standalone local signals we found, but it did not transfer competitively to real 8xH100 evaluation. It is submitted as a faithful implementation and negative/partial result for future work rather than as a leaderboard contender.
+This method had one of the strongest heavyweight standalone local signals we found. The 3-seed 8xH100 verification confirms that it transfers reproducibly, but not competitively enough to challenge the dense frontier. It is submitted as a faithful implementation and negative/partial result for future work rather than as a leaderboard contender.
 
 ## Run Command
 

--- a/records/track_non_record_16mb/2026-04-09_FaithfulConditionalMemory/README.md
+++ b/records/track_non_record_16mb/2026-04-09_FaithfulConditionalMemory/README.md
@@ -1,0 +1,73 @@
+# Faithful Conditional Memory
+
+This is a non-record methodological submission exploring a faithful standalone conditional-memory architecture inspired by scalable lookup memory. The model augments a transformer with compressed n-gram lookup tables, contextual key/value projections, and internal-layer memory injection.
+
+## Why This Is Interesting
+
+- Uses tokenizer-normalized compressed lookup keys rather than a plain dense residual path
+- Builds prime-sized multi-hash n-gram tables
+- Injects learned memory features into selected transformer layers
+- Showed strong standalone local signs of life before cloud evaluation
+
+## Method Summary
+
+The submission adds a memory path that:
+
+1. Normalizes tokenizer pieces into compressed text identities
+2. Hashes 2-gram and 3-gram contexts into multiple memory heads
+3. Looks up learned memory embeddings
+4. Projects them into contextual keys and values
+5. Gates and injects them back into the transformer at selected layers
+
+This gives the model explicit reusable token-pattern memory in addition to self-attention.
+
+## Real 8xH100 Result
+
+- Track: non-record 16MB
+- Seed: `42`
+- `final_int8_zlib_roundtrip_exact val_loss: 2.72026400`
+- `final_int8_zlib_roundtrip_exact val_bpb: 1.61095535`
+- Total submission size: `2,773,498` bytes
+
+## Strongest Local Signs Of Life
+
+Before cloud testing, the best standalone local branch reached:
+
+- `2.55013473`
+- `2.55742361`
+- `2.60430848`
+
+on longer proxy runs across three seeds.
+
+## Interpretation
+
+This method had one of the strongest heavyweight standalone local signals we found, but it did not transfer competitively to real 8xH100 evaluation. It is submitted as a faithful implementation and negative/partial result for future work rather than as a leaderboard contender.
+
+## Run Command
+
+```bash
+RUN_ID=screen_memory_seed42 \
+DATA_PATH=./data/datasets/fineweb10B_sp1024/ \
+TOKENIZER_PATH=./data/tokenizers/fineweb_1024_bpe.model \
+VOCAB_SIZE=1024 \
+NUM_LAYERS=4 MODEL_DIM=256 NUM_HEADS=4 NUM_KV_HEADS=2 \
+TRAIN_BATCH_TOKENS=8192 TRAIN_SEQ_LEN=256 \
+VAL_BATCH_SIZE=32768 VAL_MAX_TOKENS=262144 \
+VAL_LOSS_EVERY=0 TRAIN_LOG_EVERY=200 \
+ITERATIONS=200000 MAX_WALLCLOCK_SECONDS=600 \
+DISABLE_COMPILE=1 SWA_ENABLED=0 \
+USE_EXCLUSIVE_SELF_ATTENTION=1 \
+TIED_EMBED_LR=0.003 EMBED_LR=0.003 HEAD_LR=0.003 \
+MATRIX_LR=0.003 SCALAR_LR=0.003 WEIGHT_DECAY=0.01 \
+ENGRAM_VOCAB_SIZES=2048,2048 ENGRAM_LAYER_IDS=1,3 \
+ENGRAM_N_EMBED_PER_NGRAM=128 ENGRAM_N_HEAD_PER_NGRAM=4 \
+ENGRAM_KERNEL_SIZE=4 SEED=42 \
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+## Compliance
+
+- [x] Artifact under 16MB
+- [x] Runs on real 8xH100 SXM
+- [x] No validation leakage
+- [x] Non-record submission

--- a/records/track_non_record_16mb/2026-04-09_FaithfulConditionalMemory/screen_memory_seed1337.txt
+++ b/records/track_non_record_16mb/2026-04-09_FaithfulConditionalMemory/screen_memory_seed1337.txt
@@ -1,0 +1,10 @@
+logs/screen_memory_seed1337.txt
+seed:1337
+...
+step:13985/200000 val_loss:2.8223 val_bpb:1.6713 train_time:600036ms step_avg:42.91ms
+stopping_early: wallclock_cap train_time:600036ms step:13985/200000
+Serialized model int6+zstd: 2706000 bytes
+Total submission size int8+zlib: 2769754 bytes
+final_eval_mode:sliding_window stride:64 batch_seqs:32
+final_int8_zlib_roundtrip val_loss:2.7586 val_bpb:1.6336 eval_time:298ms
+final_int8_zlib_roundtrip_exact val_loss:2.75858221 val_bpb:1.63364760

--- a/records/track_non_record_16mb/2026-04-09_FaithfulConditionalMemory/screen_memory_seed2024.txt
+++ b/records/track_non_record_16mb/2026-04-09_FaithfulConditionalMemory/screen_memory_seed2024.txt
@@ -1,0 +1,10 @@
+logs/screen_memory_seed2024.txt
+seed:2024
+...
+step:13985/200000 val_loss:2.8068 val_bpb:1.6621 train_time:600049ms step_avg:42.91ms
+stopping_early: wallclock_cap train_time:600049ms step:13985/200000
+Serialized model int6+zstd: 2709192 bytes
+Total submission size int8+zlib: 2772946 bytes
+final_eval_mode:sliding_window stride:64 batch_seqs:32
+final_int8_zlib_roundtrip val_loss:2.7376 val_bpb:1.6212 eval_time:290ms
+final_int8_zlib_roundtrip_exact val_loss:2.73756576 val_bpb:1.62120154

--- a/records/track_non_record_16mb/2026-04-09_FaithfulConditionalMemory/screen_memory_seed42.txt
+++ b/records/track_non_record_16mb/2026-04-09_FaithfulConditionalMemory/screen_memory_seed42.txt
@@ -1,0 +1,25 @@
+logs/screen_memory_seed42.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:262144
+model_params:3966032
+world_size:8 grad_accum_steps:1
+compile_enabled:False
+attention_mode:engram_ref num_heads:4 num_kv_heads:2
+attention_extras:exclusive_self_attention=True
+engram:layers:[1, 3] vocab_sizes:[2048, 2048] max_ngram:3 embed_per_ngram:128 heads_per_ngram:4 kernel:4
+faithful_optimizer:adamw embed_lr:0.003 matrix_lr:0.003 head_lr:0.003
+train_batch_tokens:8192 train_seq_len:256 iterations:200000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:42
+...
+step:16868/200000 val_loss:2.7851 val_bpb:1.6493 train_time:599992ms step_avg:35.57ms
+stopping_early: wallclock_cap train_time:599992ms step:16868/200000
+peak memory allocated: 227 MiB reserved: 270 MiB
+Serialized model: 12674858 bytes
+Code size: 63754 bytes
+Total submission size: 12738612 bytes
+Serialized model int6+zstd: 2709744 bytes
+Total submission size int8+zlib: 2773498 bytes
+final_eval_mode:sliding_window stride:64 batch_seqs:32
+final_int8_zlib_roundtrip val_loss:2.7203 val_bpb:1.6110 eval_time:152ms
+final_int8_zlib_roundtrip_exact val_loss:2.72026400 val_bpb:1.61095535

--- a/records/track_non_record_16mb/2026-04-09_FaithfulConditionalMemory/submission.json
+++ b/records/track_non_record_16mb/2026-04-09_FaithfulConditionalMemory/submission.json
@@ -1,0 +1,10 @@
+{
+  "track": "non_record_16mb",
+  "date": "2026-04-09",
+  "name": "Faithful Conditional Memory",
+  "author": "wisebreadloaf",
+  "github_id": "wisebreadloaf",
+  "val_bpb": 1.61095535,
+  "val_loss": 2.72026400,
+  "bytes_total": 2773498
+}

--- a/records/track_non_record_16mb/2026-04-09_FaithfulConditionalMemory/train_gpt.py
+++ b/records/track_non_record_16mb/2026-04-09_FaithfulConditionalMemory/train_gpt.py
@@ -1,0 +1,1720 @@
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: To keep readable for newcomers, let's make sure `train_gpt.py` and `train_gpt_mlx.py` never are longer than 1500 lines.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import re
+import subprocess
+import sys
+import time
+import unicodedata
+import uuid
+import zlib
+from pathlib import Path
+
+try:
+    import zstandard
+
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+
+
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get(
+        "TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model"
+    )
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 42))
+
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 500))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 100))
+    val_max_tokens = int(os.environ.get("VAL_MAX_TOKENS", 0))
+
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 10))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 3.0))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    weight_decay = float(os.environ.get("WEIGHT_DECAY", 0.04))
+
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))
+
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 10240))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+    use_exclusive_self_attention = bool(
+        int(os.environ.get("USE_EXCLUSIVE_SELF_ATTENTION", "0"))
+    )
+    engram_vocab_sizes = tuple(
+        int(x) for x in os.environ.get("ENGRAM_VOCAB_SIZES", "4096,4096").split(",")
+    )
+    engram_max_ngram = int(os.environ.get("ENGRAM_MAX_NGRAM", 3))
+    engram_n_embed_per_ngram = int(os.environ.get("ENGRAM_N_EMBED_PER_NGRAM", 128))
+    engram_n_head_per_ngram = int(os.environ.get("ENGRAM_N_HEAD_PER_NGRAM", 4))
+    engram_layer_ids = tuple(
+        int(x) for x in os.environ.get("ENGRAM_LAYER_IDS", "1,3").split(",") if x
+    )
+    engram_kernel_size = int(os.environ.get("ENGRAM_KERNEL_SIZE", 4))
+    engram_seed = int(os.environ.get("ENGRAM_SEED", 0))
+
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.4))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    disable_compile = bool(int(os.environ.get("DISABLE_COMPILE", "0")))
+
+
+# -----------------------------
+# MUON OPTIMIZER
+# -----------------------------
+
+
+def zeropower_via_newtonschulz5(
+    G: Tensor, steps: int = 10, eps: float = 1e-7
+) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr: float,
+        momentum: float,
+        backend_steps: int,
+        nesterov: bool = True,
+        weight_decay: float = 0.0,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+            ),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(
+                total_params, device=params[0].device, dtype=torch.bfloat16
+            )
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                if wd > 0:
+                    p.data.mul_(1.0 - lr * wd)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION
+# -----------------------------
+
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def maybe_cap_validation_tokens(
+    val_tokens: Tensor, seq_len: int, max_tokens: int
+) -> Tensor:
+    if max_tokens <= 0:
+        return val_tokens
+    usable = min(
+        ((val_tokens.numel() - 1) // seq_len) * seq_len,
+        (max_tokens // seq_len) * seq_len,
+    )
+    if usable <= 0:
+        raise ValueError(
+            f"VAL_MAX_TOKENS={max_tokens} is too small for TRAIN_SEQ_LEN={seq_len}"
+        )
+    return val_tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (
+                has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]
+            ).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION (INT8 legacy + INT6 mixed)
+# -----------------------------
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear,bigram.scale",
+    ).split(",")
+    if pattern
+)
+FP16_KEEP_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "FP16_KEEP_NAME_PATTERNS", "tok_emb,blocks.8.attn.c_k"
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(
+            torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None]
+        )
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = (
+            torch.clamp(torch.round(clipped / scale[:, None]), -127, 127)
+            .to(torch.int8)
+            .contiguous()
+        )
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+    clip_abs = (
+        float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item())
+        if t32.numel()
+        else 0.0
+    )
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = (
+        torch.clamp(
+            torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127
+        )
+        .to(torch.int8)
+        .contiguous()
+    )
+    return q, scale
+
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if (
+        ".mlp." in name
+        or ".memory" in name
+        or "hash_mapping" in name
+        or "multi_head_embedding" in name
+    ):
+        return "mlp"
+    if "bigram" in name:
+        return "bigram"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+
+
+def quantize_intN_per_row(t: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        row_max = t32.abs().amax(dim=1)
+        scale = (row_max / clip_range).clamp_min(1e-12).to(torch.float16)
+        scale = scale.clamp_min(torch.finfo(torch.float16).tiny)
+        q = torch.clamp(
+            torch.round(t32 / scale.float()[:, None]), -(clip_range + 1), clip_range
+        ).to(torch.int8)
+        return q, scale
+    amax = t32.abs().max().item()
+    scale = torch.tensor(max(amax / clip_range, 1e-12), dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -(clip_range + 1), clip_range).to(
+        torch.int8
+    )
+    return q, scale
+
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 8192:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if any(pattern in name for pattern in FP16_KEEP_NAME_PATTERNS):
+            result[name] = t.to(dtype=torch.float16).contiguous()
+            meta[name] = "passthrough_fp16"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            clip = 15 if cat == "mlp" else 31  # int5 for MLP, int6 for attention
+            q, s = quantize_intN_per_row(t, clip_range=clip)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": f"int{5 if cat == 'mlp' else 6}"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+
+
+def dequantize_mixed_int6(
+    result: dict[str, Tensor], meta: dict[str, object], template_sd: dict[str, Tensor]
+) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta[name]
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (
+                q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))
+            ).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(
+        self, global_tokens: int, seq_len: int, grad_accum_steps: int
+    ) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (
+                param.ndim < 2
+                or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+            ) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(
+        self, seq_len: int, device: torch.device, dtype: torch.dtype
+    ) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        cos = self._cos_cached.to(dtype=dtype)
+        sin = self._sin_cached.to(dtype=dtype)
+        if not torch.is_inference_mode_enabled():
+            cos = cos.clone()
+            sin = sin.clone()
+        return cos, sin
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        use_exclusive_self_attention: bool,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+        self.use_exclusive_self_attention = use_exclusive_self_attention
+
+    def apply_exclusive(self, y: Tensor, v: Tensor) -> Tensor:
+        if not self.use_exclusive_self_attention:
+            return y
+        if self.num_kv_heads != self.num_heads:
+            v = v.repeat_interleave(self.num_heads // self.num_kv_heads, dim=1)
+        dot = (y * v).sum(dim=-1, keepdim=True)
+        denom = v.square().sum(dim=-1, keepdim=True).clamp_min(1e-6)
+        return y - dot * v / denom
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = (
+            self.c_q(x)
+            .reshape(bsz, seqlen, self.num_heads, self.head_dim)
+            .transpose(1, 2)
+        )
+        k = (
+            self.c_k(x)
+            .reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+            .transpose(1, 2)
+        )
+        v = (
+            self.c_v(x)
+            .reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+            .transpose(1, 2)
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        y = self.apply_exclusive(y, v)
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: float):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class SmearGate(nn.Module):
+    """Blend each token's embedding with the previous token's embedding."""
+
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+
+class BigramHashEmbedding(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = (
+            CastedLinear(bigram_dim, model_dim, bias=False)
+            if bigram_dim != model_dim
+            else None
+        )
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+def _normalize_token_text(text: str) -> str:
+    text = text.replace("▁", " ")
+    text = unicodedata.normalize("NFKC", text)
+    text = unicodedata.normalize("NFD", text)
+    text = "".join(ch for ch in text if unicodedata.category(ch) != "Mn")
+    text = text.lower()
+    text = re.sub(r"\s+", " ", text).strip()
+    return text if text else " "
+
+
+def _build_engram_lookup(vocab_size: int, tokenizer_path: str) -> np.ndarray:
+    sp = spm.SentencePieceProcessor(model_file=tokenizer_path)
+    key_to_new: dict[str, int] = {}
+    lookup = np.empty(vocab_size, dtype=np.int64)
+    for tid in range(vocab_size):
+        try:
+            text = sp.decode_ids([tid])
+        except Exception:
+            text = sp.id_to_piece(tid)
+        if not text or "�" in text:
+            text = sp.id_to_piece(tid)
+        key = _normalize_token_text(text)
+        if key not in key_to_new:
+            key_to_new[key] = len(key_to_new)
+        lookup[tid] = key_to_new[key]
+    return lookup
+
+
+def _is_prime(n: int) -> bool:
+    if n < 2:
+        return False
+    if n % 2 == 0:
+        return n == 2
+    d = 3
+    while d * d <= n:
+        if n % d == 0:
+            return False
+        d += 2
+    return True
+
+
+def _next_prime(start: int, seen: set[int]) -> int:
+    candidate = start + 1
+    while True:
+        if _is_prime(candidate) and candidate not in seen:
+            return candidate
+        candidate += 1
+
+
+class NgramHashMappingTorch(nn.Module):
+    def __init__(
+        self,
+        compressed_lookup: np.ndarray,
+        vocab_sizes: tuple[int, ...],
+        max_ngram_size: int,
+        n_head_per_ngram: int,
+        layer_ids: tuple[int, ...],
+        seed: int,
+        pad_id: int,
+    ):
+        super().__init__()
+        self.max_ngram_size = max_ngram_size
+        self.n_head_per_ngram = n_head_per_ngram
+        self.layer_ids = layer_ids
+        self.pad_id = int(compressed_lookup[pad_id]) if pad_id >= 0 else 0
+        self.register_buffer(
+            "lookup_table", torch.from_numpy(compressed_lookup).long(), persistent=False
+        )
+        seen: set[int] = set()
+        layer_vocab_sizes = []
+        layer_multipliers = []
+        for layer_id in layer_ids:
+            g = np.random.default_rng(int(seed + 10007 * int(layer_id)))
+            multipliers = g.integers(
+                low=1, high=2**31 - 1, size=(max_ngram_size,), dtype=np.int64
+            )
+            layer_multipliers.append(torch.from_numpy(multipliers * 2 + 1).long())
+            this_layer_sizes = []
+            for vocab_size in vocab_sizes:
+                head_sizes = []
+                search = vocab_size - 1
+                for _ in range(n_head_per_ngram):
+                    prime = _next_prime(search, seen)
+                    seen.add(prime)
+                    head_sizes.append(prime)
+                    search = prime
+                this_layer_sizes.extend(head_sizes)
+            layer_vocab_sizes.append(torch.tensor(this_layer_sizes, dtype=torch.long))
+        self.register_buffer(
+            "layer_multipliers", torch.stack(layer_multipliers), persistent=False
+        )
+        self.register_buffer(
+            "layer_vocab_sizes", torch.stack(layer_vocab_sizes), persistent=False
+        )
+
+    def forward(self, input_ids: Tensor, layer_id: int) -> Tensor:
+        layer_pos = self.layer_ids.index(layer_id)
+        x = self.lookup_table[input_ids.long()]
+        bsz, seqlen = x.shape
+        shifts = []
+        for k in range(self.max_ngram_size):
+            if k == 0:
+                shifts.append(x)
+            else:
+                pad = torch.full((bsz, k), self.pad_id, device=x.device, dtype=x.dtype)
+                shifts.append(torch.cat((pad, x[:, :-k]), dim=1))
+        multipliers = self.layer_multipliers[layer_pos].to(device=x.device)
+        all_hashes: list[Tensor] = []
+        head_sizes = self.layer_vocab_sizes[layer_pos].to(device=x.device)
+        head_idx = 0
+        for n in range(2, self.max_ngram_size + 1):
+            mix = shifts[0] * multipliers[0]
+            for k in range(1, n):
+                mix = torch.bitwise_xor(mix, shifts[k] * multipliers[k])
+            for _ in range(self.n_head_per_ngram):
+                all_hashes.append(torch.remainder(mix, head_sizes[head_idx]))
+                head_idx += 1
+        return torch.stack(all_hashes, dim=2).long()
+
+
+class MultiHeadEmbedding(nn.Module):
+    def __init__(self, list_of_N: list[int], dim: int):
+        super().__init__()
+        offsets = [0]
+        for n in list_of_N[:-1]:
+            offsets.append(offsets[-1] + n)
+        self.register_buffer(
+            "offsets", torch.tensor(offsets, dtype=torch.long), persistent=False
+        )
+        self.embedding = nn.Embedding(sum(list_of_N), dim)
+
+    def forward(self, input_ids: Tensor) -> Tensor:
+        return self.embedding(input_ids + self.offsets)
+
+
+class ShortConv(nn.Module):
+    def __init__(self, hidden_size: int, kernel_size: int, dilation: int):
+        super().__init__()
+        self.norm = nn.RMSNorm(hidden_size)
+        self.conv = nn.Conv1d(
+            hidden_size,
+            hidden_size,
+            kernel_size=kernel_size,
+            groups=hidden_size,
+            bias=False,
+            padding=(kernel_size - 1) * dilation,
+            dilation=dilation,
+        )
+        self.act = nn.SiLU()
+
+    def forward(self, x: Tensor) -> Tensor:
+        y = self.norm(x).transpose(1, 2)
+        y = self.conv(y)[..., : x.size(1)].transpose(1, 2)
+        return self.act(y)
+
+
+class EngramMemory(nn.Module):
+    def __init__(
+        self,
+        layer_id: int,
+        compressed_lookup: np.ndarray,
+        tokenizer_path: str,
+        pad_id: int,
+        model_dim: int,
+        vocab_sizes: tuple[int, ...],
+        max_ngram_size: int,
+        n_embed_per_ngram: int,
+        n_head_per_ngram: int,
+        layer_ids: tuple[int, ...],
+        kernel_size: int,
+        seed: int,
+    ):
+        super().__init__()
+        self.layer_id = layer_id
+        self.hash_mapping = NgramHashMappingTorch(
+            compressed_lookup,
+            vocab_sizes,
+            max_ngram_size,
+            n_head_per_ngram,
+            layer_ids,
+            seed,
+            pad_id,
+        )
+        list_of_N = self.hash_mapping.layer_vocab_sizes[
+            self.hash_mapping.layer_ids.index(layer_id)
+        ].tolist()
+        per_head_dim = n_embed_per_ngram // n_head_per_ngram
+        self.multi_head_embedding = MultiHeadEmbedding(list_of_N, per_head_dim)
+        self.short_conv = ShortConv(model_dim, kernel_size, max_ngram_size)
+        engram_hidden_size = (max_ngram_size - 1) * n_embed_per_ngram
+        self.value_proj = nn.Linear(engram_hidden_size, model_dim)
+        self.key_proj = nn.Linear(engram_hidden_size, model_dim)
+        self.norm_key = nn.RMSNorm(model_dim)
+        self.norm_query = nn.RMSNorm(model_dim)
+
+    def forward(self, hidden_states: Tensor, input_ids: Tensor) -> Tensor:
+        hash_ids = self.hash_mapping(input_ids, self.layer_id)
+        embeddings = (
+            self.multi_head_embedding(hash_ids)
+            .flatten(start_dim=-2)
+            .to(hidden_states.dtype)
+        )
+        key = self.norm_key(self.key_proj(embeddings))
+        query = self.norm_query(hidden_states)
+        gate = (key * query).sum(dim=-1) / math.sqrt(hidden_states.size(-1))
+        gate = gate.abs().clamp_min(1e-6).sqrt() * gate.sign()
+        gate = gate.sigmoid().unsqueeze(-1)
+        value = gate * self.value_proj(embeddings)
+        return value + self.short_conv(value)
+
+
+class MemoryBlock(nn.Module):
+    def __init__(
+        self,
+        layer_id: int,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: float,
+        rope_base: float,
+        qk_gain_init: float,
+        use_exclusive_self_attention: bool,
+        memory: EngramMemory | None,
+    ):
+        super().__init__()
+        self.memory = memory
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim,
+            num_heads,
+            num_kv_heads,
+            rope_base,
+            qk_gain_init,
+            use_exclusive_self_attention,
+        )
+        self.mlp = MLP(dim, mlp_mult)
+
+    def forward(self, x: Tensor, input_ids: Tensor) -> Tensor:
+        if self.memory is not None:
+            x = x + self.memory(x, input_ids)
+        x = x + self.attn(self.attn_norm(x))
+        x = x + self.mlp(self.mlp_norm(x))
+        return x
+
+
+class MemoryGPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: float,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        tokenizer_path: str,
+        train_seq_len: int,
+        engram_vocab_sizes: tuple[int, ...],
+        engram_max_ngram: int,
+        engram_n_embed_per_ngram: int,
+        engram_n_head_per_ngram: int,
+        engram_layer_ids: tuple[int, ...],
+        engram_kernel_size: int,
+        engram_seed: int,
+        use_exclusive_self_attention: bool = False,
+    ):
+        super().__init__()
+        self.tie_embeddings = tie_embeddings
+        self.logit_softcap = logit_softcap
+        self.tied_embed_init_std = tied_embed_init_std
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        compressed_lookup = _build_engram_lookup(vocab_size, tokenizer_path)
+        self.blocks = nn.ModuleList()
+        for i in range(num_layers):
+            memory = None
+            if i in engram_layer_ids:
+                memory = EngramMemory(
+                    i,
+                    compressed_lookup,
+                    tokenizer_path,
+                    0,
+                    model_dim,
+                    engram_vocab_sizes,
+                    engram_max_ngram,
+                    engram_n_embed_per_ngram,
+                    engram_n_head_per_ngram,
+                    engram_layer_ids,
+                    engram_kernel_size,
+                    engram_seed,
+                )
+            self.blocks.append(
+                MemoryBlock(
+                    i,
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                    use_exclusive_self_attention,
+                    memory,
+                )
+            )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        )
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _hidden(self, input_ids: Tensor) -> Tensor:
+        x = F.rms_norm(self.tok_emb(input_ids), (self.tok_emb.embedding_dim,))
+        for block in self.blocks:
+            x = block(x, input_ids)
+        return self.final_norm(x)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self._hidden(input_ids).reshape(-1, self.tok_emb.embedding_dim)
+        targets = target_ids.reshape(-1)
+        logits_proj = (
+            F.linear(x, self.tok_emb.weight) if self.tie_embeddings else self.lm_head(x)
+        )
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        x = self._hidden(input_ids)
+        logits_proj = (
+            F.linear(x, self.tok_emb.weight) if self.tie_embeddings else self.lm_head(x)
+        )
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+) -> tuple[float, float]:
+    seq_len = args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+    window_starts = [
+        ws
+        for ws in range(0, total_tokens, stride)
+        if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0
+    ]
+    total_windows = len(window_starts)
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi : bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws : end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = base_model.forward_logits(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(
+                    torch.float64
+                )
+                byte_count += tb.sum()
+            if rank == 0 and (bi // batch_seqs) % 50 == 0:
+                done = min(bi + batch_seqs, len(my_windows))
+                pct = done / len(my_windows) * 100
+                running_bpb = 0.0
+                if token_count.item() > 0:
+                    rl = (loss_sum / token_count).item()
+                    running_bpb = (
+                        rl / math.log(2.0) * (token_count.item() / byte_count.item())
+                    )
+                print(
+                    f"  sliding_eval [{pct:5.1f}%] {done}/{len(my_windows)} windows running_bpb={running_bpb:.6f}",
+                    flush=True,
+                )
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(
+            ["nvidia-smi"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        ).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(
+            f"Script only setup for SentencePiece .model file: {args.tokenizer_path}"
+        )
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = maybe_cap_validation_tokens(
+        load_validation_tokens(args.val_files, args.train_seq_len),
+        args.train_seq_len,
+        args.val_max_tokens,
+    )
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = (
+        build_sentencepiece_luts(sp, args.vocab_size, device)
+    )
+    log0(
+        f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}"
+    )
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # MODEL + OPTIMIZER SETUP
+    base_model = (
+        MemoryGPT(
+            vocab_size=args.vocab_size,
+            num_layers=args.num_layers,
+            model_dim=args.model_dim,
+            num_heads=args.num_heads,
+            num_kv_heads=args.num_kv_heads,
+            mlp_mult=args.mlp_mult,
+            tie_embeddings=args.tie_embeddings,
+            tied_embed_init_std=args.tied_embed_init_std,
+            logit_softcap=args.logit_softcap,
+            rope_base=args.rope_base,
+            qk_gain_init=args.qk_gain_init,
+            tokenizer_path=args.tokenizer_path,
+            train_seq_len=args.train_seq_len,
+            engram_vocab_sizes=args.engram_vocab_sizes,
+            engram_max_ngram=args.engram_max_ngram,
+            engram_n_embed_per_ngram=args.engram_n_embed_per_ngram,
+            engram_n_head_per_ngram=args.engram_n_head_per_ngram,
+            engram_layer_ids=args.engram_layer_ids,
+            engram_kernel_size=args.engram_kernel_size,
+            engram_seed=args.engram_seed,
+            use_exclusive_self_attention=args.use_exclusive_self_attention,
+        )
+        .to(device)
+        .bfloat16()
+    )
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    compiled_model = (
+        base_model
+        if args.disable_compile
+        else torch.compile(base_model, dynamic=False, fullgraph=True)
+    )
+    model: nn.Module = (
+        DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False)
+        if distributed
+        else compiled_model
+    )
+
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    other_params = [
+        p
+        for name, p in base_model.named_parameters()
+        if name not in {"tok_emb.weight", "lm_head.weight"}
+    ]
+    param_groups = [
+        {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr},
+        {"params": other_params, "lr": args.matrix_lr, "base_lr": args.matrix_lr},
+    ]
+    if base_model.lm_head is not None:
+        param_groups.append(
+            {
+                "params": [base_model.lm_head.weight],
+                "lr": args.head_lr,
+                "base_lr": args.head_lr,
+            }
+        )
+    optimizers: list[torch.optim.Optimizer] = [
+        torch.optim.AdamW(
+            param_groups,
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            weight_decay=args.weight_decay,
+            fused=True,
+        )
+    ]
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"compile_enabled:{not args.disable_compile}")
+    log0(
+        f"attention_mode:engram_ref num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}"
+    )
+    if args.use_exclusive_self_attention:
+        log0("attention_extras:exclusive_self_attention=True")
+    log0(
+        f"engram:layers:{list(args.engram_layer_ids)} vocab_sizes:{list(args.engram_vocab_sizes)} max_ngram:{args.engram_max_ngram} embed_per_ngram:{args.engram_n_embed_per_ngram} heads_per_ngram:{args.engram_n_head_per_ngram} kernel:{args.engram_kernel_size}"
+    )
+    log0(
+        f"faithful_optimizer:adamw embed_lr:{token_lr} matrix_lr:{args.matrix_lr} head_lr:{args.head_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    # DATA LOADER & MODEL WARMUP
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = (
+        1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    )
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return (
+                max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0)
+                if warmdown_start <= step < args.iterations
+                else 1.0
+            )
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return (
+            remaining_ms / max(warmdown_ms, 1e-9)
+            if remaining_ms <= warmdown_ms
+            else 1.0
+        )
+
+    if args.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for name, tensor in base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in optimizers
+        ]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = (
+                        micro_step == grad_accum_steps - 1
+                    )
+                x, y = train_loader.next_batch(
+                    args.train_batch_tokens, args.train_seq_len, grad_accum_steps
+                )
+                with torch.autocast(
+                    device_type="cuda", dtype=torch.bfloat16, enabled=True
+                ):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if (
+                args.warmup_steps <= 20
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == args.warmup_steps
+            ):
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(
+            args.train_files, rank, world_size, device
+        )
+
+    # MAIN TRAINING LOOP
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (
+            stop_after_step is not None and step >= stop_after_step
+        )
+
+        should_validate = last_step or (
+            args.val_loss_every > 0 and step % args.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(
+                args.train_batch_tokens, args.train_seq_len, grad_accum_steps
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+
+        # SWA: collect checkpoints during warmdown
+        if (
+            args.swa_enabled
+            and scale < args.swa_start_frac
+            and step % args.swa_every == 0
+        ):
+            if swa_state is None:
+                swa_state = {
+                    name: t.detach().cpu().clone()
+                    for name, t in base_model.state_dict().items()
+                }
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+
+        should_log_train = args.train_log_every > 0 and (
+            step <= 10
+            or step % args.train_log_every == 0
+            or stop_after_step is not None
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # Apply SWA if collected
+    if args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"swa:applying averaged {swa_count} checkpoints")
+        current_state = base_model.state_dict()
+        avg_state = {
+            name: (tensor / swa_count).to(dtype=current_state[name].dtype)
+            for name, tensor in swa_state.items()
+        }
+        base_model.load_state_dict(avg_state, strict=True)
+
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    # Magnitude pruning: zero out smallest weights to improve compression
+    with torch.no_grad():
+        for name, param in base_model.named_parameters():
+            if param.ndim == 2 and param.numel() > 65536:
+                threshold = torch.quantile(param.abs().float().flatten(), 0.03)
+                mask = param.abs() < threshold
+                param.masked_fill_(mask, 0.0)
+
+    # INT6 mixed quantization + zstd/zlib export
+    sd_cpu = {k: v.detach().cpu() for k, v in base_model.state_dict().items()}
+    quant_result, quant_meta = mixed_quantize_int6(sd_cpu, {"mlp", "attn", "bigram"})
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    if _COMPRESSOR == "zstd":
+        quant_blob = zstandard.ZstdCompressor(level=22).compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, 9)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+{_COMPRESSOR}: {quant_file_bytes} bytes")
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    if _COMPRESSOR == "zstd":
+        decompressed = zstandard.ZstdDecompressor().decompress(quant_blob_disk)
+    else:
+        decompressed = zlib.decompress(quant_blob_disk)
+    quant_state = torch.load(io.BytesIO(decompressed), map_location="cpu")
+    deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], sd_cpu)
+    base_model.load_state_dict(deq_state, strict=True)
+
+    # Sliding window eval on int6-roundtripped weights
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    if args.eval_stride > 0 and args.eval_stride < args.train_seq_len:
+        log0(
+            f"final_eval_mode:sliding_window stride:{args.eval_stride} batch_seqs:{args.eval_batch_seqs}"
+        )
+        q_val_loss, q_val_bpb = eval_val_sliding(
+            args,
+            base_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            stride=args.eval_stride,
+            batch_seqs=args.eval_batch_seqs,
+        )
+    else:
+        log0("final_eval_mode:standard")
+        q_val_loss, q_val_bpb = eval_val(
+            args,
+            model,
+            rank,
+            world_size,
+            device,
+            grad_accum_steps,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+        )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(
+        f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}"
+    )
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+# fixes applied
+# tuned


### PR DESCRIPTION
## Summary

Adds a non-record 16MB submission for a faithful standalone conditional-memory architecture.

This submission explores:
- tokenizer-normalized compressed lookup identities
- multi-hash n-gram memory tables
- contextual key/value projections
- internal-layer memory injection

## Result
- 8xH100 result:
  - `final_int8_zlib_roundtrip_exact val_bpb: 1.61095535`
- Artifact size:
  - `2,773,498` bytes

## Why submit this
This method showed strong standalone local signs of life before cloud evaluation, but did not transfer competitively enough to challenge the dense frontier. It is submitted as a non-record methodological contribution and negative/partial result for future work.

## Included
- `README.md`
- `submission.json`
- `train_gpt.py`
- cloud log