### PR TITLE
Record: Varlen attention + fused MLP + doc-independent TTT (1.07336)

### DIFF
--- a/records/track_10min_16mb/2026-04-10_VarLenAttn/README.md
+++ b/records/track_10min_16mb/2026-04-10_VarLenAttn/README.md
@@ -1,0 +1,72 @@
+# Record: Varlen attention + fused MLP + TTT
+
+**val_loss: 2.7806 | val_bpb: 1.07643** | **~15.99 MB** | 8×H100 SXM, 600s train + ~360s TTT eval
+| Seed | SW Loss | SW BPB | TTT Loss | TTT BPB |
+|------|---------|--------|----------|---------|
+| 0 | 2.78822313 | 1.07940806 | 2.78138792 | 1.07676194 |
+| 1 | 2.78698310 | 1.07892801 | 2.78033428 | 1.07635404 |
+| 2 | 2.78652675 | 1.07875134 | 2.77993034 | 1.07619767 |
+| **Mean** | **2.78724** | **1.07903** | **2.78055** | **1.07644** |
+
+Best PR bpb ([PR #1523](https://github.com/openai/parameter-golf/pull/1523)): 1.0778. **delta=.0014**
+Merged record bpb ([PR #1493](https://github.com/openai/parameter-golf/pull/1493)): 1.0810. **delta=.0047**
+
+Increased training speed ~5% via variable length attention, a fused kernel, and grouping together small parameters, yielding ~.002 nats when comparing sliding window eval. Re-added document-based LoRA TTT which has *no inter-sequence dependence* and beats previous record by ~.003 nats.
+
+## Main changes
+
+Applied changes from [my old PR](https://github.com/openai/parameter-golf/pull/1354) to a recent record PR: [Record: SP8192 + Triple Recurrence + Banking + Fused MLP + Muon 0.97 — val_bpb 1.0778 (3-seed mean) #1523](https://github.com/openai/parameter-golf/pull/1523). Most of below is copied from my previous PR.
+
+This involves 3 things:
+
+### 1. Variable length attention (~2% faster training, ~0.001 nats)
+
+Replaced dense causal attention with Flash Attention 3's `flash_attn_varlen_func`. During training, documents are packed into flat token buffers with `cu_seqlens` boundaries so attention is computed within documents only — the model never attends across unrelated documents that happen to be adjacent in a batch.
+
+This does two things:
+- Removes the need for the model to learn to ignore pre-BOS content from unrelated documents
+- Reduces wasted FLOPs: e.g. 10 short (100-token) docs packed into a 1k-token buffer cost proportional to `100 * 100**2 = 1M` attention FLOPs vs `10 * 1000**2 = 10M` with dense attention.
+
+### 2. Fused MLP + grouped small params (~3% faster training, ~0.001 nats)
+
+A custom Triton kernel (`linear_leaky_relu_square_kernel`) fuses the up-projection, LeakyReLU(0.5)² activation, and squaring into a single kernel. Based on similar kernels from [modded-nanogpt](https://github.com/KellerJordan/modded-nanogpt/blob/master/triton_kernels.py). I also group the many tiny replicated scalar/control gradients into a single all-reduce to avoid a pile of tiny collectives.
+
+### 3. Doc-based test-time training (TTT) (~0.003 nats)
+
+> [Blog explaining LoRA-based TTT from past record](https://samacquaviva.com/projects/parameter-golf/)
+
+Although it is technically legal in this competition to train on tokens from previous documents in the dataset, I am spiritually opposed to this. Under the current formulation, if the eval set was bigger, the expectation of the loss would be lower which seems broken. So in this implementation, there is score-first TTT applied to each sequence in the validation set *independently* (and efficiently using batched LoRAs), which is strictly harder.
+
+Re-adds LoRA-based TTT, based on [my old implementation](https://github.com/openai/parameter-golf/blob/main/records/track_10min_16mb/2026-03-17_LoRA_TTT/README.md), but > 2x faster which allows for using smaller chunk sizes which leads to better performance. This is an instance of "Case 3" according to [this classification](https://samacquaviva.com/projects/ttt-clarification/). The TTT gain is only ~.003 nats over sliding window evaluation, as compared to ~.007 in [my previous PR](https://github.com/openai/parameter-golf/pull/1354) and ~.006 in the most recent record which trains on the entire validation sequence. This gap is probably closeable with better hparams, I largely just took my hparams optimized for the non-looped transformer.
+
+It's interesting to note that adding test-time training improves loss more than adding ~215 steps. These 215 steps train on `786432*215=169,082,880` tokens to gain ~.002 nats. The average sequence length in the validation set is ~200 tokens which means test-time training here gains ~.003 nats / 800 tokens on average (valid bc sequences are trained independently). So, in a way, TTT is `~(.003/800) / (.002/169082880) >= 300k` times more token efficient than pre-training: it helps to be in distribution :)
+
+## Other small changes
+
+- Added some useful dev things, like loading from a checkpoint just for eval
+- Didn't submit minified code, instead wrote that utility into the script so that it is easier for people to build off of this
+
+## Replicating runs + dev
+
+```bash
+# setup
+uv venv
+source .venv/bin/activate
+uv pip install -r records/track_10min_16mb/2026-04-10_VarLenAttn/requirements.txt
+uv pip install --break-system-packages flash_attn_3 --find-links https://windreamer.github.io/flash-attention3-wheels/cu128_torch291
+uv pip install torch==2.9.1+cu128 --extra-index-url https://download.pytorch.org/whl/cu128
+
+MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf \
+  python3 data/cached_challenge_fineweb.py --variant sp8192 --train-shards  128
+
+# train + eval
+SEED=0
+ARTIFACT_DIR="runs/varlen${SEED}" SEED=$SEED \
+    torchrun --standalone --nproc_per_node=8 \
+    records/track_10min_16mb/2026-04-10_VarLenAttn/train_gpt.py
+
+# eval saved checkpoint w/ TTT (useful for dev)
+EVAL_ONLY_PATH="runs/varlen${SEED}/final_model.pt" SEED=$SEED \
+    torchrun --standalone --nproc_per_node=8 \
+    records/track_10min_16mb/2026-04-10_VarLenAttn/train_gpt.py
+```

--- a/records/track_10min_16mb/2026-04-10_VarLenAttn/README.md
+++ b/records/track_10min_16mb/2026-04-10_VarLenAttn/README.md
@@ -1,21 +1,23 @@
 # Record: Varlen attention + fused MLP + TTT
 
-**val_loss: 2.7806 | val_bpb: 1.07643** | **~15.99 MB** | 8×H100 SXM, 600s train + ~360s TTT eval
-| Seed | SW Loss | SW BPB | TTT Loss | TTT BPB |
-|------|---------|--------|----------|---------|
-| 0 | 2.78822313 | 1.07940806 | 2.78138792 | 1.07676194 |
-| 1 | 2.78698310 | 1.07892801 | 2.78033428 | 1.07635404 |
-| 2 | 2.78652675 | 1.07875134 | 2.77993034 | 1.07619767 |
-| **Mean** | **2.78724** | **1.07903** | **2.78055** | **1.07644** |
+**val_loss: 2.77261 | val_bpb: 1.07336** | **~15.99 MB** | 8×H100 SXM, 587s train + ~340s TTT eval
+| Seed | BPB | Loss |
+|------|-----|------|
+| 0 | 1.07258208 | 2.77059090 |
+| 1 | 1.07324696 | 2.77230836 |
+| 2 | 1.07426259 | 2.77493185 |
+| **Mean** | **1.07336388** | **2.77261037** |
+| **Std** | **0.00084633** | **0.00218618** |
 
-Best PR bpb ([PR #1523](https://github.com/openai/parameter-golf/pull/1523)): 1.0778. **delta=.0014**
-Merged record bpb ([PR #1493](https://github.com/openai/parameter-golf/pull/1493)): 1.0810. **delta=.0047**
+Best PR bpb ([PR #1529](https://github.com/openai/parameter-golf/pull/1529)): bpb=1.0753 (**delta=0.0019**), loss=2.7776 (**delta=0.0050**)
 
-Increased training speed ~5% via variable length attention, a fused kernel, and grouping together small parameters, yielding ~.002 nats when comparing sliding window eval. Re-added document-based LoRA TTT which has *no inter-sequence dependence* and beats previous record by ~.003 nats.
+Merged record bpb ([PR #1493](https://github.com/openai/parameter-golf/pull/1493)): bpb=1.0810 (**delta=0.0076**), loss=2.7923 (**delta=0.0197**)
+
+Increased training speed ~5% via variable length attention, a fused MLP triton kernel (no `cutlass_evt_fusion` dep), and grouping together small parameters, yielding ~.002 nats when comparing sliding window eval. Re-added document-based LoRA TTT which has *no inter-sequence dependence* and improves over strided evaluation by ~.008 nats.
 
 ## Main changes
 
-Applied changes from [my old PR](https://github.com/openai/parameter-golf/pull/1354) to a recent record PR: [Record: SP8192 + Triple Recurrence + Banking + Fused MLP + Muon 0.97 — val_bpb 1.0778 (3-seed mean) #1523](https://github.com/openai/parameter-golf/pull/1523). Most of below is copied from my previous PR.
+Applied changes from [my old PR](https://github.com/openai/parameter-golf/pull/1354) to a recent record PR: [#1523](https://github.com/openai/parameter-golf/pull/1523). But [PR #1552](https://github.com/openai/parameter-golf/pull/1552) beat my previous bpb before I submitted the PR, so I incorporated their (orthogonal) improvements. Most of below is copied from my previous PR [#1354](https://github.com/openai/parameter-golf/pull/1354).
 
 This involves 3 things:
 
@@ -37,14 +39,17 @@ A custom Triton kernel (`linear_leaky_relu_square_kernel`) fuses the up-projecti
 
 Although it is technically legal in this competition to train on tokens from previous documents in the dataset, I am spiritually opposed to this. Under the current formulation, if the eval set was bigger, the expectation of the loss would be lower which seems broken. So in this implementation, there is score-first TTT applied to each sequence in the validation set *independently* (and efficiently using batched LoRAs), which is strictly harder.
 
-Re-adds LoRA-based TTT, based on [my old implementation](https://github.com/openai/parameter-golf/blob/main/records/track_10min_16mb/2026-03-17_LoRA_TTT/README.md), but > 2x faster which allows for using smaller chunk sizes which leads to better performance. This is an instance of "Case 3" according to [this classification](https://samacquaviva.com/projects/ttt-clarification/). The TTT gain is only ~.003 nats over sliding window evaluation, as compared to ~.007 in [my previous PR](https://github.com/openai/parameter-golf/pull/1354) and ~.006 in the most recent record which trains on the entire validation sequence. This gap is probably closeable with better hparams, I largely just took my hparams optimized for the non-looped transformer.
+Re-adds LoRA-based TTT, based on [my old implementation](https://github.com/openai/parameter-golf/blob/main/records/track_10min_16mb/2026-03-17_LoRA_TTT/README.md), but > 2x faster which allows for using smaller chunk sizes which leads to better performance. This is an instance of "Case 3" according to [this classification](https://samacquaviva.com/projects/ttt-clarification/).
 
 It's interesting to note that adding test-time training improves loss more than adding ~215 steps. These 215 steps train on `786432*215=169,082,880` tokens to gain ~.002 nats. The average sequence length in the validation set is ~200 tokens which means test-time training here gains ~.003 nats / 800 tokens on average (valid bc sequences are trained independently). So, in a way, TTT is `~(.003/800) / (.002/169082880) >= 300k` times more token efficient than pre-training: it helps to be in distribution :)
 
 ## Other small changes
 
-- Added some useful dev things, like loading from a checkpoint just for eval
-- Didn't submit minified code, instead wrote that utility into the script so that it is easier for people to build off of this
+Made some changes to make replication and dev based on this PR easier:
+
+- Load from a checkpoint just for eval
+- Didn't submit minified code, instead wrote that utility into the script when calculating file size so that it is easier for people to build off of this
+- Store unminified code in logs
 
 ## Replicating runs + dev
 

--- a/records/track_10min_16mb/2026-04-10_VarLenAttn/logs/train0.txt
+++ b/records/track_10min_16mb/2026-04-10_VarLenAttn/logs/train0.txt
@@ -1,0 +1,341 @@
+====================================================================================================
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  artifact_dir: runs/varlen0
+  beta1: 0.9
+  beta2: 0.95
+  compressor: brotli
+  data_dir: ./data/
+  datasets_dir: ./data/datasets/fineweb10B_sp8192
+  distributed: True
+  ema_decay: 0.997
+  embed_bits: 8
+  embed_clip_sigmas: 20.0
+  embed_lr: 0.6
+  embed_wd: 0.095
+  embedding_dim: 512
+  enable_looping_at: 0.35
+  etlb_clip: 3.0
+  etlb_lr: 0.05
+  etlb_steps: 5
+  eval_only_path: 
+  eval_seq_len: 2048
+  eval_stride: 64
+  gptq_calibration_batches: 64
+  gptq_reserve_seconds: 12.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  head_lr: 0.008
+  is_main_process: True
+  iterations: 20000
+  ln_scale: True
+  local_rank: 0
+  logfile: runs/varlen0/11e133ec-2d1b-409b-8951-f3a43f5a3f50.txt
+  logit_softcap: 30.0
+  loop_end: 5
+  loop_start: 3
+  matrix_bits: 6
+  matrix_clip_sigmas: 12.85
+  matrix_lr: 0.022
+  max_wallclock_seconds: 600.0
+  min_lr: 0.0
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: runs/varlen0/final_model.pt
+  muon_backend_steps: 5
+  muon_beta2: 0.95
+  muon_momentum: 0.97
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_row_normalize: True
+  muon_wd: 0.095
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  num_loops: 2
+  parallel_start_layer: 7
+  qk_gain_init: 5.0
+  quantized_model_path: runs/varlen0/final_model.int6.ptz
+  rank: 0
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  rope_yarn: False
+  run_id: 11e133ec-2d1b-409b-8951-f3a43f5a3f50
+  scalar_lr: 0.02
+  seed: 0
+  skip_gates_enabled: True
+  sliding_window_enabled: False
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  tokenizer_path: ./data/tokenizers/fineweb_8192_bpe.model
+  train_batch_tokens: 786432
+  train_files: ./data/datasets/fineweb10B_sp8192/fineweb_train_*.bin
+  train_log_every: 500
+  train_seq_len: 2048
+  ttt_batch_size: 64
+  ttt_beta1: 0.0
+  ttt_beta2: 0.999
+  ttt_chunk_size: 64
+  ttt_enabled: True
+  ttt_eval_batches: 
+  ttt_eval_seq_len: 2048
+  ttt_grad_steps: 1
+  ttt_k_lora: True
+  ttt_lora_lr: 0.0001
+  ttt_lora_rank: 96
+  ttt_mlp_lora: True
+  ttt_o_lora: True
+  ttt_optimizer: adam
+  ttt_output_dir: 
+  ttt_weight_decay: 0.5
+  val_batch_tokens: 524288
+  val_doc_fraction: 1.0
+  val_files: ./data/datasets/fineweb10B_sp8192/fineweb_val_*.bin
+  val_loss_every: 4000
+  vocab_size: 8192
+  warmdown_frac: 0.667
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.9.1+cu128
+Fri Apr 10 21:54:16 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   48C    P0            125W /  700W |    1519MiB /  81559MiB |      2%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   37C    P0            118W /  700W |    1519MiB /  81559MiB |      2%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   38C    P0            116W /  700W |    1519MiB /  81559MiB |      3%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   36C    P0            118W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   40C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   34C    P0            114W /  700W |    1519MiB /  81559MiB |      2%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   36C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   35C    P0            116W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A         1732496      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A         1732497      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A         1732498      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A         1732499      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A         1732500      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A         1732501      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A         1732502      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A         1732503      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+train_shards: 128
+val_tokens: 40540160
+model_params:35944537
+gptq:reserving 12s, effective=588000ms
+warmup_cu_buckets:64,128,192,256 iters_each:3
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup:enabled encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+loop_warmup_step: 1/20
+loop_warmup_step: 2/20
+loop_warmup_step: 3/20
+loop_warmup_step: 4/20
+loop_warmup_step: 5/20
+loop_warmup_step: 6/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+0/20000 val_loss: 9.0085 val_bpb: 3.4874
+1/20000 train_loss: 9.0089 train_time: 0.0m tok/s: 18850472
+2/20000 train_loss: 12.2347 train_time: 0.0m tok/s: 13811925
+3/20000 train_loss: 11.1722 train_time: 0.0m tok/s: 11479577
+4/20000 train_loss: 9.5567 train_time: 0.0m tok/s: 10527592
+5/20000 train_loss: 8.1979 train_time: 0.0m tok/s: 10056434
+500/20000 train_loss: 3.2864 train_time: 0.8m tok/s: 8290951
+1000/20000 train_loss: 3.0354 train_time: 1.6m tok/s: 8259228
+1500/20000 train_loss: 3.0451 train_time: 2.4m tok/s: 8256335
+2000/20000 train_loss: 3.0101 train_time: 3.2m tok/s: 8251977
+layer_loop:enabled step:2159 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2500/20000 train_loss: 3.0883 train_time: 4.2m tok/s: 7723640
+3000/20000 train_loss: 2.9246 train_time: 5.4m tok/s: 7273318
+3500/20000 train_loss: 2.9912 train_time: 6.6m tok/s: 6983412
+4000/20000 train_loss: 2.9199 train_time: 7.7m tok/s: 6779882
+4000/20000 val_loss: 2.8943 val_bpb: 1.1204
+4500/20000 train_loss: 2.8670 train_time: 8.9m tok/s: 6630508
+4890/20000 val_loss: 2.7794 val_bpb: 1.0760
+stopping_early: wallclock_cap train_time: 588188ms step: 4890/20000
+peak memory allocated: 40019 MiB reserved: 44088 MiB
+ema:applying EMA weights
+
+beginning eval timer
+pre-quantization post-ema val_loss:2.77999363 val_bpb:1.07618748 eval_time:7628ms
+Serialized model: 135408623 bytes
+Code size (uncompressed): 122556 bytes
+Code size (compressed): 26760 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 12.4s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int8): tok_emb.weight
+  passthrough (float16): blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, lane_merge, skip_gates, skip_weights
+Serialized model quantized+brotli: 15965480 bytes
+Total submission size quantized+brotli: 15992240 bytes
+quantized val_loss:2.80837934 val_bpb:1.08717612 eval_time:8614ms
+ttt_lora:warming up compile
+ttt_lora:compile warmup done (86.4s)
+ttt_lora:docs:50000 rank:96 lr:0.0001 chunk:64
+ttt_progress: batch 778/782 batch_loss:2.7982 batch_bpb:1.1194 running_loss:2.7982 running_bpb:1.1194 doc_len:7961-8997
+ttt_progress: batch 773/782 batch_loss:2.6647 batch_bpb:1.0813 running_loss:2.7465 running_bpb:1.1048 doc_len:5203-5550
+ttt_progress: batch 771/782 batch_loss:2.7699 batch_bpb:1.0830 running_loss:2.7526 running_bpb:1.0990 doc_len:4701-4937
+ttt_progress: batch 767/782 batch_loss:2.7646 batch_bpb:1.1038 running_loss:2.7547 running_bpb:1.0999 doc_len:3963-4123
+ttt_progress: batch 762/782 batch_loss:2.8361 batch_bpb:1.0795 running_loss:2.7656 running_bpb:1.0970 doc_len:3431-3533
+ttt_progress: batch 757/782 batch_loss:2.6475 batch_bpb:1.0232 running_loss:2.7531 running_bpb:1.0891 doc_len:3033-3108
+ttt_progress: batch 751/782 batch_loss:2.8008 batch_bpb:1.0752 running_loss:2.7572 running_bpb:1.0879 doc_len:2689-2740
+ttt_progress: batch 743/782 batch_loss:2.7197 batch_bpb:1.0471 running_loss:2.7546 running_bpb:1.0850 doc_len:2355-2388
+ttt_progress: batch 736/782 batch_loss:2.6838 batch_bpb:1.0461 running_loss:2.7504 running_bpb:1.0827 doc_len:2140-2165
+ttt_progress: batch 730/782 batch_loss:2.7717 batch_bpb:1.0912 running_loss:2.7515 running_bpb:1.0831 doc_len:1995-2016
+ttt_progress: batch 725/782 batch_loss:2.7673 batch_bpb:1.0726 running_loss:2.7523 running_bpb:1.0826 doc_len:1900-1915
+ttt_progress: batch 719/782 batch_loss:2.6914 batch_bpb:1.0320 running_loss:2.7497 running_bpb:1.0804 doc_len:1793-1816
+ttt_progress: batch 706/782 batch_loss:2.7223 batch_bpb:1.0465 running_loss:2.7487 running_bpb:1.0791 doc_len:1617-1627
+ttt_progress: batch 700/782 batch_loss:2.6859 batch_bpb:1.0483 running_loss:2.7465 running_bpb:1.0780 doc_len:1552-1562
+ttt_progress: batch 695/782 batch_loss:2.7890 batch_bpb:1.0813 running_loss:2.7479 running_bpb:1.0781 doc_len:1504-1513
+ttt_progress: batch 689/782 batch_loss:2.7864 batch_bpb:1.0661 running_loss:2.7490 running_bpb:1.0778 doc_len:1450-1458
+ttt_progress: batch 684/782 batch_loss:2.8037 batch_bpb:1.0779 running_loss:2.7506 running_bpb:1.0778 doc_len:1407-1414
+ttt_progress: batch 671/782 batch_loss:2.8909 batch_bpb:1.1204 running_loss:2.7542 running_bpb:1.0789 doc_len:1316-1321
+ttt_progress: batch 667/782 batch_loss:2.8291 batch_bpb:1.1083 running_loss:2.7561 running_bpb:1.0796 doc_len:1288-1295
+ttt_progress: batch 659/782 batch_loss:2.7212 batch_bpb:1.0247 running_loss:2.7552 running_bpb:1.0783 doc_len:1239-1245
+ttt_progress: batch 652/782 batch_loss:2.8055 batch_bpb:1.0749 running_loss:2.7564 running_bpb:1.0782 doc_len:1198-1203
+ttt_progress: batch 647/782 batch_loss:2.7576 batch_bpb:1.0498 running_loss:2.7564 running_bpb:1.0776 doc_len:1171-1177
+ttt_progress: batch 642/782 batch_loss:2.7899 batch_bpb:1.0853 running_loss:2.7571 running_bpb:1.0778 doc_len:1144-1150
+ttt_progress: batch 635/782 batch_loss:2.7431 batch_bpb:1.0618 running_loss:2.7568 running_bpb:1.0775 doc_len:1111-1116
+ttt_progress: batch 628/782 batch_loss:2.7790 batch_bpb:1.0510 running_loss:2.7572 running_bpb:1.0770 doc_len:1078-1082
+ttt_progress: batch 621/782 batch_loss:2.8442 batch_bpb:1.0893 running_loss:2.7587 running_bpb:1.0772 doc_len:1046-1050
+ttt_progress: batch 614/782 batch_loss:2.7915 batch_bpb:1.0677 running_loss:2.7592 running_bpb:1.0770 doc_len:1016-1020
+ttt_progress: batch 607/782 batch_loss:2.7017 batch_bpb:1.0412 running_loss:2.7583 running_bpb:1.0764 doc_len:986-990
+ttt_progress: batch 600/782 batch_loss:2.8012 batch_bpb:1.0634 running_loss:2.7590 running_bpb:1.0762 doc_len:958-963
+ttt_progress: batch 588/782 batch_loss:2.7432 batch_bpb:1.0466 running_loss:2.7588 running_bpb:1.0758 doc_len:917-921
+ttt_progress: batch 581/782 batch_loss:2.7314 batch_bpb:1.0189 running_loss:2.7584 running_bpb:1.0750 doc_len:894-897
+ttt_progress: batch 579/782 batch_loss:2.6506 batch_bpb:1.0102 running_loss:2.7569 running_bpb:1.0741 doc_len:888-891
+ttt_progress: batch 572/782 batch_loss:2.9496 batch_bpb:1.1225 running_loss:2.7594 running_bpb:1.0747 doc_len:865-868
+ttt_progress: batch 565/782 batch_loss:2.7786 batch_bpb:1.0647 running_loss:2.7597 running_bpb:1.0746 doc_len:843-846
+ttt_progress: batch 556/782 batch_loss:2.8380 batch_bpb:1.0850 running_loss:2.7606 running_bpb:1.0747 doc_len:815-818
+ttt_progress: batch 549/782 batch_loss:2.7675 batch_bpb:1.0648 running_loss:2.7607 running_bpb:1.0746 doc_len:795-798
+ttt_progress: batch 543/782 batch_loss:2.7911 batch_bpb:1.0478 running_loss:2.7610 running_bpb:1.0743 doc_len:779-782
+ttt_progress: batch 537/782 batch_loss:2.7180 batch_bpb:1.0277 running_loss:2.7605 running_bpb:1.0738 doc_len:764-767
+ttt_progress: batch 532/782 batch_loss:2.8225 batch_bpb:1.0598 running_loss:2.7612 running_bpb:1.0736 doc_len:752-754
+ttt_progress: batch 525/782 batch_loss:2.7902 batch_bpb:1.0735 running_loss:2.7615 running_bpb:1.0736 doc_len:735-737
+ttt_progress: batch 518/782 batch_loss:2.7350 batch_bpb:1.0534 running_loss:2.7612 running_bpb:1.0734 doc_len:717-720
+ttt_progress: batch 511/782 batch_loss:2.7802 batch_bpb:1.0501 running_loss:2.7614 running_bpb:1.0732 doc_len:700-703
+ttt_progress: batch 504/782 batch_loss:2.8755 batch_bpb:1.1018 running_loss:2.7625 running_bpb:1.0735 doc_len:685-686
+ttt_progress: batch 497/782 batch_loss:2.8433 batch_bpb:1.0841 running_loss:2.7632 running_bpb:1.0736 doc_len:668-671
+ttt_progress: batch 490/782 batch_loss:2.8600 batch_bpb:1.0929 running_loss:2.7640 running_bpb:1.0737 doc_len:653-655
+ttt_progress: batch 483/782 batch_loss:2.7519 batch_bpb:1.0524 running_loss:2.7639 running_bpb:1.0736 doc_len:639-641
+ttt_progress: batch 476/782 batch_loss:2.7636 batch_bpb:1.0555 running_loss:2.7639 running_bpb:1.0734 doc_len:624-626
+ttt_progress: batch 469/782 batch_loss:2.8012 batch_bpb:1.1139 running_loss:2.7642 running_bpb:1.0737 doc_len:610-611
+ttt_progress: batch 462/782 batch_loss:2.8786 batch_bpb:1.0725 running_loss:2.7651 running_bpb:1.0737 doc_len:597-599
+ttt_progress: batch 455/782 batch_loss:2.8079 batch_bpb:1.0768 running_loss:2.7654 running_bpb:1.0737 doc_len:584-586
+ttt_progress: batch 448/782 batch_loss:2.7334 batch_bpb:1.0384 running_loss:2.7652 running_bpb:1.0735 doc_len:571-573
+ttt_progress: batch 441/782 batch_loss:2.7196 batch_bpb:1.0469 running_loss:2.7648 running_bpb:1.0733 doc_len:559-560
+ttt_progress: batch 434/782 batch_loss:2.7359 batch_bpb:1.0455 running_loss:2.7647 running_bpb:1.0731 doc_len:545-547
+ttt_progress: batch 427/782 batch_loss:2.7645 batch_bpb:1.0681 running_loss:2.7647 running_bpb:1.0731 doc_len:533-535
+ttt_progress: batch 420/782 batch_loss:2.7950 batch_bpb:1.0645 running_loss:2.7648 running_bpb:1.0730 doc_len:521-522
+ttt_progress: batch 413/782 batch_loss:2.6533 batch_bpb:1.0004 running_loss:2.7642 running_bpb:1.0725 doc_len:510-511
+ttt_progress: batch 406/782 batch_loss:2.8464 batch_bpb:1.1082 running_loss:2.7646 running_bpb:1.0728 doc_len:498-500
+ttt_progress: batch 399/782 batch_loss:2.7508 batch_bpb:1.0420 running_loss:2.7646 running_bpb:1.0726 doc_len:487-489
+ttt_progress: batch 392/782 batch_loss:2.8025 batch_bpb:1.0821 running_loss:2.7648 running_bpb:1.0726 doc_len:476-478
+ttt_progress: batch 385/782 batch_loss:2.8944 batch_bpb:1.1029 running_loss:2.7655 running_bpb:1.0728 doc_len:466-467
+ttt_progress: batch 378/782 batch_loss:2.8304 batch_bpb:1.1013 running_loss:2.7659 running_bpb:1.0730 doc_len:456-457
+ttt_progress: batch 371/782 batch_loss:2.8083 batch_bpb:1.0734 running_loss:2.7661 running_bpb:1.0730 doc_len:446-447
+ttt_progress: batch 364/782 batch_loss:2.7392 batch_bpb:1.0684 running_loss:2.7659 running_bpb:1.0729 doc_len:436-437
+ttt_progress: batch 357/782 batch_loss:2.8704 batch_bpb:1.0861 running_loss:2.7665 running_bpb:1.0730 doc_len:426-427
+ttt_progress: batch 350/782 batch_loss:2.7358 batch_bpb:1.0611 running_loss:2.7663 running_bpb:1.0729 doc_len:417-418
+ttt_progress: batch 343/782 batch_loss:2.8005 batch_bpb:1.0686 running_loss:2.7665 running_bpb:1.0729 doc_len:407-408
+ttt_progress: batch 336/782 batch_loss:2.9610 batch_bpb:1.1701 running_loss:2.7674 running_bpb:1.0734 doc_len:398-399
+ttt_progress: batch 329/782 batch_loss:2.8405 batch_bpb:1.1080 running_loss:2.7677 running_bpb:1.0735 doc_len:389-390
+ttt_progress: batch 322/782 batch_loss:2.7642 batch_bpb:1.0801 running_loss:2.7677 running_bpb:1.0735 doc_len:380-381
+ttt_progress: batch 315/782 batch_loss:2.7314 batch_bpb:1.0740 running_loss:2.7675 running_bpb:1.0735 doc_len:370-371
+ttt_progress: batch 308/782 batch_loss:2.8013 batch_bpb:1.0883 running_loss:2.7677 running_bpb:1.0736 doc_len:362-363
+ttt_progress: batch 301/782 batch_loss:2.7979 batch_bpb:1.0880 running_loss:2.7678 running_bpb:1.0737 doc_len:353-354
+ttt_progress: batch 293/782 batch_loss:2.7720 batch_bpb:1.0709 running_loss:2.7678 running_bpb:1.0736 doc_len:343-345
+ttt_progress: batch 287/782 batch_loss:2.8658 batch_bpb:1.1179 running_loss:2.7682 running_bpb:1.0738 doc_len:336-337
+ttt_progress: batch 279/782 batch_loss:2.8570 batch_bpb:1.0920 running_loss:2.7685 running_bpb:1.0739 doc_len:327-329
+ttt_progress: batch 273/782 batch_loss:2.7740 batch_bpb:1.0625 running_loss:2.7685 running_bpb:1.0738 doc_len:321-322
+ttt_progress: batch 266/782 batch_loss:2.8576 batch_bpb:1.0989 running_loss:2.7688 running_bpb:1.0739 doc_len:313-314
+ttt_progress: batch 259/782 batch_loss:2.8605 batch_bpb:1.1407 running_loss:2.7691 running_bpb:1.0741 doc_len:305-306
+ttt_progress: batch 253/782 batch_loss:2.7687 batch_bpb:1.0873 running_loss:2.7691 running_bpb:1.0742 doc_len:298-299
+ttt_progress: batch 246/782 batch_loss:2.9074 batch_bpb:1.1388 running_loss:2.7696 running_bpb:1.0744 doc_len:291-292
+ttt_progress: batch 239/782 batch_loss:2.9062 batch_bpb:1.1398 running_loss:2.7700 running_bpb:1.0746 doc_len:284-285
+ttt_progress: batch 232/782 batch_loss:2.9452 batch_bpb:1.1392 running_loss:2.7705 running_bpb:1.0748 doc_len:277-278
+ttt_progress: batch 225/782 batch_loss:2.8848 batch_bpb:1.1235 running_loss:2.7708 running_bpb:1.0749 doc_len:270-271
+ttt_progress: batch 218/782 batch_loss:2.7575 batch_bpb:1.1088 running_loss:2.7708 running_bpb:1.0750 doc_len:263-264
+ttt_progress: batch 211/782 batch_loss:2.9042 batch_bpb:1.1570 running_loss:2.7712 running_bpb:1.0752 doc_len:256-257
+ttt_progress: batch 204/782 batch_loss:2.9163 batch_bpb:1.1344 running_loss:2.7716 running_bpb:1.0754 doc_len:250-251
+ttt_progress: batch 197/782 batch_loss:2.8614 batch_bpb:1.1284 running_loss:2.7718 running_bpb:1.0755 doc_len:244-245
+ttt_progress: batch 190/782 batch_loss:2.8889 batch_bpb:1.0982 running_loss:2.7721 running_bpb:1.0756 doc_len:237-238
+ttt_progress: batch 183/782 batch_loss:2.8749 batch_bpb:1.1476 running_loss:2.7723 running_bpb:1.0758 doc_len:231-232
+ttt_progress: batch 176/782 batch_loss:2.8204 batch_bpb:1.1065 running_loss:2.7725 running_bpb:1.0758 doc_len:225-226
+ttt_progress: batch 169/782 batch_loss:2.9235 batch_bpb:1.1681 running_loss:2.7728 running_bpb:1.0760 doc_len:219-220
+ttt_progress: batch 162/782 batch_loss:2.9715 batch_bpb:1.1530 running_loss:2.7733 running_bpb:1.0762 doc_len:213-214
+ttt_progress: batch 155/782 batch_loss:2.8873 batch_bpb:1.1348 running_loss:2.7735 running_bpb:1.0763 doc_len:207-208
+ttt_progress: batch 150/782 batch_loss:2.9537 batch_bpb:1.1610 running_loss:2.7739 running_bpb:1.0765 doc_len:204-204
+ttt_progress: batch 142/782 batch_loss:2.9687 batch_bpb:1.1638 running_loss:2.7743 running_bpb:1.0767 doc_len:197-198
+ttt_progress: batch 135/782 batch_loss:2.9409 batch_bpb:1.1457 running_loss:2.7746 running_bpb:1.0768 doc_len:191-192
+ttt_progress: batch 129/782 batch_loss:2.9543 batch_bpb:1.1860 running_loss:2.7750 running_bpb:1.0770 doc_len:187-187
+ttt_progress: batch 120/782 batch_loss:2.9862 batch_bpb:1.1734 running_loss:2.7754 running_bpb:1.0772 doc_len:180-181
+ttt_progress: batch 113/782 batch_loss:3.0405 batch_bpb:1.1955 running_loss:2.7759 running_bpb:1.0774 doc_len:175-176
+ttt_progress: batch 106/782 batch_loss:2.9568 batch_bpb:1.1943 running_loss:2.7762 running_bpb:1.0776 doc_len:170-171
+ttt_progress: batch 100/782 batch_loss:2.9431 batch_bpb:1.1553 running_loss:2.7765 running_bpb:1.0778 doc_len:165-166
+ttt_progress: batch 92/782 batch_loss:2.9057 batch_bpb:1.1752 running_loss:2.7767 running_bpb:1.0779 doc_len:159-160
+ttt_progress: batch 86/782 batch_loss:3.0440 batch_bpb:1.2669 running_loss:2.7771 running_bpb:1.0782 doc_len:154-155
+ttt_progress: batch 79/782 batch_loss:3.0290 batch_bpb:1.2026 running_loss:2.7775 running_bpb:1.0784 doc_len:149-150
+ttt_progress: batch 71/782 batch_loss:2.9670 batch_bpb:1.1576 running_loss:2.7778 running_bpb:1.0785 doc_len:143-144
+ttt_progress: batch 66/782 batch_loss:3.1154 batch_bpb:1.2761 running_loss:2.7783 running_bpb:1.0788 doc_len:139-140
+ttt_progress: batch 58/782 batch_loss:2.9845 batch_bpb:1.2310 running_loss:2.7785 running_bpb:1.0790 doc_len:133-134
+ttt_progress: batch 52/782 batch_loss:3.0628 batch_bpb:1.1984 running_loss:2.7789 running_bpb:1.0791 doc_len:128-129
+ttt_progress: batch 49/782 batch_loss:2.9736 batch_bpb:1.1731 running_loss:2.7792 running_bpb:1.0793 doc_len:126-126
+ttt_progress: batch 41/782 batch_loss:3.1284 batch_bpb:1.2786 running_loss:2.7796 running_bpb:1.0795 doc_len:119-120
+ttt_progress: batch 34/782 batch_loss:3.0761 batch_bpb:1.2453 running_loss:2.7799 running_bpb:1.0797 doc_len:114-115
+ttt_progress: batch 28/782 batch_loss:3.0250 batch_bpb:1.2181 running_loss:2.7802 running_bpb:1.0798 doc_len:108-109
+ttt_progress: batch 21/782 batch_loss:3.2041 batch_bpb:1.2458 running_loss:2.7807 running_bpb:1.0800 doc_len:102-103
+ttt_progress: batch 14/782 batch_loss:3.1357 batch_bpb:1.2333 running_loss:2.7810 running_bpb:1.0801 doc_len:94-95
+ttt_progress: batch 7/782 batch_loss:3.2148 batch_bpb:1.2335 running_loss:2.7814 running_bpb:1.0803 doc_len:84-86
+quantized_ttt_lora val_loss:2.78138792 val_bpb:1.07676194 eval_time:276377ms
+total_eval_time:372.2s
+total_eval_time_with_compile:458.6s

--- a/records/track_10min_16mb/2026-04-10_VarLenAttn/logs/train0.txt
+++ b/records/track_10min_16mb/2026-04-10_VarLenAttn/logs/train0.txt
@@ -2,18 +2,18 @@
 Hyperparameters:
   adam_eps: 1e-08
   adam_wd: 0.02
-  artifact_dir: runs/varlen0
+  artifact_dir: runs/varlen0-new-tuned
   beta1: 0.9
   beta2: 0.95
   compressor: brotli
   data_dir: ./data/
   datasets_dir: ./data/datasets/fineweb10B_sp8192
   distributed: True
-  ema_decay: 0.997
+  ema_decay: 0.9965
   embed_bits: 8
   embed_clip_sigmas: 20.0
   embed_lr: 0.6
-  embed_wd: 0.095
+  embed_wd: 0.085
   embedding_dim: 512
   enable_looping_at: 0.35
   etlb_clip: 3.0
@@ -23,7 +23,7 @@ Hyperparameters:
   eval_seq_len: 2048
   eval_stride: 64
   gptq_calibration_batches: 64
-  gptq_reserve_seconds: 12.0
+  gptq_reserve_seconds: 13.0
   grad_accum_steps: 1
   grad_clip_norm: 0.3
   head_lr: 0.008
@@ -31,7 +31,7 @@ Hyperparameters:
   iterations: 20000
   ln_scale: True
   local_rank: 0
-  logfile: runs/varlen0/11e133ec-2d1b-409b-8951-f3a43f5a3f50.txt
+  logfile: runs/varlen0-new-tuned/59992bed-07ce-4d1a-8841-7e9bb9c402df.txt
   logit_softcap: 30.0
   loop_end: 5
   loop_start: 3
@@ -42,7 +42,7 @@ Hyperparameters:
   min_lr: 0.0
   mlp_mult: 4.0
   model_dim: 512
-  model_path: runs/varlen0/final_model.pt
+  model_path: runs/varlen0-new-tuned/final_model.pt
   muon_backend_steps: 5
   muon_beta2: 0.95
   muon_momentum: 0.97
@@ -54,15 +54,16 @@ Hyperparameters:
   num_kv_heads: 4
   num_layers: 11
   num_loops: 2
-  parallel_start_layer: 7
+  parallel_final_lane: mean
+  parallel_start_layer: 8
   qk_gain_init: 5.0
-  quantized_model_path: runs/varlen0/final_model.int6.ptz
+  quantized_model_path: runs/varlen0-new-tuned/final_model.int6.ptz
   rank: 0
   rope_base: 10000.0
   rope_dims: 16
   rope_train_seq_len: 2048
   rope_yarn: False
-  run_id: 11e133ec-2d1b-409b-8951-f3a43f5a3f50
+  run_id: 59992bed-07ce-4d1a-8841-7e9bb9c402df
   scalar_lr: 0.02
   seed: 0
   skip_gates_enabled: True
@@ -78,11 +79,12 @@ Hyperparameters:
   ttt_batch_size: 64
   ttt_beta1: 0.0
   ttt_beta2: 0.999
-  ttt_chunk_size: 64
+  ttt_chunk_size: 32
   ttt_enabled: True
   ttt_eval_batches: 
   ttt_eval_seq_len: 2048
   ttt_grad_steps: 1
+  ttt_hash_embed_size: 0
   ttt_k_lora: True
   ttt_lora_lr: 0.0001
   ttt_lora_rank: 96
@@ -96,14 +98,2955 @@ Hyperparameters:
   val_files: ./data/datasets/fineweb10B_sp8192/fineweb_val_*.bin
   val_loss_every: 4000
   vocab_size: 8192
-  warmdown_frac: 0.667
+  warmdown_frac: 0.72
   warmup_steps: 20
   world_size: 8
   xsa_last_n: 11
 ====================================================================================================
+Source code:
+====================================================================================================
+import base64, collections, copy, fcntl, glob, io, json, lzma, math, os
+from pathlib import Path
+import random, re, subprocess, sys, time, uuid, numpy as np, sentencepiece as spm, torch, torch.distributed as dist, torch.nn.functional as F
+from torch import nn
+from flash_attn_interface import (
+    flash_attn_func as flash_attn_3_func,
+    flash_attn_varlen_func,
+)
+from concurrent.futures import ThreadPoolExecutor
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+class Hyperparameters:
+    data_dir = os.environ.get("DATA_DIR", "./data/")
+    seed = int(os.environ.get("SEED", 1337))
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.72))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 6e2))
+    val_batch_tokens = int(os.environ.get("VAL_BATCH_TOKENS", 524288))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    sliding_window_enabled = bool(int(os.environ.get("SLIDING_WINDOW_ENABLED", "0")))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 8192))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    embedding_dim = int(os.environ.get("EMBEDDING_DIM", 512))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 4.0))
+    skip_gates_enabled = bool(int(os.environ.get("SKIP_GATES_ENABLED", "1")))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 3e1))
+    rope_base = float(os.environ.get("ROPE_BASE", 1e4))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    rope_train_seq_len = int(os.environ.get("ROPE_TRAIN_SEQ_LEN", 2048))
+    rope_yarn = bool(int(os.environ.get("ROPE_YARN", "0")))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 5.0))
+    num_loops = int(os.environ.get("NUM_LOOPS", 2))
+    loop_start = int(os.environ.get("LOOP_START", 3))
+    loop_end = int(os.environ.get("LOOP_END", 5))
+    enable_looping_at = float(os.environ.get("ENABLE_LOOPING_AT", 0.35))
+    parallel_start_layer = int(os.environ.get("PARALLEL_START_LAYER", 8))
+    parallel_final_lane = os.environ.get("PARALLEL_FINAL_LANE", "mlp")
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.022))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.97))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-08))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.02))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_lora_rank = int(os.environ.get("TTT_LORA_RANK", 96))
+    ttt_lora_lr = float(os.environ.get("TTT_LORA_LR", 0.0001))
+    ttt_chunk_size = int(os.environ.get("TTT_CHUNK_SIZE", 32))
+    ttt_eval_seq_len = int(os.environ.get("TTT_EVAL_SEQ_LEN", 2048))
+    ttt_batch_size = int(os.environ.get("TTT_BATCH_SIZE", 64))
+    ttt_grad_steps = int(os.environ.get("TTT_GRAD_STEPS", 1))
+    ttt_weight_decay = float(os.environ.get("TTT_WEIGHT_DECAY", 0.5))
+    ttt_beta1 = float(os.environ.get("TTT_BETA1", 0))
+    ttt_beta2 = float(os.environ.get("TTT_BETA2", 0.999))
+    ttt_k_lora = bool(int(os.environ.get("TTT_K_LORA", "1")))
+    ttt_mlp_lora = bool(int(os.environ.get("TTT_MLP_LORA", "1")))
+    ttt_o_lora = bool(int(os.environ.get("TTT_O_LORA", "1")))
+    ttt_hash_embed_size = int(os.environ.get("TTT_HASH_EMBED_SIZE", 0))
+    ttt_optimizer = os.environ.get("TTT_OPTIMIZER", "adam")
+    ttt_eval_batches = os.environ.get("TTT_EVAL_BATCHES", "")
+    ttt_output_dir = os.environ.get("TTT_OUTPUT_DIR", "")
+    val_doc_fraction = float(os.environ.get("VAL_DOC_FRACTION", 1.0))
+    etlb_lr = float(os.environ.get("ETLB_LR", 0.05))
+    etlb_steps = int(os.environ.get("ETLB_STEPS", 5))
+    etlb_clip = float(os.environ.get("ETLB_CLIP", 3.0))
+    compressor = os.environ.get("COMPRESSOR", "brotli")
+    gptq_calibration_batches = int(os.environ.get("GPTQ_CALIBRATION_BATCHES", 64))
+    gptq_reserve_seconds = float(os.environ.get("GPTQ_RESERVE_SECONDS", 13.0))
+    matrix_bits = int(os.environ.get("MATRIX_BITS", 6))
+    embed_bits = int(os.environ.get("EMBED_BITS", 8))
+    matrix_clip_sigmas = float(os.environ.get("MATRIX_CLIP_SIGMAS", 12.85))
+    embed_clip_sigmas = float(os.environ.get("EMBED_CLIP_SIGMAS", 2e1))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_main_process = rank == 0
+    grad_accum_steps = 8 // world_size
+    datasets_dir = os.path.join(data_dir, "datasets", f"fineweb10B_sp{vocab_size}")
+    train_files = os.path.join(datasets_dir, "fineweb_train_*.bin")
+    val_files = os.path.join(datasets_dir, "fineweb_val_*.bin")
+    tokenizer_path = os.path.join(
+        data_dir, "tokenizers", f"fineweb_{vocab_size}_bpe.model"
+    )
+    artifact_dir = os.environ.get("ARTIFACT_DIR", "")
+    eval_only_path = os.environ.get("EVAL_ONLY_PATH", "")
+    logfile = (
+        os.path.join(artifact_dir, f"{run_id}.txt")
+        if artifact_dir
+        else f"logs/{run_id}.txt"
+    )
+    model_path = (
+        os.path.join(artifact_dir, "final_model.pt")
+        if artifact_dir
+        else "final_model.pt"
+    )
+    quantized_model_path = (
+        os.path.join(artifact_dir, "final_model.int6.ptz")
+        if artifact_dir
+        else "final_model.int6.ptz"
+    )
+
+
+_logger_hparams = None
+
+
+def set_logging_hparams(h):
+    global _logger_hparams
+    _logger_hparams = h
+
+
+def log(msg, console=True):
+    if _logger_hparams is None:
+        print(msg)
+        return
+    if _logger_hparams.is_main_process:
+        if console:
+            print(msg)
+        if _logger_hparams.logfile is not None:
+            with open(_logger_hparams.logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+
+class ValidationData:
+    def __init__(self, h, device):
+        self.sp = spm.SentencePieceProcessor(model_file=h.tokenizer_path)
+        if int(self.sp.vocab_size()) != h.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={h.vocab_size} does not match tokenizer vocab_size={int(self.sp.vocab_size())}"
+            )
+        self.val_tokens = load_validation_tokens(h.val_files, h.eval_seq_len)
+        (
+            self.base_bytes_lut,
+            self.has_leading_space_lut,
+            self.is_boundary_token_lut,
+        ) = build_sentencepiece_luts(self.sp, h.vocab_size, device)
+
+
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sp_vocab_size = int(sp.vocab_size())
+    assert (
+        sp.piece_to_id("▁") != sp.unk_id()
+    ), "Tokenizer must have '▁' (space) as its own token for correct BPB byte counting"
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = (tokens.numel() - 1) // seq_len * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def load_data_shard(file):
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE = {}
+_MMAP_CACHE = {}
+
+
+def _read_num_tokens(file):
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+
+def _get_shard_memmap(file):
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode="r", dtype="<u2", offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+BOS_ID = None
+
+
+def get_next_multiple_of_n(v, n):
+    return ((v + n - 1) // n) * n
+
+
+def _build_cu_seqlens(bos_pos, total_len, device, max_doc_len=0, bucket_size=64):
+    if not bos_pos or bos_pos[0] != 0:
+        bos_pos = [0] + bos_pos
+    seg_starts = []
+    starts_with_end = bos_pos + [total_len]
+    for i in range(len(starts_with_end) - 1):
+        start = starts_with_end[i]
+        end = starts_with_end[i + 1]
+        if max_doc_len > 0:
+            pos = start
+            while pos < end:
+                seg_starts.append(pos)
+                pos += max_doc_len
+        else:
+            seg_starts.append(start)
+    boundaries = seg_starts + [total_len]
+    padded_len = get_next_multiple_of_n(len(boundaries), bucket_size)
+    cu = torch.full((padded_len,), total_len, dtype=torch.int32, device=device)
+    cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+    seg_ends = seg_starts[1:] + [total_len]
+    max_seqlen = max(end - start for start, end in zip(seg_starts, seg_ends))
+    return cu, max_seqlen
+
+class DocumentPackingLoader:
+    _shard_pool = ThreadPoolExecutor(1)
+
+    def __init__(self, h, device, cu_bucket_size=64):
+        self.rank = h.rank
+        self.world_size = h.world_size
+        self.device = device
+        self.cu_bucket_size = cu_bucket_size
+        self.max_seq_len = h.train_seq_len
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files
+        self.file_iter = iter(self.files)
+        self._init_shard(load_data_shard(next(self.file_iter)))
+        self._next_shard = self._submit_next_shard()
+        self._batch_pool = ThreadPoolExecutor(1)
+        self._next_batch = None
+
+    def _init_shard(self, tokens):
+        global BOS_ID
+        self.tokens = tokens
+        self.shard_size = tokens.numel()
+        if BOS_ID is None:
+            BOS_ID = 1
+        self.bos_idx = (
+            (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        )
+        if self.bos_idx.size == 0:
+            self.bos_idx = np.array([0], dtype=np.int64)
+        self.cursor = int(self.bos_idx[0])
+
+    def _submit_next_shard(self):
+        try:
+            path = next(self.file_iter)
+            return self._shard_pool.submit(load_data_shard, path)
+        except StopIteration:
+            return None
+
+    def _advance_shard(self):
+        if self._next_shard is None:
+            self.file_iter = iter(self.files)
+            self._next_shard = self._shard_pool.submit(
+                load_data_shard, next(self.file_iter)
+            )
+        self._init_shard(self._next_shard.result())
+        self._next_shard = self._submit_next_shard()
+
+    def _local_doc_starts(self, local_start, total_len):
+        lo = np.searchsorted(self.bos_idx, local_start, side="left")
+        hi = np.searchsorted(self.bos_idx, local_start + total_len, side="left")
+        return (self.bos_idx[lo:hi] - local_start).tolist()
+
+    def _prepare_batch(self, num_tokens_local, max_seq_len):
+        per_rank_span = num_tokens_local + 1
+        global_span = per_rank_span * self.world_size
+        while self.cursor + global_span > self.shard_size:
+            self._advance_shard()
+        local_start = self.cursor + self.rank * per_rank_span
+        buf = self.tokens[local_start : local_start + per_rank_span]
+        inputs = buf[:-1].to(dtype=torch.int64).pin_memory()
+        targets = buf[1:].to(dtype=torch.int64).pin_memory()
+        starts = self._local_doc_starts(local_start, inputs.numel())
+        cu_seqlens, max_seqlen = _build_cu_seqlens(
+            starts, inputs.numel(), inputs.device, max_seq_len, self.cu_bucket_size
+        )
+        cu_seqlens = cu_seqlens.pin_memory()
+        self.cursor += global_span
+        return inputs, targets, cu_seqlens, max_seqlen
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        num_tokens_local = global_tokens // (self.world_size * grad_accum_steps)
+        if self._next_batch is not None:
+            inputs, targets, cu_seqlens, max_seqlen = self._next_batch.result()
+        else:
+            inputs, targets, cu_seqlens, max_seqlen = self._prepare_batch(
+                num_tokens_local, self.max_seq_len
+            )
+        self._next_batch = self._batch_pool.submit(
+            self._prepare_batch, num_tokens_local, self.max_seq_len
+        )
+        return (
+            inputs[None].to(self.device, non_blocking=True),
+            targets[None].to(self.device, non_blocking=True),
+            cu_seqlens.to(self.device, non_blocking=True),
+            max_seqlen,
+        )
+
+
+class ShuffledSequenceLoader:
+    def __init__(self, h, device):
+        self.world_size = h.world_size
+        self.seq_len = h.train_seq_len
+        self.device = device
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files[h.rank :: h.world_size]
+        self.rng = np.random.Generator(np.random.PCG64(h.rank))
+        self.num_tokens = [_read_num_tokens(f) for f in self.files]
+        self.start_inds = [[] for _ in self.files]
+        for si in range(len(self.files)):
+            self._reset_shard(si)
+
+    def _reset_shard(self, si):
+        max_phase = min(
+            self.seq_len - 1, max(0, self.num_tokens[si] - self.seq_len - 1)
+        )
+        phase = int(self.rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        num_sequences = (self.num_tokens[si] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[si] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for bi in range(device_batch_size):
+            total = remaining.sum()
+            if total <= 0:
+                for si in range(len(self.files)):
+                    self._reset_shard(si)
+                remaining = np.array(
+                    [len(s) for s in self.start_inds], dtype=np.float64
+                )
+                total = remaining.sum()
+            probs = remaining / total
+            si = int(self.rng.choice(len(self.files), p=probs))
+            start_ind = self.start_inds[si].pop()
+            remaining[si] -= 1
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[bi] = window[:-1]
+            y[bi] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x):
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+@triton.jit
+def linear_leaky_relu_square_kernel(
+    a_desc,
+    b_desc,
+    c_desc,
+    aux_desc,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    FORWARD: tl.constexpr,
+):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+    tile_id_c = start_pid - NUM_SMS
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+        tile_id_c += NUM_SMS
+        offs_am_c = offs_am
+        offs_bn_c = offs_bn
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+        c0 = acc0.to(dtype)
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            pre0 = aux_desc.load([offs_am_c, offs_bn_c])
+            pre1 = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c0 = c0 * tl.where(pre0 > 0, 2.0 * pre0, 0.5 * pre0)
+            c1 = c1 * tl.where(pre1 > 0, 2.0 * pre1, 0.5 * pre1)
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+        if FORWARD:
+            aux0 = tl.where(c0 > 0, c0, 0.5 * c0)
+            aux1 = tl.where(c1 > 0, c1, 0.5 * c1)
+            aux_desc.store([offs_am_c, offs_bn_c], aux0 * aux0)
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], aux1 * aux1)
+
+
+def linear_leaky_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K2 = b.shape
+    assert K == K2
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    forward = aux is None
+    if aux is None:
+        aux = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 256, 64
+    num_stages = 4 if forward else 3
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    grid = lambda _meta: (
+        min(num_sms, triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N)),
+    )
+    linear_leaky_relu_square_kernel[grid](
+        a_desc,
+        b_desc,
+        c_desc,
+        aux_desc,
+        M,
+        N,
+        K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        NUM_SMS=num_sms,
+        FORWARD=forward,
+        num_stages=num_stages,
+        num_warps=8,
+    )
+    if forward:
+        return c, aux
+    return c
+
+
+class FusedLinearLeakyReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, w1, w2):
+        x_flat = x.reshape(-1, x.shape[-1])
+        pre, post = linear_leaky_relu_square(x_flat, w1)
+        out = F.linear(post, w2)
+        ctx.save_for_backward(x, w1, w2, pre, post)
+        return out.view(*x.shape[:-1], out.shape[-1])
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, w1, w2, pre, post = ctx.saved_tensors
+        x_flat = x.reshape(-1, x.shape[-1])
+        grad_output_flat = grad_output.reshape(-1, grad_output.shape[-1])
+        dw2 = grad_output_flat.T @ post
+        dpre = linear_leaky_relu_square(grad_output_flat, w2.T.contiguous(), aux=pre)
+        dw1 = dpre.T @ x_flat
+        dx = dpre @ w1
+        return dx.view_as(x), dw1, dw2
+
+
+FusedLeakyReLUSquareMLP = FusedLinearLeakyReLUSquareFunction.apply
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=1e4, train_seq_len=1024, rope_dims=0, yarn=True):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.yarn = yarn
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / base ** (
+            torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+
+    def forward(self, seq_len, device, dtype):
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached < seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if self.yarn and seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * scale ** (rd / (rd - 2))
+                inv_freq = 1.0 / new_base ** (
+                    torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd
+                )
+            else:
+                inv_freq = self.inv_freq.float().to(device)
+            t = torch.arange(seq_len, device=device, dtype=torch.float32)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached[:, :seq_len].to(dtype=dtype), self._sin_cached[:, :seq_len].to(dtype=dtype)
+
+
+def apply_rotary_emb(x, cos, sin, rope_dims=0):
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=True
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len, yarn=yarn)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x, q_w, k_w, v_w, out_w, cu_seqlens=None, max_seqlen=0):
+        bsz, seqlen, dim = x.shape
+        q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if cu_seqlens is not None:
+            y = flash_attn_varlen_func(
+                q[0],
+                k[0],
+                v[0],
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+                causal=True,
+                window_size=(-1, -1),
+            )[None]
+        else:
+            y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        self._last_proj_input = y.detach() if getattr(self, "_calib", False) else None
+        return F.linear(y, out_w.to(x.dtype))
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        self.use_fused = True
+
+    def forward(self, x, up_w, down_w):
+        if self.training and self.use_fused:
+            return FusedLeakyReLUSquareMLP(x, up_w.to(x.dtype), down_w.to(x.dtype))
+        hidden = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5).square()
+        self._last_down_input = hidden.detach() if getattr(self, "_calib", False) else None
+        return F.linear(hidden, down_w.to(x.dtype))
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        num_kv_heads,
+        mlp_mult,
+        rope_base,
+        qk_gain_init,
+        train_seq_len,
+        layer_idx=0,
+        ln_scale=False,
+        yarn=True,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=yarn
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(
+            torch.stack((torch.ones(dim), torch.zeros(dim))).float()
+        )
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+
+    def forward(self, x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=None, max_seqlen=0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(
+            self.attn_norm(x_in) * self.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[
+            None, None, :
+        ] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        return x_out
+
+    def forward_attn(self, x, x0, q_w, k_w, v_w, out_w, cu_seqlens=None, max_seqlen=0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(
+            self.attn_norm(x_in) * self.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        return x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+
+    def forward_mlp(self, x, up_w, down_w):
+        return x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(
+            self.mlp_norm(x) * self.ln_scale_factor, up_w, down_w
+        )
+
+
+class GPT(nn.Module):
+    def __init__(self, h):
+        super().__init__()
+        if h.logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {h.logit_softcap}")
+        self.tie_embeddings = h.tie_embeddings
+        self.tied_embed_init_std = h.tied_embed_init_std
+        self.logit_softcap = h.logit_softcap
+        self.tok_emb = nn.Embedding(h.vocab_size, h.embedding_dim)
+        if h.embedding_dim != h.model_dim:
+            self.embed_proj = CastedLinear(h.embedding_dim, h.model_dim, bias=False)
+            self.head_proj = CastedLinear(h.model_dim, h.embedding_dim, bias=False)
+        else:
+            self.embed_proj = None
+            self.head_proj = None
+        self.num_layers = h.num_layers
+        head_dim = h.model_dim // h.num_heads
+        kv_dim = h.num_kv_heads * head_dim
+        hidden_dim = int(h.mlp_mult * h.model_dim)
+        self.qo_bank = nn.Parameter(torch.empty(2 * h.num_layers, h.model_dim, h.model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * h.num_layers, kv_dim, h.model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(h.num_layers, hidden_dim, h.model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(h.num_layers, h.model_dim, hidden_dim))
+        self.num_encoder_layers = h.num_layers // 2
+        self.num_decoder_layers = h.num_layers - self.num_encoder_layers
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    h.model_dim,
+                    h.num_heads,
+                    h.num_kv_heads,
+                    h.mlp_mult,
+                    h.rope_base,
+                    h.qk_gain_init,
+                    h.train_seq_len,
+                    layer_idx=i,
+                    ln_scale=h.ln_scale,
+                    yarn=h.rope_yarn,
+                )
+                for i in range(h.num_layers)
+            ]
+        )
+        if h.rope_dims > 0:
+            head_dim = h.model_dim // h.num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = h.rope_dims
+                block.attn.rotary = Rotary(
+                    head_dim,
+                    base=h.rope_base,
+                    train_seq_len=h.train_seq_len,
+                    rope_dims=h.rope_dims,
+                    yarn=h.rope_yarn,
+                )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None
+            if h.tie_embeddings
+            else CastedLinear(h.embedding_dim, h.vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if h.xsa_last_n > 0:
+            for i in range(max(0, h.num_layers - h.xsa_last_n), h.num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self.looping_active = False
+        if h.num_loops > 0:
+            loop_seg = list(range(h.loop_start, h.loop_end + 1))
+            all_indices = list(range(h.loop_start))
+            for _ in range(h.num_loops + 1):
+                all_indices.extend(loop_seg)
+            all_indices.extend(range(h.loop_end + 1, h.num_layers))
+            num_enc = len(all_indices) // 2
+            self.encoder_indices = all_indices[:num_enc]
+            self.decoder_indices = all_indices[num_enc:]
+        else:
+            self.encoder_indices = list(range(self.num_encoder_layers))
+            self.decoder_indices = list(range(self.num_encoder_layers, h.num_layers))
+        self.num_skip_weights = min(
+            len(self.encoder_indices), len(self.decoder_indices)
+        )
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+        )
+        self.skip_gates = (
+            nn.Parameter(
+                torch.zeros(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+            )
+            if h.skip_gates_enabled
+            else None
+        )
+        self.parallel_start_layer = h.parallel_start_layer
+        self.parallel_final_lane = h.parallel_final_lane.lower()
+        self.parallel_post_lambdas = nn.Parameter(
+            torch.ones(h.num_layers, 2, 2, dtype=torch.float32)
+        )
+        self.parallel_resid_lambdas = nn.Parameter(
+            torch.full((h.num_layers, 2), 1.1, dtype=torch.float32)
+        )
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.qo_bank.data[n + i])
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.mlp_down_bank.data[i])
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _bank_weights(self, i):
+        n = self.num_layers
+        return (
+            self.qo_bank[i],
+            self.kv_bank[i],
+            self.kv_bank[n + i],
+            self.qo_bank[n + i],
+            self.mlp_up_bank[i],
+            self.mlp_down_bank[i],
+        )
+
+    def _parallel_block(
+        self, block_idx, lane0, lane1, x0,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+        cu_seqlens=None, max_seqlen=0,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        attn_out = block.attn(
+            block.attn_norm(attn_read) * block.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+        )
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * block.mlp(
+            block.mlp_norm(mlp_read) * block.ln_scale_factor, up_w, down_w
+        )
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+    def _final_parallel_hidden(self, lane0, lane1):
+        if self.parallel_final_lane == "mlp":
+            return lane1
+        if self.parallel_final_lane == "attn":
+            return lane0
+        return 0.5 * (lane0 + lane1)
+
+    def forward_logits(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else range(self.num_encoder_layers)
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else range(
+                self.num_encoder_layers,
+                self.num_encoder_layers + self.num_decoder_layers,
+            )
+        )
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block(
+                    i, lane0, lane1, x0, q_w, k_w, v_w, out_w, up_w, down_w,
+                    cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        if self.head_proj is not None:
+            x = self.head_proj(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(self, input_ids, target_ids, cu_seqlens=None, max_seqlen=0):
+        logits = self.forward_logits(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        return F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            target_ids.reshape(-1),
+            reduction="mean",
+        )
+
+    def forward_ttt(self, input_ids, target_ids, lora, hash_out=None):
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        if hash_out is not None:
+            x = x + hash_out.to(x.dtype)
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else list(range(self.num_encoder_layers))
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else list(
+                range(
+                    self.num_encoder_layers,
+                    self.num_encoder_layers + self.num_decoder_layers,
+                )
+            )
+        )
+        slot = 0
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block_with_lora(
+                    i, lane0, lane1, x0, lora, slot,
+                    q_w, k_w, v_w, out_w, up_w, down_w,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        if self.head_proj is not None:
+            x = self.head_proj(x)
+        if self.tie_embeddings:
+            logits = F.linear(x, self.tok_emb.weight)
+        else:
+            logits = self.lm_head(x)
+        logits = logits + lora.lm_head_lora(x)
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        bsz, sl, V = logits.shape
+        return F.cross_entropy(
+            logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none"
+        ).reshape(bsz, sl)
+
+    def _block_with_lora(self, block, x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w):
+        mix = block.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = block.attn_norm(x_in) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q = (F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_heads, attn.head_dim
+        )
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        x_out = x_in + block.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        mlp_n = block.mlp_norm(x_out) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        x_out = x_out + block.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * mlp_out
+        return x_out
+
+    def _block_with_lora_attn(self, block, x, x0, lora, slot, q_w, k_w, v_w, out_w):
+        mix = block.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = block.attn_norm(x_in) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q = (F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_heads, attn.head_dim
+        )
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        return x_in + block.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+
+    def _block_with_lora_mlp(self, block, x, lora, slot, up_w, down_w):
+        mlp_n = block.mlp_norm(x) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        return x + block.mlp_scale.to(dtype=x.dtype)[None, None, :] * mlp_out
+
+    def _parallel_block_with_lora(
+        self, block_idx, lane0, lane1, x0, lora, slot,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        n = block.attn_norm(attn_read) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q = (F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_heads, attn.head_dim
+        )
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_n = block.mlp_norm(mlp_read) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * mlp_out
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+
+class BatchedLinearLoRA(nn.Module):
+    def __init__(self, bsz, in_features, out_features, rank):
+        super().__init__()
+        self._bound = 1.0 / math.sqrt(in_features)
+        self.A = nn.Parameter(
+            torch.empty(bsz, rank, in_features).uniform_(-self._bound, self._bound)
+        )
+        self.B = nn.Parameter(torch.zeros(bsz, out_features, rank))
+
+    def reset(self):
+        with torch.no_grad():
+            self.A.uniform_(-self._bound, self._bound)
+            self.B.zero_()
+
+    def forward(self, x):
+        return (x @ self.A.transpose(1, 2)) @ self.B.transpose(1, 2)
+
+
+class BatchedTTTLoRA(nn.Module):
+    def __init__(self, bsz, model, rank, k_lora=True, mlp_lora=True, o_lora=True,
+                 hash_embed_size=0):
+        super().__init__()
+        self.bsz = bsz
+        dim = model.qo_bank.shape[-1]
+        vocab = model.tok_emb.num_embeddings
+        if getattr(model, "looping_active", False):
+            num_slots = len(model.encoder_indices) + len(model.decoder_indices)
+        else:
+            num_slots = len(model.blocks)
+        kv_dim = model.blocks[0].attn.num_kv_heads * (
+            dim // model.blocks[0].attn.num_heads
+        )
+        embed_dim = model.tok_emb.embedding_dim
+        self.lm_head_lora = BatchedLinearLoRA(bsz, embed_dim, vocab, rank)
+        self.q_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+        )
+        self.v_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+        )
+        self.k_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+            )
+            if k_lora
+            else None
+        )
+        self.mlp_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if mlp_lora
+            else None
+        )
+        self.o_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if o_lora
+            else None
+        )
+        self.hash_embed_size = hash_embed_size
+        if hash_embed_size > 0:
+            self.hash_embed = nn.Embedding(hash_embed_size, dim)
+            nn.init.zeros_(self.hash_embed.weight)
+        else:
+            self.hash_embed = None
+
+    def hash_embed_forward(self, input_ids):
+        if self.hash_embed is None:
+            return None
+        prev = torch.zeros_like(input_ids)
+        prev[:, 1:] = input_ids[:, :-1]
+        h_idx = (prev * 2039 + input_ids) % self.hash_embed_size
+        return self.hash_embed(h_idx)
+
+    def reset(self):
+        with torch.no_grad():
+            self.lm_head_lora.reset()
+            for loras in [self.q_loras, self.v_loras, self.k_loras,
+                          self.mlp_loras, self.o_loras]:
+                if loras is not None:
+                    for lora in loras:
+                        lora.reset()
+            if self.hash_embed is not None:
+                self.hash_embed.weight.zero_()
+
+
+def classify_param(name):
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or ".proj." in name and ".mlp." not in name:
+        return "attn"
+    return "other"
+
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps=10, eps=1e-07):
+    a, b, c = 3.4445, -4.775, 2.0315
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr,
+        momentum,
+        backend_steps,
+        nesterov=True,
+        weight_decay=0.0,
+        row_normalize=False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append({
+                    "p": p,
+                    "B": B,
+                    "padded_grad": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard_mom": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "full_update": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "scale": max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                })
+        self._bank_meta.sort(key=lambda m: -m["p"].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m["p"]
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m["padded_grad"]
+            pg[: m["B"]].copy_(p.grad.bfloat16())
+            if pg.shape[0] > m["B"]:
+                pg[m["B"] :].zero_()
+            fut = dist.reduce_scatter_tensor(
+                m["shard"], pg, op=dist.ReduceOp.AVG, async_op=True
+            )
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        if not self._built:
+            self._build()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+            row_normalize = group.get("row_normalize", False)
+            prev_ag_handle = None
+            prev_m = None
+            sharded = self._distributed and hasattr(self, "_rs_futures")
+            for idx, m in enumerate(self._bank_meta):
+                p = m["p"]
+                if p.grad is None:
+                    continue
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m["p"]
+                    upd = prev_m["full_update"][: prev_m["B"]]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+                if sharded and self._rs_futures[idx] is not None:
+                    self._rs_futures[idx].wait()
+                    g = m["shard"]
+                    buf = m["shard_mom"]
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+                if row_normalize:
+                    rn = update.float().norm(dim=-1, keepdim=True).clamp_min(1e-07)
+                    update = update / rn.to(update.dtype)
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m["full_update"], update, async_op=True
+                    )
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update.to(dtype=p.dtype), alpha=-lr * m["scale"])
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m["p"]
+                upd = prev_m["full_update"][: prev_m["B"]]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+            if hasattr(self, "_rs_futures"):
+                del self._rs_futures
+        return loss
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,parallel_post_lambdas,parallel_resid_lambdas",
+    ).split(",")
+    if pattern
+)
+
+
+PACKED_REPLICATED_GRAD_MAX_NUMEL = 1 << 15
+
+
+class Optimizers:
+    def __init__(self, h, base_model):
+        matrix_params = [
+            base_model.qo_bank,
+            base_model.kv_bank,
+            base_model.mlp_up_bank,
+            base_model.mlp_down_bank,
+        ]
+        block_named_params = list(base_model.blocks.named_parameters())
+        scalar_params = [
+            p
+            for (name, p) in block_named_params
+            if p.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        if base_model.skip_weights.numel() > 0:
+            scalar_params.append(base_model.skip_weights)
+        if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
+            scalar_params.append(base_model.skip_gates)
+        if base_model.parallel_post_lambdas is not None:
+            scalar_params.append(base_model.parallel_post_lambdas)
+        if base_model.parallel_resid_lambdas is not None:
+            scalar_params.append(base_model.parallel_resid_lambdas)
+        token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
+        tok_params = [
+            {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+        ]
+        self.optimizer_tok = torch.optim.AdamW(
+            tok_params,
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.embed_wd,
+            fused=True,
+        )
+        self.optimizer_muon = Muon(
+            matrix_params,
+            lr=h.matrix_lr,
+            momentum=h.muon_momentum,
+            backend_steps=h.muon_backend_steps,
+            weight_decay=h.muon_wd,
+            row_normalize=h.muon_row_normalize,
+        )
+        for group in self.optimizer_muon.param_groups:
+            group["base_lr"] = h.matrix_lr
+        self.optimizer_scalar = torch.optim.AdamW(
+            [{"params": scalar_params, "lr": h.scalar_lr, "base_lr": h.scalar_lr}],
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.adam_wd,
+            fused=True,
+        )
+        self.optimizers = [
+            self.optimizer_tok,
+            self.optimizer_muon,
+            self.optimizer_scalar,
+        ]
+        if base_model.lm_head is not None:
+            self.optimizer_head = torch.optim.Adam(
+                [
+                    {
+                        "params": [base_model.lm_head.weight],
+                        "lr": h.head_lr,
+                        "base_lr": h.head_lr,
+                    }
+                ],
+                betas=(h.beta1, h.beta2),
+                eps=h.adam_eps,
+                fused=True,
+            )
+            self.optimizers.insert(1, self.optimizer_head)
+        else:
+            self.optimizer_head = None
+        self.replicated_params = list(tok_params[0]["params"])
+        self.replicated_params.extend(scalar_params)
+        if base_model.lm_head is not None:
+            self.replicated_params.append(base_model.lm_head.weight)
+        self.replicated_large_params = []
+        self.replicated_packed_params = []
+        for p in self.replicated_params:
+            if p.numel() <= PACKED_REPLICATED_GRAD_MAX_NUMEL:
+                self.replicated_packed_params.append(p)
+            else:
+                self.replicated_large_params.append(p)
+
+    def __iter__(self):
+        return iter(self.optimizers)
+
+    def zero_grad_all(self):
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    def _all_reduce_packed_grads(self):
+        grads_by_key = collections.defaultdict(list)
+        for p in self.replicated_packed_params:
+            if p.grad is not None:
+                grads_by_key[(p.grad.device, p.grad.dtype)].append(p.grad)
+        for grads in grads_by_key.values():
+            flat = torch.empty(
+                sum(g.numel() for g in grads),
+                device=grads[0].device,
+                dtype=grads[0].dtype,
+            )
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                flat[offset : offset + n].copy_(g.contiguous().view(-1))
+                offset += n
+            dist.all_reduce(flat, op=dist.ReduceOp.AVG)
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                g.copy_(flat[offset : offset + n].view_as(g))
+                offset += n
+
+    def step(self, distributed=False):
+        self.optimizer_muon.launch_reduce_scatters()
+        if distributed:
+            reduce_handles = [
+                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG, async_op=True)
+                for p in self.replicated_large_params
+                if p.grad is not None
+            ]
+            self._all_reduce_packed_grads()
+            for handle in reduce_handles:
+                handle.wait()
+        self.optimizer_tok.step()
+        self.optimizer_scalar.step()
+        if self.optimizer_head is not None:
+            self.optimizer_head.step()
+        self.optimizer_muon.step()
+        self.zero_grad_all()
+
+
+def restore_fp32_params(model):
+    for module in model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    for name, param in model.named_parameters():
+        if (
+            param.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ) and param.dtype != torch.float32:
+            param.data = param.data.float()
+    if hasattr(model, "qo_bank"):
+        model.qo_bank.data = model.qo_bank.data.float()
+        model.kv_bank.data = model.kv_bank.data.float()
+        model.mlp_up_bank.data = model.mlp_up_bank.data.float()
+        model.mlp_down_bank.data = model.mlp_down_bank.data.float()
+
+
+def collect_hessians(model, train_loader, h, device, n_calibration_batches=64):
+    hessians = {}
+    hooks = []
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = True
+        block.mlp._calib = True
+        block.mlp.use_fused = False
+
+    def make_attn_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            for suffix in ["c_q", "c_k", "c_v"]:
+                name = f"blocks.{layer_idx}.attn.{suffix}.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            y = module._last_proj_input
+            if y is not None:
+                y = y.float()
+                if y.ndim == 3:
+                    y = y.reshape(-1, y.shape[-1])
+                name = f"blocks.{layer_idx}.attn.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        y.shape[1], y.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(y.T, y)
+        return hook_fn
+
+    def make_mlp_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            name = f"blocks.{layer_idx}.mlp.fc.weight"
+            if name not in hessians:
+                hessians[name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[name].addmm_(x.T, x)
+            h_act = module._last_down_input
+            if h_act is not None:
+                h_act = h_act.float()
+                if h_act.ndim == 3:
+                    h_act = h_act.reshape(-1, h_act.shape[-1])
+                name = f"blocks.{layer_idx}.mlp.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        h_act.shape[1], h_act.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(h_act.T, h_act)
+        return hook_fn
+
+    for i, block in enumerate(model.blocks):
+        hooks.append(block.attn.register_forward_hook(make_attn_hook(i)))
+        hooks.append(block.mlp.register_forward_hook(make_mlp_hook(i)))
+    if model.tie_embeddings:
+        hook_module = (
+            model.head_proj if model.head_proj is not None else model.final_norm
+        )
+
+        def make_output_hook(name):
+            def hook_fn(module, inp, out):
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            return hook_fn
+
+        hooks.append(
+            hook_module.register_forward_hook(make_output_hook("tok_emb.weight"))
+        )
+    model.eval()
+    with torch.no_grad():
+        for _ in range(n_calibration_batches):
+            x, _ = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+            model.forward_logits(x)
+    for hook in hooks:
+        hook.remove()
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = False
+        block.mlp._calib = False
+        block.mlp.use_fused = True
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / n_calibration_batches
+    return hessians
+
+
+def gptq_quantize_weight(w, H, clip_sigmas=3.0, clip_range=63, block_size=128):
+    W_orig = w.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * H.diag().mean()
+    H.diagonal().add_(damp)
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+    Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    row_std = W_orig.std(dim=1)
+    s = (clip_sigmas * row_std / clip_range).clamp_min(1e-10).to(torch.float16)
+    sf = s.float()
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    W_work = W_perm.clone()
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W_work[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros(rows, i2 - i1)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            d = Hinv_block[j, j]
+            q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - q_col.float() * sf) / d
+            Err[:, j] = err
+            W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+        if i2 < cols:
+            W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+    return Q[:, invperm], s
+
+
+def gptq_mixed_quantize(state_dict, hessians, h):
+    result = {}
+    meta = {}
+    for (name, tensor) in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough (float16)"
+            continue
+        cs = h.embed_clip_sigmas if "tok_emb" in name else h.matrix_clip_sigmas
+        bits = h.embed_bits if "tok_emb" in name else h.matrix_bits
+        q, s = gptq_quantize_weight(
+            t, hessians[name], clip_sigmas=cs, clip_range=2 ** (bits - 1) - 1
+        )
+        result[name + ".q"] = q
+        result[name + ".scale"] = s
+        meta[name] = f"gptq (int{bits})"
+    categories = collections.defaultdict(set)
+    for (name, cat) in meta.items():
+        short = re.sub("\\.\\d+$", "", re.sub("blocks\\.\\d+", "blocks", name))
+        categories[cat].add(short)
+    log("Quantized weights:")
+    for cat in sorted(categories):
+        log(f"  {cat}: {', '.join(sorted(categories[cat]))}")
+    return result, meta
+
+
+def dequantize_mixed(result, meta, template_sd):
+    out = {}
+    for (name, orig) in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if "passthrough" in info:
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (
+                q.float() * s.float().view(q.shape[0], *[1] * (q.ndim - 1))
+            ).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+_BSHF_MAGIC = b"BSHF"
+
+
+def _byte_shuffle(data, stride=2):
+    if stride <= 1 or len(data) < stride:
+        return data
+    src = np.frombuffer(data, dtype=np.uint8)
+    n = len(src)
+    out = np.empty(n, dtype=np.uint8)
+    dest_off = 0
+    for pos in range(stride):
+        chunk = src[pos::stride]
+        out[dest_off : dest_off + len(chunk)] = chunk
+        dest_off += len(chunk)
+    return _BSHF_MAGIC + bytes([stride]) + out.tobytes()
+
+
+def _byte_unshuffle(data):
+    if len(data) < 5 or data[:4] != _BSHF_MAGIC:
+        return data
+    stride = data[4]
+    if stride < 2:
+        return data[5:]
+    payload = np.frombuffer(data, dtype=np.uint8, offset=5)
+    n = len(payload)
+    out = np.empty(n, dtype=np.uint8)
+    src_off = 0
+    for pos in range(stride):
+        chunk_len = n // stride + (1 if pos < n % stride else 0)
+        out[pos::stride][:chunk_len] = payload[src_off : src_off + chunk_len]
+        src_off += chunk_len
+    return out.tobytes()
+
+
+def _compress(data, compressor):
+    data = _byte_shuffle(data)
+    if compressor == "lzma":
+        return lzma.compress(data, preset=6)
+    elif compressor == "brotli":
+        import brotli
+
+        return brotli.compress(data, quality=11)
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def _decompress(data, compressor):
+    if compressor == "lzma":
+        raw = lzma.decompress(data)
+    elif compressor == "brotli":
+        import brotli
+
+        raw = brotli.decompress(data)
+    else:
+        raise ValueError(f"Unknown compressor: {compressor!r}")
+    raw = _byte_unshuffle(raw)
+    return raw
+
+
+def _unbank_state_dict(state_dict, num_layers):
+    sd = {}
+    n = num_layers
+    for k, v in state_dict.items():
+        t = v.detach().cpu()
+        if k == "qo_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_q.weight"] = t[i]
+                sd[f"blocks.{i}.attn.proj.weight"] = t[n + i]
+        elif k == "kv_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_k.weight"] = t[i]
+                sd[f"blocks.{i}.attn.c_v.weight"] = t[n + i]
+        elif k == "mlp_up_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.fc.weight"] = t[i]
+        elif k == "mlp_down_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.proj.weight"] = t[i]
+        else:
+            sd[k] = t
+    return sd
+
+
+def _rebank_state_dict(flat_sd, num_layers, model_dim, kv_dim, hidden_dim):
+    sd = {}
+    n = num_layers
+    sd["qo_bank"] = torch.zeros(2 * n, model_dim, model_dim)
+    sd["kv_bank"] = torch.zeros(2 * n, kv_dim, model_dim)
+    sd["mlp_up_bank"] = torch.zeros(n, hidden_dim, model_dim)
+    sd["mlp_down_bank"] = torch.zeros(n, model_dim, hidden_dim)
+    for i in range(n):
+        sd["qo_bank"][i] = flat_sd[f"blocks.{i}.attn.c_q.weight"]
+        sd["qo_bank"][n + i] = flat_sd[f"blocks.{i}.attn.proj.weight"]
+        sd["kv_bank"][i] = flat_sd[f"blocks.{i}.attn.c_k.weight"]
+        sd["kv_bank"][n + i] = flat_sd[f"blocks.{i}.attn.c_v.weight"]
+        sd["mlp_up_bank"][i] = flat_sd[f"blocks.{i}.mlp.fc.weight"]
+        sd["mlp_down_bank"][i] = flat_sd[f"blocks.{i}.mlp.proj.weight"]
+    for k, v in flat_sd.items():
+        if not (
+            k.startswith("blocks.")
+            and any(
+                p in k
+                for p in [
+                    ".attn.c_q.", ".attn.c_k.", ".attn.c_v.",
+                    ".attn.proj.", ".mlp.fc.", ".mlp.proj.",
+                ]
+            )
+        ):
+            sd[k] = v
+    return sd
+
+
+def _compressed_code_size(code):
+    code_raw = code.encode("utf-8")
+    minified = subprocess.run(
+        ["pyminify", "--no-rename-locals", "--no-hoist-literals", "--remove-literal-statements", "-"],
+        input=code_raw, capture_output=True, check=True,
+    ).stdout
+    compressed = lzma.compress(minified)
+    encoded = base64.b85encode(compressed)
+    wrapper = b'import lzma as L,base64 as B\nexec(L.decompress(B.b85decode("' + encoded + b'")))\n'
+    return len(code_raw), len(wrapper)
+
+
+def serialize(h, base_model, code):
+    code_bytes_uncompressed, code_bytes = _compressed_code_size(code)
+    if h.is_main_process:
+        torch.save(base_model.state_dict(), h.model_path)
+        model_bytes = os.path.getsize(h.model_path)
+        log(f"Serialized model: {model_bytes} bytes")
+        log(f"Code size (uncompressed): {code_bytes_uncompressed} bytes")
+        log(f"Code size (compressed): {code_bytes} bytes")
+    sd_cpu = _unbank_state_dict(base_model.state_dict(), h.num_layers)
+    device = torch.device("cuda", h.local_rank)
+    log("GPTQ:collecting Hessians from calibration data...")
+    t0 = time.perf_counter()
+    calib_loader = ShuffledSequenceLoader(h, device)
+    hessians = collect_hessians(
+        base_model,
+        calib_loader,
+        h,
+        device,
+        n_calibration_batches=h.gptq_calibration_batches,
+    )
+    log(f"GPTQ:collected {len(hessians)} Hessians in {time.perf_counter()-t0:.1f}s")
+    quant_result, quant_meta = gptq_mixed_quantize(sd_cpu, hessians, h)
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = _compress(quant_raw, h.compressor)
+    quant_file_bytes = len(quant_blob)
+    bytes_total = quant_file_bytes + code_bytes
+    if h.is_main_process:
+        with open(h.quantized_model_path, "wb") as f:
+            f.write(quant_blob)
+        log(f"Serialized model quantized+{h.compressor}: {quant_file_bytes} bytes")
+        log(f"Total submission size quantized+{h.compressor}: {bytes_total} bytes")
+    return bytes_total, quant_file_bytes
+
+
+def deserialize(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    flat_template = _unbank_state_dict(eval_model.state_dict(), h.num_layers)
+    with open(h.quantized_model_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(_decompress(quant_blob_disk, h.compressor)), map_location="cpu"
+    )
+    deq_flat = dequantize_mixed(quant_state["w"], quant_state["m"], flat_template)
+    head_dim = h.model_dim // h.num_heads
+    kv_dim = h.num_kv_heads * head_dim
+    hidden_dim = int(h.mlp_mult * h.model_dim)
+    deq_state = _rebank_state_dict(deq_flat, h.num_layers, h.model_dim, kv_dim, hidden_dim)
+    eval_model.load_state_dict(deq_state, strict=True)
+    return eval_model
+
+
+def _loss_bpb(loss_sum, token_count, byte_count):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    return val_loss, val_bpb
+
+
+def eval_val(h, device, val_data, model, forward_logits_fn=None):
+    seq_len = h.eval_seq_len
+    local_batch_tokens = h.val_batch_tokens // (h.world_size * h.grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            f"VAL_BATCH_SIZE must provide at least one sequence per rank; got VAL_BATCH_SIZE={h.val_batch_tokens}, WORLD_SIZE={h.world_size}, GRAD_ACCUM_STEPS={h.grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = total_seqs * h.rank // h.world_size
+    seq_end = total_seqs * (h.rank + 1) // h.world_size
+
+    # TODO: Don't truncate this.
+    seq_end = seq_start + ((seq_end - seq_start) // local_batch_seqs) * local_batch_seqs
+
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    run_forward_logits = (
+        (model.module.forward_logits if hasattr(model, "module") else model.forward_logits)
+        if forward_logits_fn is None
+        else forward_logits_fn
+    )
+    model.eval()
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    with torch.no_grad():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_data.val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1]
+            y = local[1:]
+            bos_pos = (x == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                bos_pos, x.numel(), x.device, h.eval_seq_len, 64
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = run_forward_logits(
+                    x[None], cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                ).detach()
+            per_token_loss = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y.reshape(-1),
+                reduction="none",
+            )
+            val_loss_sum += per_token_loss.to(torch.float64).sum()
+            val_token_count += float(y.numel())
+            prev_ids = x
+            tgt_ids = y
+            token_bytes = val_data.base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (
+                val_data.has_leading_space_lut[tgt_ids]
+                & ~val_data.is_boundary_token_lut[prev_ids]
+            ).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    model.train()
+    return _loss_bpb(val_loss_sum, val_token_count, val_byte_count)
+
+
+def eval_val_sliding(h, device, val_data, base_model, forward_logits_fn=None, batch_seqs=32):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    run_forward_logits = base_model.forward_logits if forward_logits_fn is None else forward_logits_fn
+    seq_len = h.eval_seq_len
+    stride = h.eval_stride
+    total_tokens = val_data.val_tokens.numel() - 1
+    context_size = seq_len - stride
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if ws + context_size < total_tokens]
+    total_windows = len(window_starts)
+    my_s = (total_windows * h.rank) // h.world_size
+    my_e = (total_windows * (h.rank + 1)) // h.world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    total_batches = (len(my_windows) + batch_seqs - 1) // batch_seqs
+    is_master = h.rank == 0
+    cu_bucket = 64
+    t_sw_start = time.perf_counter()
+    with torch.no_grad():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_idx = bi // batch_seqs
+            if is_master and (batch_idx % 50 == 0 or batch_idx == total_batches - 1):
+                elapsed = time.perf_counter() - t_sw_start
+                rl = float(loss_sum.item() / token_count.item()) if token_count.item() > 0 else 0.0
+                rb = float((rl / math.log(2.0)) * token_count.item() / byte_count.item()) if byte_count.item() > 0 else 0.0
+                log(f"sliding_progress: batch {batch_idx+1}/{total_batches} "
+                    f"tokens:{int(token_count.item())} running_loss:{rl:.4f} running_bpb:{rb:.4f} "
+                    f"elapsed:{elapsed:.1f}s")
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            x_parts = []
+            y_parts = []
+            cu_starts = []
+            score_ranges = []
+            offset = 0
+            for ws in batch_ws:
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                chunk_cpu = val_data.val_tokens[ws:end + 1]
+                bos_pos = (chunk_cpu[:-1] == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+                if not bos_pos or bos_pos[0] != 0:
+                    bos_pos = [0] + bos_pos
+                cu_starts.extend(offset + pos for pos in bos_pos)
+                chunk = chunk_cpu.to(dtype=torch.int64, device=device)
+                x_parts.append(chunk[:-1])
+                y_parts.append(chunk[1:])
+                score_ranges.append((offset, wlen, ws))
+                offset += wlen
+            x_cat = torch.cat(x_parts, dim=0)[None]
+            y_cat = torch.cat(y_parts, dim=0)
+            boundaries = cu_starts + [offset]
+            padded_len = get_next_multiple_of_n(len(boundaries), cu_bucket)
+            cu_seqlens = torch.full((padded_len,), offset, dtype=torch.int32, device=device)
+            cu_seqlens[:len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = run_forward_logits(x_cat, cu_seqlens=cu_seqlens, max_seqlen=seq_len)
+            flat_nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_cat,
+                reduction="none",
+            )
+            flat_x = x_cat.reshape(-1)
+            for off, wlen, ws in score_ranges:
+                s = 0 if ws == 0 else context_size
+                lo = off + s
+                hi = off + wlen
+                scored_nll = flat_nll[lo:hi].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(hi - lo)
+                tgt = y_cat[lo:hi]
+                prev = flat_x[lo:hi]
+                tb = val_data.base_bytes_lut[tgt].to(torch.float64)
+                tb += (val_data.has_leading_space_lut[tgt] & ~val_data.is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    base_model.train()
+    return _loss_bpb(loss_sum, token_count, byte_count)
+
+
+def _find_docs(all_tokens):
+    bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0].numpy()
+    docs = []
+    for i in range(len(bos_positions)):
+        start = int(bos_positions[i])
+        end = (
+            int(bos_positions[i + 1])
+            if i + 1 < len(bos_positions)
+            else all_tokens.numel()
+        )
+        if i + 1 < len(bos_positions):
+            end += 1
+        assert end - start >= 2
+        docs.append((start, end - start))
+    return docs
+
+
+def _build_ttt_global_batches(doc_entries, h, ascending=False):
+    batch_size = h.ttt_batch_size
+    global_doc_entries = sorted(doc_entries, key=lambda x: x[1][1])
+    global_batches = [
+        global_doc_entries[i : i + batch_size]
+        for i in range(0, len(global_doc_entries), batch_size)
+    ]
+    indexed = list(enumerate(global_batches))
+    if not ascending:
+        indexed.sort(key=lambda ib: -max(dl for _, (_, dl) in ib[1]))
+    return indexed
+
+
+def _init_batch_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(4, "little"))
+
+
+def _claim_next_batch(counter_path, queue_len):
+    try:
+        with open(counter_path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            idx = int.from_bytes(f.read(4), "little")
+            f.seek(0)
+            f.write((idx + 1).to_bytes(4, "little"))
+            f.flush()
+    except FileNotFoundError:
+        return queue_len
+    return idx
+
+
+def _compute_chunk_window(ci, pred_len, num_chunks, chunk_size, eval_seq_len):
+    chunk_end = pred_len if ci == num_chunks - 1 else (ci + 1) * chunk_size
+    win_start = max(0, chunk_end - eval_seq_len)
+    win_len = chunk_end - win_start
+    chunk_start = ci * chunk_size
+    chunk_offset = chunk_start - win_start
+    chunk_len = chunk_end - chunk_start
+    return win_start, win_len, chunk_offset, chunk_len
+
+
+def _accumulate_bpb(
+    ptl,
+    x,
+    y,
+    chunk_offsets,
+    chunk_lens,
+    pos_idx,
+    base_bytes_lut,
+    has_leading_space_lut,
+    is_boundary_token_lut,
+    loss_sum,
+    byte_sum,
+    token_count,
+):
+    pos = pos_idx[: x.size(1)].unsqueeze(0)
+    mask = (
+        (chunk_lens.unsqueeze(1) > 0)
+        & (pos >= chunk_offsets.unsqueeze(1))
+        & (pos < (chunk_offsets + chunk_lens).unsqueeze(1))
+    )
+    mask_f64 = mask.to(torch.float64)
+    tok_bytes = base_bytes_lut[y].to(torch.float64)
+    tok_bytes += (has_leading_space_lut[y] & ~is_boundary_token_lut[x]).to(
+        torch.float64
+    )
+    loss_sum += (ptl.to(torch.float64) * mask_f64).sum()
+    byte_sum += (tok_bytes * mask_f64).sum()
+    token_count += chunk_lens.to(torch.float64).sum()
+
+def eval_val_ttt_lora(h, base_model, device, val_data, forward_ttt_train):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+    all_tokens = val_data.val_tokens
+    all_tokens_idx = all_tokens.to(torch.int32)
+    docs = _find_docs(all_tokens)
+    doc_entries = list(enumerate(docs))
+    if h.val_doc_fraction < 1.0:
+        sample_n = max(1, int(round(len(docs) * h.val_doc_fraction)))
+        sampled_indices = sorted(
+            random.Random(h.seed).sample(range(len(docs)), sample_n)
+        )
+        doc_entries = [(i, docs[i]) for i in sampled_indices]
+    log(
+        f"ttt_lora:docs:{len(doc_entries)} rank:{h.ttt_lora_rank} lr:{h.ttt_lora_lr} chunk:{h.ttt_chunk_size}"
+    )
+    if os.environ.get("TTT_DEBUG_BYPASS") and h.rank == 0:
+        test_doc = doc_entries[0][1]
+        ds, dl = test_doc
+        log(f"DEBUG: test doc start={ds} len={dl}")
+        toks = all_tokens_idx[ds : ds + dl].to(device=device, dtype=torch.int64)
+        x_d = toks[:-1].unsqueeze(0)
+        y_d = toks[1:].unsqueeze(0)
+        with torch.no_grad(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            logits_d = base_model.forward_logits(x_d)
+        ptl_d = F.cross_entropy(
+            logits_d.float().reshape(-1, logits_d.size(-1)),
+            y_d.reshape(-1), reduction="none",
+        )
+        direct_loss = ptl_d.mean().item()
+        direct_bpb = direct_loss / math.log(2.0)
+        log(f"DEBUG: direct forward_logits loss={direct_loss:.6f} bpb={direct_bpb:.6f} ntokens={y_d.numel()}")
+        toks_first5 = toks[:5].tolist()
+        ptl_first5 = ptl_d[:5].tolist()
+        log(f"DEBUG: first 5 tokens={toks_first5} ptl={[f'{v:.4f}' for v in ptl_first5]}")
+    chunk_size, eval_seq_len = h.ttt_chunk_size, h.ttt_eval_seq_len
+    eval_batch_set = None
+    if h.ttt_eval_batches:
+        eval_batch_set = set(int(x) for x in h.ttt_eval_batches.split(",") if x.strip())
+    use_ascending = eval_batch_set is not None
+    global_batches_sorted = _build_ttt_global_batches(doc_entries, h, ascending=use_ascending)
+    queue_len = len(global_batches_sorted)
+    counter_path = f"/tmp/ttt_counter_{h.run_id}"
+    if h.rank == 0:
+        _init_batch_counter(counter_path)
+    if dist.is_available() and dist.is_initialized():
+        path_list = [counter_path]
+        dist.broadcast_object_list(path_list, src=0)
+        counter_path = path_list[0]
+        dist.barrier()
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    t_start = time.perf_counter()
+    local_batch_count = 0
+    reusable_lora = BatchedTTTLoRA(
+        h.ttt_batch_size, base_model, h.ttt_lora_rank,
+        k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+        hash_embed_size=h.ttt_hash_embed_size,
+    ).to(device)
+
+    def _build_opt(lora):
+        if h.ttt_optimizer == "sgd":
+            return torch.optim.SGD(
+                lora.parameters(), lr=h.ttt_lora_lr,
+                momentum=h.ttt_beta1, weight_decay=h.ttt_weight_decay,
+            )
+        return torch.optim.AdamW(
+            lora.parameters(), lr=h.ttt_lora_lr,
+            betas=(h.ttt_beta1, h.ttt_beta2),
+            eps=1e-10, weight_decay=h.ttt_weight_decay, fused=True,
+        )
+
+    reusable_opt = _build_opt(reusable_lora)
+    progress_f = None
+    if h.ttt_output_dir and h.rank == 0:
+        os.makedirs(h.ttt_output_dir, exist_ok=True)
+        progress_f = open(os.path.join(h.ttt_output_dir, "progress.jsonl"), "w")
+    try:
+      while True:
+        queue_idx = _claim_next_batch(counter_path, queue_len)
+        if queue_idx >= queue_len:
+            break
+        orig_batch_idx, batch_entries = global_batches_sorted[queue_idx]
+        batch = [doc for _, doc in batch_entries]
+        bsz = len(batch)
+        prev_loss = loss_sum.item()
+        prev_bytes = byte_sum.item()
+        prev_tokens = token_count.item()
+        if bsz == reusable_lora.bsz:
+            reusable_lora.reset()
+            for s in reusable_opt.state.values():
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor):
+                        v.zero_()
+                    elif k == "step":
+                        s[k] = 0
+            cur_lora = reusable_lora
+            cur_opt = reusable_opt
+        else:
+            cur_lora = BatchedTTTLoRA(
+                bsz, base_model, h.ttt_lora_rank,
+                k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+                hash_embed_size=h.ttt_hash_embed_size,
+            ).to(device)
+            cur_opt = _build_opt(cur_lora)
+        pred_lens = [doc_len - 1 for _, doc_len in batch]
+        num_chunks = [(pl + chunk_size - 1) // chunk_size for pl in pred_lens]
+        max_nc = max(num_chunks)
+        num_chunks_t = torch.tensor(num_chunks, dtype=torch.int64, device=device)
+        for ci in range(max_nc):
+            active = [ci < nc for nc in num_chunks]
+            needs_train = any(ci < nc - 1 for nc in num_chunks)
+            tok_starts = torch.zeros(bsz, dtype=torch.int64)
+            tok_wls = torch.zeros(bsz, dtype=torch.int64)
+            chunk_offsets_cpu = torch.zeros(bsz, dtype=torch.int64)
+            chunk_lens_cpu = torch.zeros(bsz, dtype=torch.int64)
+            for b in range(bsz):
+                if not active[b]:
+                    continue
+                doc_start, doc_len = batch[b]
+                win_start, win_len, chunk_offset, chunk_len = _compute_chunk_window(
+                    ci, pred_lens[b], num_chunks[b], chunk_size, eval_seq_len
+                )
+                tok_starts[b] = doc_start + win_start
+                tok_wls[b] = win_len
+                chunk_offsets_cpu[b] = chunk_offset
+                chunk_lens_cpu[b] = chunk_len
+            _, context_size, chunk_offset, _ = _compute_chunk_window(
+                ci, (ci + 1) * chunk_size, ci + 1, chunk_size, eval_seq_len
+            )
+            col_idx = torch.arange(context_size + 1)
+            idx = tok_starts.unsqueeze(1) + col_idx.unsqueeze(0)
+            idx.clamp_(max=all_tokens.numel() - 1)
+            gathered_gpu = all_tokens_idx[idx].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            valid = (col_idx[:context_size].unsqueeze(0) < tok_wls.unsqueeze(1)).to(
+                device, non_blocking=True
+            )
+            chunk_offsets = chunk_offsets_cpu.to(device, non_blocking=True)
+            chunk_lens = chunk_lens_cpu.to(device, non_blocking=True)
+            x = torch.where(valid, gathered_gpu[:, :context_size], 0)
+            y = torch.where(valid, gathered_gpu[:, 1 : context_size + 1], 0)
+            ctx_pos = torch.arange(context_size, device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+            with torch.no_grad():
+                _accumulate_bpb(
+                    per_tok_loss,
+                    x,
+                    y,
+                    chunk_offsets,
+                    chunk_lens,
+                    ctx_pos,
+                    val_data.base_bytes_lut,
+                    val_data.has_leading_space_lut,
+                    val_data.is_boundary_token_lut,
+                    loss_sum,
+                    byte_sum,
+                    token_count,
+                )
+            if needs_train:
+                activate_chunk_mask = (num_chunks_t - 1 > ci).float()
+                for gi in range(h.ttt_grad_steps):
+                    if gi > 0:
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+                    per_doc = per_tok_loss[
+                        :, chunk_offset : chunk_offset + chunk_size
+                    ].mean(dim=-1)
+                    cur_opt.zero_grad(set_to_none=True)
+                    (per_doc * activate_chunk_mask).sum().backward()
+                    cur_opt.step()
+            else:
+                del per_tok_loss
+        local_batch_count += 1
+        batch_num = orig_batch_idx + 1
+        doc_lens = [dl for _, dl in batch]
+        should_report = False
+        if eval_batch_set is not None:
+            should_report = batch_num in eval_batch_set
+        else:
+            # should_report = local_batch_count % 10 == 0
+            should_report = True
+        if should_report:
+            cur_tokens = token_count.item()
+            cur_loss_val = loss_sum.item()
+            cur_bytes_val = byte_sum.item()
+            dt = cur_tokens - prev_tokens
+            if dt > 0:
+                b_loss = (cur_loss_val - prev_loss) / dt
+                b_bpb = b_loss / math.log(2.0) * (dt / (cur_bytes_val - prev_bytes))
+            else:
+                b_loss = b_bpb = 0.0
+            r_loss = cur_loss_val / max(cur_tokens, 1)
+            r_bpb = r_loss / math.log(2.0) * (cur_tokens / max(cur_bytes_val, 1))
+            elapsed = time.perf_counter() - t_start
+            log(
+                f"ttt_progress: batch {batch_num}/{queue_len} batch_loss:{b_loss:.4f} "
+                f"batch_bpb:{b_bpb:.4f} running_loss:{r_loss:.4f} running_bpb:{r_bpb:.4f} "
+                f"doc_len:{min(doc_lens)}-{max(doc_lens)}"
+            )
+            if progress_f is not None:
+                progress_f.write(
+                    json.dumps({
+                        "batch": batch_num, "total_batches": queue_len,
+                        "batch_loss": round(b_loss, 8), "batch_bpb": round(b_bpb, 8),
+                        "running_loss": round(r_loss, 8), "running_bpb": round(r_bpb, 8),
+                        "doc_len_min": min(doc_lens), "doc_len_max": max(doc_lens),
+                        "chunk_size": chunk_size,
+                        "elapsed_s": round(elapsed, 3),
+                        "batch_t_s": round(elapsed, 3),
+                    }) + "\n"
+                )
+                progress_f.flush()
+        del cur_lora, cur_opt
+    finally:
+        if progress_f is not None:
+            progress_f.close()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.train()
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_sum.item())
+    return val_loss, val_bpb
+
+
+def timed_eval(label, fn, *args, **kwargs):
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    val_loss, val_bpb = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    elapsed_ms = 1e3 * (time.perf_counter() - t0)
+    log(
+        f"{label} val_loss:{val_loss:.8f} val_bpb:{val_bpb:.8f} eval_time:{elapsed_ms:.0f}ms"
+    )
+    return val_loss, val_bpb
+
+
+def train_model(h, device, val_data):
+    base_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        base_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    model = compiled_model
+    log(f"model_params:{sum(p.numel()for p in base_model.parameters())}")
+    optimizers = Optimizers(h, base_model)
+    train_loader = DocumentPackingLoader(h, device)
+    max_wallclock_ms = (
+        1e3 * h.max_wallclock_seconds if h.max_wallclock_seconds > 0 else None
+    )
+    if max_wallclock_ms is not None:
+        max_wallclock_ms -= h.gptq_reserve_seconds * 1e3
+        log(
+            f"gptq:reserving {h.gptq_reserve_seconds:.0f}s, effective={max_wallclock_ms:.0f}ms"
+        )
+
+    def training_frac(step, elapsed_ms):
+        if max_wallclock_ms is None:
+            return step / max(h.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-09)
+
+    def lr_mul(frac):
+        if h.warmdown_frac <= 0:
+            return 1.0
+        if frac >= 1.0 - h.warmdown_frac:
+            return max((1.0 - frac) / h.warmdown_frac, h.min_lr)
+        return 1.0
+
+    def step_fn(step, lr_scale):
+        optimizers.zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(h.grad_accum_steps):
+            x, y, cu_seqlens, _max_seqlen = train_loader.next_batch(
+                h.train_batch_tokens, h.grad_accum_steps
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y, cu_seqlens=cu_seqlens, max_seqlen=h.train_seq_len)
+            train_loss += loss.detach()
+            (loss / h.grad_accum_steps).backward()
+        train_loss /= h.grad_accum_steps
+        frac = (
+            min(step / h.muon_momentum_warmup_steps, 1.0)
+            if h.muon_momentum_warmup_steps > 0
+            else 1.0
+        )
+        muon_momentum = (
+            1 - frac
+        ) * h.muon_momentum_warmup_start + frac * h.muon_momentum
+        for group in optimizers.optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * lr_scale
+        if h.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), h.grad_clip_norm)
+        optimizers.step(distributed=h.distributed)
+        return train_loss
+
+    if h.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for (name, tensor) in base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in optimizers
+        ]
+        model.train()
+        num_tokens_local = h.train_batch_tokens // h.world_size
+        for blk in base_model.blocks:
+            blk.attn.rotary(num_tokens_local, device, torch.bfloat16)
+        cu_bucket_size = train_loader.cu_bucket_size
+        warmup_cu_buckets = tuple(cu_bucket_size * i for i in range(1, 5))
+        warmup_cu_iters = 3
+        x, y, cu_seqlens, _ = train_loader.next_batch(
+            h.train_batch_tokens, h.grad_accum_steps
+        )
+        log(f"warmup_cu_buckets:{','.join(str(b) for b in warmup_cu_buckets)} iters_each:{warmup_cu_iters}")
+        def _run_cu_bucket_warmup():
+            for bucket_len in warmup_cu_buckets:
+                boundaries = list(range(0, x.size(1), max(h.train_seq_len, 1)))
+                if boundaries[-1] != x.size(1):
+                    boundaries.append(x.size(1))
+                cu = torch.full((bucket_len,), x.size(1), dtype=torch.int32, device=device)
+                cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+                for _ in range(warmup_cu_iters):
+                    optimizers.zero_grad_all()
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                        wloss = model(x, y, cu_seqlens=cu, max_seqlen=h.train_seq_len)
+                    (wloss / h.grad_accum_steps).backward()
+            optimizers.zero_grad_all()
+        _run_cu_bucket_warmup()
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            _run_cu_bucket_warmup()
+            base_model.looping_active = False
+        for warmup_step in range(h.warmup_steps):
+            step_fn(warmup_step, 1.0)
+            if (
+                warmup_step <= 5
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == h.warmup_steps
+            ):
+                log(f"warmup_step: {warmup_step+1}/{h.warmup_steps}")
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            log(
+                f"loop_warmup:enabled encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            for warmup_step in range(h.warmup_steps):
+                step_fn(warmup_step, 1.0)
+                if (
+                    warmup_step <= 5
+                    or (warmup_step + 1) % 10 == 0
+                    or warmup_step + 1 == h.warmup_steps
+                ):
+                    log(f"loop_warmup_step: {warmup_step+1}/{h.warmup_steps}")
+            base_model.looping_active = False
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for (opt, state) in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        optimizers.zero_grad_all()
+        train_loader = DocumentPackingLoader(h, device)
+    ema_state = {
+        name: t.detach().float().clone()
+        for (name, t) in base_model.state_dict().items()
+    }
+    ema_decay = h.ema_decay
+    training_time_ms = 0.0
+    stop_after_step = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = (
+            step == h.iterations
+            or stop_after_step is not None
+            and step >= stop_after_step
+        )
+        should_validate = (
+            last_step or h.val_loss_every > 0 and step % h.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1e3 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                h, device, val_data, model, compiled_forward_logits
+            )
+            log(
+                f"{step}/{h.iterations} val_loss: {val_loss:.4f} val_bpb: {val_bpb:.4f}"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < h.iterations:
+                log(
+                    f"stopping_early: wallclock_cap train_time: {training_time_ms:.0f}ms step: {step}/{h.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        frac = training_frac(step, elapsed_ms)
+        scale = lr_mul(frac)
+        if (
+            h.num_loops > 0
+            and not base_model.looping_active
+            and frac >= h.enable_looping_at
+        ):
+            base_model.looping_active = True
+            log(
+                f"layer_loop:enabled step:{step} frac:{frac:.3f} encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+        train_loss = step_fn(step, scale)
+        with torch.no_grad():
+            for (name, t) in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(
+                    t.detach().float(), alpha=1.0 - ema_decay
+                )
+        step += 1
+        approx_training_time_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        should_log_train = h.train_log_every > 0 and (
+            step <= 5 or step % h.train_log_every == 0 or stop_after_step is not None
+        )
+        if should_log_train:
+            tok_per_sec = step * h.train_batch_tokens / (approx_training_time_ms / 1e3)
+            log(
+                f"{step}/{h.iterations} train_loss: {train_loss.item():.4f} train_time: {approx_training_time_ms/60000:.1f}m tok/s: {tok_per_sec:.0f}"
+            )
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if h.distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated()//1024//1024} MiB reserved: {torch.cuda.max_memory_reserved()//1024//1024} MiB"
+    )
+    log("ema:applying EMA weights")
+    current_state = base_model.state_dict()
+    avg_state = {
+        name: t.to(dtype=current_state[name].dtype) for (name, t) in ema_state.items()
+    }
+    base_model.load_state_dict(avg_state, strict=True)
+    return base_model, compiled_model, compiled_forward_logits
+
+
+def train_and_eval(h, device):
+    random.seed(h.seed)
+    np.random.seed(h.seed)
+    torch.manual_seed(h.seed)
+    torch.cuda.manual_seed_all(h.seed)
+    if h.artifact_dir and h.is_main_process:
+        os.makedirs(h.artifact_dir, exist_ok=True)
+    val_data = ValidationData(h, device)
+    if h.eval_only_path:
+        log(f"eval_only:loading checkpoint from {h.eval_only_path}")
+        base_model = GPT(h).to(device).bfloat16()
+        restore_fp32_params(base_model)
+        base_model.load_state_dict(torch.load(h.eval_only_path, map_location=device))
+        if h.num_loops > 0:
+            base_model.looping_active = True
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+        compiled_forward_logits = torch.compile(
+            base_model.forward_logits, dynamic=False, fullgraph=True
+        )
+    else:
+        log(
+            f"train_shards: {len(list(Path(h.datasets_dir).resolve().glob('fineweb_train_*.bin')))}"
+        )
+        log(f"val_tokens: {val_data.val_tokens.numel()-1}")
+        base_model, compiled_model, compiled_forward_logits = train_model(
+            h, device, val_data
+        )
+    _skip_training = bool(h.eval_only_path)
+    torch._dynamo.reset()
+    timed_eval(
+        "diagnostic pre-quantization post-ema",
+        eval_val,
+        h,
+        device,
+        val_data,
+        compiled_model,
+        compiled_forward_logits,
+    )
+    if not _skip_training:
+        serialize(h, base_model, Path(__file__).read_text(encoding="utf-8"))
+    else:
+        log("eval_only: skipping serialize (already have quantized model)")
+        if not os.path.exists(h.quantized_model_path):
+            log("eval_only: no quantized model found, running serialize anyway")
+            serialize(h, base_model, Path(__file__).read_text(encoding="utf-8"))
+    if h.distributed:
+        dist.barrier()
+    eval_model = deserialize(h, device)
+    if h.num_loops > 0:
+        eval_model.looping_active = True
+    compiled_model = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        eval_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    timed_eval(
+        "diagnostic quantized",
+        eval_val,
+        h,
+        device,
+        val_data,
+        compiled_model,
+        compiled_forward_logits,
+    )
+    if h.sliding_window_enabled:
+        timed_eval(
+            "diagnostic quantized_sliding_window",
+            eval_val_sliding,
+            h,
+            device,
+            val_data,
+            eval_model,
+            forward_logits_fn=compiled_forward_logits,
+        )
+    if h.ttt_enabled:
+        del eval_model, compiled_model
+        torch._dynamo.reset()
+        torch.cuda.empty_cache()
+        ttt_model = deserialize(h, device)
+        if h.num_loops > 0:
+            ttt_model.looping_active = True
+        for p in ttt_model.parameters():
+            p.requires_grad_(False)
+        if h.ttt_hash_embed_size > 0:
+            for block in ttt_model.blocks:
+                block.mlp.use_fused = False
+            log("ttt_lora: hash embed active, disabling fused MLP for lower backward memory")
+
+        if h.rope_yarn:
+            _yarn_seqlen = h.train_batch_tokens // h.grad_accum_steps
+            for block in ttt_model.blocks:
+                block.attn.rotary(_yarn_seqlen, device, torch.bfloat16)
+        else:
+            for block in ttt_model.blocks:
+                block.attn.rotary._cos_cached = None
+                block.attn.rotary._sin_cached = None
+                block.attn.rotary._seq_len_cached = 0
+                block.attn.rotary(h.ttt_eval_seq_len, device, torch.bfloat16)
+
+        def _fwd_ttt_inner(input_ids, target_ids, lora, hash_out=None):
+            return ttt_model.forward_ttt(input_ids, target_ids, lora=lora, hash_out=hash_out)
+
+        _fwd_ttt_compiled_inner = None
+
+        def _fwd_ttt(input_ids, target_ids, lora):
+            nonlocal _fwd_ttt_compiled_inner
+            hash_out = lora.hash_embed_forward(input_ids)
+            if _fwd_ttt_compiled_inner is None:
+                _fwd_ttt_compiled_inner = torch.compile(_fwd_ttt_inner, dynamic=True)
+            return _fwd_ttt_compiled_inner(input_ids, target_ids, lora=lora, hash_out=hash_out)
+
+        _ttt_debug_bypass = bool(os.environ.get("TTT_DEBUG_BYPASS"))
+        if _ttt_debug_bypass:
+            def _fwd_ttt_bypass(input_ids, target_ids, lora):
+                logits = ttt_model.forward_logits(input_ids)
+                dummy = lora.q_loras[0].B.sum() * 0
+                logits = logits + dummy
+                bsz, sl, V = logits.shape
+                return F.cross_entropy(
+                    logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none"
+                ).reshape(bsz, sl)
+            fwd_ttt_compiled = _fwd_ttt_bypass
+            log("ttt_lora:DEBUG BYPASS active - using forward_logits directly (no compile warmup)")
+        else:
+            fwd_ttt_compiled = _fwd_ttt
+            log(f"ttt_lora:warming up compile")
+            global BOS_ID
+            if BOS_ID is None:
+                BOS_ID = 1
+            ds0 = 0
+            val_tokens_idx = val_data.val_tokens.to(torch.int32)
+            t_warmup = time.perf_counter()
+            warmup_bszes = [h.ttt_batch_size]
+            for bsz in warmup_bszes:
+                wl = BatchedTTTLoRA(
+                    bsz, ttt_model, h.ttt_lora_rank,
+                    k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+                    hash_embed_size=h.ttt_hash_embed_size,
+                ).to(device)
+                wo = torch.optim.AdamW(
+                    wl.parameters(),
+                    lr=h.ttt_lora_lr,
+                    betas=(h.ttt_beta1, h.ttt_beta2),
+                    eps=1e-10,
+                    weight_decay=h.ttt_weight_decay,
+                    fused=True,
+                )
+                for ctx_len in (h.ttt_chunk_size, h.ttt_eval_seq_len):
+                    col_w = torch.arange(ctx_len + 1)
+                    idx_w = (ds0 + col_w).clamp_(max=val_data.val_tokens.numel() - 1)
+                    row_w = val_tokens_idx[idx_w].to(device=device, dtype=torch.int64)
+                    xw = row_w[:ctx_len].unsqueeze(0).expand(bsz, -1).contiguous()
+                    yw = row_w[1 : ctx_len + 1].unsqueeze(0).expand(bsz, -1).contiguous()
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        ptl = fwd_ttt_compiled(xw, yw, lora=wl)
+                    ptl[:, : min(h.ttt_chunk_size, ctx_len)].mean(dim=-1).sum().backward()
+                    wo.step()
+                    wo.zero_grad(set_to_none=True)
+                del wl, wo
+            del val_tokens_idx
+            torch.cuda.empty_cache()
+            compile_elapsed = time.perf_counter() - t_warmup
+            log(f"ttt_lora:compile warmup done ({compile_elapsed:.1f}s)")
+        log("\nbeginning TTT eval timer")
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_val_loss, ttt_val_bpb = eval_val_ttt_lora(
+            h, ttt_model, device, val_data, forward_ttt_train=fwd_ttt_compiled
+        )
+        torch.cuda.synchronize()
+        ttt_eval_elapsed = time.perf_counter() - t_ttt
+        log(
+            f"quantized_ttt_lora val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f} eval_time:{1e3*ttt_eval_elapsed:.0f}ms"
+        )
+        log(f"total_eval_time:{ttt_eval_elapsed:.1f}s")
+        del ttt_model
+
+
+def main():
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    torch._dynamo.config.optimize_ddp = False
+    torch._dynamo.config.cache_size_limit = 16
+    h = Hyperparameters()
+    set_logging_hparams(h)
+    if h.is_main_process:
+        os.makedirs(h.artifact_dir if h.artifact_dir else "logs", exist_ok=True)
+        log(100 * "=", console=False)
+        log("Hyperparameters:", console=True)
+        for (k, v) in sorted(vars(type(h)).items()):
+            if not k.startswith("_"):
+                log(f"  {k}: {v}", console=True)
+        log("=" * 100, console=False)
+        log("Source code:", console=False)
+        log("=" * 100, console=False)
+        with open(__file__, "r", encoding="utf-8") as _src:
+            log(_src.read(), console=False)
+        log("=" * 100, console=False)
+        log(f"Running Python {sys.version}", console=False)
+        log(f"Running PyTorch {torch.__version__}", console=False)
+        log(
+            subprocess.run(
+                ["nvidia-smi"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            ).stdout,
+            console=False,
+        )
+        log("=" * 100, console=False)
+    train_and_eval(h, device)
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
 Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
 Running PyTorch 2.9.1+cu128
-Fri Apr 10 21:54:16 2026       
+Sat Apr 11 16:10:17 2026       
 +-----------------------------------------------------------------------------------------+
 | NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
 |-----------------------------------------+------------------------+----------------------+
@@ -112,35 +3055,35 @@ Fri Apr 10 21:54:16 2026
 |                                         |                        |               MIG M. |
 |=========================================+========================+======================|
 |   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
-| N/A   48C    P0            125W /  700W |    1519MiB /  81559MiB |      2%      Default |
+| N/A   44C    P0            124W /  700W |    1519MiB /  81559MiB |      1%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
-| N/A   37C    P0            118W /  700W |    1519MiB /  81559MiB |      2%      Default |
+| N/A   40C    P0            125W /  700W |    1519MiB /  81559MiB |      3%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
-| N/A   38C    P0            116W /  700W |    1519MiB /  81559MiB |      3%      Default |
+| N/A   45C    P0            135W /  700W |    1519MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
-| N/A   36C    P0            118W /  700W |    1519MiB /  81559MiB |      0%      Default |
+| N/A   40C    P0            123W /  700W |    1519MiB /  81559MiB |      2%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
-| N/A   40C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
+| N/A   44C    P0            126W /  700W |    1519MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
-| N/A   34C    P0            114W /  700W |    1519MiB /  81559MiB |      2%      Default |
+| N/A   38C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
-| N/A   36C    P0            115W /  700W |    1519MiB /  81559MiB |      0%      Default |
+| N/A   42C    P0            130W /  700W |    1519MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
-| N/A   35C    P0            116W /  700W |    1519MiB /  81559MiB |      0%      Default |
+| N/A   40C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
                                                                                          
@@ -149,21 +3092,21 @@ Fri Apr 10 21:54:16 2026
 |  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
 |        ID   ID                                                               Usage      |
 |=========================================================================================|
-|    0   N/A  N/A         1732496      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    1   N/A  N/A         1732497      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    2   N/A  N/A         1732498      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    3   N/A  N/A         1732499      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    4   N/A  N/A         1732500      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    5   N/A  N/A         1732501      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    6   N/A  N/A         1732502      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    7   N/A  N/A         1732503      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    0   N/A  N/A          302584      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          302585      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          302586      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          302587      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          302588      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          302589      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          302590      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          302591      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
 +-----------------------------------------------------------------------------------------+
 
 ====================================================================================================
 train_shards: 128
 val_tokens: 40540160
-model_params:35944537
-gptq:reserving 12s, effective=588000ms
+model_params:35944602
+gptq:reserving 13s, effective=587000ms
 warmup_cu_buckets:64,128,192,256 iters_each:3
 warmup_step: 1/20
 warmup_step: 2/20
@@ -182,160 +3125,148 @@ loop_warmup_step: 5/20
 loop_warmup_step: 6/20
 loop_warmup_step: 10/20
 loop_warmup_step: 20/20
-0/20000 val_loss: 9.0085 val_bpb: 3.4874
-1/20000 train_loss: 9.0089 train_time: 0.0m tok/s: 18850472
-2/20000 train_loss: 12.2347 train_time: 0.0m tok/s: 13811925
-3/20000 train_loss: 11.1722 train_time: 0.0m tok/s: 11479577
-4/20000 train_loss: 9.5567 train_time: 0.0m tok/s: 10527592
-5/20000 train_loss: 8.1979 train_time: 0.0m tok/s: 10056434
-500/20000 train_loss: 3.2864 train_time: 0.8m tok/s: 8290951
-1000/20000 train_loss: 3.0354 train_time: 1.6m tok/s: 8259228
-1500/20000 train_loss: 3.0451 train_time: 2.4m tok/s: 8256335
-2000/20000 train_loss: 3.0101 train_time: 3.2m tok/s: 8251977
-layer_loop:enabled step:2159 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
-2500/20000 train_loss: 3.0883 train_time: 4.2m tok/s: 7723640
-3000/20000 train_loss: 2.9246 train_time: 5.4m tok/s: 7273318
-3500/20000 train_loss: 2.9912 train_time: 6.6m tok/s: 6983412
-4000/20000 train_loss: 2.9199 train_time: 7.7m tok/s: 6779882
-4000/20000 val_loss: 2.8943 val_bpb: 1.1204
-4500/20000 train_loss: 2.8670 train_time: 8.9m tok/s: 6630508
-4890/20000 val_loss: 2.7794 val_bpb: 1.0760
-stopping_early: wallclock_cap train_time: 588188ms step: 4890/20000
-peak memory allocated: 40019 MiB reserved: 44088 MiB
+0/20000 val_loss: 9.0086 val_bpb: 3.4874
+1/20000 train_loss: 9.0089 train_time: 0.0m tok/s: 16515307
+2/20000 train_loss: 12.2848 train_time: 0.0m tok/s: 12787598
+3/20000 train_loss: 11.2651 train_time: 0.0m tok/s: 11022716
+4/20000 train_loss: 9.6529 train_time: 0.0m tok/s: 10248995
+5/20000 train_loss: 8.2562 train_time: 0.0m tok/s: 9843051
+500/20000 train_loss: 3.2527 train_time: 0.8m tok/s: 8241348
+1000/20000 train_loss: 3.0057 train_time: 1.6m tok/s: 8211974
+1500/20000 train_loss: 3.0231 train_time: 2.4m tok/s: 8210145
+2000/20000 train_loss: 2.9753 train_time: 3.2m tok/s: 8209148
+layer_loop:enabled step:2145 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2500/20000 train_loss: 3.0610 train_time: 4.3m tok/s: 7701035
+3000/20000 train_loss: 2.8987 train_time: 5.4m tok/s: 7249751
+3500/20000 train_loss: 2.9700 train_time: 6.6m tok/s: 6959141
+4000/20000 train_loss: 2.8983 train_time: 7.8m tok/s: 6755887
+4000/20000 val_loss: 2.8742 val_bpb: 1.1126
+4500/20000 train_loss: 2.8499 train_time: 8.9m tok/s: 6606485
+4867/20000 val_loss: 2.7700 val_bpb: 1.0723
+stopping_early: wallclock_cap train_time: 587193ms step: 4867/20000
+peak memory allocated: 40019 MiB reserved: 44090 MiB
 ema:applying EMA weights
-
-beginning eval timer
-pre-quantization post-ema val_loss:2.77999363 val_bpb:1.07618748 eval_time:7628ms
-Serialized model: 135408623 bytes
-Code size (uncompressed): 122556 bytes
-Code size (compressed): 26760 bytes
+diagnostic pre-quantization post-ema val_loss:2.76877360 val_bpb:1.07184400 eval_time:5993ms
+Serialized model: 135409136 bytes
+Code size (uncompressed): 121884 bytes
+Code size (compressed): 27310 bytes
 GPTQ:collecting Hessians from calibration data...
-GPTQ:collected 67 Hessians in 12.4s
+GPTQ:collected 67 Hessians in 12.6s
 Quantized weights:
   gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
   gptq (int8): tok_emb.weight
-  passthrough (float16): blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, lane_merge, skip_gates, skip_weights
-Serialized model quantized+brotli: 15965480 bytes
-Total submission size quantized+brotli: 15992240 bytes
-quantized val_loss:2.80837934 val_bpb:1.08717612 eval_time:8614ms
+  passthrough (float16): blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, skip_gates, skip_weights
+Serialized model quantized+brotli: 15969354 bytes
+Total submission size quantized+brotli: 15996664 bytes
+diagnostic quantized val_loss:2.79823422 val_bpb:1.08324876 eval_time:45933ms
 ttt_lora:warming up compile
-ttt_lora:compile warmup done (86.4s)
-ttt_lora:docs:50000 rank:96 lr:0.0001 chunk:64
-ttt_progress: batch 778/782 batch_loss:2.7982 batch_bpb:1.1194 running_loss:2.7982 running_bpb:1.1194 doc_len:7961-8997
-ttt_progress: batch 773/782 batch_loss:2.6647 batch_bpb:1.0813 running_loss:2.7465 running_bpb:1.1048 doc_len:5203-5550
-ttt_progress: batch 771/782 batch_loss:2.7699 batch_bpb:1.0830 running_loss:2.7526 running_bpb:1.0990 doc_len:4701-4937
-ttt_progress: batch 767/782 batch_loss:2.7646 batch_bpb:1.1038 running_loss:2.7547 running_bpb:1.0999 doc_len:3963-4123
-ttt_progress: batch 762/782 batch_loss:2.8361 batch_bpb:1.0795 running_loss:2.7656 running_bpb:1.0970 doc_len:3431-3533
-ttt_progress: batch 757/782 batch_loss:2.6475 batch_bpb:1.0232 running_loss:2.7531 running_bpb:1.0891 doc_len:3033-3108
-ttt_progress: batch 751/782 batch_loss:2.8008 batch_bpb:1.0752 running_loss:2.7572 running_bpb:1.0879 doc_len:2689-2740
-ttt_progress: batch 743/782 batch_loss:2.7197 batch_bpb:1.0471 running_loss:2.7546 running_bpb:1.0850 doc_len:2355-2388
-ttt_progress: batch 736/782 batch_loss:2.6838 batch_bpb:1.0461 running_loss:2.7504 running_bpb:1.0827 doc_len:2140-2165
-ttt_progress: batch 730/782 batch_loss:2.7717 batch_bpb:1.0912 running_loss:2.7515 running_bpb:1.0831 doc_len:1995-2016
-ttt_progress: batch 725/782 batch_loss:2.7673 batch_bpb:1.0726 running_loss:2.7523 running_bpb:1.0826 doc_len:1900-1915
-ttt_progress: batch 719/782 batch_loss:2.6914 batch_bpb:1.0320 running_loss:2.7497 running_bpb:1.0804 doc_len:1793-1816
-ttt_progress: batch 706/782 batch_loss:2.7223 batch_bpb:1.0465 running_loss:2.7487 running_bpb:1.0791 doc_len:1617-1627
-ttt_progress: batch 700/782 batch_loss:2.6859 batch_bpb:1.0483 running_loss:2.7465 running_bpb:1.0780 doc_len:1552-1562
-ttt_progress: batch 695/782 batch_loss:2.7890 batch_bpb:1.0813 running_loss:2.7479 running_bpb:1.0781 doc_len:1504-1513
-ttt_progress: batch 689/782 batch_loss:2.7864 batch_bpb:1.0661 running_loss:2.7490 running_bpb:1.0778 doc_len:1450-1458
-ttt_progress: batch 684/782 batch_loss:2.8037 batch_bpb:1.0779 running_loss:2.7506 running_bpb:1.0778 doc_len:1407-1414
-ttt_progress: batch 671/782 batch_loss:2.8909 batch_bpb:1.1204 running_loss:2.7542 running_bpb:1.0789 doc_len:1316-1321
-ttt_progress: batch 667/782 batch_loss:2.8291 batch_bpb:1.1083 running_loss:2.7561 running_bpb:1.0796 doc_len:1288-1295
-ttt_progress: batch 659/782 batch_loss:2.7212 batch_bpb:1.0247 running_loss:2.7552 running_bpb:1.0783 doc_len:1239-1245
-ttt_progress: batch 652/782 batch_loss:2.8055 batch_bpb:1.0749 running_loss:2.7564 running_bpb:1.0782 doc_len:1198-1203
-ttt_progress: batch 647/782 batch_loss:2.7576 batch_bpb:1.0498 running_loss:2.7564 running_bpb:1.0776 doc_len:1171-1177
-ttt_progress: batch 642/782 batch_loss:2.7899 batch_bpb:1.0853 running_loss:2.7571 running_bpb:1.0778 doc_len:1144-1150
-ttt_progress: batch 635/782 batch_loss:2.7431 batch_bpb:1.0618 running_loss:2.7568 running_bpb:1.0775 doc_len:1111-1116
-ttt_progress: batch 628/782 batch_loss:2.7790 batch_bpb:1.0510 running_loss:2.7572 running_bpb:1.0770 doc_len:1078-1082
-ttt_progress: batch 621/782 batch_loss:2.8442 batch_bpb:1.0893 running_loss:2.7587 running_bpb:1.0772 doc_len:1046-1050
-ttt_progress: batch 614/782 batch_loss:2.7915 batch_bpb:1.0677 running_loss:2.7592 running_bpb:1.0770 doc_len:1016-1020
-ttt_progress: batch 607/782 batch_loss:2.7017 batch_bpb:1.0412 running_loss:2.7583 running_bpb:1.0764 doc_len:986-990
-ttt_progress: batch 600/782 batch_loss:2.8012 batch_bpb:1.0634 running_loss:2.7590 running_bpb:1.0762 doc_len:958-963
-ttt_progress: batch 588/782 batch_loss:2.7432 batch_bpb:1.0466 running_loss:2.7588 running_bpb:1.0758 doc_len:917-921
-ttt_progress: batch 581/782 batch_loss:2.7314 batch_bpb:1.0189 running_loss:2.7584 running_bpb:1.0750 doc_len:894-897
-ttt_progress: batch 579/782 batch_loss:2.6506 batch_bpb:1.0102 running_loss:2.7569 running_bpb:1.0741 doc_len:888-891
-ttt_progress: batch 572/782 batch_loss:2.9496 batch_bpb:1.1225 running_loss:2.7594 running_bpb:1.0747 doc_len:865-868
-ttt_progress: batch 565/782 batch_loss:2.7786 batch_bpb:1.0647 running_loss:2.7597 running_bpb:1.0746 doc_len:843-846
-ttt_progress: batch 556/782 batch_loss:2.8380 batch_bpb:1.0850 running_loss:2.7606 running_bpb:1.0747 doc_len:815-818
-ttt_progress: batch 549/782 batch_loss:2.7675 batch_bpb:1.0648 running_loss:2.7607 running_bpb:1.0746 doc_len:795-798
-ttt_progress: batch 543/782 batch_loss:2.7911 batch_bpb:1.0478 running_loss:2.7610 running_bpb:1.0743 doc_len:779-782
-ttt_progress: batch 537/782 batch_loss:2.7180 batch_bpb:1.0277 running_loss:2.7605 running_bpb:1.0738 doc_len:764-767
-ttt_progress: batch 532/782 batch_loss:2.8225 batch_bpb:1.0598 running_loss:2.7612 running_bpb:1.0736 doc_len:752-754
-ttt_progress: batch 525/782 batch_loss:2.7902 batch_bpb:1.0735 running_loss:2.7615 running_bpb:1.0736 doc_len:735-737
-ttt_progress: batch 518/782 batch_loss:2.7350 batch_bpb:1.0534 running_loss:2.7612 running_bpb:1.0734 doc_len:717-720
-ttt_progress: batch 511/782 batch_loss:2.7802 batch_bpb:1.0501 running_loss:2.7614 running_bpb:1.0732 doc_len:700-703
-ttt_progress: batch 504/782 batch_loss:2.8755 batch_bpb:1.1018 running_loss:2.7625 running_bpb:1.0735 doc_len:685-686
-ttt_progress: batch 497/782 batch_loss:2.8433 batch_bpb:1.0841 running_loss:2.7632 running_bpb:1.0736 doc_len:668-671
-ttt_progress: batch 490/782 batch_loss:2.8600 batch_bpb:1.0929 running_loss:2.7640 running_bpb:1.0737 doc_len:653-655
-ttt_progress: batch 483/782 batch_loss:2.7519 batch_bpb:1.0524 running_loss:2.7639 running_bpb:1.0736 doc_len:639-641
-ttt_progress: batch 476/782 batch_loss:2.7636 batch_bpb:1.0555 running_loss:2.7639 running_bpb:1.0734 doc_len:624-626
-ttt_progress: batch 469/782 batch_loss:2.8012 batch_bpb:1.1139 running_loss:2.7642 running_bpb:1.0737 doc_len:610-611
-ttt_progress: batch 462/782 batch_loss:2.8786 batch_bpb:1.0725 running_loss:2.7651 running_bpb:1.0737 doc_len:597-599
-ttt_progress: batch 455/782 batch_loss:2.8079 batch_bpb:1.0768 running_loss:2.7654 running_bpb:1.0737 doc_len:584-586
-ttt_progress: batch 448/782 batch_loss:2.7334 batch_bpb:1.0384 running_loss:2.7652 running_bpb:1.0735 doc_len:571-573
-ttt_progress: batch 441/782 batch_loss:2.7196 batch_bpb:1.0469 running_loss:2.7648 running_bpb:1.0733 doc_len:559-560
-ttt_progress: batch 434/782 batch_loss:2.7359 batch_bpb:1.0455 running_loss:2.7647 running_bpb:1.0731 doc_len:545-547
-ttt_progress: batch 427/782 batch_loss:2.7645 batch_bpb:1.0681 running_loss:2.7647 running_bpb:1.0731 doc_len:533-535
-ttt_progress: batch 420/782 batch_loss:2.7950 batch_bpb:1.0645 running_loss:2.7648 running_bpb:1.0730 doc_len:521-522
-ttt_progress: batch 413/782 batch_loss:2.6533 batch_bpb:1.0004 running_loss:2.7642 running_bpb:1.0725 doc_len:510-511
-ttt_progress: batch 406/782 batch_loss:2.8464 batch_bpb:1.1082 running_loss:2.7646 running_bpb:1.0728 doc_len:498-500
-ttt_progress: batch 399/782 batch_loss:2.7508 batch_bpb:1.0420 running_loss:2.7646 running_bpb:1.0726 doc_len:487-489
-ttt_progress: batch 392/782 batch_loss:2.8025 batch_bpb:1.0821 running_loss:2.7648 running_bpb:1.0726 doc_len:476-478
-ttt_progress: batch 385/782 batch_loss:2.8944 batch_bpb:1.1029 running_loss:2.7655 running_bpb:1.0728 doc_len:466-467
-ttt_progress: batch 378/782 batch_loss:2.8304 batch_bpb:1.1013 running_loss:2.7659 running_bpb:1.0730 doc_len:456-457
-ttt_progress: batch 371/782 batch_loss:2.8083 batch_bpb:1.0734 running_loss:2.7661 running_bpb:1.0730 doc_len:446-447
-ttt_progress: batch 364/782 batch_loss:2.7392 batch_bpb:1.0684 running_loss:2.7659 running_bpb:1.0729 doc_len:436-437
-ttt_progress: batch 357/782 batch_loss:2.8704 batch_bpb:1.0861 running_loss:2.7665 running_bpb:1.0730 doc_len:426-427
-ttt_progress: batch 350/782 batch_loss:2.7358 batch_bpb:1.0611 running_loss:2.7663 running_bpb:1.0729 doc_len:417-418
-ttt_progress: batch 343/782 batch_loss:2.8005 batch_bpb:1.0686 running_loss:2.7665 running_bpb:1.0729 doc_len:407-408
-ttt_progress: batch 336/782 batch_loss:2.9610 batch_bpb:1.1701 running_loss:2.7674 running_bpb:1.0734 doc_len:398-399
-ttt_progress: batch 329/782 batch_loss:2.8405 batch_bpb:1.1080 running_loss:2.7677 running_bpb:1.0735 doc_len:389-390
-ttt_progress: batch 322/782 batch_loss:2.7642 batch_bpb:1.0801 running_loss:2.7677 running_bpb:1.0735 doc_len:380-381
-ttt_progress: batch 315/782 batch_loss:2.7314 batch_bpb:1.0740 running_loss:2.7675 running_bpb:1.0735 doc_len:370-371
-ttt_progress: batch 308/782 batch_loss:2.8013 batch_bpb:1.0883 running_loss:2.7677 running_bpb:1.0736 doc_len:362-363
-ttt_progress: batch 301/782 batch_loss:2.7979 batch_bpb:1.0880 running_loss:2.7678 running_bpb:1.0737 doc_len:353-354
-ttt_progress: batch 293/782 batch_loss:2.7720 batch_bpb:1.0709 running_loss:2.7678 running_bpb:1.0736 doc_len:343-345
-ttt_progress: batch 287/782 batch_loss:2.8658 batch_bpb:1.1179 running_loss:2.7682 running_bpb:1.0738 doc_len:336-337
-ttt_progress: batch 279/782 batch_loss:2.8570 batch_bpb:1.0920 running_loss:2.7685 running_bpb:1.0739 doc_len:327-329
-ttt_progress: batch 273/782 batch_loss:2.7740 batch_bpb:1.0625 running_loss:2.7685 running_bpb:1.0738 doc_len:321-322
-ttt_progress: batch 266/782 batch_loss:2.8576 batch_bpb:1.0989 running_loss:2.7688 running_bpb:1.0739 doc_len:313-314
-ttt_progress: batch 259/782 batch_loss:2.8605 batch_bpb:1.1407 running_loss:2.7691 running_bpb:1.0741 doc_len:305-306
-ttt_progress: batch 253/782 batch_loss:2.7687 batch_bpb:1.0873 running_loss:2.7691 running_bpb:1.0742 doc_len:298-299
-ttt_progress: batch 246/782 batch_loss:2.9074 batch_bpb:1.1388 running_loss:2.7696 running_bpb:1.0744 doc_len:291-292
-ttt_progress: batch 239/782 batch_loss:2.9062 batch_bpb:1.1398 running_loss:2.7700 running_bpb:1.0746 doc_len:284-285
-ttt_progress: batch 232/782 batch_loss:2.9452 batch_bpb:1.1392 running_loss:2.7705 running_bpb:1.0748 doc_len:277-278
-ttt_progress: batch 225/782 batch_loss:2.8848 batch_bpb:1.1235 running_loss:2.7708 running_bpb:1.0749 doc_len:270-271
-ttt_progress: batch 218/782 batch_loss:2.7575 batch_bpb:1.1088 running_loss:2.7708 running_bpb:1.0750 doc_len:263-264
-ttt_progress: batch 211/782 batch_loss:2.9042 batch_bpb:1.1570 running_loss:2.7712 running_bpb:1.0752 doc_len:256-257
-ttt_progress: batch 204/782 batch_loss:2.9163 batch_bpb:1.1344 running_loss:2.7716 running_bpb:1.0754 doc_len:250-251
-ttt_progress: batch 197/782 batch_loss:2.8614 batch_bpb:1.1284 running_loss:2.7718 running_bpb:1.0755 doc_len:244-245
-ttt_progress: batch 190/782 batch_loss:2.8889 batch_bpb:1.0982 running_loss:2.7721 running_bpb:1.0756 doc_len:237-238
-ttt_progress: batch 183/782 batch_loss:2.8749 batch_bpb:1.1476 running_loss:2.7723 running_bpb:1.0758 doc_len:231-232
-ttt_progress: batch 176/782 batch_loss:2.8204 batch_bpb:1.1065 running_loss:2.7725 running_bpb:1.0758 doc_len:225-226
-ttt_progress: batch 169/782 batch_loss:2.9235 batch_bpb:1.1681 running_loss:2.7728 running_bpb:1.0760 doc_len:219-220
-ttt_progress: batch 162/782 batch_loss:2.9715 batch_bpb:1.1530 running_loss:2.7733 running_bpb:1.0762 doc_len:213-214
-ttt_progress: batch 155/782 batch_loss:2.8873 batch_bpb:1.1348 running_loss:2.7735 running_bpb:1.0763 doc_len:207-208
-ttt_progress: batch 150/782 batch_loss:2.9537 batch_bpb:1.1610 running_loss:2.7739 running_bpb:1.0765 doc_len:204-204
-ttt_progress: batch 142/782 batch_loss:2.9687 batch_bpb:1.1638 running_loss:2.7743 running_bpb:1.0767 doc_len:197-198
-ttt_progress: batch 135/782 batch_loss:2.9409 batch_bpb:1.1457 running_loss:2.7746 running_bpb:1.0768 doc_len:191-192
-ttt_progress: batch 129/782 batch_loss:2.9543 batch_bpb:1.1860 running_loss:2.7750 running_bpb:1.0770 doc_len:187-187
-ttt_progress: batch 120/782 batch_loss:2.9862 batch_bpb:1.1734 running_loss:2.7754 running_bpb:1.0772 doc_len:180-181
-ttt_progress: batch 113/782 batch_loss:3.0405 batch_bpb:1.1955 running_loss:2.7759 running_bpb:1.0774 doc_len:175-176
-ttt_progress: batch 106/782 batch_loss:2.9568 batch_bpb:1.1943 running_loss:2.7762 running_bpb:1.0776 doc_len:170-171
-ttt_progress: batch 100/782 batch_loss:2.9431 batch_bpb:1.1553 running_loss:2.7765 running_bpb:1.0778 doc_len:165-166
-ttt_progress: batch 92/782 batch_loss:2.9057 batch_bpb:1.1752 running_loss:2.7767 running_bpb:1.0779 doc_len:159-160
-ttt_progress: batch 86/782 batch_loss:3.0440 batch_bpb:1.2669 running_loss:2.7771 running_bpb:1.0782 doc_len:154-155
-ttt_progress: batch 79/782 batch_loss:3.0290 batch_bpb:1.2026 running_loss:2.7775 running_bpb:1.0784 doc_len:149-150
-ttt_progress: batch 71/782 batch_loss:2.9670 batch_bpb:1.1576 running_loss:2.7778 running_bpb:1.0785 doc_len:143-144
-ttt_progress: batch 66/782 batch_loss:3.1154 batch_bpb:1.2761 running_loss:2.7783 running_bpb:1.0788 doc_len:139-140
-ttt_progress: batch 58/782 batch_loss:2.9845 batch_bpb:1.2310 running_loss:2.7785 running_bpb:1.0790 doc_len:133-134
-ttt_progress: batch 52/782 batch_loss:3.0628 batch_bpb:1.1984 running_loss:2.7789 running_bpb:1.0791 doc_len:128-129
-ttt_progress: batch 49/782 batch_loss:2.9736 batch_bpb:1.1731 running_loss:2.7792 running_bpb:1.0793 doc_len:126-126
-ttt_progress: batch 41/782 batch_loss:3.1284 batch_bpb:1.2786 running_loss:2.7796 running_bpb:1.0795 doc_len:119-120
-ttt_progress: batch 34/782 batch_loss:3.0761 batch_bpb:1.2453 running_loss:2.7799 running_bpb:1.0797 doc_len:114-115
-ttt_progress: batch 28/782 batch_loss:3.0250 batch_bpb:1.2181 running_loss:2.7802 running_bpb:1.0798 doc_len:108-109
-ttt_progress: batch 21/782 batch_loss:3.2041 batch_bpb:1.2458 running_loss:2.7807 running_bpb:1.0800 doc_len:102-103
-ttt_progress: batch 14/782 batch_loss:3.1357 batch_bpb:1.2333 running_loss:2.7810 running_bpb:1.0801 doc_len:94-95
-ttt_progress: batch 7/782 batch_loss:3.2148 batch_bpb:1.2335 running_loss:2.7814 running_bpb:1.0803 doc_len:84-86
-quantized_ttt_lora val_loss:2.78138792 val_bpb:1.07676194 eval_time:276377ms
-total_eval_time:372.2s
-total_eval_time_with_compile:458.6s
+ttt_lora:compile warmup done (122.0s)
+
+beginning TTT eval timer
+ttt_lora:docs:50000 rank:96 lr:0.0001 chunk:32
+ttt_progress: batch 778/782 batch_loss:2.7837 batch_bpb:1.1136 running_loss:2.7837 running_bpb:1.1136 doc_len:7961-8997
+ttt_progress: batch 771/782 batch_loss:2.7568 batch_bpb:1.0779 running_loss:2.7740 running_bpb:1.1005 doc_len:4701-4937
+ttt_progress: batch 766/782 batch_loss:2.5588 batch_bpb:1.0017 running_loss:2.7251 running_bpb:1.0778 doc_len:3846-3962
+ttt_progress: batch 760/782 batch_loss:2.8382 batch_bpb:1.1147 running_loss:2.7433 running_bpb:1.0838 doc_len:3255-3334
+ttt_progress: batch 754/782 batch_loss:2.6856 batch_bpb:1.0538 running_loss:2.7362 running_bpb:1.0801 doc_len:2839-2899
+ttt_progress: batch 748/782 batch_loss:2.8024 batch_bpb:1.0731 running_loss:2.7428 running_bpb:1.0794 doc_len:2539-2578
+ttt_progress: batch 742/782 batch_loss:2.7857 batch_bpb:1.0670 running_loss:2.7463 running_bpb:1.0783 doc_len:2319-2353
+ttt_progress: batch 735/782 batch_loss:2.8335 batch_bpb:1.0790 running_loss:2.7525 running_bpb:1.0784 doc_len:2116-2140
+ttt_progress: batch 730/782 batch_loss:2.7615 batch_bpb:1.0871 running_loss:2.7530 running_bpb:1.0789 doc_len:1995-2016
+ttt_progress: batch 726/782 batch_loss:2.7979 batch_bpb:1.0648 running_loss:2.7555 running_bpb:1.0781 doc_len:1915-1936
+ttt_progress: batch 716/782 batch_loss:2.8107 batch_bpb:1.0372 running_loss:2.7582 running_bpb:1.0760 doc_len:1739-1754
+ttt_progress: batch 712/782 batch_loss:2.8316 batch_bpb:1.0780 running_loss:2.7615 running_bpb:1.0761 doc_len:1684-1697
+ttt_progress: batch 707/782 batch_loss:2.7658 batch_bpb:1.0812 running_loss:2.7617 running_bpb:1.0763 doc_len:1627-1638
+ttt_progress: batch 696/782 batch_loss:2.8101 batch_bpb:1.0741 running_loss:2.7635 running_bpb:1.0762 doc_len:1513-1522
+ttt_progress: batch 690/782 batch_loss:2.8376 batch_bpb:1.0633 running_loss:2.7660 running_bpb:1.0758 doc_len:1458-1467
+ttt_progress: batch 686/782 batch_loss:2.8049 batch_bpb:1.0538 running_loss:2.7673 running_bpb:1.0750 doc_len:1422-1432
+ttt_progress: batch 679/782 batch_loss:2.8473 batch_bpb:1.0848 running_loss:2.7697 running_bpb:1.0753 doc_len:1368-1374
+ttt_progress: batch 672/782 batch_loss:2.9028 batch_bpb:1.1074 running_loss:2.7735 running_bpb:1.0763 doc_len:1321-1327
+ttt_progress: batch 663/782 batch_loss:2.7926 batch_bpb:1.0599 running_loss:2.7740 running_bpb:1.0758 doc_len:1264-1269
+ttt_progress: batch 657/782 batch_loss:2.7836 batch_bpb:1.0453 running_loss:2.7743 running_bpb:1.0750 doc_len:1227-1234
+ttt_progress: batch 649/782 batch_loss:2.8038 batch_bpb:1.0575 running_loss:2.7750 running_bpb:1.0746 doc_len:1183-1188
+ttt_progress: batch 640/782 batch_loss:2.7851 batch_bpb:1.0839 running_loss:2.7752 running_bpb:1.0748 doc_len:1134-1140
+ttt_progress: batch 636/782 batch_loss:2.7567 batch_bpb:1.0694 running_loss:2.7748 running_bpb:1.0747 doc_len:1116-1120
+ttt_progress: batch 630/782 batch_loss:2.8280 batch_bpb:1.0590 running_loss:2.7759 running_bpb:1.0744 doc_len:1087-1092
+ttt_progress: batch 619/782 batch_loss:2.7961 batch_bpb:1.0593 running_loss:2.7763 running_bpb:1.0741 doc_len:1037-1041
+ttt_progress: batch 612/782 batch_loss:2.8231 batch_bpb:1.0428 running_loss:2.7771 running_bpb:1.0735 doc_len:1007-1012
+ttt_progress: batch 606/782 batch_loss:2.8196 batch_bpb:1.0849 running_loss:2.7779 running_bpb:1.0737 doc_len:982-986
+ttt_progress: batch 601/782 batch_loss:2.7591 batch_bpb:1.0604 running_loss:2.7775 running_bpb:1.0734 doc_len:963-966
+ttt_progress: batch 590/782 batch_loss:2.7356 batch_bpb:1.0296 running_loss:2.7769 running_bpb:1.0727 doc_len:924-927
+ttt_progress: batch 586/782 batch_loss:2.7166 batch_bpb:1.0108 running_loss:2.7760 running_bpb:1.0717 doc_len:911-914
+ttt_progress: batch 578/782 batch_loss:2.8012 batch_bpb:1.0673 running_loss:2.7763 running_bpb:1.0717 doc_len:884-887
+ttt_progress: batch 570/782 batch_loss:2.7735 batch_bpb:1.0794 running_loss:2.7763 running_bpb:1.0718 doc_len:858-862
+ttt_progress: batch 561/782 batch_loss:2.7101 batch_bpb:1.0628 running_loss:2.7754 running_bpb:1.0717 doc_len:831-834
+ttt_progress: batch 551/782 batch_loss:2.8207 batch_bpb:1.0632 running_loss:2.7760 running_bpb:1.0716 doc_len:801-804
+ttt_progress: batch 543/782 batch_loss:2.7808 batch_bpb:1.0439 running_loss:2.7760 running_bpb:1.0712 doc_len:779-782
+ttt_progress: batch 535/782 batch_loss:2.7855 batch_bpb:1.0561 running_loss:2.7761 running_bpb:1.0710 doc_len:759-762
+ttt_progress: batch 527/782 batch_loss:2.7364 batch_bpb:1.0398 running_loss:2.7757 running_bpb:1.0707 doc_len:739-742
+ttt_progress: batch 519/782 batch_loss:2.7360 batch_bpb:1.0375 running_loss:2.7753 running_bpb:1.0703 doc_len:720-723
+ttt_progress: batch 511/782 batch_loss:2.7669 batch_bpb:1.0450 running_loss:2.7752 running_bpb:1.0700 doc_len:700-703
+ttt_progress: batch 505/782 batch_loss:2.7756 batch_bpb:1.0605 running_loss:2.7752 running_bpb:1.0699 doc_len:686-688
+ttt_progress: batch 496/782 batch_loss:2.8290 batch_bpb:1.0485 running_loss:2.7757 running_bpb:1.0697 doc_len:666-668
+ttt_progress: batch 492/782 batch_loss:2.8054 batch_bpb:1.0550 running_loss:2.7760 running_bpb:1.0696 doc_len:657-659
+ttt_progress: batch 484/782 batch_loss:2.7946 batch_bpb:1.0666 running_loss:2.7762 running_bpb:1.0695 doc_len:641-643
+ttt_progress: batch 472/782 batch_loss:2.8004 batch_bpb:1.0705 running_loss:2.7764 running_bpb:1.0695 doc_len:616-618
+ttt_progress: batch 463/782 batch_loss:2.7979 batch_bpb:1.0741 running_loss:2.7766 running_bpb:1.0696 doc_len:599-600
+ttt_progress: batch 456/782 batch_loss:2.8114 batch_bpb:1.0677 running_loss:2.7769 running_bpb:1.0696 doc_len:586-587
+ttt_progress: batch 448/782 batch_loss:2.7190 batch_bpb:1.0330 running_loss:2.7764 running_bpb:1.0693 doc_len:571-573
+ttt_progress: batch 443/782 batch_loss:2.7669 batch_bpb:1.0539 running_loss:2.7763 running_bpb:1.0691 doc_len:562-564
+ttt_progress: batch 434/782 batch_loss:2.7267 batch_bpb:1.0420 running_loss:2.7759 running_bpb:1.0689 doc_len:545-547
+ttt_progress: batch 424/782 batch_loss:2.7932 batch_bpb:1.0796 running_loss:2.7761 running_bpb:1.0690 doc_len:528-530
+ttt_progress: batch 416/782 batch_loss:2.7576 batch_bpb:1.0351 running_loss:2.7759 running_bpb:1.0688 doc_len:514-516
+ttt_progress: batch 409/782 batch_loss:2.7090 batch_bpb:1.0466 running_loss:2.7755 running_bpb:1.0686 doc_len:503-505
+ttt_progress: batch 401/782 batch_loss:2.7394 batch_bpb:1.0604 running_loss:2.7752 running_bpb:1.0686 doc_len:490-492
+ttt_progress: batch 394/782 batch_loss:2.8941 batch_bpb:1.1161 running_loss:2.7760 running_bpb:1.0689 doc_len:479-481
+ttt_progress: batch 389/782 batch_loss:2.7820 batch_bpb:1.0597 running_loss:2.7760 running_bpb:1.0688 doc_len:471-473
+ttt_progress: batch 381/782 batch_loss:2.8934 batch_bpb:1.0865 running_loss:2.7768 running_bpb:1.0689 doc_len:460-461
+ttt_progress: batch 372/782 batch_loss:2.8347 batch_bpb:1.0687 running_loss:2.7771 running_bpb:1.0689 doc_len:447-449
+ttt_progress: batch 365/782 batch_loss:2.7793 batch_bpb:1.0832 running_loss:2.7771 running_bpb:1.0690 doc_len:437-439
+ttt_progress: batch 357/782 batch_loss:2.8549 batch_bpb:1.0802 running_loss:2.7775 running_bpb:1.0691 doc_len:426-427
+ttt_progress: batch 349/782 batch_loss:2.9166 batch_bpb:1.1082 running_loss:2.7783 running_bpb:1.0693 doc_len:415-417
+ttt_progress: batch 341/782 batch_loss:2.8654 batch_bpb:1.0970 running_loss:2.7787 running_bpb:1.0694 doc_len:404-406
+ttt_progress: batch 333/782 batch_loss:2.9034 batch_bpb:1.1307 running_loss:2.7793 running_bpb:1.0697 doc_len:394-395
+ttt_progress: batch 325/782 batch_loss:2.8424 batch_bpb:1.0918 running_loss:2.7797 running_bpb:1.0698 doc_len:384-385
+ttt_progress: batch 316/782 batch_loss:2.7776 batch_bpb:1.0923 running_loss:2.7796 running_bpb:1.0699 doc_len:371-373
+ttt_progress: batch 308/782 batch_loss:2.7889 batch_bpb:1.0835 running_loss:2.7797 running_bpb:1.0700 doc_len:362-363
+ttt_progress: batch 300/782 batch_loss:2.8523 batch_bpb:1.0872 running_loss:2.7800 running_bpb:1.0701 doc_len:352-353
+ttt_progress: batch 292/782 batch_loss:2.7843 batch_bpb:1.0788 running_loss:2.7800 running_bpb:1.0701 doc_len:342-343
+ttt_progress: batch 284/782 batch_loss:2.8797 batch_bpb:1.0856 running_loss:2.7804 running_bpb:1.0702 doc_len:333-334
+ttt_progress: batch 276/782 batch_loss:2.8396 batch_bpb:1.1006 running_loss:2.7807 running_bpb:1.0703 doc_len:324-325
+ttt_progress: batch 268/782 batch_loss:2.8628 batch_bpb:1.1007 running_loss:2.7810 running_bpb:1.0704 doc_len:315-316
+ttt_progress: batch 260/782 batch_loss:2.8236 batch_bpb:1.1014 running_loss:2.7812 running_bpb:1.0705 doc_len:306-307
+ttt_progress: batch 252/782 batch_loss:2.8938 batch_bpb:1.1276 running_loss:2.7816 running_bpb:1.0707 doc_len:297-298
+ttt_progress: batch 243/782 batch_loss:2.8172 batch_bpb:1.0987 running_loss:2.7817 running_bpb:1.0708 doc_len:288-289
+ttt_progress: batch 238/782 batch_loss:2.8910 batch_bpb:1.1468 running_loss:2.7821 running_bpb:1.0711 doc_len:283-284
+ttt_progress: batch 230/782 batch_loss:2.9090 batch_bpb:1.1132 running_loss:2.7825 running_bpb:1.0712 doc_len:275-276
+ttt_progress: batch 222/782 batch_loss:2.8671 batch_bpb:1.1139 running_loss:2.7828 running_bpb:1.0714 doc_len:267-268
+ttt_progress: batch 214/782 batch_loss:2.9381 batch_bpb:1.1303 running_loss:2.7832 running_bpb:1.0715 doc_len:259-260
+ttt_progress: batch 205/782 batch_loss:2.8452 batch_bpb:1.1101 running_loss:2.7834 running_bpb:1.0717 doc_len:251-252
+ttt_progress: batch 197/782 batch_loss:2.8517 batch_bpb:1.1246 running_loss:2.7836 running_bpb:1.0718 doc_len:244-245
+ttt_progress: batch 188/782 batch_loss:2.9055 batch_bpb:1.1510 running_loss:2.7840 running_bpb:1.0720 doc_len:236-237
+ttt_progress: batch 180/782 batch_loss:2.9023 batch_bpb:1.1318 running_loss:2.7843 running_bpb:1.0722 doc_len:229-230
+ttt_progress: batch 171/782 batch_loss:2.8847 batch_bpb:1.1095 running_loss:2.7845 running_bpb:1.0723 doc_len:221-222
+ttt_progress: batch 162/782 batch_loss:2.9535 batch_bpb:1.1460 running_loss:2.7850 running_bpb:1.0725 doc_len:213-214
+ttt_progress: batch 153/782 batch_loss:3.0151 batch_bpb:1.1631 running_loss:2.7855 running_bpb:1.0727 doc_len:206-207
+ttt_progress: batch 147/782 batch_loss:2.9289 batch_bpb:1.1588 running_loss:2.7859 running_bpb:1.0729 doc_len:201-202
+ttt_progress: batch 138/782 batch_loss:2.9167 batch_bpb:1.1610 running_loss:2.7862 running_bpb:1.0731 doc_len:194-195
+ttt_progress: batch 132/782 batch_loss:2.9483 batch_bpb:1.1346 running_loss:2.7865 running_bpb:1.0732 doc_len:189-189
+ttt_progress: batch 123/782 batch_loss:2.9556 batch_bpb:1.1809 running_loss:2.7869 running_bpb:1.0734 doc_len:182-183
+ttt_progress: batch 115/782 batch_loss:2.8650 batch_bpb:1.1560 running_loss:2.7870 running_bpb:1.0736 doc_len:176-177
+ttt_progress: batch 106/782 batch_loss:2.9506 batch_bpb:1.1918 running_loss:2.7874 running_bpb:1.0738 doc_len:170-171
+ttt_progress: batch 100/782 batch_loss:2.9326 batch_bpb:1.1512 running_loss:2.7876 running_bpb:1.0740 doc_len:165-166
+ttt_progress: batch 92/782 batch_loss:2.8841 batch_bpb:1.1665 running_loss:2.7878 running_bpb:1.0741 doc_len:159-160
+ttt_progress: batch 85/782 batch_loss:2.9919 batch_bpb:1.2012 running_loss:2.7882 running_bpb:1.0743 doc_len:154-154
+ttt_progress: batch 77/782 batch_loss:3.0314 batch_bpb:1.1713 running_loss:2.7886 running_bpb:1.0745 doc_len:148-148
+ttt_progress: batch 69/782 batch_loss:3.0929 batch_bpb:1.2271 running_loss:2.7891 running_bpb:1.0747 doc_len:142-142
+ttt_progress: batch 60/782 batch_loss:3.0460 batch_bpb:1.2224 running_loss:2.7895 running_bpb:1.0750 doc_len:134-135
+ttt_progress: batch 52/782 batch_loss:3.0575 batch_bpb:1.1963 running_loss:2.7899 running_bpb:1.0751 doc_len:128-129
+ttt_progress: batch 46/782 batch_loss:3.1289 batch_bpb:1.2235 running_loss:2.7904 running_bpb:1.0753 doc_len:123-124
+ttt_progress: batch 37/782 batch_loss:3.0833 batch_bpb:1.2104 running_loss:2.7907 running_bpb:1.0755 doc_len:116-117
+ttt_progress: batch 29/782 batch_loss:3.0482 batch_bpb:1.2423 running_loss:2.7911 running_bpb:1.0757 doc_len:109-110
+ttt_progress: batch 22/782 batch_loss:3.1611 batch_bpb:1.2322 running_loss:2.7915 running_bpb:1.0759 doc_len:103-104
+ttt_progress: batch 15/782 batch_loss:3.2254 batch_bpb:1.2339 running_loss:2.7920 running_bpb:1.0761 doc_len:95-97
+ttt_progress: batch 9/782 batch_loss:3.1938 batch_bpb:1.2657 running_loss:2.7924 running_bpb:1.0763 doc_len:87-89
+ttt_progress: batch 1/782 batch_loss:3.3576 batch_bpb:1.2461 running_loss:2.7928 running_bpb:1.0764 doc_len:45-70
+quantized_ttt_lora val_loss:2.77059090 val_bpb:1.07258208 eval_time:338190ms
+total_eval_time:338.2s

--- a/records/track_10min_16mb/2026-04-10_VarLenAttn/logs/train1.txt
+++ b/records/track_10min_16mb/2026-04-10_VarLenAttn/logs/train1.txt
@@ -1,0 +1,328 @@
+====================================================================================================
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  artifact_dir: runs/varlen1
+  beta1: 0.9
+  beta2: 0.95
+  compressor: brotli
+  data_dir: ./data/
+  datasets_dir: ./data/datasets/fineweb10B_sp8192
+  distributed: True
+  ema_decay: 0.997
+  embed_bits: 8
+  embed_clip_sigmas: 20.0
+  embed_lr: 0.6
+  embed_wd: 0.095
+  embedding_dim: 512
+  enable_looping_at: 0.35
+  etlb_clip: 3.0
+  etlb_lr: 0.05
+  etlb_steps: 5
+  eval_only_path: 
+  eval_seq_len: 2048
+  eval_stride: 64
+  gptq_calibration_batches: 64
+  gptq_reserve_seconds: 12.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  head_lr: 0.008
+  is_main_process: True
+  iterations: 20000
+  ln_scale: True
+  local_rank: 0
+  logfile: runs/varlen1/9e75722b-6ad5-4326-b593-e9fc5b7608e8.txt
+  logit_softcap: 30.0
+  loop_end: 5
+  loop_start: 3
+  matrix_bits: 6
+  matrix_clip_sigmas: 12.85
+  matrix_lr: 0.022
+  max_wallclock_seconds: 600.0
+  min_lr: 0.0
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: runs/varlen1/final_model.pt
+  muon_backend_steps: 5
+  muon_beta2: 0.95
+  muon_momentum: 0.97
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_row_normalize: True
+  muon_wd: 0.095
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  num_loops: 2
+  parallel_start_layer: 7
+  qk_gain_init: 5.0
+  quantized_model_path: runs/varlen1/final_model.int6.ptz
+  rank: 0
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  rope_yarn: False
+  run_id: 9e75722b-6ad5-4326-b593-e9fc5b7608e8
+  scalar_lr: 0.02
+  seed: 1
+  skip_gates_enabled: True
+  sliding_window_enabled: False
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  tokenizer_path: ./data/tokenizers/fineweb_8192_bpe.model
+  train_batch_tokens: 786432
+  train_files: ./data/datasets/fineweb10B_sp8192/fineweb_train_*.bin
+  train_log_every: 500
+  train_seq_len: 2048
+  ttt_batch_size: 64
+  ttt_beta1: 0.0
+  ttt_beta2: 0.999
+  ttt_chunk_size: 64
+  ttt_enabled: True
+  ttt_eval_batches: 
+  ttt_eval_seq_len: 2048
+  ttt_grad_steps: 1
+  ttt_k_lora: True
+  ttt_lora_lr: 0.0001
+  ttt_lora_rank: 96
+  ttt_mlp_lora: True
+  ttt_o_lora: True
+  ttt_optimizer: adam
+  ttt_output_dir: 
+  ttt_weight_decay: 0.5
+  val_batch_tokens: 524288
+  val_doc_fraction: 1.0
+  val_files: ./data/datasets/fineweb10B_sp8192/fineweb_val_*.bin
+  val_loss_every: 4000
+  vocab_size: 8192
+  warmdown_frac: 0.667
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.9.1+cu128
+Fri Apr 10 22:14:34 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   51C    P0            128W /  700W |    1519MiB /  81559MiB |      2%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   40C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   43C    P0            120W /  700W |    1519MiB /  81559MiB |      2%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   39C    P0            122W /  700W |    1519MiB /  81559MiB |      3%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   44C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   37C    P0            118W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   39C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   37C    P0            117W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A         1792890      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A         1792891      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A         1792892      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A         1792893      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A         1792894      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A         1792895      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A         1792896      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A         1792897      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+train_shards: 128
+val_tokens: 40540160
+model_params:35944537
+gptq:reserving 12s, effective=588000ms
+warmup_cu_buckets:64,128,192,256 iters_each:3
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup:enabled encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+loop_warmup_step: 1/20
+loop_warmup_step: 2/20
+loop_warmup_step: 3/20
+loop_warmup_step: 4/20
+loop_warmup_step: 5/20
+loop_warmup_step: 6/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+0/20000 val_loss: 9.0091 val_bpb: 3.4876
+1/20000 train_loss: 9.0097 train_time: 0.0m tok/s: 18894887
+2/20000 train_loss: 12.2299 train_time: 0.0m tok/s: 13813993
+3/20000 train_loss: 11.1593 train_time: 0.0m tok/s: 11516120
+4/20000 train_loss: 9.5744 train_time: 0.0m tok/s: 10527575
+5/20000 train_loss: 8.2233 train_time: 0.0m tok/s: 10021538
+500/20000 train_loss: 3.2773 train_time: 0.8m tok/s: 8281518
+1000/20000 train_loss: 3.0329 train_time: 1.6m tok/s: 8262698
+1500/20000 train_loss: 3.0365 train_time: 2.4m tok/s: 8257993
+2000/20000 train_loss: 3.0030 train_time: 3.2m tok/s: 8255118
+layer_loop:enabled step:2160 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2500/20000 train_loss: 3.0887 train_time: 4.2m tok/s: 7724647
+3000/20000 train_loss: 2.9239 train_time: 5.4m tok/s: 7273098
+3500/20000 train_loss: 2.9865 train_time: 6.6m tok/s: 6982735
+4000/20000 train_loss: 2.9165 train_time: 7.7m tok/s: 6777935
+4000/20000 val_loss: 2.8922 val_bpb: 1.1196
+4500/20000 train_loss: 2.8685 train_time: 8.9m tok/s: 6628194
+4888/20000 val_loss: 2.7778 val_bpb: 1.0753
+stopping_early: wallclock_cap train_time: 588159ms step: 4888/20000
+peak memory allocated: 40019 MiB reserved: 44088 MiB
+ema:applying EMA weights
+
+beginning eval timer
+pre-quantization post-ema val_loss:2.77822001 val_bpb:1.07550088 eval_time:7601ms
+Serialized model: 135408623 bytes
+Code size (uncompressed): 122627 bytes
+Code size (compressed): 26780 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 12.4s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int8): tok_emb.weight
+  passthrough (float16): blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, lane_merge, skip_gates, skip_weights
+Serialized model quantized+brotli: 15962899 bytes
+Total submission size quantized+brotli: 15989679 bytes
+quantized val_loss:2.80726255 val_bpb:1.08674379 eval_time:8551ms
+ttt_lora:warming up compile
+ttt_lora:compile warmup done (85.6s)
+ttt_lora:docs:50000 rank:96 lr:0.0001 chunk:64
+ttt_progress: batch 779/782 batch_loss:2.6581 batch_bpb:1.0827 running_loss:2.6581 running_bpb:1.0827 doc_len:9037-11049
+ttt_progress: batch 770/782 batch_loss:2.6700 batch_bpb:1.0566 running_loss:2.6619 running_bpb:1.0743 doc_len:4479-4698
+ttt_progress: batch 762/782 batch_loss:2.8322 batch_bpb:1.0780 running_loss:2.6948 running_bpb:1.0750 doc_len:3431-3533
+ttt_progress: batch 757/782 batch_loss:2.6461 batch_bpb:1.0227 running_loss:2.6877 running_bpb:1.0672 doc_len:3033-3108
+ttt_progress: batch 750/782 batch_loss:2.8330 batch_bpb:1.0688 running_loss:2.7040 running_bpb:1.0674 doc_len:2638-2688
+ttt_progress: batch 747/782 batch_loss:2.7902 batch_bpb:1.0612 running_loss:2.7123 running_bpb:1.0667 doc_len:2501-2538
+ttt_progress: batch 736/782 batch_loss:2.6841 batch_bpb:1.0462 running_loss:2.7102 running_bpb:1.0652 doc_len:2140-2165
+ttt_progress: batch 734/782 batch_loss:2.7813 batch_bpb:1.0606 running_loss:2.7151 running_bpb:1.0649 doc_len:2091-2115
+ttt_progress: batch 724/782 batch_loss:2.7569 batch_bpb:1.0539 running_loss:2.7175 running_bpb:1.0642 doc_len:1885-1900
+ttt_progress: batch 717/782 batch_loss:2.7972 batch_bpb:1.0535 running_loss:2.7216 running_bpb:1.0636 doc_len:1754-1773
+ttt_progress: batch 711/782 batch_loss:2.7834 batch_bpb:1.0481 running_loss:2.7245 running_bpb:1.0629 doc_len:1673-1683
+ttt_progress: batch 704/782 batch_loss:2.7536 batch_bpb:1.0269 running_loss:2.7258 running_bpb:1.0613 doc_len:1595-1606
+ttt_progress: batch 696/782 batch_loss:2.8215 batch_bpb:1.0785 running_loss:2.7295 running_bpb:1.0619 doc_len:1513-1522
+ttt_progress: batch 692/782 batch_loss:2.7750 batch_bpb:1.0529 running_loss:2.7312 running_bpb:1.0616 doc_len:1477-1484
+ttt_progress: batch 683/782 batch_loss:2.7773 batch_bpb:1.0693 running_loss:2.7327 running_bpb:1.0619 doc_len:1400-1406
+ttt_progress: batch 679/782 batch_loss:2.8572 batch_bpb:1.0886 running_loss:2.7367 running_bpb:1.0627 doc_len:1368-1374
+ttt_progress: batch 672/782 batch_loss:2.9098 batch_bpb:1.1101 running_loss:2.7418 running_bpb:1.0642 doc_len:1321-1327
+ttt_progress: batch 665/782 batch_loss:2.7496 batch_bpb:1.0362 running_loss:2.7420 running_bpb:1.0634 doc_len:1275-1282
+ttt_progress: batch 653/782 batch_loss:2.7626 batch_bpb:1.0364 running_loss:2.7425 running_bpb:1.0626 doc_len:1203-1209
+ttt_progress: batch 649/782 batch_loss:2.8110 batch_bpb:1.0602 running_loss:2.7442 running_bpb:1.0626 doc_len:1183-1188
+ttt_progress: batch 642/782 batch_loss:2.7899 batch_bpb:1.0853 running_loss:2.7453 running_bpb:1.0631 doc_len:1144-1150
+ttt_progress: batch 637/782 batch_loss:2.8108 batch_bpb:1.0830 running_loss:2.7467 running_bpb:1.0636 doc_len:1120-1123
+ttt_progress: batch 630/782 batch_loss:2.8364 batch_bpb:1.0622 running_loss:2.7486 running_bpb:1.0635 doc_len:1087-1092
+ttt_progress: batch 619/782 batch_loss:2.7977 batch_bpb:1.0599 running_loss:2.7496 running_bpb:1.0635 doc_len:1037-1041
+ttt_progress: batch 612/782 batch_loss:2.8307 batch_bpb:1.0456 running_loss:2.7511 running_bpb:1.0631 doc_len:1007-1012
+ttt_progress: batch 605/782 batch_loss:2.7498 batch_bpb:1.0607 running_loss:2.7511 running_bpb:1.0631 doc_len:978-982
+ttt_progress: batch 598/782 batch_loss:2.8067 batch_bpb:1.0691 running_loss:2.7521 running_bpb:1.0632 doc_len:950-954
+ttt_progress: batch 592/782 batch_loss:2.7900 batch_bpb:1.0504 running_loss:2.7527 running_bpb:1.0629 doc_len:930-933
+ttt_progress: batch 586/782 batch_loss:2.7331 batch_bpb:1.0170 running_loss:2.7524 running_bpb:1.0622 doc_len:911-914
+ttt_progress: batch 579/782 batch_loss:2.6484 batch_bpb:1.0094 running_loss:2.7508 running_bpb:1.0614 doc_len:888-891
+ttt_progress: batch 572/782 batch_loss:2.9493 batch_bpb:1.1224 running_loss:2.7537 running_bpb:1.0623 doc_len:865-868
+ttt_progress: batch 564/782 batch_loss:2.8714 batch_bpb:1.1109 running_loss:2.7553 running_bpb:1.0630 doc_len:840-843
+ttt_progress: batch 556/782 batch_loss:2.8370 batch_bpb:1.0846 running_loss:2.7564 running_bpb:1.0633 doc_len:815-818
+ttt_progress: batch 548/782 batch_loss:2.7660 batch_bpb:1.0488 running_loss:2.7566 running_bpb:1.0631 doc_len:793-795
+ttt_progress: batch 540/782 batch_loss:2.6990 batch_bpb:1.0183 running_loss:2.7559 running_bpb:1.0625 doc_len:771-774
+ttt_progress: batch 530/782 batch_loss:2.8149 batch_bpb:1.0419 running_loss:2.7566 running_bpb:1.0622 doc_len:747-750
+ttt_progress: batch 522/782 batch_loss:2.8347 batch_bpb:1.0897 running_loss:2.7574 running_bpb:1.0626 doc_len:727-730
+ttt_progress: batch 513/782 batch_loss:2.7345 batch_bpb:1.0122 running_loss:2.7572 running_bpb:1.0620 doc_len:705-707
+ttt_progress: batch 504/782 batch_loss:2.8791 batch_bpb:1.1032 running_loss:2.7585 running_bpb:1.0624 doc_len:685-686
+ttt_progress: batch 496/782 batch_loss:2.8444 batch_bpb:1.0542 running_loss:2.7593 running_bpb:1.0623 doc_len:666-668
+ttt_progress: batch 488/782 batch_loss:2.8257 batch_bpb:1.0531 running_loss:2.7600 running_bpb:1.0622 doc_len:649-651
+ttt_progress: batch 480/782 batch_loss:2.8048 batch_bpb:1.0589 running_loss:2.7604 running_bpb:1.0622 doc_len:632-635
+ttt_progress: batch 474/782 batch_loss:2.7752 batch_bpb:1.0582 running_loss:2.7606 running_bpb:1.0622 doc_len:620-622
+ttt_progress: batch 465/782 batch_loss:2.8222 batch_bpb:1.0646 running_loss:2.7611 running_bpb:1.0622 doc_len:602-604
+ttt_progress: batch 459/782 batch_loss:2.7450 batch_bpb:1.0416 running_loss:2.7610 running_bpb:1.0620 doc_len:591-593
+ttt_progress: batch 451/782 batch_loss:2.7784 batch_bpb:1.0644 running_loss:2.7611 running_bpb:1.0620 doc_len:576-579
+ttt_progress: batch 440/782 batch_loss:2.8759 batch_bpb:1.0980 running_loss:2.7620 running_bpb:1.0623 doc_len:556-559
+ttt_progress: batch 432/782 batch_loss:2.7688 batch_bpb:1.0534 running_loss:2.7621 running_bpb:1.0623 doc_len:542-544
+ttt_progress: batch 424/782 batch_loss:2.8094 batch_bpb:1.0858 running_loss:2.7624 running_bpb:1.0624 doc_len:528-530
+ttt_progress: batch 416/782 batch_loss:2.7675 batch_bpb:1.0388 running_loss:2.7625 running_bpb:1.0623 doc_len:514-516
+ttt_progress: batch 408/782 batch_loss:2.8449 batch_bpb:1.0882 running_loss:2.7630 running_bpb:1.0624 doc_len:501-503
+ttt_progress: batch 400/782 batch_loss:2.8022 batch_bpb:1.0689 running_loss:2.7633 running_bpb:1.0625 doc_len:489-490
+ttt_progress: batch 392/782 batch_loss:2.8036 batch_bpb:1.0826 running_loss:2.7635 running_bpb:1.0626 doc_len:476-478
+ttt_progress: batch 384/782 batch_loss:2.8528 batch_bpb:1.0945 running_loss:2.7641 running_bpb:1.0628 doc_len:464-466
+ttt_progress: batch 376/782 batch_loss:2.7261 batch_bpb:1.0469 running_loss:2.7639 running_bpb:1.0627 doc_len:453-454
+ttt_progress: batch 369/782 batch_loss:2.9360 batch_bpb:1.0898 running_loss:2.7649 running_bpb:1.0629 doc_len:443-444
+ttt_progress: batch 361/782 batch_loss:2.8094 batch_bpb:1.0741 running_loss:2.7652 running_bpb:1.0629 doc_len:432-433
+ttt_progress: batch 353/782 batch_loss:2.8072 batch_bpb:1.1000 running_loss:2.7654 running_bpb:1.0631 doc_len:420-422
+ttt_progress: batch 346/782 batch_loss:2.8512 batch_bpb:1.0881 running_loss:2.7659 running_bpb:1.0633 doc_len:412-413
+ttt_progress: batch 338/782 batch_loss:2.8597 batch_bpb:1.1154 running_loss:2.7664 running_bpb:1.0636 doc_len:400-402
+ttt_progress: batch 330/782 batch_loss:2.8792 batch_bpb:1.0977 running_loss:2.7669 running_bpb:1.0637 doc_len:390-392
+ttt_progress: batch 322/782 batch_loss:2.7638 batch_bpb:1.0800 running_loss:2.7669 running_bpb:1.0638 doc_len:380-381
+ttt_progress: batch 314/782 batch_loss:2.8104 batch_bpb:1.0682 running_loss:2.7671 running_bpb:1.0638 doc_len:369-370
+ttt_progress: batch 306/782 batch_loss:2.8856 batch_bpb:1.1416 running_loss:2.7677 running_bpb:1.0642 doc_len:359-361
+ttt_progress: batch 298/782 batch_loss:2.8526 batch_bpb:1.1042 running_loss:2.7680 running_bpb:1.0644 doc_len:349-351
+ttt_progress: batch 290/782 batch_loss:2.8683 batch_bpb:1.0867 running_loss:2.7685 running_bpb:1.0645 doc_len:340-341
+ttt_progress: batch 282/782 batch_loss:2.8336 batch_bpb:1.1284 running_loss:2.7688 running_bpb:1.0647 doc_len:331-332
+ttt_progress: batch 274/782 batch_loss:2.8268 batch_bpb:1.0975 running_loss:2.7690 running_bpb:1.0648 doc_len:322-323
+ttt_progress: batch 266/782 batch_loss:2.8524 batch_bpb:1.0969 running_loss:2.7693 running_bpb:1.0650 doc_len:313-314
+ttt_progress: batch 258/782 batch_loss:2.9709 batch_bpb:1.1715 running_loss:2.7701 running_bpb:1.0654 doc_len:304-305
+ttt_progress: batch 250/782 batch_loss:2.8768 batch_bpb:1.1432 running_loss:2.7705 running_bpb:1.0656 doc_len:295-296
+ttt_progress: batch 242/782 batch_loss:2.9089 batch_bpb:1.1122 running_loss:2.7710 running_bpb:1.0658 doc_len:287-288
+ttt_progress: batch 234/782 batch_loss:2.9271 batch_bpb:1.1604 running_loss:2.7715 running_bpb:1.0661 doc_len:279-280
+ttt_progress: batch 226/782 batch_loss:2.9414 batch_bpb:1.1443 running_loss:2.7721 running_bpb:1.0664 doc_len:271-272
+ttt_progress: batch 218/782 batch_loss:2.7535 batch_bpb:1.1072 running_loss:2.7720 running_bpb:1.0665 doc_len:263-264
+ttt_progress: batch 210/782 batch_loss:2.8513 batch_bpb:1.1221 running_loss:2.7723 running_bpb:1.0667 doc_len:255-256
+ttt_progress: batch 202/782 batch_loss:2.8739 batch_bpb:1.1360 running_loss:2.7726 running_bpb:1.0669 doc_len:248-249
+ttt_progress: batch 194/782 batch_loss:2.9213 batch_bpb:1.1087 running_loss:2.7730 running_bpb:1.0670 doc_len:241-242
+ttt_progress: batch 186/782 batch_loss:2.9473 batch_bpb:1.1776 running_loss:2.7735 running_bpb:1.0673 doc_len:234-235
+ttt_progress: batch 178/782 batch_loss:2.8608 batch_bpb:1.1410 running_loss:2.7738 running_bpb:1.0675 doc_len:227-228
+ttt_progress: batch 170/782 batch_loss:2.9981 batch_bpb:1.1724 running_loss:2.7744 running_bpb:1.0678 doc_len:220-221
+ttt_progress: batch 162/782 batch_loss:2.9598 batch_bpb:1.1484 running_loss:2.7748 running_bpb:1.0680 doc_len:213-214
+ttt_progress: batch 155/782 batch_loss:2.8860 batch_bpb:1.1343 running_loss:2.7751 running_bpb:1.0682 doc_len:207-208
+ttt_progress: batch 147/782 batch_loss:2.9318 batch_bpb:1.1599 running_loss:2.7755 running_bpb:1.0684 doc_len:201-202
+ttt_progress: batch 141/782 batch_loss:2.9129 batch_bpb:1.1484 running_loss:2.7758 running_bpb:1.0686 doc_len:196-197
+ttt_progress: batch 133/782 batch_loss:3.0297 batch_bpb:1.1968 running_loss:2.7764 running_bpb:1.0688 doc_len:189-190
+ttt_progress: batch 126/782 batch_loss:2.9436 batch_bpb:1.1960 running_loss:2.7768 running_bpb:1.0691 doc_len:185-185
+ttt_progress: batch 116/782 batch_loss:3.0133 batch_bpb:1.1916 running_loss:2.7773 running_bpb:1.0694 doc_len:177-178
+ttt_progress: batch 110/782 batch_loss:3.0343 batch_bpb:1.1781 running_loss:2.7778 running_bpb:1.0696 doc_len:173-173
+ttt_progress: batch 101/782 batch_loss:2.9702 batch_bpb:1.1658 running_loss:2.7782 running_bpb:1.0698 doc_len:166-167
+ttt_progress: batch 92/782 batch_loss:2.9067 batch_bpb:1.1756 running_loss:2.7784 running_bpb:1.0700 doc_len:159-160
+ttt_progress: batch 84/782 batch_loss:3.0270 batch_bpb:1.2196 running_loss:2.7788 running_bpb:1.0702 doc_len:153-154
+ttt_progress: batch 76/782 batch_loss:3.0678 batch_bpb:1.2308 running_loss:2.7793 running_bpb:1.0705 doc_len:147-148
+ttt_progress: batch 68/782 batch_loss:3.1181 batch_bpb:1.2114 running_loss:2.7799 running_bpb:1.0707 doc_len:141-142
+ttt_progress: batch 61/782 batch_loss:2.9361 batch_bpb:1.1478 running_loss:2.7802 running_bpb:1.0708 doc_len:135-136
+ttt_progress: batch 54/782 batch_loss:3.1166 batch_bpb:1.2762 running_loss:2.7807 running_bpb:1.0711 doc_len:130-130
+ttt_progress: batch 44/782 batch_loss:3.1536 batch_bpb:1.2288 running_loss:2.7812 running_bpb:1.0713 doc_len:122-122
+ttt_progress: batch 34/782 batch_loss:3.0831 batch_bpb:1.2481 running_loss:2.7816 running_bpb:1.0716 doc_len:114-115
+ttt_progress: batch 27/782 batch_loss:3.0932 batch_bpb:1.2349 running_loss:2.7820 running_bpb:1.0718 doc_len:107-108
+ttt_progress: batch 20/782 batch_loss:3.1458 batch_bpb:1.2723 running_loss:2.7824 running_bpb:1.0720 doc_len:101-102
+ttt_progress: batch 12/782 batch_loss:3.1837 batch_bpb:1.2409 running_loss:2.7828 running_bpb:1.0722 doc_len:92-93
+ttt_progress: batch 4/782 batch_loss:3.2067 batch_bpb:1.2295 running_loss:2.7832 running_bpb:1.0723 doc_len:78-80
+quantized_ttt_lora val_loss:2.78033428 val_bpb:1.07635404 eval_time:179178ms
+total_eval_time:274.7s
+total_eval_time_with_compile:360.3s

--- a/records/track_10min_16mb/2026-04-10_VarLenAttn/logs/train1.txt
+++ b/records/track_10min_16mb/2026-04-10_VarLenAttn/logs/train1.txt
@@ -2,18 +2,18 @@
 Hyperparameters:
   adam_eps: 1e-08
   adam_wd: 0.02
-  artifact_dir: runs/varlen1
+  artifact_dir: runs/varlen1-new-tuned
   beta1: 0.9
   beta2: 0.95
   compressor: brotli
   data_dir: ./data/
   datasets_dir: ./data/datasets/fineweb10B_sp8192
   distributed: True
-  ema_decay: 0.997
+  ema_decay: 0.9965
   embed_bits: 8
   embed_clip_sigmas: 20.0
   embed_lr: 0.6
-  embed_wd: 0.095
+  embed_wd: 0.085
   embedding_dim: 512
   enable_looping_at: 0.35
   etlb_clip: 3.0
@@ -23,7 +23,7 @@ Hyperparameters:
   eval_seq_len: 2048
   eval_stride: 64
   gptq_calibration_batches: 64
-  gptq_reserve_seconds: 12.0
+  gptq_reserve_seconds: 13.0
   grad_accum_steps: 1
   grad_clip_norm: 0.3
   head_lr: 0.008
@@ -31,7 +31,7 @@ Hyperparameters:
   iterations: 20000
   ln_scale: True
   local_rank: 0
-  logfile: runs/varlen1/9e75722b-6ad5-4326-b593-e9fc5b7608e8.txt
+  logfile: runs/varlen1-new-tuned/5fc19b78-ac18-4cb6-af60-18e2b1113657.txt
   logit_softcap: 30.0
   loop_end: 5
   loop_start: 3
@@ -42,7 +42,7 @@ Hyperparameters:
   min_lr: 0.0
   mlp_mult: 4.0
   model_dim: 512
-  model_path: runs/varlen1/final_model.pt
+  model_path: runs/varlen1-new-tuned/final_model.pt
   muon_backend_steps: 5
   muon_beta2: 0.95
   muon_momentum: 0.97
@@ -54,15 +54,16 @@ Hyperparameters:
   num_kv_heads: 4
   num_layers: 11
   num_loops: 2
-  parallel_start_layer: 7
+  parallel_final_lane: mean
+  parallel_start_layer: 8
   qk_gain_init: 5.0
-  quantized_model_path: runs/varlen1/final_model.int6.ptz
+  quantized_model_path: runs/varlen1-new-tuned/final_model.int6.ptz
   rank: 0
   rope_base: 10000.0
   rope_dims: 16
   rope_train_seq_len: 2048
   rope_yarn: False
-  run_id: 9e75722b-6ad5-4326-b593-e9fc5b7608e8
+  run_id: 5fc19b78-ac18-4cb6-af60-18e2b1113657
   scalar_lr: 0.02
   seed: 1
   skip_gates_enabled: True
@@ -78,11 +79,12 @@ Hyperparameters:
   ttt_batch_size: 64
   ttt_beta1: 0.0
   ttt_beta2: 0.999
-  ttt_chunk_size: 64
+  ttt_chunk_size: 32
   ttt_enabled: True
   ttt_eval_batches: 
   ttt_eval_seq_len: 2048
   ttt_grad_steps: 1
+  ttt_hash_embed_size: 0
   ttt_k_lora: True
   ttt_lora_lr: 0.0001
   ttt_lora_rank: 96
@@ -96,14 +98,2955 @@ Hyperparameters:
   val_files: ./data/datasets/fineweb10B_sp8192/fineweb_val_*.bin
   val_loss_every: 4000
   vocab_size: 8192
-  warmdown_frac: 0.667
+  warmdown_frac: 0.72
   warmup_steps: 20
   world_size: 8
   xsa_last_n: 11
 ====================================================================================================
+Source code:
+====================================================================================================
+import base64, collections, copy, fcntl, glob, io, json, lzma, math, os
+from pathlib import Path
+import random, re, subprocess, sys, time, uuid, numpy as np, sentencepiece as spm, torch, torch.distributed as dist, torch.nn.functional as F
+from torch import nn
+from flash_attn_interface import (
+    flash_attn_func as flash_attn_3_func,
+    flash_attn_varlen_func,
+)
+from concurrent.futures import ThreadPoolExecutor
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+class Hyperparameters:
+    data_dir = os.environ.get("DATA_DIR", "./data/")
+    seed = int(os.environ.get("SEED", 1337))
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.72))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 6e2))
+    val_batch_tokens = int(os.environ.get("VAL_BATCH_TOKENS", 524288))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    sliding_window_enabled = bool(int(os.environ.get("SLIDING_WINDOW_ENABLED", "0")))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 8192))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    embedding_dim = int(os.environ.get("EMBEDDING_DIM", 512))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 4.0))
+    skip_gates_enabled = bool(int(os.environ.get("SKIP_GATES_ENABLED", "1")))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 3e1))
+    rope_base = float(os.environ.get("ROPE_BASE", 1e4))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    rope_train_seq_len = int(os.environ.get("ROPE_TRAIN_SEQ_LEN", 2048))
+    rope_yarn = bool(int(os.environ.get("ROPE_YARN", "0")))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 5.0))
+    num_loops = int(os.environ.get("NUM_LOOPS", 2))
+    loop_start = int(os.environ.get("LOOP_START", 3))
+    loop_end = int(os.environ.get("LOOP_END", 5))
+    enable_looping_at = float(os.environ.get("ENABLE_LOOPING_AT", 0.35))
+    parallel_start_layer = int(os.environ.get("PARALLEL_START_LAYER", 8))
+    parallel_final_lane = os.environ.get("PARALLEL_FINAL_LANE", "mlp")
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.022))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.97))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-08))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.02))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_lora_rank = int(os.environ.get("TTT_LORA_RANK", 96))
+    ttt_lora_lr = float(os.environ.get("TTT_LORA_LR", 0.0001))
+    ttt_chunk_size = int(os.environ.get("TTT_CHUNK_SIZE", 32))
+    ttt_eval_seq_len = int(os.environ.get("TTT_EVAL_SEQ_LEN", 2048))
+    ttt_batch_size = int(os.environ.get("TTT_BATCH_SIZE", 64))
+    ttt_grad_steps = int(os.environ.get("TTT_GRAD_STEPS", 1))
+    ttt_weight_decay = float(os.environ.get("TTT_WEIGHT_DECAY", 0.5))
+    ttt_beta1 = float(os.environ.get("TTT_BETA1", 0))
+    ttt_beta2 = float(os.environ.get("TTT_BETA2", 0.999))
+    ttt_k_lora = bool(int(os.environ.get("TTT_K_LORA", "1")))
+    ttt_mlp_lora = bool(int(os.environ.get("TTT_MLP_LORA", "1")))
+    ttt_o_lora = bool(int(os.environ.get("TTT_O_LORA", "1")))
+    ttt_hash_embed_size = int(os.environ.get("TTT_HASH_EMBED_SIZE", 0))
+    ttt_optimizer = os.environ.get("TTT_OPTIMIZER", "adam")
+    ttt_eval_batches = os.environ.get("TTT_EVAL_BATCHES", "")
+    ttt_output_dir = os.environ.get("TTT_OUTPUT_DIR", "")
+    val_doc_fraction = float(os.environ.get("VAL_DOC_FRACTION", 1.0))
+    etlb_lr = float(os.environ.get("ETLB_LR", 0.05))
+    etlb_steps = int(os.environ.get("ETLB_STEPS", 5))
+    etlb_clip = float(os.environ.get("ETLB_CLIP", 3.0))
+    compressor = os.environ.get("COMPRESSOR", "brotli")
+    gptq_calibration_batches = int(os.environ.get("GPTQ_CALIBRATION_BATCHES", 64))
+    gptq_reserve_seconds = float(os.environ.get("GPTQ_RESERVE_SECONDS", 13.0))
+    matrix_bits = int(os.environ.get("MATRIX_BITS", 6))
+    embed_bits = int(os.environ.get("EMBED_BITS", 8))
+    matrix_clip_sigmas = float(os.environ.get("MATRIX_CLIP_SIGMAS", 12.85))
+    embed_clip_sigmas = float(os.environ.get("EMBED_CLIP_SIGMAS", 2e1))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_main_process = rank == 0
+    grad_accum_steps = 8 // world_size
+    datasets_dir = os.path.join(data_dir, "datasets", f"fineweb10B_sp{vocab_size}")
+    train_files = os.path.join(datasets_dir, "fineweb_train_*.bin")
+    val_files = os.path.join(datasets_dir, "fineweb_val_*.bin")
+    tokenizer_path = os.path.join(
+        data_dir, "tokenizers", f"fineweb_{vocab_size}_bpe.model"
+    )
+    artifact_dir = os.environ.get("ARTIFACT_DIR", "")
+    eval_only_path = os.environ.get("EVAL_ONLY_PATH", "")
+    logfile = (
+        os.path.join(artifact_dir, f"{run_id}.txt")
+        if artifact_dir
+        else f"logs/{run_id}.txt"
+    )
+    model_path = (
+        os.path.join(artifact_dir, "final_model.pt")
+        if artifact_dir
+        else "final_model.pt"
+    )
+    quantized_model_path = (
+        os.path.join(artifact_dir, "final_model.int6.ptz")
+        if artifact_dir
+        else "final_model.int6.ptz"
+    )
+
+
+_logger_hparams = None
+
+
+def set_logging_hparams(h):
+    global _logger_hparams
+    _logger_hparams = h
+
+
+def log(msg, console=True):
+    if _logger_hparams is None:
+        print(msg)
+        return
+    if _logger_hparams.is_main_process:
+        if console:
+            print(msg)
+        if _logger_hparams.logfile is not None:
+            with open(_logger_hparams.logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+
+class ValidationData:
+    def __init__(self, h, device):
+        self.sp = spm.SentencePieceProcessor(model_file=h.tokenizer_path)
+        if int(self.sp.vocab_size()) != h.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={h.vocab_size} does not match tokenizer vocab_size={int(self.sp.vocab_size())}"
+            )
+        self.val_tokens = load_validation_tokens(h.val_files, h.eval_seq_len)
+        (
+            self.base_bytes_lut,
+            self.has_leading_space_lut,
+            self.is_boundary_token_lut,
+        ) = build_sentencepiece_luts(self.sp, h.vocab_size, device)
+
+
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sp_vocab_size = int(sp.vocab_size())
+    assert (
+        sp.piece_to_id("▁") != sp.unk_id()
+    ), "Tokenizer must have '▁' (space) as its own token for correct BPB byte counting"
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = (tokens.numel() - 1) // seq_len * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def load_data_shard(file):
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE = {}
+_MMAP_CACHE = {}
+
+
+def _read_num_tokens(file):
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+
+def _get_shard_memmap(file):
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode="r", dtype="<u2", offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+BOS_ID = None
+
+
+def get_next_multiple_of_n(v, n):
+    return ((v + n - 1) // n) * n
+
+
+def _build_cu_seqlens(bos_pos, total_len, device, max_doc_len=0, bucket_size=64):
+    if not bos_pos or bos_pos[0] != 0:
+        bos_pos = [0] + bos_pos
+    seg_starts = []
+    starts_with_end = bos_pos + [total_len]
+    for i in range(len(starts_with_end) - 1):
+        start = starts_with_end[i]
+        end = starts_with_end[i + 1]
+        if max_doc_len > 0:
+            pos = start
+            while pos < end:
+                seg_starts.append(pos)
+                pos += max_doc_len
+        else:
+            seg_starts.append(start)
+    boundaries = seg_starts + [total_len]
+    padded_len = get_next_multiple_of_n(len(boundaries), bucket_size)
+    cu = torch.full((padded_len,), total_len, dtype=torch.int32, device=device)
+    cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+    seg_ends = seg_starts[1:] + [total_len]
+    max_seqlen = max(end - start for start, end in zip(seg_starts, seg_ends))
+    return cu, max_seqlen
+
+class DocumentPackingLoader:
+    _shard_pool = ThreadPoolExecutor(1)
+
+    def __init__(self, h, device, cu_bucket_size=64):
+        self.rank = h.rank
+        self.world_size = h.world_size
+        self.device = device
+        self.cu_bucket_size = cu_bucket_size
+        self.max_seq_len = h.train_seq_len
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files
+        self.file_iter = iter(self.files)
+        self._init_shard(load_data_shard(next(self.file_iter)))
+        self._next_shard = self._submit_next_shard()
+        self._batch_pool = ThreadPoolExecutor(1)
+        self._next_batch = None
+
+    def _init_shard(self, tokens):
+        global BOS_ID
+        self.tokens = tokens
+        self.shard_size = tokens.numel()
+        if BOS_ID is None:
+            BOS_ID = 1
+        self.bos_idx = (
+            (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        )
+        if self.bos_idx.size == 0:
+            self.bos_idx = np.array([0], dtype=np.int64)
+        self.cursor = int(self.bos_idx[0])
+
+    def _submit_next_shard(self):
+        try:
+            path = next(self.file_iter)
+            return self._shard_pool.submit(load_data_shard, path)
+        except StopIteration:
+            return None
+
+    def _advance_shard(self):
+        if self._next_shard is None:
+            self.file_iter = iter(self.files)
+            self._next_shard = self._shard_pool.submit(
+                load_data_shard, next(self.file_iter)
+            )
+        self._init_shard(self._next_shard.result())
+        self._next_shard = self._submit_next_shard()
+
+    def _local_doc_starts(self, local_start, total_len):
+        lo = np.searchsorted(self.bos_idx, local_start, side="left")
+        hi = np.searchsorted(self.bos_idx, local_start + total_len, side="left")
+        return (self.bos_idx[lo:hi] - local_start).tolist()
+
+    def _prepare_batch(self, num_tokens_local, max_seq_len):
+        per_rank_span = num_tokens_local + 1
+        global_span = per_rank_span * self.world_size
+        while self.cursor + global_span > self.shard_size:
+            self._advance_shard()
+        local_start = self.cursor + self.rank * per_rank_span
+        buf = self.tokens[local_start : local_start + per_rank_span]
+        inputs = buf[:-1].to(dtype=torch.int64).pin_memory()
+        targets = buf[1:].to(dtype=torch.int64).pin_memory()
+        starts = self._local_doc_starts(local_start, inputs.numel())
+        cu_seqlens, max_seqlen = _build_cu_seqlens(
+            starts, inputs.numel(), inputs.device, max_seq_len, self.cu_bucket_size
+        )
+        cu_seqlens = cu_seqlens.pin_memory()
+        self.cursor += global_span
+        return inputs, targets, cu_seqlens, max_seqlen
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        num_tokens_local = global_tokens // (self.world_size * grad_accum_steps)
+        if self._next_batch is not None:
+            inputs, targets, cu_seqlens, max_seqlen = self._next_batch.result()
+        else:
+            inputs, targets, cu_seqlens, max_seqlen = self._prepare_batch(
+                num_tokens_local, self.max_seq_len
+            )
+        self._next_batch = self._batch_pool.submit(
+            self._prepare_batch, num_tokens_local, self.max_seq_len
+        )
+        return (
+            inputs[None].to(self.device, non_blocking=True),
+            targets[None].to(self.device, non_blocking=True),
+            cu_seqlens.to(self.device, non_blocking=True),
+            max_seqlen,
+        )
+
+
+class ShuffledSequenceLoader:
+    def __init__(self, h, device):
+        self.world_size = h.world_size
+        self.seq_len = h.train_seq_len
+        self.device = device
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files[h.rank :: h.world_size]
+        self.rng = np.random.Generator(np.random.PCG64(h.rank))
+        self.num_tokens = [_read_num_tokens(f) for f in self.files]
+        self.start_inds = [[] for _ in self.files]
+        for si in range(len(self.files)):
+            self._reset_shard(si)
+
+    def _reset_shard(self, si):
+        max_phase = min(
+            self.seq_len - 1, max(0, self.num_tokens[si] - self.seq_len - 1)
+        )
+        phase = int(self.rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        num_sequences = (self.num_tokens[si] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[si] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for bi in range(device_batch_size):
+            total = remaining.sum()
+            if total <= 0:
+                for si in range(len(self.files)):
+                    self._reset_shard(si)
+                remaining = np.array(
+                    [len(s) for s in self.start_inds], dtype=np.float64
+                )
+                total = remaining.sum()
+            probs = remaining / total
+            si = int(self.rng.choice(len(self.files), p=probs))
+            start_ind = self.start_inds[si].pop()
+            remaining[si] -= 1
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[bi] = window[:-1]
+            y[bi] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x):
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+@triton.jit
+def linear_leaky_relu_square_kernel(
+    a_desc,
+    b_desc,
+    c_desc,
+    aux_desc,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    FORWARD: tl.constexpr,
+):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+    tile_id_c = start_pid - NUM_SMS
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+        tile_id_c += NUM_SMS
+        offs_am_c = offs_am
+        offs_bn_c = offs_bn
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+        c0 = acc0.to(dtype)
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            pre0 = aux_desc.load([offs_am_c, offs_bn_c])
+            pre1 = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c0 = c0 * tl.where(pre0 > 0, 2.0 * pre0, 0.5 * pre0)
+            c1 = c1 * tl.where(pre1 > 0, 2.0 * pre1, 0.5 * pre1)
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+        if FORWARD:
+            aux0 = tl.where(c0 > 0, c0, 0.5 * c0)
+            aux1 = tl.where(c1 > 0, c1, 0.5 * c1)
+            aux_desc.store([offs_am_c, offs_bn_c], aux0 * aux0)
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], aux1 * aux1)
+
+
+def linear_leaky_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K2 = b.shape
+    assert K == K2
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    forward = aux is None
+    if aux is None:
+        aux = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 256, 64
+    num_stages = 4 if forward else 3
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    grid = lambda _meta: (
+        min(num_sms, triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N)),
+    )
+    linear_leaky_relu_square_kernel[grid](
+        a_desc,
+        b_desc,
+        c_desc,
+        aux_desc,
+        M,
+        N,
+        K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        NUM_SMS=num_sms,
+        FORWARD=forward,
+        num_stages=num_stages,
+        num_warps=8,
+    )
+    if forward:
+        return c, aux
+    return c
+
+
+class FusedLinearLeakyReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, w1, w2):
+        x_flat = x.reshape(-1, x.shape[-1])
+        pre, post = linear_leaky_relu_square(x_flat, w1)
+        out = F.linear(post, w2)
+        ctx.save_for_backward(x, w1, w2, pre, post)
+        return out.view(*x.shape[:-1], out.shape[-1])
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, w1, w2, pre, post = ctx.saved_tensors
+        x_flat = x.reshape(-1, x.shape[-1])
+        grad_output_flat = grad_output.reshape(-1, grad_output.shape[-1])
+        dw2 = grad_output_flat.T @ post
+        dpre = linear_leaky_relu_square(grad_output_flat, w2.T.contiguous(), aux=pre)
+        dw1 = dpre.T @ x_flat
+        dx = dpre @ w1
+        return dx.view_as(x), dw1, dw2
+
+
+FusedLeakyReLUSquareMLP = FusedLinearLeakyReLUSquareFunction.apply
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=1e4, train_seq_len=1024, rope_dims=0, yarn=True):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.yarn = yarn
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / base ** (
+            torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+
+    def forward(self, seq_len, device, dtype):
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached < seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if self.yarn and seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * scale ** (rd / (rd - 2))
+                inv_freq = 1.0 / new_base ** (
+                    torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd
+                )
+            else:
+                inv_freq = self.inv_freq.float().to(device)
+            t = torch.arange(seq_len, device=device, dtype=torch.float32)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached[:, :seq_len].to(dtype=dtype), self._sin_cached[:, :seq_len].to(dtype=dtype)
+
+
+def apply_rotary_emb(x, cos, sin, rope_dims=0):
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=True
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len, yarn=yarn)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x, q_w, k_w, v_w, out_w, cu_seqlens=None, max_seqlen=0):
+        bsz, seqlen, dim = x.shape
+        q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if cu_seqlens is not None:
+            y = flash_attn_varlen_func(
+                q[0],
+                k[0],
+                v[0],
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+                causal=True,
+                window_size=(-1, -1),
+            )[None]
+        else:
+            y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        self._last_proj_input = y.detach() if getattr(self, "_calib", False) else None
+        return F.linear(y, out_w.to(x.dtype))
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        self.use_fused = True
+
+    def forward(self, x, up_w, down_w):
+        if self.training and self.use_fused:
+            return FusedLeakyReLUSquareMLP(x, up_w.to(x.dtype), down_w.to(x.dtype))
+        hidden = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5).square()
+        self._last_down_input = hidden.detach() if getattr(self, "_calib", False) else None
+        return F.linear(hidden, down_w.to(x.dtype))
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        num_kv_heads,
+        mlp_mult,
+        rope_base,
+        qk_gain_init,
+        train_seq_len,
+        layer_idx=0,
+        ln_scale=False,
+        yarn=True,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=yarn
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(
+            torch.stack((torch.ones(dim), torch.zeros(dim))).float()
+        )
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+
+    def forward(self, x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=None, max_seqlen=0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(
+            self.attn_norm(x_in) * self.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[
+            None, None, :
+        ] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        return x_out
+
+    def forward_attn(self, x, x0, q_w, k_w, v_w, out_w, cu_seqlens=None, max_seqlen=0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(
+            self.attn_norm(x_in) * self.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        return x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+
+    def forward_mlp(self, x, up_w, down_w):
+        return x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(
+            self.mlp_norm(x) * self.ln_scale_factor, up_w, down_w
+        )
+
+
+class GPT(nn.Module):
+    def __init__(self, h):
+        super().__init__()
+        if h.logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {h.logit_softcap}")
+        self.tie_embeddings = h.tie_embeddings
+        self.tied_embed_init_std = h.tied_embed_init_std
+        self.logit_softcap = h.logit_softcap
+        self.tok_emb = nn.Embedding(h.vocab_size, h.embedding_dim)
+        if h.embedding_dim != h.model_dim:
+            self.embed_proj = CastedLinear(h.embedding_dim, h.model_dim, bias=False)
+            self.head_proj = CastedLinear(h.model_dim, h.embedding_dim, bias=False)
+        else:
+            self.embed_proj = None
+            self.head_proj = None
+        self.num_layers = h.num_layers
+        head_dim = h.model_dim // h.num_heads
+        kv_dim = h.num_kv_heads * head_dim
+        hidden_dim = int(h.mlp_mult * h.model_dim)
+        self.qo_bank = nn.Parameter(torch.empty(2 * h.num_layers, h.model_dim, h.model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * h.num_layers, kv_dim, h.model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(h.num_layers, hidden_dim, h.model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(h.num_layers, h.model_dim, hidden_dim))
+        self.num_encoder_layers = h.num_layers // 2
+        self.num_decoder_layers = h.num_layers - self.num_encoder_layers
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    h.model_dim,
+                    h.num_heads,
+                    h.num_kv_heads,
+                    h.mlp_mult,
+                    h.rope_base,
+                    h.qk_gain_init,
+                    h.train_seq_len,
+                    layer_idx=i,
+                    ln_scale=h.ln_scale,
+                    yarn=h.rope_yarn,
+                )
+                for i in range(h.num_layers)
+            ]
+        )
+        if h.rope_dims > 0:
+            head_dim = h.model_dim // h.num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = h.rope_dims
+                block.attn.rotary = Rotary(
+                    head_dim,
+                    base=h.rope_base,
+                    train_seq_len=h.train_seq_len,
+                    rope_dims=h.rope_dims,
+                    yarn=h.rope_yarn,
+                )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None
+            if h.tie_embeddings
+            else CastedLinear(h.embedding_dim, h.vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if h.xsa_last_n > 0:
+            for i in range(max(0, h.num_layers - h.xsa_last_n), h.num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self.looping_active = False
+        if h.num_loops > 0:
+            loop_seg = list(range(h.loop_start, h.loop_end + 1))
+            all_indices = list(range(h.loop_start))
+            for _ in range(h.num_loops + 1):
+                all_indices.extend(loop_seg)
+            all_indices.extend(range(h.loop_end + 1, h.num_layers))
+            num_enc = len(all_indices) // 2
+            self.encoder_indices = all_indices[:num_enc]
+            self.decoder_indices = all_indices[num_enc:]
+        else:
+            self.encoder_indices = list(range(self.num_encoder_layers))
+            self.decoder_indices = list(range(self.num_encoder_layers, h.num_layers))
+        self.num_skip_weights = min(
+            len(self.encoder_indices), len(self.decoder_indices)
+        )
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+        )
+        self.skip_gates = (
+            nn.Parameter(
+                torch.zeros(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+            )
+            if h.skip_gates_enabled
+            else None
+        )
+        self.parallel_start_layer = h.parallel_start_layer
+        self.parallel_final_lane = h.parallel_final_lane.lower()
+        self.parallel_post_lambdas = nn.Parameter(
+            torch.ones(h.num_layers, 2, 2, dtype=torch.float32)
+        )
+        self.parallel_resid_lambdas = nn.Parameter(
+            torch.full((h.num_layers, 2), 1.1, dtype=torch.float32)
+        )
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.qo_bank.data[n + i])
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.mlp_down_bank.data[i])
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _bank_weights(self, i):
+        n = self.num_layers
+        return (
+            self.qo_bank[i],
+            self.kv_bank[i],
+            self.kv_bank[n + i],
+            self.qo_bank[n + i],
+            self.mlp_up_bank[i],
+            self.mlp_down_bank[i],
+        )
+
+    def _parallel_block(
+        self, block_idx, lane0, lane1, x0,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+        cu_seqlens=None, max_seqlen=0,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        attn_out = block.attn(
+            block.attn_norm(attn_read) * block.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+        )
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * block.mlp(
+            block.mlp_norm(mlp_read) * block.ln_scale_factor, up_w, down_w
+        )
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+    def _final_parallel_hidden(self, lane0, lane1):
+        if self.parallel_final_lane == "mlp":
+            return lane1
+        if self.parallel_final_lane == "attn":
+            return lane0
+        return 0.5 * (lane0 + lane1)
+
+    def forward_logits(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else range(self.num_encoder_layers)
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else range(
+                self.num_encoder_layers,
+                self.num_encoder_layers + self.num_decoder_layers,
+            )
+        )
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block(
+                    i, lane0, lane1, x0, q_w, k_w, v_w, out_w, up_w, down_w,
+                    cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        if self.head_proj is not None:
+            x = self.head_proj(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(self, input_ids, target_ids, cu_seqlens=None, max_seqlen=0):
+        logits = self.forward_logits(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        return F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            target_ids.reshape(-1),
+            reduction="mean",
+        )
+
+    def forward_ttt(self, input_ids, target_ids, lora, hash_out=None):
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        if hash_out is not None:
+            x = x + hash_out.to(x.dtype)
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else list(range(self.num_encoder_layers))
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else list(
+                range(
+                    self.num_encoder_layers,
+                    self.num_encoder_layers + self.num_decoder_layers,
+                )
+            )
+        )
+        slot = 0
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block_with_lora(
+                    i, lane0, lane1, x0, lora, slot,
+                    q_w, k_w, v_w, out_w, up_w, down_w,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        if self.head_proj is not None:
+            x = self.head_proj(x)
+        if self.tie_embeddings:
+            logits = F.linear(x, self.tok_emb.weight)
+        else:
+            logits = self.lm_head(x)
+        logits = logits + lora.lm_head_lora(x)
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        bsz, sl, V = logits.shape
+        return F.cross_entropy(
+            logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none"
+        ).reshape(bsz, sl)
+
+    def _block_with_lora(self, block, x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w):
+        mix = block.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = block.attn_norm(x_in) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q = (F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_heads, attn.head_dim
+        )
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        x_out = x_in + block.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        mlp_n = block.mlp_norm(x_out) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        x_out = x_out + block.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * mlp_out
+        return x_out
+
+    def _block_with_lora_attn(self, block, x, x0, lora, slot, q_w, k_w, v_w, out_w):
+        mix = block.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = block.attn_norm(x_in) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q = (F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_heads, attn.head_dim
+        )
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        return x_in + block.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+
+    def _block_with_lora_mlp(self, block, x, lora, slot, up_w, down_w):
+        mlp_n = block.mlp_norm(x) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        return x + block.mlp_scale.to(dtype=x.dtype)[None, None, :] * mlp_out
+
+    def _parallel_block_with_lora(
+        self, block_idx, lane0, lane1, x0, lora, slot,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        n = block.attn_norm(attn_read) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q = (F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_heads, attn.head_dim
+        )
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_n = block.mlp_norm(mlp_read) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * mlp_out
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+
+class BatchedLinearLoRA(nn.Module):
+    def __init__(self, bsz, in_features, out_features, rank):
+        super().__init__()
+        self._bound = 1.0 / math.sqrt(in_features)
+        self.A = nn.Parameter(
+            torch.empty(bsz, rank, in_features).uniform_(-self._bound, self._bound)
+        )
+        self.B = nn.Parameter(torch.zeros(bsz, out_features, rank))
+
+    def reset(self):
+        with torch.no_grad():
+            self.A.uniform_(-self._bound, self._bound)
+            self.B.zero_()
+
+    def forward(self, x):
+        return (x @ self.A.transpose(1, 2)) @ self.B.transpose(1, 2)
+
+
+class BatchedTTTLoRA(nn.Module):
+    def __init__(self, bsz, model, rank, k_lora=True, mlp_lora=True, o_lora=True,
+                 hash_embed_size=0):
+        super().__init__()
+        self.bsz = bsz
+        dim = model.qo_bank.shape[-1]
+        vocab = model.tok_emb.num_embeddings
+        if getattr(model, "looping_active", False):
+            num_slots = len(model.encoder_indices) + len(model.decoder_indices)
+        else:
+            num_slots = len(model.blocks)
+        kv_dim = model.blocks[0].attn.num_kv_heads * (
+            dim // model.blocks[0].attn.num_heads
+        )
+        embed_dim = model.tok_emb.embedding_dim
+        self.lm_head_lora = BatchedLinearLoRA(bsz, embed_dim, vocab, rank)
+        self.q_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+        )
+        self.v_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+        )
+        self.k_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+            )
+            if k_lora
+            else None
+        )
+        self.mlp_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if mlp_lora
+            else None
+        )
+        self.o_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if o_lora
+            else None
+        )
+        self.hash_embed_size = hash_embed_size
+        if hash_embed_size > 0:
+            self.hash_embed = nn.Embedding(hash_embed_size, dim)
+            nn.init.zeros_(self.hash_embed.weight)
+        else:
+            self.hash_embed = None
+
+    def hash_embed_forward(self, input_ids):
+        if self.hash_embed is None:
+            return None
+        prev = torch.zeros_like(input_ids)
+        prev[:, 1:] = input_ids[:, :-1]
+        h_idx = (prev * 2039 + input_ids) % self.hash_embed_size
+        return self.hash_embed(h_idx)
+
+    def reset(self):
+        with torch.no_grad():
+            self.lm_head_lora.reset()
+            for loras in [self.q_loras, self.v_loras, self.k_loras,
+                          self.mlp_loras, self.o_loras]:
+                if loras is not None:
+                    for lora in loras:
+                        lora.reset()
+            if self.hash_embed is not None:
+                self.hash_embed.weight.zero_()
+
+
+def classify_param(name):
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or ".proj." in name and ".mlp." not in name:
+        return "attn"
+    return "other"
+
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps=10, eps=1e-07):
+    a, b, c = 3.4445, -4.775, 2.0315
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr,
+        momentum,
+        backend_steps,
+        nesterov=True,
+        weight_decay=0.0,
+        row_normalize=False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append({
+                    "p": p,
+                    "B": B,
+                    "padded_grad": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard_mom": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "full_update": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "scale": max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                })
+        self._bank_meta.sort(key=lambda m: -m["p"].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m["p"]
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m["padded_grad"]
+            pg[: m["B"]].copy_(p.grad.bfloat16())
+            if pg.shape[0] > m["B"]:
+                pg[m["B"] :].zero_()
+            fut = dist.reduce_scatter_tensor(
+                m["shard"], pg, op=dist.ReduceOp.AVG, async_op=True
+            )
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        if not self._built:
+            self._build()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+            row_normalize = group.get("row_normalize", False)
+            prev_ag_handle = None
+            prev_m = None
+            sharded = self._distributed and hasattr(self, "_rs_futures")
+            for idx, m in enumerate(self._bank_meta):
+                p = m["p"]
+                if p.grad is None:
+                    continue
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m["p"]
+                    upd = prev_m["full_update"][: prev_m["B"]]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+                if sharded and self._rs_futures[idx] is not None:
+                    self._rs_futures[idx].wait()
+                    g = m["shard"]
+                    buf = m["shard_mom"]
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+                if row_normalize:
+                    rn = update.float().norm(dim=-1, keepdim=True).clamp_min(1e-07)
+                    update = update / rn.to(update.dtype)
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m["full_update"], update, async_op=True
+                    )
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update.to(dtype=p.dtype), alpha=-lr * m["scale"])
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m["p"]
+                upd = prev_m["full_update"][: prev_m["B"]]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+            if hasattr(self, "_rs_futures"):
+                del self._rs_futures
+        return loss
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,parallel_post_lambdas,parallel_resid_lambdas",
+    ).split(",")
+    if pattern
+)
+
+
+PACKED_REPLICATED_GRAD_MAX_NUMEL = 1 << 15
+
+
+class Optimizers:
+    def __init__(self, h, base_model):
+        matrix_params = [
+            base_model.qo_bank,
+            base_model.kv_bank,
+            base_model.mlp_up_bank,
+            base_model.mlp_down_bank,
+        ]
+        block_named_params = list(base_model.blocks.named_parameters())
+        scalar_params = [
+            p
+            for (name, p) in block_named_params
+            if p.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        if base_model.skip_weights.numel() > 0:
+            scalar_params.append(base_model.skip_weights)
+        if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
+            scalar_params.append(base_model.skip_gates)
+        if base_model.parallel_post_lambdas is not None:
+            scalar_params.append(base_model.parallel_post_lambdas)
+        if base_model.parallel_resid_lambdas is not None:
+            scalar_params.append(base_model.parallel_resid_lambdas)
+        token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
+        tok_params = [
+            {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+        ]
+        self.optimizer_tok = torch.optim.AdamW(
+            tok_params,
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.embed_wd,
+            fused=True,
+        )
+        self.optimizer_muon = Muon(
+            matrix_params,
+            lr=h.matrix_lr,
+            momentum=h.muon_momentum,
+            backend_steps=h.muon_backend_steps,
+            weight_decay=h.muon_wd,
+            row_normalize=h.muon_row_normalize,
+        )
+        for group in self.optimizer_muon.param_groups:
+            group["base_lr"] = h.matrix_lr
+        self.optimizer_scalar = torch.optim.AdamW(
+            [{"params": scalar_params, "lr": h.scalar_lr, "base_lr": h.scalar_lr}],
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.adam_wd,
+            fused=True,
+        )
+        self.optimizers = [
+            self.optimizer_tok,
+            self.optimizer_muon,
+            self.optimizer_scalar,
+        ]
+        if base_model.lm_head is not None:
+            self.optimizer_head = torch.optim.Adam(
+                [
+                    {
+                        "params": [base_model.lm_head.weight],
+                        "lr": h.head_lr,
+                        "base_lr": h.head_lr,
+                    }
+                ],
+                betas=(h.beta1, h.beta2),
+                eps=h.adam_eps,
+                fused=True,
+            )
+            self.optimizers.insert(1, self.optimizer_head)
+        else:
+            self.optimizer_head = None
+        self.replicated_params = list(tok_params[0]["params"])
+        self.replicated_params.extend(scalar_params)
+        if base_model.lm_head is not None:
+            self.replicated_params.append(base_model.lm_head.weight)
+        self.replicated_large_params = []
+        self.replicated_packed_params = []
+        for p in self.replicated_params:
+            if p.numel() <= PACKED_REPLICATED_GRAD_MAX_NUMEL:
+                self.replicated_packed_params.append(p)
+            else:
+                self.replicated_large_params.append(p)
+
+    def __iter__(self):
+        return iter(self.optimizers)
+
+    def zero_grad_all(self):
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    def _all_reduce_packed_grads(self):
+        grads_by_key = collections.defaultdict(list)
+        for p in self.replicated_packed_params:
+            if p.grad is not None:
+                grads_by_key[(p.grad.device, p.grad.dtype)].append(p.grad)
+        for grads in grads_by_key.values():
+            flat = torch.empty(
+                sum(g.numel() for g in grads),
+                device=grads[0].device,
+                dtype=grads[0].dtype,
+            )
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                flat[offset : offset + n].copy_(g.contiguous().view(-1))
+                offset += n
+            dist.all_reduce(flat, op=dist.ReduceOp.AVG)
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                g.copy_(flat[offset : offset + n].view_as(g))
+                offset += n
+
+    def step(self, distributed=False):
+        self.optimizer_muon.launch_reduce_scatters()
+        if distributed:
+            reduce_handles = [
+                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG, async_op=True)
+                for p in self.replicated_large_params
+                if p.grad is not None
+            ]
+            self._all_reduce_packed_grads()
+            for handle in reduce_handles:
+                handle.wait()
+        self.optimizer_tok.step()
+        self.optimizer_scalar.step()
+        if self.optimizer_head is not None:
+            self.optimizer_head.step()
+        self.optimizer_muon.step()
+        self.zero_grad_all()
+
+
+def restore_fp32_params(model):
+    for module in model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    for name, param in model.named_parameters():
+        if (
+            param.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ) and param.dtype != torch.float32:
+            param.data = param.data.float()
+    if hasattr(model, "qo_bank"):
+        model.qo_bank.data = model.qo_bank.data.float()
+        model.kv_bank.data = model.kv_bank.data.float()
+        model.mlp_up_bank.data = model.mlp_up_bank.data.float()
+        model.mlp_down_bank.data = model.mlp_down_bank.data.float()
+
+
+def collect_hessians(model, train_loader, h, device, n_calibration_batches=64):
+    hessians = {}
+    hooks = []
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = True
+        block.mlp._calib = True
+        block.mlp.use_fused = False
+
+    def make_attn_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            for suffix in ["c_q", "c_k", "c_v"]:
+                name = f"blocks.{layer_idx}.attn.{suffix}.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            y = module._last_proj_input
+            if y is not None:
+                y = y.float()
+                if y.ndim == 3:
+                    y = y.reshape(-1, y.shape[-1])
+                name = f"blocks.{layer_idx}.attn.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        y.shape[1], y.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(y.T, y)
+        return hook_fn
+
+    def make_mlp_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            name = f"blocks.{layer_idx}.mlp.fc.weight"
+            if name not in hessians:
+                hessians[name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[name].addmm_(x.T, x)
+            h_act = module._last_down_input
+            if h_act is not None:
+                h_act = h_act.float()
+                if h_act.ndim == 3:
+                    h_act = h_act.reshape(-1, h_act.shape[-1])
+                name = f"blocks.{layer_idx}.mlp.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        h_act.shape[1], h_act.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(h_act.T, h_act)
+        return hook_fn
+
+    for i, block in enumerate(model.blocks):
+        hooks.append(block.attn.register_forward_hook(make_attn_hook(i)))
+        hooks.append(block.mlp.register_forward_hook(make_mlp_hook(i)))
+    if model.tie_embeddings:
+        hook_module = (
+            model.head_proj if model.head_proj is not None else model.final_norm
+        )
+
+        def make_output_hook(name):
+            def hook_fn(module, inp, out):
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            return hook_fn
+
+        hooks.append(
+            hook_module.register_forward_hook(make_output_hook("tok_emb.weight"))
+        )
+    model.eval()
+    with torch.no_grad():
+        for _ in range(n_calibration_batches):
+            x, _ = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+            model.forward_logits(x)
+    for hook in hooks:
+        hook.remove()
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = False
+        block.mlp._calib = False
+        block.mlp.use_fused = True
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / n_calibration_batches
+    return hessians
+
+
+def gptq_quantize_weight(w, H, clip_sigmas=3.0, clip_range=63, block_size=128):
+    W_orig = w.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * H.diag().mean()
+    H.diagonal().add_(damp)
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+    Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    row_std = W_orig.std(dim=1)
+    s = (clip_sigmas * row_std / clip_range).clamp_min(1e-10).to(torch.float16)
+    sf = s.float()
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    W_work = W_perm.clone()
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W_work[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros(rows, i2 - i1)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            d = Hinv_block[j, j]
+            q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - q_col.float() * sf) / d
+            Err[:, j] = err
+            W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+        if i2 < cols:
+            W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+    return Q[:, invperm], s
+
+
+def gptq_mixed_quantize(state_dict, hessians, h):
+    result = {}
+    meta = {}
+    for (name, tensor) in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough (float16)"
+            continue
+        cs = h.embed_clip_sigmas if "tok_emb" in name else h.matrix_clip_sigmas
+        bits = h.embed_bits if "tok_emb" in name else h.matrix_bits
+        q, s = gptq_quantize_weight(
+            t, hessians[name], clip_sigmas=cs, clip_range=2 ** (bits - 1) - 1
+        )
+        result[name + ".q"] = q
+        result[name + ".scale"] = s
+        meta[name] = f"gptq (int{bits})"
+    categories = collections.defaultdict(set)
+    for (name, cat) in meta.items():
+        short = re.sub("\\.\\d+$", "", re.sub("blocks\\.\\d+", "blocks", name))
+        categories[cat].add(short)
+    log("Quantized weights:")
+    for cat in sorted(categories):
+        log(f"  {cat}: {', '.join(sorted(categories[cat]))}")
+    return result, meta
+
+
+def dequantize_mixed(result, meta, template_sd):
+    out = {}
+    for (name, orig) in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if "passthrough" in info:
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (
+                q.float() * s.float().view(q.shape[0], *[1] * (q.ndim - 1))
+            ).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+_BSHF_MAGIC = b"BSHF"
+
+
+def _byte_shuffle(data, stride=2):
+    if stride <= 1 or len(data) < stride:
+        return data
+    src = np.frombuffer(data, dtype=np.uint8)
+    n = len(src)
+    out = np.empty(n, dtype=np.uint8)
+    dest_off = 0
+    for pos in range(stride):
+        chunk = src[pos::stride]
+        out[dest_off : dest_off + len(chunk)] = chunk
+        dest_off += len(chunk)
+    return _BSHF_MAGIC + bytes([stride]) + out.tobytes()
+
+
+def _byte_unshuffle(data):
+    if len(data) < 5 or data[:4] != _BSHF_MAGIC:
+        return data
+    stride = data[4]
+    if stride < 2:
+        return data[5:]
+    payload = np.frombuffer(data, dtype=np.uint8, offset=5)
+    n = len(payload)
+    out = np.empty(n, dtype=np.uint8)
+    src_off = 0
+    for pos in range(stride):
+        chunk_len = n // stride + (1 if pos < n % stride else 0)
+        out[pos::stride][:chunk_len] = payload[src_off : src_off + chunk_len]
+        src_off += chunk_len
+    return out.tobytes()
+
+
+def _compress(data, compressor):
+    data = _byte_shuffle(data)
+    if compressor == "lzma":
+        return lzma.compress(data, preset=6)
+    elif compressor == "brotli":
+        import brotli
+
+        return brotli.compress(data, quality=11)
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def _decompress(data, compressor):
+    if compressor == "lzma":
+        raw = lzma.decompress(data)
+    elif compressor == "brotli":
+        import brotli
+
+        raw = brotli.decompress(data)
+    else:
+        raise ValueError(f"Unknown compressor: {compressor!r}")
+    raw = _byte_unshuffle(raw)
+    return raw
+
+
+def _unbank_state_dict(state_dict, num_layers):
+    sd = {}
+    n = num_layers
+    for k, v in state_dict.items():
+        t = v.detach().cpu()
+        if k == "qo_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_q.weight"] = t[i]
+                sd[f"blocks.{i}.attn.proj.weight"] = t[n + i]
+        elif k == "kv_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_k.weight"] = t[i]
+                sd[f"blocks.{i}.attn.c_v.weight"] = t[n + i]
+        elif k == "mlp_up_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.fc.weight"] = t[i]
+        elif k == "mlp_down_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.proj.weight"] = t[i]
+        else:
+            sd[k] = t
+    return sd
+
+
+def _rebank_state_dict(flat_sd, num_layers, model_dim, kv_dim, hidden_dim):
+    sd = {}
+    n = num_layers
+    sd["qo_bank"] = torch.zeros(2 * n, model_dim, model_dim)
+    sd["kv_bank"] = torch.zeros(2 * n, kv_dim, model_dim)
+    sd["mlp_up_bank"] = torch.zeros(n, hidden_dim, model_dim)
+    sd["mlp_down_bank"] = torch.zeros(n, model_dim, hidden_dim)
+    for i in range(n):
+        sd["qo_bank"][i] = flat_sd[f"blocks.{i}.attn.c_q.weight"]
+        sd["qo_bank"][n + i] = flat_sd[f"blocks.{i}.attn.proj.weight"]
+        sd["kv_bank"][i] = flat_sd[f"blocks.{i}.attn.c_k.weight"]
+        sd["kv_bank"][n + i] = flat_sd[f"blocks.{i}.attn.c_v.weight"]
+        sd["mlp_up_bank"][i] = flat_sd[f"blocks.{i}.mlp.fc.weight"]
+        sd["mlp_down_bank"][i] = flat_sd[f"blocks.{i}.mlp.proj.weight"]
+    for k, v in flat_sd.items():
+        if not (
+            k.startswith("blocks.")
+            and any(
+                p in k
+                for p in [
+                    ".attn.c_q.", ".attn.c_k.", ".attn.c_v.",
+                    ".attn.proj.", ".mlp.fc.", ".mlp.proj.",
+                ]
+            )
+        ):
+            sd[k] = v
+    return sd
+
+
+def _compressed_code_size(code):
+    code_raw = code.encode("utf-8")
+    minified = subprocess.run(
+        ["pyminify", "--no-rename-locals", "--no-hoist-literals", "--remove-literal-statements", "-"],
+        input=code_raw, capture_output=True, check=True,
+    ).stdout
+    compressed = lzma.compress(minified)
+    encoded = base64.b85encode(compressed)
+    wrapper = b'import lzma as L,base64 as B\nexec(L.decompress(B.b85decode("' + encoded + b'")))\n'
+    return len(code_raw), len(wrapper)
+
+
+def serialize(h, base_model, code):
+    code_bytes_uncompressed, code_bytes = _compressed_code_size(code)
+    if h.is_main_process:
+        torch.save(base_model.state_dict(), h.model_path)
+        model_bytes = os.path.getsize(h.model_path)
+        log(f"Serialized model: {model_bytes} bytes")
+        log(f"Code size (uncompressed): {code_bytes_uncompressed} bytes")
+        log(f"Code size (compressed): {code_bytes} bytes")
+    sd_cpu = _unbank_state_dict(base_model.state_dict(), h.num_layers)
+    device = torch.device("cuda", h.local_rank)
+    log("GPTQ:collecting Hessians from calibration data...")
+    t0 = time.perf_counter()
+    calib_loader = ShuffledSequenceLoader(h, device)
+    hessians = collect_hessians(
+        base_model,
+        calib_loader,
+        h,
+        device,
+        n_calibration_batches=h.gptq_calibration_batches,
+    )
+    log(f"GPTQ:collected {len(hessians)} Hessians in {time.perf_counter()-t0:.1f}s")
+    quant_result, quant_meta = gptq_mixed_quantize(sd_cpu, hessians, h)
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = _compress(quant_raw, h.compressor)
+    quant_file_bytes = len(quant_blob)
+    bytes_total = quant_file_bytes + code_bytes
+    if h.is_main_process:
+        with open(h.quantized_model_path, "wb") as f:
+            f.write(quant_blob)
+        log(f"Serialized model quantized+{h.compressor}: {quant_file_bytes} bytes")
+        log(f"Total submission size quantized+{h.compressor}: {bytes_total} bytes")
+    return bytes_total, quant_file_bytes
+
+
+def deserialize(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    flat_template = _unbank_state_dict(eval_model.state_dict(), h.num_layers)
+    with open(h.quantized_model_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(_decompress(quant_blob_disk, h.compressor)), map_location="cpu"
+    )
+    deq_flat = dequantize_mixed(quant_state["w"], quant_state["m"], flat_template)
+    head_dim = h.model_dim // h.num_heads
+    kv_dim = h.num_kv_heads * head_dim
+    hidden_dim = int(h.mlp_mult * h.model_dim)
+    deq_state = _rebank_state_dict(deq_flat, h.num_layers, h.model_dim, kv_dim, hidden_dim)
+    eval_model.load_state_dict(deq_state, strict=True)
+    return eval_model
+
+
+def _loss_bpb(loss_sum, token_count, byte_count):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    return val_loss, val_bpb
+
+
+def eval_val(h, device, val_data, model, forward_logits_fn=None):
+    seq_len = h.eval_seq_len
+    local_batch_tokens = h.val_batch_tokens // (h.world_size * h.grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            f"VAL_BATCH_SIZE must provide at least one sequence per rank; got VAL_BATCH_SIZE={h.val_batch_tokens}, WORLD_SIZE={h.world_size}, GRAD_ACCUM_STEPS={h.grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = total_seqs * h.rank // h.world_size
+    seq_end = total_seqs * (h.rank + 1) // h.world_size
+
+    # TODO: Don't truncate this.
+    seq_end = seq_start + ((seq_end - seq_start) // local_batch_seqs) * local_batch_seqs
+
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    run_forward_logits = (
+        (model.module.forward_logits if hasattr(model, "module") else model.forward_logits)
+        if forward_logits_fn is None
+        else forward_logits_fn
+    )
+    model.eval()
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    with torch.no_grad():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_data.val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1]
+            y = local[1:]
+            bos_pos = (x == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                bos_pos, x.numel(), x.device, h.eval_seq_len, 64
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = run_forward_logits(
+                    x[None], cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                ).detach()
+            per_token_loss = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y.reshape(-1),
+                reduction="none",
+            )
+            val_loss_sum += per_token_loss.to(torch.float64).sum()
+            val_token_count += float(y.numel())
+            prev_ids = x
+            tgt_ids = y
+            token_bytes = val_data.base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (
+                val_data.has_leading_space_lut[tgt_ids]
+                & ~val_data.is_boundary_token_lut[prev_ids]
+            ).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    model.train()
+    return _loss_bpb(val_loss_sum, val_token_count, val_byte_count)
+
+
+def eval_val_sliding(h, device, val_data, base_model, forward_logits_fn=None, batch_seqs=32):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    run_forward_logits = base_model.forward_logits if forward_logits_fn is None else forward_logits_fn
+    seq_len = h.eval_seq_len
+    stride = h.eval_stride
+    total_tokens = val_data.val_tokens.numel() - 1
+    context_size = seq_len - stride
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if ws + context_size < total_tokens]
+    total_windows = len(window_starts)
+    my_s = (total_windows * h.rank) // h.world_size
+    my_e = (total_windows * (h.rank + 1)) // h.world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    total_batches = (len(my_windows) + batch_seqs - 1) // batch_seqs
+    is_master = h.rank == 0
+    cu_bucket = 64
+    t_sw_start = time.perf_counter()
+    with torch.no_grad():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_idx = bi // batch_seqs
+            if is_master and (batch_idx % 50 == 0 or batch_idx == total_batches - 1):
+                elapsed = time.perf_counter() - t_sw_start
+                rl = float(loss_sum.item() / token_count.item()) if token_count.item() > 0 else 0.0
+                rb = float((rl / math.log(2.0)) * token_count.item() / byte_count.item()) if byte_count.item() > 0 else 0.0
+                log(f"sliding_progress: batch {batch_idx+1}/{total_batches} "
+                    f"tokens:{int(token_count.item())} running_loss:{rl:.4f} running_bpb:{rb:.4f} "
+                    f"elapsed:{elapsed:.1f}s")
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            x_parts = []
+            y_parts = []
+            cu_starts = []
+            score_ranges = []
+            offset = 0
+            for ws in batch_ws:
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                chunk_cpu = val_data.val_tokens[ws:end + 1]
+                bos_pos = (chunk_cpu[:-1] == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+                if not bos_pos or bos_pos[0] != 0:
+                    bos_pos = [0] + bos_pos
+                cu_starts.extend(offset + pos for pos in bos_pos)
+                chunk = chunk_cpu.to(dtype=torch.int64, device=device)
+                x_parts.append(chunk[:-1])
+                y_parts.append(chunk[1:])
+                score_ranges.append((offset, wlen, ws))
+                offset += wlen
+            x_cat = torch.cat(x_parts, dim=0)[None]
+            y_cat = torch.cat(y_parts, dim=0)
+            boundaries = cu_starts + [offset]
+            padded_len = get_next_multiple_of_n(len(boundaries), cu_bucket)
+            cu_seqlens = torch.full((padded_len,), offset, dtype=torch.int32, device=device)
+            cu_seqlens[:len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = run_forward_logits(x_cat, cu_seqlens=cu_seqlens, max_seqlen=seq_len)
+            flat_nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_cat,
+                reduction="none",
+            )
+            flat_x = x_cat.reshape(-1)
+            for off, wlen, ws in score_ranges:
+                s = 0 if ws == 0 else context_size
+                lo = off + s
+                hi = off + wlen
+                scored_nll = flat_nll[lo:hi].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(hi - lo)
+                tgt = y_cat[lo:hi]
+                prev = flat_x[lo:hi]
+                tb = val_data.base_bytes_lut[tgt].to(torch.float64)
+                tb += (val_data.has_leading_space_lut[tgt] & ~val_data.is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    base_model.train()
+    return _loss_bpb(loss_sum, token_count, byte_count)
+
+
+def _find_docs(all_tokens):
+    bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0].numpy()
+    docs = []
+    for i in range(len(bos_positions)):
+        start = int(bos_positions[i])
+        end = (
+            int(bos_positions[i + 1])
+            if i + 1 < len(bos_positions)
+            else all_tokens.numel()
+        )
+        if i + 1 < len(bos_positions):
+            end += 1
+        assert end - start >= 2
+        docs.append((start, end - start))
+    return docs
+
+
+def _build_ttt_global_batches(doc_entries, h, ascending=False):
+    batch_size = h.ttt_batch_size
+    global_doc_entries = sorted(doc_entries, key=lambda x: x[1][1])
+    global_batches = [
+        global_doc_entries[i : i + batch_size]
+        for i in range(0, len(global_doc_entries), batch_size)
+    ]
+    indexed = list(enumerate(global_batches))
+    if not ascending:
+        indexed.sort(key=lambda ib: -max(dl for _, (_, dl) in ib[1]))
+    return indexed
+
+
+def _init_batch_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(4, "little"))
+
+
+def _claim_next_batch(counter_path, queue_len):
+    try:
+        with open(counter_path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            idx = int.from_bytes(f.read(4), "little")
+            f.seek(0)
+            f.write((idx + 1).to_bytes(4, "little"))
+            f.flush()
+    except FileNotFoundError:
+        return queue_len
+    return idx
+
+
+def _compute_chunk_window(ci, pred_len, num_chunks, chunk_size, eval_seq_len):
+    chunk_end = pred_len if ci == num_chunks - 1 else (ci + 1) * chunk_size
+    win_start = max(0, chunk_end - eval_seq_len)
+    win_len = chunk_end - win_start
+    chunk_start = ci * chunk_size
+    chunk_offset = chunk_start - win_start
+    chunk_len = chunk_end - chunk_start
+    return win_start, win_len, chunk_offset, chunk_len
+
+
+def _accumulate_bpb(
+    ptl,
+    x,
+    y,
+    chunk_offsets,
+    chunk_lens,
+    pos_idx,
+    base_bytes_lut,
+    has_leading_space_lut,
+    is_boundary_token_lut,
+    loss_sum,
+    byte_sum,
+    token_count,
+):
+    pos = pos_idx[: x.size(1)].unsqueeze(0)
+    mask = (
+        (chunk_lens.unsqueeze(1) > 0)
+        & (pos >= chunk_offsets.unsqueeze(1))
+        & (pos < (chunk_offsets + chunk_lens).unsqueeze(1))
+    )
+    mask_f64 = mask.to(torch.float64)
+    tok_bytes = base_bytes_lut[y].to(torch.float64)
+    tok_bytes += (has_leading_space_lut[y] & ~is_boundary_token_lut[x]).to(
+        torch.float64
+    )
+    loss_sum += (ptl.to(torch.float64) * mask_f64).sum()
+    byte_sum += (tok_bytes * mask_f64).sum()
+    token_count += chunk_lens.to(torch.float64).sum()
+
+def eval_val_ttt_lora(h, base_model, device, val_data, forward_ttt_train):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+    all_tokens = val_data.val_tokens
+    all_tokens_idx = all_tokens.to(torch.int32)
+    docs = _find_docs(all_tokens)
+    doc_entries = list(enumerate(docs))
+    if h.val_doc_fraction < 1.0:
+        sample_n = max(1, int(round(len(docs) * h.val_doc_fraction)))
+        sampled_indices = sorted(
+            random.Random(h.seed).sample(range(len(docs)), sample_n)
+        )
+        doc_entries = [(i, docs[i]) for i in sampled_indices]
+    log(
+        f"ttt_lora:docs:{len(doc_entries)} rank:{h.ttt_lora_rank} lr:{h.ttt_lora_lr} chunk:{h.ttt_chunk_size}"
+    )
+    if os.environ.get("TTT_DEBUG_BYPASS") and h.rank == 0:
+        test_doc = doc_entries[0][1]
+        ds, dl = test_doc
+        log(f"DEBUG: test doc start={ds} len={dl}")
+        toks = all_tokens_idx[ds : ds + dl].to(device=device, dtype=torch.int64)
+        x_d = toks[:-1].unsqueeze(0)
+        y_d = toks[1:].unsqueeze(0)
+        with torch.no_grad(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            logits_d = base_model.forward_logits(x_d)
+        ptl_d = F.cross_entropy(
+            logits_d.float().reshape(-1, logits_d.size(-1)),
+            y_d.reshape(-1), reduction="none",
+        )
+        direct_loss = ptl_d.mean().item()
+        direct_bpb = direct_loss / math.log(2.0)
+        log(f"DEBUG: direct forward_logits loss={direct_loss:.6f} bpb={direct_bpb:.6f} ntokens={y_d.numel()}")
+        toks_first5 = toks[:5].tolist()
+        ptl_first5 = ptl_d[:5].tolist()
+        log(f"DEBUG: first 5 tokens={toks_first5} ptl={[f'{v:.4f}' for v in ptl_first5]}")
+    chunk_size, eval_seq_len = h.ttt_chunk_size, h.ttt_eval_seq_len
+    eval_batch_set = None
+    if h.ttt_eval_batches:
+        eval_batch_set = set(int(x) for x in h.ttt_eval_batches.split(",") if x.strip())
+    use_ascending = eval_batch_set is not None
+    global_batches_sorted = _build_ttt_global_batches(doc_entries, h, ascending=use_ascending)
+    queue_len = len(global_batches_sorted)
+    counter_path = f"/tmp/ttt_counter_{h.run_id}"
+    if h.rank == 0:
+        _init_batch_counter(counter_path)
+    if dist.is_available() and dist.is_initialized():
+        path_list = [counter_path]
+        dist.broadcast_object_list(path_list, src=0)
+        counter_path = path_list[0]
+        dist.barrier()
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    t_start = time.perf_counter()
+    local_batch_count = 0
+    reusable_lora = BatchedTTTLoRA(
+        h.ttt_batch_size, base_model, h.ttt_lora_rank,
+        k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+        hash_embed_size=h.ttt_hash_embed_size,
+    ).to(device)
+
+    def _build_opt(lora):
+        if h.ttt_optimizer == "sgd":
+            return torch.optim.SGD(
+                lora.parameters(), lr=h.ttt_lora_lr,
+                momentum=h.ttt_beta1, weight_decay=h.ttt_weight_decay,
+            )
+        return torch.optim.AdamW(
+            lora.parameters(), lr=h.ttt_lora_lr,
+            betas=(h.ttt_beta1, h.ttt_beta2),
+            eps=1e-10, weight_decay=h.ttt_weight_decay, fused=True,
+        )
+
+    reusable_opt = _build_opt(reusable_lora)
+    progress_f = None
+    if h.ttt_output_dir and h.rank == 0:
+        os.makedirs(h.ttt_output_dir, exist_ok=True)
+        progress_f = open(os.path.join(h.ttt_output_dir, "progress.jsonl"), "w")
+    try:
+      while True:
+        queue_idx = _claim_next_batch(counter_path, queue_len)
+        if queue_idx >= queue_len:
+            break
+        orig_batch_idx, batch_entries = global_batches_sorted[queue_idx]
+        batch = [doc for _, doc in batch_entries]
+        bsz = len(batch)
+        prev_loss = loss_sum.item()
+        prev_bytes = byte_sum.item()
+        prev_tokens = token_count.item()
+        if bsz == reusable_lora.bsz:
+            reusable_lora.reset()
+            for s in reusable_opt.state.values():
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor):
+                        v.zero_()
+                    elif k == "step":
+                        s[k] = 0
+            cur_lora = reusable_lora
+            cur_opt = reusable_opt
+        else:
+            cur_lora = BatchedTTTLoRA(
+                bsz, base_model, h.ttt_lora_rank,
+                k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+                hash_embed_size=h.ttt_hash_embed_size,
+            ).to(device)
+            cur_opt = _build_opt(cur_lora)
+        pred_lens = [doc_len - 1 for _, doc_len in batch]
+        num_chunks = [(pl + chunk_size - 1) // chunk_size for pl in pred_lens]
+        max_nc = max(num_chunks)
+        num_chunks_t = torch.tensor(num_chunks, dtype=torch.int64, device=device)
+        for ci in range(max_nc):
+            active = [ci < nc for nc in num_chunks]
+            needs_train = any(ci < nc - 1 for nc in num_chunks)
+            tok_starts = torch.zeros(bsz, dtype=torch.int64)
+            tok_wls = torch.zeros(bsz, dtype=torch.int64)
+            chunk_offsets_cpu = torch.zeros(bsz, dtype=torch.int64)
+            chunk_lens_cpu = torch.zeros(bsz, dtype=torch.int64)
+            for b in range(bsz):
+                if not active[b]:
+                    continue
+                doc_start, doc_len = batch[b]
+                win_start, win_len, chunk_offset, chunk_len = _compute_chunk_window(
+                    ci, pred_lens[b], num_chunks[b], chunk_size, eval_seq_len
+                )
+                tok_starts[b] = doc_start + win_start
+                tok_wls[b] = win_len
+                chunk_offsets_cpu[b] = chunk_offset
+                chunk_lens_cpu[b] = chunk_len
+            _, context_size, chunk_offset, _ = _compute_chunk_window(
+                ci, (ci + 1) * chunk_size, ci + 1, chunk_size, eval_seq_len
+            )
+            col_idx = torch.arange(context_size + 1)
+            idx = tok_starts.unsqueeze(1) + col_idx.unsqueeze(0)
+            idx.clamp_(max=all_tokens.numel() - 1)
+            gathered_gpu = all_tokens_idx[idx].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            valid = (col_idx[:context_size].unsqueeze(0) < tok_wls.unsqueeze(1)).to(
+                device, non_blocking=True
+            )
+            chunk_offsets = chunk_offsets_cpu.to(device, non_blocking=True)
+            chunk_lens = chunk_lens_cpu.to(device, non_blocking=True)
+            x = torch.where(valid, gathered_gpu[:, :context_size], 0)
+            y = torch.where(valid, gathered_gpu[:, 1 : context_size + 1], 0)
+            ctx_pos = torch.arange(context_size, device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+            with torch.no_grad():
+                _accumulate_bpb(
+                    per_tok_loss,
+                    x,
+                    y,
+                    chunk_offsets,
+                    chunk_lens,
+                    ctx_pos,
+                    val_data.base_bytes_lut,
+                    val_data.has_leading_space_lut,
+                    val_data.is_boundary_token_lut,
+                    loss_sum,
+                    byte_sum,
+                    token_count,
+                )
+            if needs_train:
+                activate_chunk_mask = (num_chunks_t - 1 > ci).float()
+                for gi in range(h.ttt_grad_steps):
+                    if gi > 0:
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+                    per_doc = per_tok_loss[
+                        :, chunk_offset : chunk_offset + chunk_size
+                    ].mean(dim=-1)
+                    cur_opt.zero_grad(set_to_none=True)
+                    (per_doc * activate_chunk_mask).sum().backward()
+                    cur_opt.step()
+            else:
+                del per_tok_loss
+        local_batch_count += 1
+        batch_num = orig_batch_idx + 1
+        doc_lens = [dl for _, dl in batch]
+        should_report = False
+        if eval_batch_set is not None:
+            should_report = batch_num in eval_batch_set
+        else:
+            # should_report = local_batch_count % 10 == 0
+            should_report = True
+        if should_report:
+            cur_tokens = token_count.item()
+            cur_loss_val = loss_sum.item()
+            cur_bytes_val = byte_sum.item()
+            dt = cur_tokens - prev_tokens
+            if dt > 0:
+                b_loss = (cur_loss_val - prev_loss) / dt
+                b_bpb = b_loss / math.log(2.0) * (dt / (cur_bytes_val - prev_bytes))
+            else:
+                b_loss = b_bpb = 0.0
+            r_loss = cur_loss_val / max(cur_tokens, 1)
+            r_bpb = r_loss / math.log(2.0) * (cur_tokens / max(cur_bytes_val, 1))
+            elapsed = time.perf_counter() - t_start
+            log(
+                f"ttt_progress: batch {batch_num}/{queue_len} batch_loss:{b_loss:.4f} "
+                f"batch_bpb:{b_bpb:.4f} running_loss:{r_loss:.4f} running_bpb:{r_bpb:.4f} "
+                f"doc_len:{min(doc_lens)}-{max(doc_lens)}"
+            )
+            if progress_f is not None:
+                progress_f.write(
+                    json.dumps({
+                        "batch": batch_num, "total_batches": queue_len,
+                        "batch_loss": round(b_loss, 8), "batch_bpb": round(b_bpb, 8),
+                        "running_loss": round(r_loss, 8), "running_bpb": round(r_bpb, 8),
+                        "doc_len_min": min(doc_lens), "doc_len_max": max(doc_lens),
+                        "chunk_size": chunk_size,
+                        "elapsed_s": round(elapsed, 3),
+                        "batch_t_s": round(elapsed, 3),
+                    }) + "\n"
+                )
+                progress_f.flush()
+        del cur_lora, cur_opt
+    finally:
+        if progress_f is not None:
+            progress_f.close()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.train()
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_sum.item())
+    return val_loss, val_bpb
+
+
+def timed_eval(label, fn, *args, **kwargs):
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    val_loss, val_bpb = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    elapsed_ms = 1e3 * (time.perf_counter() - t0)
+    log(
+        f"{label} val_loss:{val_loss:.8f} val_bpb:{val_bpb:.8f} eval_time:{elapsed_ms:.0f}ms"
+    )
+    return val_loss, val_bpb
+
+
+def train_model(h, device, val_data):
+    base_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        base_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    model = compiled_model
+    log(f"model_params:{sum(p.numel()for p in base_model.parameters())}")
+    optimizers = Optimizers(h, base_model)
+    train_loader = DocumentPackingLoader(h, device)
+    max_wallclock_ms = (
+        1e3 * h.max_wallclock_seconds if h.max_wallclock_seconds > 0 else None
+    )
+    if max_wallclock_ms is not None:
+        max_wallclock_ms -= h.gptq_reserve_seconds * 1e3
+        log(
+            f"gptq:reserving {h.gptq_reserve_seconds:.0f}s, effective={max_wallclock_ms:.0f}ms"
+        )
+
+    def training_frac(step, elapsed_ms):
+        if max_wallclock_ms is None:
+            return step / max(h.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-09)
+
+    def lr_mul(frac):
+        if h.warmdown_frac <= 0:
+            return 1.0
+        if frac >= 1.0 - h.warmdown_frac:
+            return max((1.0 - frac) / h.warmdown_frac, h.min_lr)
+        return 1.0
+
+    def step_fn(step, lr_scale):
+        optimizers.zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(h.grad_accum_steps):
+            x, y, cu_seqlens, _max_seqlen = train_loader.next_batch(
+                h.train_batch_tokens, h.grad_accum_steps
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y, cu_seqlens=cu_seqlens, max_seqlen=h.train_seq_len)
+            train_loss += loss.detach()
+            (loss / h.grad_accum_steps).backward()
+        train_loss /= h.grad_accum_steps
+        frac = (
+            min(step / h.muon_momentum_warmup_steps, 1.0)
+            if h.muon_momentum_warmup_steps > 0
+            else 1.0
+        )
+        muon_momentum = (
+            1 - frac
+        ) * h.muon_momentum_warmup_start + frac * h.muon_momentum
+        for group in optimizers.optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * lr_scale
+        if h.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), h.grad_clip_norm)
+        optimizers.step(distributed=h.distributed)
+        return train_loss
+
+    if h.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for (name, tensor) in base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in optimizers
+        ]
+        model.train()
+        num_tokens_local = h.train_batch_tokens // h.world_size
+        for blk in base_model.blocks:
+            blk.attn.rotary(num_tokens_local, device, torch.bfloat16)
+        cu_bucket_size = train_loader.cu_bucket_size
+        warmup_cu_buckets = tuple(cu_bucket_size * i for i in range(1, 5))
+        warmup_cu_iters = 3
+        x, y, cu_seqlens, _ = train_loader.next_batch(
+            h.train_batch_tokens, h.grad_accum_steps
+        )
+        log(f"warmup_cu_buckets:{','.join(str(b) for b in warmup_cu_buckets)} iters_each:{warmup_cu_iters}")
+        def _run_cu_bucket_warmup():
+            for bucket_len in warmup_cu_buckets:
+                boundaries = list(range(0, x.size(1), max(h.train_seq_len, 1)))
+                if boundaries[-1] != x.size(1):
+                    boundaries.append(x.size(1))
+                cu = torch.full((bucket_len,), x.size(1), dtype=torch.int32, device=device)
+                cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+                for _ in range(warmup_cu_iters):
+                    optimizers.zero_grad_all()
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                        wloss = model(x, y, cu_seqlens=cu, max_seqlen=h.train_seq_len)
+                    (wloss / h.grad_accum_steps).backward()
+            optimizers.zero_grad_all()
+        _run_cu_bucket_warmup()
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            _run_cu_bucket_warmup()
+            base_model.looping_active = False
+        for warmup_step in range(h.warmup_steps):
+            step_fn(warmup_step, 1.0)
+            if (
+                warmup_step <= 5
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == h.warmup_steps
+            ):
+                log(f"warmup_step: {warmup_step+1}/{h.warmup_steps}")
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            log(
+                f"loop_warmup:enabled encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            for warmup_step in range(h.warmup_steps):
+                step_fn(warmup_step, 1.0)
+                if (
+                    warmup_step <= 5
+                    or (warmup_step + 1) % 10 == 0
+                    or warmup_step + 1 == h.warmup_steps
+                ):
+                    log(f"loop_warmup_step: {warmup_step+1}/{h.warmup_steps}")
+            base_model.looping_active = False
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for (opt, state) in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        optimizers.zero_grad_all()
+        train_loader = DocumentPackingLoader(h, device)
+    ema_state = {
+        name: t.detach().float().clone()
+        for (name, t) in base_model.state_dict().items()
+    }
+    ema_decay = h.ema_decay
+    training_time_ms = 0.0
+    stop_after_step = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = (
+            step == h.iterations
+            or stop_after_step is not None
+            and step >= stop_after_step
+        )
+        should_validate = (
+            last_step or h.val_loss_every > 0 and step % h.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1e3 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                h, device, val_data, model, compiled_forward_logits
+            )
+            log(
+                f"{step}/{h.iterations} val_loss: {val_loss:.4f} val_bpb: {val_bpb:.4f}"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < h.iterations:
+                log(
+                    f"stopping_early: wallclock_cap train_time: {training_time_ms:.0f}ms step: {step}/{h.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        frac = training_frac(step, elapsed_ms)
+        scale = lr_mul(frac)
+        if (
+            h.num_loops > 0
+            and not base_model.looping_active
+            and frac >= h.enable_looping_at
+        ):
+            base_model.looping_active = True
+            log(
+                f"layer_loop:enabled step:{step} frac:{frac:.3f} encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+        train_loss = step_fn(step, scale)
+        with torch.no_grad():
+            for (name, t) in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(
+                    t.detach().float(), alpha=1.0 - ema_decay
+                )
+        step += 1
+        approx_training_time_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        should_log_train = h.train_log_every > 0 and (
+            step <= 5 or step % h.train_log_every == 0 or stop_after_step is not None
+        )
+        if should_log_train:
+            tok_per_sec = step * h.train_batch_tokens / (approx_training_time_ms / 1e3)
+            log(
+                f"{step}/{h.iterations} train_loss: {train_loss.item():.4f} train_time: {approx_training_time_ms/60000:.1f}m tok/s: {tok_per_sec:.0f}"
+            )
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if h.distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated()//1024//1024} MiB reserved: {torch.cuda.max_memory_reserved()//1024//1024} MiB"
+    )
+    log("ema:applying EMA weights")
+    current_state = base_model.state_dict()
+    avg_state = {
+        name: t.to(dtype=current_state[name].dtype) for (name, t) in ema_state.items()
+    }
+    base_model.load_state_dict(avg_state, strict=True)
+    return base_model, compiled_model, compiled_forward_logits
+
+
+def train_and_eval(h, device):
+    random.seed(h.seed)
+    np.random.seed(h.seed)
+    torch.manual_seed(h.seed)
+    torch.cuda.manual_seed_all(h.seed)
+    if h.artifact_dir and h.is_main_process:
+        os.makedirs(h.artifact_dir, exist_ok=True)
+    val_data = ValidationData(h, device)
+    if h.eval_only_path:
+        log(f"eval_only:loading checkpoint from {h.eval_only_path}")
+        base_model = GPT(h).to(device).bfloat16()
+        restore_fp32_params(base_model)
+        base_model.load_state_dict(torch.load(h.eval_only_path, map_location=device))
+        if h.num_loops > 0:
+            base_model.looping_active = True
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+        compiled_forward_logits = torch.compile(
+            base_model.forward_logits, dynamic=False, fullgraph=True
+        )
+    else:
+        log(
+            f"train_shards: {len(list(Path(h.datasets_dir).resolve().glob('fineweb_train_*.bin')))}"
+        )
+        log(f"val_tokens: {val_data.val_tokens.numel()-1}")
+        base_model, compiled_model, compiled_forward_logits = train_model(
+            h, device, val_data
+        )
+    _skip_training = bool(h.eval_only_path)
+    torch._dynamo.reset()
+    timed_eval(
+        "diagnostic pre-quantization post-ema",
+        eval_val,
+        h,
+        device,
+        val_data,
+        compiled_model,
+        compiled_forward_logits,
+    )
+    if not _skip_training:
+        serialize(h, base_model, Path(__file__).read_text(encoding="utf-8"))
+    else:
+        log("eval_only: skipping serialize (already have quantized model)")
+        if not os.path.exists(h.quantized_model_path):
+            log("eval_only: no quantized model found, running serialize anyway")
+            serialize(h, base_model, Path(__file__).read_text(encoding="utf-8"))
+    if h.distributed:
+        dist.barrier()
+    eval_model = deserialize(h, device)
+    if h.num_loops > 0:
+        eval_model.looping_active = True
+    compiled_model = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        eval_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    timed_eval(
+        "diagnostic quantized",
+        eval_val,
+        h,
+        device,
+        val_data,
+        compiled_model,
+        compiled_forward_logits,
+    )
+    if h.sliding_window_enabled:
+        timed_eval(
+            "diagnostic quantized_sliding_window",
+            eval_val_sliding,
+            h,
+            device,
+            val_data,
+            eval_model,
+            forward_logits_fn=compiled_forward_logits,
+        )
+    if h.ttt_enabled:
+        del eval_model, compiled_model
+        torch._dynamo.reset()
+        torch.cuda.empty_cache()
+        ttt_model = deserialize(h, device)
+        if h.num_loops > 0:
+            ttt_model.looping_active = True
+        for p in ttt_model.parameters():
+            p.requires_grad_(False)
+        if h.ttt_hash_embed_size > 0:
+            for block in ttt_model.blocks:
+                block.mlp.use_fused = False
+            log("ttt_lora: hash embed active, disabling fused MLP for lower backward memory")
+
+        if h.rope_yarn:
+            _yarn_seqlen = h.train_batch_tokens // h.grad_accum_steps
+            for block in ttt_model.blocks:
+                block.attn.rotary(_yarn_seqlen, device, torch.bfloat16)
+        else:
+            for block in ttt_model.blocks:
+                block.attn.rotary._cos_cached = None
+                block.attn.rotary._sin_cached = None
+                block.attn.rotary._seq_len_cached = 0
+                block.attn.rotary(h.ttt_eval_seq_len, device, torch.bfloat16)
+
+        def _fwd_ttt_inner(input_ids, target_ids, lora, hash_out=None):
+            return ttt_model.forward_ttt(input_ids, target_ids, lora=lora, hash_out=hash_out)
+
+        _fwd_ttt_compiled_inner = None
+
+        def _fwd_ttt(input_ids, target_ids, lora):
+            nonlocal _fwd_ttt_compiled_inner
+            hash_out = lora.hash_embed_forward(input_ids)
+            if _fwd_ttt_compiled_inner is None:
+                _fwd_ttt_compiled_inner = torch.compile(_fwd_ttt_inner, dynamic=True)
+            return _fwd_ttt_compiled_inner(input_ids, target_ids, lora=lora, hash_out=hash_out)
+
+        _ttt_debug_bypass = bool(os.environ.get("TTT_DEBUG_BYPASS"))
+        if _ttt_debug_bypass:
+            def _fwd_ttt_bypass(input_ids, target_ids, lora):
+                logits = ttt_model.forward_logits(input_ids)
+                dummy = lora.q_loras[0].B.sum() * 0
+                logits = logits + dummy
+                bsz, sl, V = logits.shape
+                return F.cross_entropy(
+                    logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none"
+                ).reshape(bsz, sl)
+            fwd_ttt_compiled = _fwd_ttt_bypass
+            log("ttt_lora:DEBUG BYPASS active - using forward_logits directly (no compile warmup)")
+        else:
+            fwd_ttt_compiled = _fwd_ttt
+            log(f"ttt_lora:warming up compile")
+            global BOS_ID
+            if BOS_ID is None:
+                BOS_ID = 1
+            ds0 = 0
+            val_tokens_idx = val_data.val_tokens.to(torch.int32)
+            t_warmup = time.perf_counter()
+            warmup_bszes = [h.ttt_batch_size]
+            for bsz in warmup_bszes:
+                wl = BatchedTTTLoRA(
+                    bsz, ttt_model, h.ttt_lora_rank,
+                    k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+                    hash_embed_size=h.ttt_hash_embed_size,
+                ).to(device)
+                wo = torch.optim.AdamW(
+                    wl.parameters(),
+                    lr=h.ttt_lora_lr,
+                    betas=(h.ttt_beta1, h.ttt_beta2),
+                    eps=1e-10,
+                    weight_decay=h.ttt_weight_decay,
+                    fused=True,
+                )
+                for ctx_len in (h.ttt_chunk_size, h.ttt_eval_seq_len):
+                    col_w = torch.arange(ctx_len + 1)
+                    idx_w = (ds0 + col_w).clamp_(max=val_data.val_tokens.numel() - 1)
+                    row_w = val_tokens_idx[idx_w].to(device=device, dtype=torch.int64)
+                    xw = row_w[:ctx_len].unsqueeze(0).expand(bsz, -1).contiguous()
+                    yw = row_w[1 : ctx_len + 1].unsqueeze(0).expand(bsz, -1).contiguous()
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        ptl = fwd_ttt_compiled(xw, yw, lora=wl)
+                    ptl[:, : min(h.ttt_chunk_size, ctx_len)].mean(dim=-1).sum().backward()
+                    wo.step()
+                    wo.zero_grad(set_to_none=True)
+                del wl, wo
+            del val_tokens_idx
+            torch.cuda.empty_cache()
+            compile_elapsed = time.perf_counter() - t_warmup
+            log(f"ttt_lora:compile warmup done ({compile_elapsed:.1f}s)")
+        log("\nbeginning TTT eval timer")
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_val_loss, ttt_val_bpb = eval_val_ttt_lora(
+            h, ttt_model, device, val_data, forward_ttt_train=fwd_ttt_compiled
+        )
+        torch.cuda.synchronize()
+        ttt_eval_elapsed = time.perf_counter() - t_ttt
+        log(
+            f"quantized_ttt_lora val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f} eval_time:{1e3*ttt_eval_elapsed:.0f}ms"
+        )
+        log(f"total_eval_time:{ttt_eval_elapsed:.1f}s")
+        del ttt_model
+
+
+def main():
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    torch._dynamo.config.optimize_ddp = False
+    torch._dynamo.config.cache_size_limit = 16
+    h = Hyperparameters()
+    set_logging_hparams(h)
+    if h.is_main_process:
+        os.makedirs(h.artifact_dir if h.artifact_dir else "logs", exist_ok=True)
+        log(100 * "=", console=False)
+        log("Hyperparameters:", console=True)
+        for (k, v) in sorted(vars(type(h)).items()):
+            if not k.startswith("_"):
+                log(f"  {k}: {v}", console=True)
+        log("=" * 100, console=False)
+        log("Source code:", console=False)
+        log("=" * 100, console=False)
+        with open(__file__, "r", encoding="utf-8") as _src:
+            log(_src.read(), console=False)
+        log("=" * 100, console=False)
+        log(f"Running Python {sys.version}", console=False)
+        log(f"Running PyTorch {torch.__version__}", console=False)
+        log(
+            subprocess.run(
+                ["nvidia-smi"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            ).stdout,
+            console=False,
+        )
+        log("=" * 100, console=False)
+    train_and_eval(h, device)
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
 Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
 Running PyTorch 2.9.1+cu128
-Fri Apr 10 22:14:34 2026       
+Sat Apr 11 16:56:34 2026       
 +-----------------------------------------------------------------------------------------+
 | NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
 |-----------------------------------------+------------------------+----------------------+
@@ -112,15 +3055,15 @@ Fri Apr 10 22:14:34 2026
 |                                         |                        |               MIG M. |
 |=========================================+========================+======================|
 |   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
-| N/A   51C    P0            128W /  700W |    1519MiB /  81559MiB |      2%      Default |
+| N/A   41C    P0            122W /  700W |    1519MiB /  81559MiB |      2%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
-| N/A   40C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+| N/A   39C    P0            124W /  700W |    1519MiB /  81559MiB |      2%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
-| N/A   43C    P0            120W /  700W |    1519MiB /  81559MiB |      2%      Default |
+| N/A   42C    P0            131W /  700W |    1519MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
@@ -128,19 +3071,19 @@ Fri Apr 10 22:14:34 2026
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
-| N/A   44C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+| N/A   42C    P0            125W /  700W |    1519MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
-| N/A   37C    P0            118W /  700W |    1519MiB /  81559MiB |      0%      Default |
+| N/A   37C    P0            114W /  700W |    1519MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
-| N/A   39C    P0            121W /  700W |    1519MiB /  81559MiB |      0%      Default |
+| N/A   40C    P0            130W /  700W |    1519MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
-| N/A   37C    P0            117W /  700W |    1519MiB /  81559MiB |      0%      Default |
+| N/A   39C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
                                                                                          
@@ -149,21 +3092,21 @@ Fri Apr 10 22:14:34 2026
 |  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
 |        ID   ID                                                               Usage      |
 |=========================================================================================|
-|    0   N/A  N/A         1792890      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    1   N/A  N/A         1792891      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    2   N/A  N/A         1792892      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    3   N/A  N/A         1792893      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    4   N/A  N/A         1792894      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    5   N/A  N/A         1792895      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    6   N/A  N/A         1792896      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    7   N/A  N/A         1792897      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    0   N/A  N/A          444348      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          444349      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          444350      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          444351      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          444352      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          444353      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          444354      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          444355      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
 +-----------------------------------------------------------------------------------------+
 
 ====================================================================================================
 train_shards: 128
 val_tokens: 40540160
-model_params:35944537
-gptq:reserving 12s, effective=588000ms
+model_params:35944602
+gptq:reserving 13s, effective=587000ms
 warmup_cu_buckets:64,128,192,256 iters_each:3
 warmup_step: 1/20
 warmup_step: 2/20
@@ -183,146 +3126,145 @@ loop_warmup_step: 6/20
 loop_warmup_step: 10/20
 loop_warmup_step: 20/20
 0/20000 val_loss: 9.0091 val_bpb: 3.4876
-1/20000 train_loss: 9.0097 train_time: 0.0m tok/s: 18894887
-2/20000 train_loss: 12.2299 train_time: 0.0m tok/s: 13813993
-3/20000 train_loss: 11.1593 train_time: 0.0m tok/s: 11516120
-4/20000 train_loss: 9.5744 train_time: 0.0m tok/s: 10527575
-5/20000 train_loss: 8.2233 train_time: 0.0m tok/s: 10021538
-500/20000 train_loss: 3.2773 train_time: 0.8m tok/s: 8281518
-1000/20000 train_loss: 3.0329 train_time: 1.6m tok/s: 8262698
-1500/20000 train_loss: 3.0365 train_time: 2.4m tok/s: 8257993
-2000/20000 train_loss: 3.0030 train_time: 3.2m tok/s: 8255118
-layer_loop:enabled step:2160 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
-2500/20000 train_loss: 3.0887 train_time: 4.2m tok/s: 7724647
-3000/20000 train_loss: 2.9239 train_time: 5.4m tok/s: 7273098
-3500/20000 train_loss: 2.9865 train_time: 6.6m tok/s: 6982735
-4000/20000 train_loss: 2.9165 train_time: 7.7m tok/s: 6777935
-4000/20000 val_loss: 2.8922 val_bpb: 1.1196
-4500/20000 train_loss: 2.8685 train_time: 8.9m tok/s: 6628194
-4888/20000 val_loss: 2.7778 val_bpb: 1.0753
-stopping_early: wallclock_cap train_time: 588159ms step: 4888/20000
-peak memory allocated: 40019 MiB reserved: 44088 MiB
+1/20000 train_loss: 9.0097 train_time: 0.0m tok/s: 16276462
+2/20000 train_loss: 12.2840 train_time: 0.0m tok/s: 12730797
+3/20000 train_loss: 11.2607 train_time: 0.0m tok/s: 10929352
+4/20000 train_loss: 9.6641 train_time: 0.0m tok/s: 10150086
+5/20000 train_loss: 8.2657 train_time: 0.0m tok/s: 9783877
+500/20000 train_loss: 3.2568 train_time: 0.8m tok/s: 8234914
+1000/20000 train_loss: 3.0095 train_time: 1.6m tok/s: 8197306
+1500/20000 train_loss: 3.0181 train_time: 2.4m tok/s: 8200891
+2000/20000 train_loss: 2.9777 train_time: 3.2m tok/s: 8199735
+layer_loop:enabled step:2143 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2500/20000 train_loss: 3.0624 train_time: 4.3m tok/s: 7689925
+3000/20000 train_loss: 2.8991 train_time: 5.4m tok/s: 7238293
+3500/20000 train_loss: 2.9688 train_time: 6.6m tok/s: 6949208
+4000/20000 train_loss: 2.8984 train_time: 7.8m tok/s: 6714558
+4000/20000 val_loss: 2.8733 val_bpb: 1.1123
+4500/20000 train_loss: 2.8480 train_time: 9.0m tok/s: 6570853
+4845/20000 val_loss: 2.7713 val_bpb: 1.0728
+stopping_early: wallclock_cap train_time: 587061ms step: 4845/20000
+peak memory allocated: 40019 MiB reserved: 44090 MiB
 ema:applying EMA weights
-
-beginning eval timer
-pre-quantization post-ema val_loss:2.77822001 val_bpb:1.07550088 eval_time:7601ms
-Serialized model: 135408623 bytes
-Code size (uncompressed): 122627 bytes
-Code size (compressed): 26780 bytes
+diagnostic pre-quantization post-ema val_loss:2.77007744 val_bpb:1.07234874 eval_time:5948ms
+Serialized model: 135409136 bytes
+Code size (uncompressed): 116636 bytes
+Code size (compressed): 26845 bytes
 GPTQ:collecting Hessians from calibration data...
-GPTQ:collected 67 Hessians in 12.4s
+GPTQ:collected 67 Hessians in 12.6s
 Quantized weights:
   gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
   gptq (int8): tok_emb.weight
-  passthrough (float16): blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, lane_merge, skip_gates, skip_weights
-Serialized model quantized+brotli: 15962899 bytes
-Total submission size quantized+brotli: 15989679 bytes
-quantized val_loss:2.80726255 val_bpb:1.08674379 eval_time:8551ms
+  passthrough (float16): blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, skip_gates, skip_weights
+Serialized model quantized+brotli: 15967029 bytes
+Total submission size quantized+brotli: 15993874 bytes
+diagnostic quantized val_loss:2.80052355 val_bpb:1.08413500 eval_time:9328ms
 ttt_lora:warming up compile
-ttt_lora:compile warmup done (85.6s)
-ttt_lora:docs:50000 rank:96 lr:0.0001 chunk:64
-ttt_progress: batch 779/782 batch_loss:2.6581 batch_bpb:1.0827 running_loss:2.6581 running_bpb:1.0827 doc_len:9037-11049
-ttt_progress: batch 770/782 batch_loss:2.6700 batch_bpb:1.0566 running_loss:2.6619 running_bpb:1.0743 doc_len:4479-4698
-ttt_progress: batch 762/782 batch_loss:2.8322 batch_bpb:1.0780 running_loss:2.6948 running_bpb:1.0750 doc_len:3431-3533
-ttt_progress: batch 757/782 batch_loss:2.6461 batch_bpb:1.0227 running_loss:2.6877 running_bpb:1.0672 doc_len:3033-3108
-ttt_progress: batch 750/782 batch_loss:2.8330 batch_bpb:1.0688 running_loss:2.7040 running_bpb:1.0674 doc_len:2638-2688
-ttt_progress: batch 747/782 batch_loss:2.7902 batch_bpb:1.0612 running_loss:2.7123 running_bpb:1.0667 doc_len:2501-2538
-ttt_progress: batch 736/782 batch_loss:2.6841 batch_bpb:1.0462 running_loss:2.7102 running_bpb:1.0652 doc_len:2140-2165
-ttt_progress: batch 734/782 batch_loss:2.7813 batch_bpb:1.0606 running_loss:2.7151 running_bpb:1.0649 doc_len:2091-2115
-ttt_progress: batch 724/782 batch_loss:2.7569 batch_bpb:1.0539 running_loss:2.7175 running_bpb:1.0642 doc_len:1885-1900
-ttt_progress: batch 717/782 batch_loss:2.7972 batch_bpb:1.0535 running_loss:2.7216 running_bpb:1.0636 doc_len:1754-1773
-ttt_progress: batch 711/782 batch_loss:2.7834 batch_bpb:1.0481 running_loss:2.7245 running_bpb:1.0629 doc_len:1673-1683
-ttt_progress: batch 704/782 batch_loss:2.7536 batch_bpb:1.0269 running_loss:2.7258 running_bpb:1.0613 doc_len:1595-1606
-ttt_progress: batch 696/782 batch_loss:2.8215 batch_bpb:1.0785 running_loss:2.7295 running_bpb:1.0619 doc_len:1513-1522
-ttt_progress: batch 692/782 batch_loss:2.7750 batch_bpb:1.0529 running_loss:2.7312 running_bpb:1.0616 doc_len:1477-1484
-ttt_progress: batch 683/782 batch_loss:2.7773 batch_bpb:1.0693 running_loss:2.7327 running_bpb:1.0619 doc_len:1400-1406
-ttt_progress: batch 679/782 batch_loss:2.8572 batch_bpb:1.0886 running_loss:2.7367 running_bpb:1.0627 doc_len:1368-1374
-ttt_progress: batch 672/782 batch_loss:2.9098 batch_bpb:1.1101 running_loss:2.7418 running_bpb:1.0642 doc_len:1321-1327
-ttt_progress: batch 665/782 batch_loss:2.7496 batch_bpb:1.0362 running_loss:2.7420 running_bpb:1.0634 doc_len:1275-1282
-ttt_progress: batch 653/782 batch_loss:2.7626 batch_bpb:1.0364 running_loss:2.7425 running_bpb:1.0626 doc_len:1203-1209
-ttt_progress: batch 649/782 batch_loss:2.8110 batch_bpb:1.0602 running_loss:2.7442 running_bpb:1.0626 doc_len:1183-1188
-ttt_progress: batch 642/782 batch_loss:2.7899 batch_bpb:1.0853 running_loss:2.7453 running_bpb:1.0631 doc_len:1144-1150
-ttt_progress: batch 637/782 batch_loss:2.8108 batch_bpb:1.0830 running_loss:2.7467 running_bpb:1.0636 doc_len:1120-1123
-ttt_progress: batch 630/782 batch_loss:2.8364 batch_bpb:1.0622 running_loss:2.7486 running_bpb:1.0635 doc_len:1087-1092
-ttt_progress: batch 619/782 batch_loss:2.7977 batch_bpb:1.0599 running_loss:2.7496 running_bpb:1.0635 doc_len:1037-1041
-ttt_progress: batch 612/782 batch_loss:2.8307 batch_bpb:1.0456 running_loss:2.7511 running_bpb:1.0631 doc_len:1007-1012
-ttt_progress: batch 605/782 batch_loss:2.7498 batch_bpb:1.0607 running_loss:2.7511 running_bpb:1.0631 doc_len:978-982
-ttt_progress: batch 598/782 batch_loss:2.8067 batch_bpb:1.0691 running_loss:2.7521 running_bpb:1.0632 doc_len:950-954
-ttt_progress: batch 592/782 batch_loss:2.7900 batch_bpb:1.0504 running_loss:2.7527 running_bpb:1.0629 doc_len:930-933
-ttt_progress: batch 586/782 batch_loss:2.7331 batch_bpb:1.0170 running_loss:2.7524 running_bpb:1.0622 doc_len:911-914
-ttt_progress: batch 579/782 batch_loss:2.6484 batch_bpb:1.0094 running_loss:2.7508 running_bpb:1.0614 doc_len:888-891
-ttt_progress: batch 572/782 batch_loss:2.9493 batch_bpb:1.1224 running_loss:2.7537 running_bpb:1.0623 doc_len:865-868
-ttt_progress: batch 564/782 batch_loss:2.8714 batch_bpb:1.1109 running_loss:2.7553 running_bpb:1.0630 doc_len:840-843
-ttt_progress: batch 556/782 batch_loss:2.8370 batch_bpb:1.0846 running_loss:2.7564 running_bpb:1.0633 doc_len:815-818
-ttt_progress: batch 548/782 batch_loss:2.7660 batch_bpb:1.0488 running_loss:2.7566 running_bpb:1.0631 doc_len:793-795
-ttt_progress: batch 540/782 batch_loss:2.6990 batch_bpb:1.0183 running_loss:2.7559 running_bpb:1.0625 doc_len:771-774
-ttt_progress: batch 530/782 batch_loss:2.8149 batch_bpb:1.0419 running_loss:2.7566 running_bpb:1.0622 doc_len:747-750
-ttt_progress: batch 522/782 batch_loss:2.8347 batch_bpb:1.0897 running_loss:2.7574 running_bpb:1.0626 doc_len:727-730
-ttt_progress: batch 513/782 batch_loss:2.7345 batch_bpb:1.0122 running_loss:2.7572 running_bpb:1.0620 doc_len:705-707
-ttt_progress: batch 504/782 batch_loss:2.8791 batch_bpb:1.1032 running_loss:2.7585 running_bpb:1.0624 doc_len:685-686
-ttt_progress: batch 496/782 batch_loss:2.8444 batch_bpb:1.0542 running_loss:2.7593 running_bpb:1.0623 doc_len:666-668
-ttt_progress: batch 488/782 batch_loss:2.8257 batch_bpb:1.0531 running_loss:2.7600 running_bpb:1.0622 doc_len:649-651
-ttt_progress: batch 480/782 batch_loss:2.8048 batch_bpb:1.0589 running_loss:2.7604 running_bpb:1.0622 doc_len:632-635
-ttt_progress: batch 474/782 batch_loss:2.7752 batch_bpb:1.0582 running_loss:2.7606 running_bpb:1.0622 doc_len:620-622
-ttt_progress: batch 465/782 batch_loss:2.8222 batch_bpb:1.0646 running_loss:2.7611 running_bpb:1.0622 doc_len:602-604
-ttt_progress: batch 459/782 batch_loss:2.7450 batch_bpb:1.0416 running_loss:2.7610 running_bpb:1.0620 doc_len:591-593
-ttt_progress: batch 451/782 batch_loss:2.7784 batch_bpb:1.0644 running_loss:2.7611 running_bpb:1.0620 doc_len:576-579
-ttt_progress: batch 440/782 batch_loss:2.8759 batch_bpb:1.0980 running_loss:2.7620 running_bpb:1.0623 doc_len:556-559
-ttt_progress: batch 432/782 batch_loss:2.7688 batch_bpb:1.0534 running_loss:2.7621 running_bpb:1.0623 doc_len:542-544
-ttt_progress: batch 424/782 batch_loss:2.8094 batch_bpb:1.0858 running_loss:2.7624 running_bpb:1.0624 doc_len:528-530
-ttt_progress: batch 416/782 batch_loss:2.7675 batch_bpb:1.0388 running_loss:2.7625 running_bpb:1.0623 doc_len:514-516
-ttt_progress: batch 408/782 batch_loss:2.8449 batch_bpb:1.0882 running_loss:2.7630 running_bpb:1.0624 doc_len:501-503
-ttt_progress: batch 400/782 batch_loss:2.8022 batch_bpb:1.0689 running_loss:2.7633 running_bpb:1.0625 doc_len:489-490
-ttt_progress: batch 392/782 batch_loss:2.8036 batch_bpb:1.0826 running_loss:2.7635 running_bpb:1.0626 doc_len:476-478
-ttt_progress: batch 384/782 batch_loss:2.8528 batch_bpb:1.0945 running_loss:2.7641 running_bpb:1.0628 doc_len:464-466
-ttt_progress: batch 376/782 batch_loss:2.7261 batch_bpb:1.0469 running_loss:2.7639 running_bpb:1.0627 doc_len:453-454
-ttt_progress: batch 369/782 batch_loss:2.9360 batch_bpb:1.0898 running_loss:2.7649 running_bpb:1.0629 doc_len:443-444
-ttt_progress: batch 361/782 batch_loss:2.8094 batch_bpb:1.0741 running_loss:2.7652 running_bpb:1.0629 doc_len:432-433
-ttt_progress: batch 353/782 batch_loss:2.8072 batch_bpb:1.1000 running_loss:2.7654 running_bpb:1.0631 doc_len:420-422
-ttt_progress: batch 346/782 batch_loss:2.8512 batch_bpb:1.0881 running_loss:2.7659 running_bpb:1.0633 doc_len:412-413
-ttt_progress: batch 338/782 batch_loss:2.8597 batch_bpb:1.1154 running_loss:2.7664 running_bpb:1.0636 doc_len:400-402
-ttt_progress: batch 330/782 batch_loss:2.8792 batch_bpb:1.0977 running_loss:2.7669 running_bpb:1.0637 doc_len:390-392
-ttt_progress: batch 322/782 batch_loss:2.7638 batch_bpb:1.0800 running_loss:2.7669 running_bpb:1.0638 doc_len:380-381
-ttt_progress: batch 314/782 batch_loss:2.8104 batch_bpb:1.0682 running_loss:2.7671 running_bpb:1.0638 doc_len:369-370
-ttt_progress: batch 306/782 batch_loss:2.8856 batch_bpb:1.1416 running_loss:2.7677 running_bpb:1.0642 doc_len:359-361
-ttt_progress: batch 298/782 batch_loss:2.8526 batch_bpb:1.1042 running_loss:2.7680 running_bpb:1.0644 doc_len:349-351
-ttt_progress: batch 290/782 batch_loss:2.8683 batch_bpb:1.0867 running_loss:2.7685 running_bpb:1.0645 doc_len:340-341
-ttt_progress: batch 282/782 batch_loss:2.8336 batch_bpb:1.1284 running_loss:2.7688 running_bpb:1.0647 doc_len:331-332
-ttt_progress: batch 274/782 batch_loss:2.8268 batch_bpb:1.0975 running_loss:2.7690 running_bpb:1.0648 doc_len:322-323
-ttt_progress: batch 266/782 batch_loss:2.8524 batch_bpb:1.0969 running_loss:2.7693 running_bpb:1.0650 doc_len:313-314
-ttt_progress: batch 258/782 batch_loss:2.9709 batch_bpb:1.1715 running_loss:2.7701 running_bpb:1.0654 doc_len:304-305
-ttt_progress: batch 250/782 batch_loss:2.8768 batch_bpb:1.1432 running_loss:2.7705 running_bpb:1.0656 doc_len:295-296
-ttt_progress: batch 242/782 batch_loss:2.9089 batch_bpb:1.1122 running_loss:2.7710 running_bpb:1.0658 doc_len:287-288
-ttt_progress: batch 234/782 batch_loss:2.9271 batch_bpb:1.1604 running_loss:2.7715 running_bpb:1.0661 doc_len:279-280
-ttt_progress: batch 226/782 batch_loss:2.9414 batch_bpb:1.1443 running_loss:2.7721 running_bpb:1.0664 doc_len:271-272
-ttt_progress: batch 218/782 batch_loss:2.7535 batch_bpb:1.1072 running_loss:2.7720 running_bpb:1.0665 doc_len:263-264
-ttt_progress: batch 210/782 batch_loss:2.8513 batch_bpb:1.1221 running_loss:2.7723 running_bpb:1.0667 doc_len:255-256
-ttt_progress: batch 202/782 batch_loss:2.8739 batch_bpb:1.1360 running_loss:2.7726 running_bpb:1.0669 doc_len:248-249
-ttt_progress: batch 194/782 batch_loss:2.9213 batch_bpb:1.1087 running_loss:2.7730 running_bpb:1.0670 doc_len:241-242
-ttt_progress: batch 186/782 batch_loss:2.9473 batch_bpb:1.1776 running_loss:2.7735 running_bpb:1.0673 doc_len:234-235
-ttt_progress: batch 178/782 batch_loss:2.8608 batch_bpb:1.1410 running_loss:2.7738 running_bpb:1.0675 doc_len:227-228
-ttt_progress: batch 170/782 batch_loss:2.9981 batch_bpb:1.1724 running_loss:2.7744 running_bpb:1.0678 doc_len:220-221
-ttt_progress: batch 162/782 batch_loss:2.9598 batch_bpb:1.1484 running_loss:2.7748 running_bpb:1.0680 doc_len:213-214
-ttt_progress: batch 155/782 batch_loss:2.8860 batch_bpb:1.1343 running_loss:2.7751 running_bpb:1.0682 doc_len:207-208
-ttt_progress: batch 147/782 batch_loss:2.9318 batch_bpb:1.1599 running_loss:2.7755 running_bpb:1.0684 doc_len:201-202
-ttt_progress: batch 141/782 batch_loss:2.9129 batch_bpb:1.1484 running_loss:2.7758 running_bpb:1.0686 doc_len:196-197
-ttt_progress: batch 133/782 batch_loss:3.0297 batch_bpb:1.1968 running_loss:2.7764 running_bpb:1.0688 doc_len:189-190
-ttt_progress: batch 126/782 batch_loss:2.9436 batch_bpb:1.1960 running_loss:2.7768 running_bpb:1.0691 doc_len:185-185
-ttt_progress: batch 116/782 batch_loss:3.0133 batch_bpb:1.1916 running_loss:2.7773 running_bpb:1.0694 doc_len:177-178
-ttt_progress: batch 110/782 batch_loss:3.0343 batch_bpb:1.1781 running_loss:2.7778 running_bpb:1.0696 doc_len:173-173
-ttt_progress: batch 101/782 batch_loss:2.9702 batch_bpb:1.1658 running_loss:2.7782 running_bpb:1.0698 doc_len:166-167
-ttt_progress: batch 92/782 batch_loss:2.9067 batch_bpb:1.1756 running_loss:2.7784 running_bpb:1.0700 doc_len:159-160
-ttt_progress: batch 84/782 batch_loss:3.0270 batch_bpb:1.2196 running_loss:2.7788 running_bpb:1.0702 doc_len:153-154
-ttt_progress: batch 76/782 batch_loss:3.0678 batch_bpb:1.2308 running_loss:2.7793 running_bpb:1.0705 doc_len:147-148
-ttt_progress: batch 68/782 batch_loss:3.1181 batch_bpb:1.2114 running_loss:2.7799 running_bpb:1.0707 doc_len:141-142
-ttt_progress: batch 61/782 batch_loss:2.9361 batch_bpb:1.1478 running_loss:2.7802 running_bpb:1.0708 doc_len:135-136
-ttt_progress: batch 54/782 batch_loss:3.1166 batch_bpb:1.2762 running_loss:2.7807 running_bpb:1.0711 doc_len:130-130
-ttt_progress: batch 44/782 batch_loss:3.1536 batch_bpb:1.2288 running_loss:2.7812 running_bpb:1.0713 doc_len:122-122
-ttt_progress: batch 34/782 batch_loss:3.0831 batch_bpb:1.2481 running_loss:2.7816 running_bpb:1.0716 doc_len:114-115
-ttt_progress: batch 27/782 batch_loss:3.0932 batch_bpb:1.2349 running_loss:2.7820 running_bpb:1.0718 doc_len:107-108
-ttt_progress: batch 20/782 batch_loss:3.1458 batch_bpb:1.2723 running_loss:2.7824 running_bpb:1.0720 doc_len:101-102
-ttt_progress: batch 12/782 batch_loss:3.1837 batch_bpb:1.2409 running_loss:2.7828 running_bpb:1.0722 doc_len:92-93
-ttt_progress: batch 4/782 batch_loss:3.2067 batch_bpb:1.2295 running_loss:2.7832 running_bpb:1.0723 doc_len:78-80
-quantized_ttt_lora val_loss:2.78033428 val_bpb:1.07635404 eval_time:179178ms
-total_eval_time:274.7s
-total_eval_time_with_compile:360.3s
+ttt_lora:compile warmup done (160.7s)
+
+beginning TTT eval timer
+ttt_lora:docs:50000 rank:96 lr:0.0001 chunk:32
+ttt_progress: batch 775/782 batch_loss:2.6883 batch_bpb:1.0642 running_loss:2.6883 running_bpb:1.0642 doc_len:5853-6355
+ttt_progress: batch 774/782 batch_loss:2.7283 batch_bpb:1.0775 running_loss:2.7076 running_bpb:1.0706 doc_len:5552-5852
+ttt_progress: batch 769/782 batch_loss:2.7712 batch_bpb:1.0967 running_loss:2.7248 running_bpb:1.0777 doc_len:4307-4479
+ttt_progress: batch 764/782 batch_loss:2.7637 batch_bpb:1.0981 running_loss:2.7320 running_bpb:1.0815 doc_len:3639-3742
+ttt_progress: batch 758/782 batch_loss:2.8747 batch_bpb:1.0847 running_loss:2.7515 running_bpb:1.0819 doc_len:3108-3187
+ttt_progress: batch 752/782 batch_loss:2.7637 batch_bpb:1.0603 running_loss:2.7528 running_bpb:1.0795 doc_len:2740-2793
+ttt_progress: batch 743/782 batch_loss:2.7107 batch_bpb:1.0436 running_loss:2.7493 running_bpb:1.0765 doc_len:2355-2388
+ttt_progress: batch 740/782 batch_loss:2.7331 batch_bpb:1.0318 running_loss:2.7481 running_bpb:1.0730 doc_len:2254-2285
+ttt_progress: batch 731/782 batch_loss:2.7797 batch_bpb:1.0609 running_loss:2.7501 running_bpb:1.0723 doc_len:2017-2041
+ttt_progress: batch 727/782 batch_loss:2.7751 batch_bpb:1.0564 running_loss:2.7515 running_bpb:1.0713 doc_len:1936-1960
+ttt_progress: batch 716/782 batch_loss:2.8094 batch_bpb:1.0367 running_loss:2.7543 running_bpb:1.0696 doc_len:1739-1754
+ttt_progress: batch 714/782 batch_loss:2.8069 batch_bpb:1.0684 running_loss:2.7566 running_bpb:1.0695 doc_len:1711-1725
+ttt_progress: batch 706/782 batch_loss:2.7164 batch_bpb:1.0442 running_loss:2.7550 running_bpb:1.0685 doc_len:1617-1627
+ttt_progress: batch 698/782 batch_loss:2.7831 batch_bpb:1.0315 running_loss:2.7560 running_bpb:1.0670 doc_len:1534-1543
+ttt_progress: batch 688/782 batch_loss:2.7472 batch_bpb:1.0481 running_loss:2.7557 running_bpb:1.0664 doc_len:1441-1450
+ttt_progress: batch 683/782 batch_loss:2.7757 batch_bpb:1.0687 running_loss:2.7564 running_bpb:1.0665 doc_len:1400-1406
+ttt_progress: batch 679/782 batch_loss:2.8532 batch_bpb:1.0870 running_loss:2.7593 running_bpb:1.0671 doc_len:1368-1374
+ttt_progress: batch 671/782 batch_loss:2.8781 batch_bpb:1.1155 running_loss:2.7627 running_bpb:1.0685 doc_len:1316-1321
+ttt_progress: batch 660/782 batch_loss:2.8509 batch_bpb:1.0909 running_loss:2.7650 running_bpb:1.0690 doc_len:1245-1250
+ttt_progress: batch 653/782 batch_loss:2.7584 batch_bpb:1.0348 running_loss:2.7648 running_bpb:1.0682 doc_len:1203-1209
+ttt_progress: batch 649/782 batch_loss:2.8034 batch_bpb:1.0573 running_loss:2.7657 running_bpb:1.0679 doc_len:1183-1188
+ttt_progress: batch 639/782 batch_loss:2.8537 batch_bpb:1.0810 running_loss:2.7677 running_bpb:1.0682 doc_len:1129-1134
+ttt_progress: batch 633/782 batch_loss:2.8212 batch_bpb:1.1008 running_loss:2.7688 running_bpb:1.0689 doc_len:1101-1105
+ttt_progress: batch 626/782 batch_loss:2.8095 batch_bpb:1.0439 running_loss:2.7696 running_bpb:1.0684 doc_len:1068-1073
+ttt_progress: batch 619/782 batch_loss:2.7931 batch_bpb:1.0581 running_loss:2.7700 running_bpb:1.0682 doc_len:1037-1041
+ttt_progress: batch 613/782 batch_loss:2.8239 batch_bpb:1.0629 running_loss:2.7710 running_bpb:1.0681 doc_len:1012-1016
+ttt_progress: batch 606/782 batch_loss:2.8183 batch_bpb:1.0844 running_loss:2.7718 running_bpb:1.0684 doc_len:982-986
+ttt_progress: batch 601/782 batch_loss:2.7572 batch_bpb:1.0596 running_loss:2.7716 running_bpb:1.0682 doc_len:963-966
+ttt_progress: batch 590/782 batch_loss:2.7347 batch_bpb:1.0292 running_loss:2.7710 running_bpb:1.0676 doc_len:924-927
+ttt_progress: batch 587/782 batch_loss:2.7831 batch_bpb:1.0627 running_loss:2.7712 running_bpb:1.0675 doc_len:914-917
+ttt_progress: batch 580/782 batch_loss:2.7291 batch_bpb:1.0369 running_loss:2.7706 running_bpb:1.0670 doc_len:891-894
+ttt_progress: batch 571/782 batch_loss:2.7130 batch_bpb:1.0349 running_loss:2.7698 running_bpb:1.0666 doc_len:862-865
+ttt_progress: batch 563/782 batch_loss:2.8007 batch_bpb:1.0624 running_loss:2.7702 running_bpb:1.0665 doc_len:837-840
+ttt_progress: batch 552/782 batch_loss:2.7969 batch_bpb:1.0423 running_loss:2.7705 running_bpb:1.0662 doc_len:804-806
+ttt_progress: batch 544/782 batch_loss:2.7539 batch_bpb:1.0429 running_loss:2.7703 running_bpb:1.0659 doc_len:782-785
+ttt_progress: batch 536/782 batch_loss:2.7851 batch_bpb:1.0743 running_loss:2.7705 running_bpb:1.0660 doc_len:762-764
+ttt_progress: batch 530/782 batch_loss:2.8087 batch_bpb:1.0397 running_loss:2.7709 running_bpb:1.0657 doc_len:747-750
+ttt_progress: batch 521/782 batch_loss:2.7692 batch_bpb:1.0507 running_loss:2.7709 running_bpb:1.0655 doc_len:725-727
+ttt_progress: batch 513/782 batch_loss:2.7306 batch_bpb:1.0107 running_loss:2.7705 running_bpb:1.0649 doc_len:705-707
+ttt_progress: batch 504/782 batch_loss:2.8688 batch_bpb:1.0992 running_loss:2.7715 running_bpb:1.0653 doc_len:685-686
+ttt_progress: batch 496/782 batch_loss:2.8324 batch_bpb:1.0498 running_loss:2.7721 running_bpb:1.0651 doc_len:666-668
+ttt_progress: batch 488/782 batch_loss:2.8191 batch_bpb:1.0506 running_loss:2.7725 running_bpb:1.0650 doc_len:649-651
+ttt_progress: batch 480/782 batch_loss:2.7924 batch_bpb:1.0542 running_loss:2.7727 running_bpb:1.0649 doc_len:632-635
+ttt_progress: batch 472/782 batch_loss:2.8040 batch_bpb:1.0719 running_loss:2.7730 running_bpb:1.0649 doc_len:616-618
+ttt_progress: batch 464/782 batch_loss:2.7178 batch_bpb:1.0770 running_loss:2.7725 running_bpb:1.0650 doc_len:600-602
+ttt_progress: batch 456/782 batch_loss:2.8114 batch_bpb:1.0677 running_loss:2.7728 running_bpb:1.0651 doc_len:586-587
+ttt_progress: batch 448/782 batch_loss:2.7264 batch_bpb:1.0357 running_loss:2.7725 running_bpb:1.0648 doc_len:571-573
+ttt_progress: batch 440/782 batch_loss:2.8630 batch_bpb:1.0931 running_loss:2.7732 running_bpb:1.0650 doc_len:556-559
+ttt_progress: batch 432/782 batch_loss:2.7588 batch_bpb:1.0496 running_loss:2.7731 running_bpb:1.0649 doc_len:542-544
+ttt_progress: batch 425/782 batch_loss:2.7551 batch_bpb:1.0482 running_loss:2.7729 running_bpb:1.0648 doc_len:530-532
+ttt_progress: batch 416/782 batch_loss:2.7594 batch_bpb:1.0358 running_loss:2.7728 running_bpb:1.0646 doc_len:514-516
+ttt_progress: batch 408/782 batch_loss:2.8351 batch_bpb:1.0844 running_loss:2.7733 running_bpb:1.0647 doc_len:501-503
+ttt_progress: batch 400/782 batch_loss:2.7965 batch_bpb:1.0667 running_loss:2.7734 running_bpb:1.0647 doc_len:489-490
+ttt_progress: batch 392/782 batch_loss:2.7918 batch_bpb:1.0780 running_loss:2.7735 running_bpb:1.0648 doc_len:476-478
+ttt_progress: batch 384/782 batch_loss:2.8424 batch_bpb:1.0905 running_loss:2.7740 running_bpb:1.0650 doc_len:464-466
+ttt_progress: batch 376/782 batch_loss:2.7126 batch_bpb:1.0418 running_loss:2.7736 running_bpb:1.0649 doc_len:453-454
+ttt_progress: batch 368/782 batch_loss:2.8531 batch_bpb:1.0886 running_loss:2.7740 running_bpb:1.0650 doc_len:441-443
+ttt_progress: batch 360/782 batch_loss:2.8352 batch_bpb:1.0812 running_loss:2.7744 running_bpb:1.0651 doc_len:430-432
+ttt_progress: batch 352/782 batch_loss:2.7603 batch_bpb:1.0973 running_loss:2.7743 running_bpb:1.0652 doc_len:419-420
+ttt_progress: batch 344/782 batch_loss:2.8842 batch_bpb:1.1056 running_loss:2.7749 running_bpb:1.0655 doc_len:408-410
+ttt_progress: batch 336/782 batch_loss:2.9514 batch_bpb:1.1663 running_loss:2.7758 running_bpb:1.0660 doc_len:398-399
+ttt_progress: batch 328/782 batch_loss:2.7917 batch_bpb:1.0825 running_loss:2.7759 running_bpb:1.0660 doc_len:388-389
+ttt_progress: batch 320/782 batch_loss:2.7586 batch_bpb:1.0761 running_loss:2.7758 running_bpb:1.0661 doc_len:377-378
+ttt_progress: batch 312/782 batch_loss:2.7300 batch_bpb:1.0657 running_loss:2.7756 running_bpb:1.0661 doc_len:367-368
+ttt_progress: batch 304/782 batch_loss:2.9071 batch_bpb:1.1322 running_loss:2.7762 running_bpb:1.0664 doc_len:357-358
+ttt_progress: batch 296/782 batch_loss:2.8035 batch_bpb:1.0842 running_loss:2.7763 running_bpb:1.0665 doc_len:347-348
+ttt_progress: batch 288/782 batch_loss:2.8061 batch_bpb:1.1017 running_loss:2.7764 running_bpb:1.0666 doc_len:337-339
+ttt_progress: batch 279/782 batch_loss:2.8500 batch_bpb:1.0893 running_loss:2.7767 running_bpb:1.0667 doc_len:327-329
+ttt_progress: batch 272/782 batch_loss:2.8593 batch_bpb:1.1092 running_loss:2.7770 running_bpb:1.0669 doc_len:320-321
+ttt_progress: batch 264/782 batch_loss:2.8950 batch_bpb:1.1459 running_loss:2.7775 running_bpb:1.0672 doc_len:311-312
+ttt_progress: batch 256/782 batch_loss:2.8802 batch_bpb:1.1291 running_loss:2.7779 running_bpb:1.0674 doc_len:301-302
+ttt_progress: batch 248/782 batch_loss:2.8860 batch_bpb:1.1014 running_loss:2.7782 running_bpb:1.0675 doc_len:293-294
+ttt_progress: batch 240/782 batch_loss:2.9126 batch_bpb:1.1560 running_loss:2.7787 running_bpb:1.0678 doc_len:285-286
+ttt_progress: batch 233/782 batch_loss:2.8597 batch_bpb:1.1236 running_loss:2.7790 running_bpb:1.0680 doc_len:278-279
+ttt_progress: batch 226/782 batch_loss:2.9320 batch_bpb:1.1406 running_loss:2.7795 running_bpb:1.0682 doc_len:271-272
+ttt_progress: batch 219/782 batch_loss:2.8972 batch_bpb:1.1304 running_loss:2.7799 running_bpb:1.0684 doc_len:264-265
+ttt_progress: batch 212/782 batch_loss:2.9215 batch_bpb:1.1434 running_loss:2.7803 running_bpb:1.0686 doc_len:257-258
+ttt_progress: batch 203/782 batch_loss:2.7660 batch_bpb:1.0866 running_loss:2.7803 running_bpb:1.0687 doc_len:249-250
+ttt_progress: batch 196/782 batch_loss:2.8991 batch_bpb:1.1616 running_loss:2.7806 running_bpb:1.0689 doc_len:243-244
+ttt_progress: batch 189/782 batch_loss:2.9627 batch_bpb:1.2025 running_loss:2.7811 running_bpb:1.0693 doc_len:237-237
+ttt_progress: batch 181/782 batch_loss:2.8669 batch_bpb:1.1520 running_loss:2.7813 running_bpb:1.0695 doc_len:230-230
+ttt_progress: batch 171/782 batch_loss:2.8901 batch_bpb:1.1116 running_loss:2.7816 running_bpb:1.0696 doc_len:221-222
+ttt_progress: batch 163/782 batch_loss:2.8846 batch_bpb:1.1322 running_loss:2.7819 running_bpb:1.0698 doc_len:214-215
+ttt_progress: batch 153/782 batch_loss:3.0097 batch_bpb:1.1610 running_loss:2.7824 running_bpb:1.0700 doc_len:206-207
+ttt_progress: batch 146/782 batch_loss:2.9030 batch_bpb:1.1524 running_loss:2.7827 running_bpb:1.0702 doc_len:200-201
+ttt_progress: batch 139/782 batch_loss:2.9900 batch_bpb:1.1572 running_loss:2.7832 running_bpb:1.0704 doc_len:195-195
+ttt_progress: batch 130/782 batch_loss:3.1370 batch_bpb:1.2331 running_loss:2.7840 running_bpb:1.0707 doc_len:187-188
+ttt_progress: batch 122/782 batch_loss:2.8866 batch_bpb:1.1549 running_loss:2.7842 running_bpb:1.0709 doc_len:181-182
+ttt_progress: batch 114/782 batch_loss:2.9969 batch_bpb:1.1865 running_loss:2.7846 running_bpb:1.0711 doc_len:176-176
+ttt_progress: batch 104/782 batch_loss:2.9944 batch_bpb:1.1652 running_loss:2.7850 running_bpb:1.0713 doc_len:168-169
+ttt_progress: batch 95/782 batch_loss:2.9974 batch_bpb:1.2206 running_loss:2.7854 running_bpb:1.0716 doc_len:161-162
+ttt_progress: batch 87/782 batch_loss:3.0162 batch_bpb:1.2055 running_loss:2.7858 running_bpb:1.0718 doc_len:155-156
+ttt_progress: batch 79/782 batch_loss:3.0283 batch_bpb:1.2023 running_loss:2.7863 running_bpb:1.0720 doc_len:149-150
+ttt_progress: batch 72/782 batch_loss:2.9258 batch_bpb:1.1890 running_loss:2.7865 running_bpb:1.0722 doc_len:144-144
+ttt_progress: batch 63/782 batch_loss:3.0164 batch_bpb:1.2166 running_loss:2.7869 running_bpb:1.0724 doc_len:137-138
+ttt_progress: batch 56/782 batch_loss:3.0614 batch_bpb:1.2065 running_loss:2.7873 running_bpb:1.0726 doc_len:131-132
+ttt_progress: batch 47/782 batch_loss:2.9424 batch_bpb:1.1759 running_loss:2.7875 running_bpb:1.0728 doc_len:124-125
+ttt_progress: batch 40/782 batch_loss:2.9937 batch_bpb:1.2042 running_loss:2.7878 running_bpb:1.0729 doc_len:119-119
+ttt_progress: batch 30/782 batch_loss:3.1394 batch_bpb:1.2575 running_loss:2.7882 running_bpb:1.0732 doc_len:110-111
+ttt_progress: batch 21/782 batch_loss:3.1773 batch_bpb:1.2354 running_loss:2.7887 running_bpb:1.0734 doc_len:102-103
+ttt_progress: batch 13/782 batch_loss:3.1367 batch_bpb:1.2625 running_loss:2.7890 running_bpb:1.0735 doc_len:93-94
+ttt_progress: batch 4/782 batch_loss:3.2125 batch_bpb:1.2317 running_loss:2.7894 running_bpb:1.0737 doc_len:78-80
+quantized_ttt_lora val_loss:2.77230836 val_bpb:1.07324696 eval_time:343324ms
+total_eval_time:343.3s

--- a/records/track_10min_16mb/2026-04-10_VarLenAttn/logs/train2.txt
+++ b/records/track_10min_16mb/2026-04-10_VarLenAttn/logs/train2.txt
@@ -1,0 +1,328 @@
+====================================================================================================
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  artifact_dir: runs/varlen2
+  beta1: 0.9
+  beta2: 0.95
+  compressor: brotli
+  data_dir: ./data/
+  datasets_dir: ./data/datasets/fineweb10B_sp8192
+  distributed: True
+  ema_decay: 0.997
+  embed_bits: 8
+  embed_clip_sigmas: 20.0
+  embed_lr: 0.6
+  embed_wd: 0.095
+  embedding_dim: 512
+  enable_looping_at: 0.35
+  etlb_clip: 3.0
+  etlb_lr: 0.05
+  etlb_steps: 5
+  eval_only_path: 
+  eval_seq_len: 2048
+  eval_stride: 64
+  gptq_calibration_batches: 64
+  gptq_reserve_seconds: 12.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  head_lr: 0.008
+  is_main_process: True
+  iterations: 20000
+  ln_scale: True
+  local_rank: 0
+  logfile: runs/varlen2/b73d59aa-750c-4740-9e3d-145de9568a11.txt
+  logit_softcap: 30.0
+  loop_end: 5
+  loop_start: 3
+  matrix_bits: 6
+  matrix_clip_sigmas: 12.85
+  matrix_lr: 0.022
+  max_wallclock_seconds: 600.0
+  min_lr: 0.0
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: runs/varlen2/final_model.pt
+  muon_backend_steps: 5
+  muon_beta2: 0.95
+  muon_momentum: 0.97
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_row_normalize: True
+  muon_wd: 0.095
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  num_loops: 2
+  parallel_start_layer: 7
+  qk_gain_init: 5.0
+  quantized_model_path: runs/varlen2/final_model.int6.ptz
+  rank: 0
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  rope_yarn: False
+  run_id: b73d59aa-750c-4740-9e3d-145de9568a11
+  scalar_lr: 0.02
+  seed: 2
+  skip_gates_enabled: True
+  sliding_window_enabled: False
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  tokenizer_path: ./data/tokenizers/fineweb_8192_bpe.model
+  train_batch_tokens: 786432
+  train_files: ./data/datasets/fineweb10B_sp8192/fineweb_train_*.bin
+  train_log_every: 500
+  train_seq_len: 2048
+  ttt_batch_size: 64
+  ttt_beta1: 0.0
+  ttt_beta2: 0.999
+  ttt_chunk_size: 64
+  ttt_enabled: True
+  ttt_eval_batches: 
+  ttt_eval_seq_len: 2048
+  ttt_grad_steps: 1
+  ttt_k_lora: True
+  ttt_lora_lr: 0.0001
+  ttt_lora_rank: 96
+  ttt_mlp_lora: True
+  ttt_o_lora: True
+  ttt_optimizer: adam
+  ttt_output_dir: 
+  ttt_weight_decay: 0.5
+  val_batch_tokens: 524288
+  val_doc_fraction: 1.0
+  val_files: ./data/datasets/fineweb10B_sp8192/fineweb_val_*.bin
+  val_loss_every: 4000
+  vocab_size: 8192
+  warmdown_frac: 0.667
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+====================================================================================================
+Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
+Running PyTorch 2.9.1+cu128
+Fri Apr 10 22:48:52 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
+| N/A   52C    P0            128W /  700W |    1519MiB /  81559MiB |      1%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
+| N/A   40C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
+| N/A   43C    P0            121W /  700W |    1519MiB /  81559MiB |      2%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
+| N/A   39C    P0            122W /  700W |    1519MiB /  81559MiB |      2%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
+| N/A   45C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
+| N/A   38C    P0            116W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
+| N/A   41C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
+| N/A   38C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+                                                                                         
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A         1923701      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A         1923702      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A         1923703      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A         1923704      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A         1923705      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A         1923706      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A         1923707      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A         1923708      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+train_shards: 128
+val_tokens: 40540160
+model_params:35944537
+gptq:reserving 12s, effective=588000ms
+warmup_cu_buckets:64,128,192,256 iters_each:3
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup:enabled encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+loop_warmup_step: 1/20
+loop_warmup_step: 2/20
+loop_warmup_step: 3/20
+loop_warmup_step: 4/20
+loop_warmup_step: 5/20
+loop_warmup_step: 6/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+0/20000 val_loss: 9.0048 val_bpb: 3.4859
+1/20000 train_loss: 9.0044 train_time: 0.0m tok/s: 17402505
+2/20000 train_loss: 12.1620 train_time: 0.0m tok/s: 13572479
+3/20000 train_loss: 11.1394 train_time: 0.0m tok/s: 11442657
+4/20000 train_loss: 9.5694 train_time: 0.0m tok/s: 10548433
+5/20000 train_loss: 8.2082 train_time: 0.0m tok/s: 10099152
+500/20000 train_loss: 3.2840 train_time: 0.8m tok/s: 8332231
+1000/20000 train_loss: 3.0429 train_time: 1.6m tok/s: 8322705
+1500/20000 train_loss: 3.0440 train_time: 2.4m tok/s: 8321366
+2000/20000 train_loss: 3.0130 train_time: 3.2m tok/s: 8319692
+layer_loop:enabled step:2175 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2500/20000 train_loss: 3.0937 train_time: 4.2m tok/s: 7837630
+3000/20000 train_loss: 2.9311 train_time: 5.4m tok/s: 7339753
+3500/20000 train_loss: 2.9924 train_time: 6.5m tok/s: 7041994
+4000/20000 train_loss: 2.9201 train_time: 7.7m tok/s: 6832657
+4000/20000 val_loss: 2.8967 val_bpb: 1.1214
+4500/20000 train_loss: 2.8723 train_time: 8.8m tok/s: 6679533
+4920/20000 val_loss: 2.7790 val_bpb: 1.0758
+stopping_early: wallclock_cap train_time: 588111ms step: 4920/20000
+peak memory allocated: 40019 MiB reserved: 44088 MiB
+ema:applying EMA weights
+
+beginning eval timer
+pre-quantization post-ema val_loss:2.77937808 val_bpb:1.07594919 eval_time:7704ms
+Serialized model: 135408623 bytes
+Code size (uncompressed): 124045 bytes
+Code size (compressed): 27085 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 12.5s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int8): tok_emb.weight
+  passthrough (float16): blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, lane_merge, skip_gates, skip_weights
+Serialized model quantized+brotli: 15967464 bytes
+Total submission size quantized+brotli: 15994549 bytes
+quantized val_loss:2.80668282 val_bpb:1.08651937 eval_time:8814ms
+ttt_lora:warming up compile
+ttt_lora:compile warmup done (90.9s)
+ttt_lora:docs:50000 rank:96 lr:0.0001 chunk:64
+ttt_progress: batch 778/782 batch_loss:2.7965 batch_bpb:1.1187 running_loss:2.7965 running_bpb:1.1187 doc_len:7961-8997
+ttt_progress: batch 772/782 batch_loss:2.7752 batch_bpb:1.1100 running_loss:2.7885 running_bpb:1.1155 doc_len:4937-5193
+ttt_progress: batch 768/782 batch_loss:2.7112 batch_bpb:1.0880 running_loss:2.7702 running_bpb:1.1090 doc_len:4128-4306
+ttt_progress: batch 762/782 batch_loss:2.8330 batch_bpb:1.0783 running_loss:2.7805 running_bpb:1.1037 doc_len:3431-3533
+ttt_progress: batch 756/782 batch_loss:2.7914 batch_bpb:1.0819 running_loss:2.7819 running_bpb:1.1010 doc_len:2973-3032
+ttt_progress: batch 750/782 batch_loss:2.8335 batch_bpb:1.0690 running_loss:2.7870 running_bpb:1.0977 doc_len:2638-2688
+ttt_progress: batch 744/782 batch_loss:2.6622 batch_bpb:1.0606 running_loss:2.7767 running_bpb:1.0946 doc_len:2388-2419
+ttt_progress: batch 737/782 batch_loss:2.8045 batch_bpb:1.0694 running_loss:2.7787 running_bpb:1.0928 doc_len:2165-2193
+ttt_progress: batch 732/782 batch_loss:2.8301 batch_bpb:1.1015 running_loss:2.7818 running_bpb:1.0934 doc_len:2041-2062
+ttt_progress: batch 725/782 batch_loss:2.7653 batch_bpb:1.0718 running_loss:2.7809 running_bpb:1.0922 doc_len:1900-1915
+ttt_progress: batch 718/782 batch_loss:2.7829 batch_bpb:1.0727 running_loss:2.7810 running_bpb:1.0912 doc_len:1773-1792
+ttt_progress: batch 711/782 batch_loss:2.7812 batch_bpb:1.0473 running_loss:2.7810 running_bpb:1.0893 doc_len:1673-1683
+ttt_progress: batch 704/782 batch_loss:2.7515 batch_bpb:1.0262 running_loss:2.7799 running_bpb:1.0867 doc_len:1595-1606
+ttt_progress: batch 697/782 batch_loss:2.7701 batch_bpb:1.0437 running_loss:2.7795 running_bpb:1.0850 doc_len:1522-1534
+ttt_progress: batch 691/782 batch_loss:2.7102 batch_bpb:1.0465 running_loss:2.7772 running_bpb:1.0837 doc_len:1467-1476
+ttt_progress: batch 683/782 batch_loss:2.7750 batch_bpb:1.0684 running_loss:2.7771 running_bpb:1.0832 doc_len:1400-1406
+ttt_progress: batch 679/782 batch_loss:2.8602 batch_bpb:1.0897 running_loss:2.7796 running_bpb:1.0834 doc_len:1368-1374
+ttt_progress: batch 672/782 batch_loss:2.9098 batch_bpb:1.1101 running_loss:2.7832 running_bpb:1.0842 doc_len:1321-1327
+ttt_progress: batch 665/782 batch_loss:2.7475 batch_bpb:1.0354 running_loss:2.7822 running_bpb:1.0829 doc_len:1275-1282
+ttt_progress: batch 653/782 batch_loss:2.7689 batch_bpb:1.0388 running_loss:2.7819 running_bpb:1.0818 doc_len:1203-1209
+ttt_progress: batch 651/782 batch_loss:2.7266 batch_bpb:1.0472 running_loss:2.7806 running_bpb:1.0809 doc_len:1193-1198
+ttt_progress: batch 644/782 batch_loss:2.7398 batch_bpb:1.0338 running_loss:2.7797 running_bpb:1.0799 doc_len:1155-1160
+ttt_progress: batch 633/782 batch_loss:2.8306 batch_bpb:1.1044 running_loss:2.7808 running_bpb:1.0804 doc_len:1101-1105
+ttt_progress: batch 626/782 batch_loss:2.8189 batch_bpb:1.0474 running_loss:2.7815 running_bpb:1.0797 doc_len:1068-1073
+ttt_progress: batch 619/782 batch_loss:2.7980 batch_bpb:1.0600 running_loss:2.7818 running_bpb:1.0793 doc_len:1037-1041
+ttt_progress: batch 612/782 batch_loss:2.8287 batch_bpb:1.0449 running_loss:2.7827 running_bpb:1.0787 doc_len:1007-1012
+ttt_progress: batch 606/782 batch_loss:2.8219 batch_bpb:1.0857 running_loss:2.7833 running_bpb:1.0788 doc_len:982-986
+ttt_progress: batch 599/782 batch_loss:2.7464 batch_bpb:1.0548 running_loss:2.7827 running_bpb:1.0784 doc_len:954-958
+ttt_progress: batch 595/782 batch_loss:2.7360 batch_bpb:1.0578 running_loss:2.7820 running_bpb:1.0781 doc_len:940-943
+ttt_progress: batch 588/782 batch_loss:2.7471 batch_bpb:1.0481 running_loss:2.7815 running_bpb:1.0776 doc_len:917-921
+ttt_progress: batch 580/782 batch_loss:2.7370 batch_bpb:1.0399 running_loss:2.7808 running_bpb:1.0771 doc_len:891-894
+ttt_progress: batch 571/782 batch_loss:2.7185 batch_bpb:1.0370 running_loss:2.7800 running_bpb:1.0765 doc_len:862-865
+ttt_progress: batch 563/782 batch_loss:2.8080 batch_bpb:1.0652 running_loss:2.7803 running_bpb:1.0763 doc_len:837-840
+ttt_progress: batch 553/782 batch_loss:2.7710 batch_bpb:1.0616 running_loss:2.7802 running_bpb:1.0762 doc_len:806-809
+ttt_progress: batch 545/782 batch_loss:2.7933 batch_bpb:1.0563 running_loss:2.7804 running_bpb:1.0759 doc_len:785-788
+ttt_progress: batch 537/782 batch_loss:2.7176 batch_bpb:1.0276 running_loss:2.7796 running_bpb:1.0753 doc_len:764-767
+ttt_progress: batch 531/782 batch_loss:2.7756 batch_bpb:1.0527 running_loss:2.7796 running_bpb:1.0751 doc_len:750-752
+ttt_progress: batch 523/782 batch_loss:2.8180 batch_bpb:1.0583 running_loss:2.7800 running_bpb:1.0749 doc_len:730-732
+ttt_progress: batch 515/782 batch_loss:2.7897 batch_bpb:1.0753 running_loss:2.7801 running_bpb:1.0749 doc_len:710-713
+ttt_progress: batch 504/782 batch_loss:2.8790 batch_bpb:1.1031 running_loss:2.7811 running_bpb:1.0752 doc_len:685-686
+ttt_progress: batch 495/782 batch_loss:2.7713 batch_bpb:1.0581 running_loss:2.7810 running_bpb:1.0750 doc_len:664-666
+ttt_progress: batch 487/782 batch_loss:2.8226 batch_bpb:1.0783 running_loss:2.7814 running_bpb:1.0750 doc_len:647-649
+ttt_progress: batch 479/782 batch_loss:2.7187 batch_bpb:1.0376 running_loss:2.7808 running_bpb:1.0747 doc_len:630-632
+ttt_progress: batch 472/782 batch_loss:2.8031 batch_bpb:1.0715 running_loss:2.7810 running_bpb:1.0747 doc_len:616-618
+ttt_progress: batch 463/782 batch_loss:2.8044 batch_bpb:1.0765 running_loss:2.7812 running_bpb:1.0747 doc_len:599-600
+ttt_progress: batch 454/782 batch_loss:2.8381 batch_bpb:1.0747 running_loss:2.7817 running_bpb:1.0747 doc_len:582-584
+ttt_progress: batch 446/782 batch_loss:2.8338 batch_bpb:1.0938 running_loss:2.7821 running_bpb:1.0748 doc_len:568-569
+ttt_progress: batch 441/782 batch_loss:2.7168 batch_bpb:1.0458 running_loss:2.7816 running_bpb:1.0746 doc_len:559-560
+ttt_progress: batch 433/782 batch_loss:2.7800 batch_bpb:1.0670 running_loss:2.7816 running_bpb:1.0746 doc_len:544-545
+ttt_progress: batch 425/782 batch_loss:2.7652 batch_bpb:1.0520 running_loss:2.7815 running_bpb:1.0744 doc_len:530-532
+ttt_progress: batch 416/782 batch_loss:2.7647 batch_bpb:1.0378 running_loss:2.7813 running_bpb:1.0741 doc_len:514-516
+ttt_progress: batch 407/782 batch_loss:2.7793 batch_bpb:1.0580 running_loss:2.7813 running_bpb:1.0740 doc_len:500-501
+ttt_progress: batch 399/782 batch_loss:2.7529 batch_bpb:1.0428 running_loss:2.7811 running_bpb:1.0738 doc_len:487-489
+ttt_progress: batch 391/782 batch_loss:2.8292 batch_bpb:1.1018 running_loss:2.7814 running_bpb:1.0740 doc_len:475-476
+ttt_progress: batch 383/782 batch_loss:2.8504 batch_bpb:1.0916 running_loss:2.7819 running_bpb:1.0741 doc_len:463-464
+ttt_progress: batch 375/782 batch_loss:2.8067 batch_bpb:1.1060 running_loss:2.7820 running_bpb:1.0743 doc_len:452-453
+ttt_progress: batch 367/782 batch_loss:2.8356 batch_bpb:1.0650 running_loss:2.7823 running_bpb:1.0742 doc_len:440-441
+ttt_progress: batch 359/782 batch_loss:2.8013 batch_bpb:1.0827 running_loss:2.7824 running_bpb:1.0743 doc_len:429-430
+ttt_progress: batch 351/782 batch_loss:2.8400 batch_bpb:1.0931 running_loss:2.7827 running_bpb:1.0744 doc_len:418-419
+ttt_progress: batch 343/782 batch_loss:2.8061 batch_bpb:1.0707 running_loss:2.7828 running_bpb:1.0744 doc_len:407-408
+ttt_progress: batch 335/782 batch_loss:2.7215 batch_bpb:1.0907 running_loss:2.7825 running_bpb:1.0744 doc_len:396-398
+ttt_progress: batch 327/782 batch_loss:2.7794 batch_bpb:1.0790 running_loss:2.7825 running_bpb:1.0745 doc_len:387-388
+ttt_progress: batch 319/782 batch_loss:2.8373 batch_bpb:1.1131 running_loss:2.7828 running_bpb:1.0746 doc_len:376-377
+ttt_progress: batch 311/782 batch_loss:2.8603 batch_bpb:1.0957 running_loss:2.7831 running_bpb:1.0747 doc_len:365-367
+ttt_progress: batch 303/782 batch_loss:2.8183 batch_bpb:1.0918 running_loss:2.7833 running_bpb:1.0748 doc_len:355-357
+ttt_progress: batch 295/782 batch_loss:2.8592 batch_bpb:1.1273 running_loss:2.7836 running_bpb:1.0750 doc_len:345-347
+ttt_progress: batch 287/782 batch_loss:2.8730 batch_bpb:1.1207 running_loss:2.7840 running_bpb:1.0752 doc_len:336-337
+ttt_progress: batch 280/782 batch_loss:2.8281 batch_bpb:1.0976 running_loss:2.7842 running_bpb:1.0753 doc_len:329-329
+ttt_progress: batch 271/782 batch_loss:2.7804 batch_bpb:1.0715 running_loss:2.7841 running_bpb:1.0753 doc_len:319-320
+ttt_progress: batch 264/782 batch_loss:2.9074 batch_bpb:1.1508 running_loss:2.7846 running_bpb:1.0756 doc_len:311-312
+ttt_progress: batch 256/782 batch_loss:2.8897 batch_bpb:1.1327 running_loss:2.7850 running_bpb:1.0758 doc_len:301-302
+ttt_progress: batch 248/782 batch_loss:2.8891 batch_bpb:1.1025 running_loss:2.7854 running_bpb:1.0759 doc_len:293-294
+ttt_progress: batch 240/782 batch_loss:2.9109 batch_bpb:1.1553 running_loss:2.7858 running_bpb:1.0761 doc_len:285-286
+ttt_progress: batch 231/782 batch_loss:2.8292 batch_bpb:1.1035 running_loss:2.7859 running_bpb:1.0762 doc_len:276-277
+ttt_progress: batch 223/782 batch_loss:2.8367 batch_bpb:1.0921 running_loss:2.7861 running_bpb:1.0763 doc_len:268-269
+ttt_progress: batch 215/782 batch_loss:2.8555 batch_bpb:1.1458 running_loss:2.7863 running_bpb:1.0765 doc_len:260-261
+ttt_progress: batch 208/782 batch_loss:2.8251 batch_bpb:1.1155 running_loss:2.7864 running_bpb:1.0766 doc_len:254-254
+ttt_progress: batch 200/782 batch_loss:2.8611 batch_bpb:1.0996 running_loss:2.7866 running_bpb:1.0767 doc_len:247-247
+ttt_progress: batch 191/782 batch_loss:2.9412 batch_bpb:1.1485 running_loss:2.7871 running_bpb:1.0769 doc_len:238-239
+ttt_progress: batch 183/782 batch_loss:2.8787 batch_bpb:1.1491 running_loss:2.7873 running_bpb:1.0770 doc_len:231-232
+ttt_progress: batch 175/782 batch_loss:2.8480 batch_bpb:1.1164 running_loss:2.7875 running_bpb:1.0772 doc_len:225-225
+ttt_progress: batch 166/782 batch_loss:2.9806 batch_bpb:1.1491 running_loss:2.7880 running_bpb:1.0773 doc_len:217-218
+ttt_progress: batch 160/782 batch_loss:2.8727 batch_bpb:1.1290 running_loss:2.7882 running_bpb:1.0775 doc_len:212-212
+ttt_progress: batch 151/782 batch_loss:2.7982 batch_bpb:1.1028 running_loss:2.7882 running_bpb:1.0775 doc_len:204-205
+ttt_progress: batch 143/782 batch_loss:3.0176 batch_bpb:1.1953 running_loss:2.7887 running_bpb:1.0778 doc_len:198-199
+ttt_progress: batch 135/782 batch_loss:2.9396 batch_bpb:1.1452 running_loss:2.7891 running_bpb:1.0779 doc_len:191-192
+ttt_progress: batch 129/782 batch_loss:2.9416 batch_bpb:1.1809 running_loss:2.7894 running_bpb:1.0781 doc_len:187-187
+ttt_progress: batch 121/782 batch_loss:2.8553 batch_bpb:1.1312 running_loss:2.7895 running_bpb:1.0783 doc_len:181-181
+ttt_progress: batch 112/782 batch_loss:3.0043 batch_bpb:1.1620 running_loss:2.7900 running_bpb:1.0784 doc_len:174-175
+ttt_progress: batch 104/782 batch_loss:2.9984 batch_bpb:1.1667 running_loss:2.7904 running_bpb:1.0786 doc_len:168-169
+ttt_progress: batch 96/782 batch_loss:2.9433 batch_bpb:1.1504 running_loss:2.7907 running_bpb:1.0787 doc_len:162-163
+ttt_progress: batch 88/782 batch_loss:3.1064 batch_bpb:1.2095 running_loss:2.7912 running_bpb:1.0790 doc_len:156-157
+ttt_progress: batch 79/782 batch_loss:3.0381 batch_bpb:1.2062 running_loss:2.7916 running_bpb:1.0792 doc_len:149-150
+ttt_progress: batch 72/782 batch_loss:2.9425 batch_bpb:1.1958 running_loss:2.7919 running_bpb:1.0793 doc_len:144-144
+ttt_progress: batch 63/782 batch_loss:3.0106 batch_bpb:1.2142 running_loss:2.7922 running_bpb:1.0795 doc_len:137-138
+ttt_progress: batch 53/782 batch_loss:3.1383 batch_bpb:1.2372 running_loss:2.7927 running_bpb:1.0798 doc_len:129-130
+ttt_progress: batch 44/782 batch_loss:3.1521 batch_bpb:1.2283 running_loss:2.7932 running_bpb:1.0800 doc_len:122-122
+ttt_progress: batch 34/782 batch_loss:3.0834 batch_bpb:1.2482 running_loss:2.7936 running_bpb:1.0802 doc_len:114-115
+ttt_progress: batch 27/782 batch_loss:3.0995 batch_bpb:1.2374 running_loss:2.7940 running_bpb:1.0804 doc_len:107-108
+ttt_progress: batch 19/782 batch_loss:3.1425 batch_bpb:1.2273 running_loss:2.7944 running_bpb:1.0805 doc_len:100-101
+ttt_progress: batch 11/782 batch_loss:3.2323 batch_bpb:1.2632 running_loss:2.7948 running_bpb:1.0807 doc_len:90-92
+ttt_progress: batch 3/782 batch_loss:3.3365 batch_bpb:1.2654 running_loss:2.7953 running_bpb:1.0809 doc_len:75-78
+quantized_ttt_lora val_loss:2.77993034 val_bpb:1.07619767 eval_time:177562ms
+total_eval_time:274.7s
+total_eval_time_with_compile:365.6s

--- a/records/track_10min_16mb/2026-04-10_VarLenAttn/logs/train2.txt
+++ b/records/track_10min_16mb/2026-04-10_VarLenAttn/logs/train2.txt
@@ -2,28 +2,25 @@
 Hyperparameters:
   adam_eps: 1e-08
   adam_wd: 0.02
-  artifact_dir: runs/varlen2
+  artifact_dir: runs/varlen2-new-tuned
   beta1: 0.9
   beta2: 0.95
   compressor: brotli
   data_dir: ./data/
   datasets_dir: ./data/datasets/fineweb10B_sp8192
   distributed: True
-  ema_decay: 0.997
+  ema_decay: 0.9965
   embed_bits: 8
   embed_clip_sigmas: 20.0
   embed_lr: 0.6
-  embed_wd: 0.095
+  embed_wd: 0.085
   embedding_dim: 512
   enable_looping_at: 0.35
-  etlb_clip: 3.0
-  etlb_lr: 0.05
-  etlb_steps: 5
   eval_only_path: 
   eval_seq_len: 2048
   eval_stride: 64
   gptq_calibration_batches: 64
-  gptq_reserve_seconds: 12.0
+  gptq_reserve_seconds: 13.0
   grad_accum_steps: 1
   grad_clip_norm: 0.3
   head_lr: 0.008
@@ -31,7 +28,7 @@ Hyperparameters:
   iterations: 20000
   ln_scale: True
   local_rank: 0
-  logfile: runs/varlen2/b73d59aa-750c-4740-9e3d-145de9568a11.txt
+  logfile: runs/varlen2-new-tuned/55139fb1-a884-42a1-931c-d4a9e47b5cb5.txt
   logit_softcap: 30.0
   loop_end: 5
   loop_start: 3
@@ -42,7 +39,7 @@ Hyperparameters:
   min_lr: 0.0
   mlp_mult: 4.0
   model_dim: 512
-  model_path: runs/varlen2/final_model.pt
+  model_path: runs/varlen2-new-tuned/final_model.pt
   muon_backend_steps: 5
   muon_beta2: 0.95
   muon_momentum: 0.97
@@ -54,15 +51,16 @@ Hyperparameters:
   num_kv_heads: 4
   num_layers: 11
   num_loops: 2
-  parallel_start_layer: 7
+  parallel_final_lane: mean
+  parallel_start_layer: 8
   qk_gain_init: 5.0
-  quantized_model_path: runs/varlen2/final_model.int6.ptz
+  quantized_model_path: runs/varlen2-new-tuned/final_model.int6.ptz
   rank: 0
   rope_base: 10000.0
   rope_dims: 16
   rope_train_seq_len: 2048
   rope_yarn: False
-  run_id: b73d59aa-750c-4740-9e3d-145de9568a11
+  run_id: 55139fb1-a884-42a1-931c-d4a9e47b5cb5
   scalar_lr: 0.02
   seed: 2
   skip_gates_enabled: True
@@ -78,7 +76,7 @@ Hyperparameters:
   ttt_batch_size: 64
   ttt_beta1: 0.0
   ttt_beta2: 0.999
-  ttt_chunk_size: 64
+  ttt_chunk_size: 32
   ttt_enabled: True
   ttt_eval_batches: 
   ttt_eval_seq_len: 2048
@@ -96,14 +94,2867 @@ Hyperparameters:
   val_files: ./data/datasets/fineweb10B_sp8192/fineweb_val_*.bin
   val_loss_every: 4000
   vocab_size: 8192
-  warmdown_frac: 0.667
+  warmdown_frac: 0.72
   warmup_steps: 20
   world_size: 8
   xsa_last_n: 11
 ====================================================================================================
+Source code:
+====================================================================================================
+import base64, collections, copy, fcntl, glob, io, json, lzma, math, os
+from pathlib import Path
+import random, re, subprocess, sys, time, uuid, numpy as np, sentencepiece as spm, torch, torch.distributed as dist, torch.nn.functional as F
+from torch import nn
+from flash_attn_interface import (
+    flash_attn_func as flash_attn_3_func,
+    flash_attn_varlen_func,
+)
+from concurrent.futures import ThreadPoolExecutor
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+class Hyperparameters:
+    data_dir = os.environ.get("DATA_DIR", "./data/")
+    seed = int(os.environ.get("SEED", 1337))
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.72))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 6e2))
+    val_batch_tokens = int(os.environ.get("VAL_BATCH_TOKENS", 524288))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    sliding_window_enabled = bool(int(os.environ.get("SLIDING_WINDOW_ENABLED", "0")))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 8192))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    embedding_dim = int(os.environ.get("EMBEDDING_DIM", 512))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 4.0))
+    skip_gates_enabled = bool(int(os.environ.get("SKIP_GATES_ENABLED", "1")))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 3e1))
+    rope_base = float(os.environ.get("ROPE_BASE", 1e4))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    rope_train_seq_len = int(os.environ.get("ROPE_TRAIN_SEQ_LEN", 2048))
+    rope_yarn = bool(int(os.environ.get("ROPE_YARN", "0")))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 5.0))
+    num_loops = int(os.environ.get("NUM_LOOPS", 2))
+    loop_start = int(os.environ.get("LOOP_START", 3))
+    loop_end = int(os.environ.get("LOOP_END", 5))
+    enable_looping_at = float(os.environ.get("ENABLE_LOOPING_AT", 0.35))
+    parallel_start_layer = int(os.environ.get("PARALLEL_START_LAYER", 8))
+    parallel_final_lane = os.environ.get("PARALLEL_FINAL_LANE", "mean")
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.022))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.97))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-08))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.02))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_lora_rank = int(os.environ.get("TTT_LORA_RANK", 96))
+    ttt_lora_lr = float(os.environ.get("TTT_LORA_LR", 0.0001))
+    ttt_chunk_size = int(os.environ.get("TTT_CHUNK_SIZE", 32))
+    ttt_eval_seq_len = int(os.environ.get("TTT_EVAL_SEQ_LEN", 2048))
+    ttt_batch_size = int(os.environ.get("TTT_BATCH_SIZE", 64))
+    ttt_grad_steps = int(os.environ.get("TTT_GRAD_STEPS", 1))
+    ttt_weight_decay = float(os.environ.get("TTT_WEIGHT_DECAY", 0.5))
+    ttt_beta1 = float(os.environ.get("TTT_BETA1", 0))
+    ttt_beta2 = float(os.environ.get("TTT_BETA2", 0.999))
+    ttt_k_lora = bool(int(os.environ.get("TTT_K_LORA", "1")))
+    ttt_mlp_lora = bool(int(os.environ.get("TTT_MLP_LORA", "1")))
+    ttt_o_lora = bool(int(os.environ.get("TTT_O_LORA", "1")))
+    ttt_optimizer = os.environ.get("TTT_OPTIMIZER", "adam")
+    ttt_eval_batches = os.environ.get("TTT_EVAL_BATCHES", "")
+    ttt_output_dir = os.environ.get("TTT_OUTPUT_DIR", "")
+    val_doc_fraction = float(os.environ.get("VAL_DOC_FRACTION", 1.0))
+    compressor = os.environ.get("COMPRESSOR", "brotli")
+    gptq_calibration_batches = int(os.environ.get("GPTQ_CALIBRATION_BATCHES", 64))
+    gptq_reserve_seconds = float(os.environ.get("GPTQ_RESERVE_SECONDS", 13.0))
+    matrix_bits = int(os.environ.get("MATRIX_BITS", 6))
+    embed_bits = int(os.environ.get("EMBED_BITS", 8))
+    matrix_clip_sigmas = float(os.environ.get("MATRIX_CLIP_SIGMAS", 12.85))
+    embed_clip_sigmas = float(os.environ.get("EMBED_CLIP_SIGMAS", 2e1))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_main_process = rank == 0
+    grad_accum_steps = 8 // world_size
+    datasets_dir = os.path.join(data_dir, "datasets", f"fineweb10B_sp{vocab_size}")
+    train_files = os.path.join(datasets_dir, "fineweb_train_*.bin")
+    val_files = os.path.join(datasets_dir, "fineweb_val_*.bin")
+    tokenizer_path = os.path.join(
+        data_dir, "tokenizers", f"fineweb_{vocab_size}_bpe.model"
+    )
+    artifact_dir = os.environ.get("ARTIFACT_DIR", "")
+    eval_only_path = os.environ.get("EVAL_ONLY_PATH", "")
+    logfile = (
+        os.path.join(artifact_dir, f"{run_id}.txt")
+        if artifact_dir
+        else f"logs/{run_id}.txt"
+    )
+    model_path = (
+        os.path.join(artifact_dir, "final_model.pt")
+        if artifact_dir
+        else "final_model.pt"
+    )
+    quantized_model_path = (
+        os.path.join(artifact_dir, "final_model.int6.ptz")
+        if artifact_dir
+        else "final_model.int6.ptz"
+    )
+
+
+_logger_hparams = None
+
+
+def set_logging_hparams(h):
+    global _logger_hparams
+    _logger_hparams = h
+
+
+def log(msg, console=True):
+    if _logger_hparams is None:
+        print(msg)
+        return
+    if _logger_hparams.is_main_process:
+        if console:
+            print(msg)
+        if _logger_hparams.logfile is not None:
+            with open(_logger_hparams.logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+
+class ValidationData:
+    def __init__(self, h, device):
+        self.sp = spm.SentencePieceProcessor(model_file=h.tokenizer_path)
+        if int(self.sp.vocab_size()) != h.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={h.vocab_size} does not match tokenizer vocab_size={int(self.sp.vocab_size())}"
+            )
+        self.val_tokens = load_validation_tokens(h.val_files, h.eval_seq_len)
+        (
+            self.base_bytes_lut,
+            self.has_leading_space_lut,
+            self.is_boundary_token_lut,
+        ) = build_sentencepiece_luts(self.sp, h.vocab_size, device)
+
+
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sp_vocab_size = int(sp.vocab_size())
+    assert (
+        sp.piece_to_id("▁") != sp.unk_id()
+    ), "Tokenizer must have '▁' (space) as its own token for correct BPB byte counting"
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = (tokens.numel() - 1) // seq_len * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def load_data_shard(file):
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE = {}
+_MMAP_CACHE = {}
+
+
+def _read_num_tokens(file):
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+
+def _get_shard_memmap(file):
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode="r", dtype="<u2", offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+BOS_ID = None
+
+
+def get_next_multiple_of_n(v, n):
+    return ((v + n - 1) // n) * n
+
+
+def _build_cu_seqlens(bos_pos, total_len, device, max_doc_len=0, bucket_size=64):
+    if not bos_pos or bos_pos[0] != 0:
+        bos_pos = [0] + bos_pos
+    seg_starts = []
+    starts_with_end = bos_pos + [total_len]
+    for i in range(len(starts_with_end) - 1):
+        start = starts_with_end[i]
+        end = starts_with_end[i + 1]
+        if max_doc_len > 0:
+            pos = start
+            while pos < end:
+                seg_starts.append(pos)
+                pos += max_doc_len
+        else:
+            seg_starts.append(start)
+    boundaries = seg_starts + [total_len]
+    padded_len = get_next_multiple_of_n(len(boundaries), bucket_size)
+    cu = torch.full((padded_len,), total_len, dtype=torch.int32, device=device)
+    cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+    seg_ends = seg_starts[1:] + [total_len]
+    max_seqlen = max(end - start for start, end in zip(seg_starts, seg_ends))
+    return cu, max_seqlen
+
+class DocumentPackingLoader:
+    _shard_pool = ThreadPoolExecutor(1)
+
+    def __init__(self, h, device, cu_bucket_size=64):
+        self.rank = h.rank
+        self.world_size = h.world_size
+        self.device = device
+        self.cu_bucket_size = cu_bucket_size
+        self.max_seq_len = h.train_seq_len
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files
+        self.file_iter = iter(self.files)
+        self._init_shard(load_data_shard(next(self.file_iter)))
+        self._next_shard = self._submit_next_shard()
+        self._batch_pool = ThreadPoolExecutor(1)
+        self._next_batch = None
+
+    def _init_shard(self, tokens):
+        global BOS_ID
+        self.tokens = tokens
+        self.shard_size = tokens.numel()
+        if BOS_ID is None:
+            BOS_ID = 1
+        self.bos_idx = (
+            (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        )
+        if self.bos_idx.size == 0:
+            self.bos_idx = np.array([0], dtype=np.int64)
+        self.cursor = int(self.bos_idx[0])
+
+    def _submit_next_shard(self):
+        try:
+            path = next(self.file_iter)
+            return self._shard_pool.submit(load_data_shard, path)
+        except StopIteration:
+            return None
+
+    def _advance_shard(self):
+        if self._next_shard is None:
+            self.file_iter = iter(self.files)
+            self._next_shard = self._shard_pool.submit(
+                load_data_shard, next(self.file_iter)
+            )
+        self._init_shard(self._next_shard.result())
+        self._next_shard = self._submit_next_shard()
+
+    def _local_doc_starts(self, local_start, total_len):
+        lo = np.searchsorted(self.bos_idx, local_start, side="left")
+        hi = np.searchsorted(self.bos_idx, local_start + total_len, side="left")
+        return (self.bos_idx[lo:hi] - local_start).tolist()
+
+    def _prepare_batch(self, num_tokens_local, max_seq_len):
+        per_rank_span = num_tokens_local + 1
+        global_span = per_rank_span * self.world_size
+        while self.cursor + global_span > self.shard_size:
+            self._advance_shard()
+        local_start = self.cursor + self.rank * per_rank_span
+        buf = self.tokens[local_start : local_start + per_rank_span]
+        inputs = buf[:-1].to(dtype=torch.int64).pin_memory()
+        targets = buf[1:].to(dtype=torch.int64).pin_memory()
+        starts = self._local_doc_starts(local_start, inputs.numel())
+        cu_seqlens, max_seqlen = _build_cu_seqlens(
+            starts, inputs.numel(), inputs.device, max_seq_len, self.cu_bucket_size
+        )
+        cu_seqlens = cu_seqlens.pin_memory()
+        self.cursor += global_span
+        return inputs, targets, cu_seqlens, max_seqlen
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        num_tokens_local = global_tokens // (self.world_size * grad_accum_steps)
+        if self._next_batch is not None:
+            inputs, targets, cu_seqlens, max_seqlen = self._next_batch.result()
+        else:
+            inputs, targets, cu_seqlens, max_seqlen = self._prepare_batch(
+                num_tokens_local, self.max_seq_len
+            )
+        self._next_batch = self._batch_pool.submit(
+            self._prepare_batch, num_tokens_local, self.max_seq_len
+        )
+        return (
+            inputs[None].to(self.device, non_blocking=True),
+            targets[None].to(self.device, non_blocking=True),
+            cu_seqlens.to(self.device, non_blocking=True),
+            max_seqlen,
+        )
+
+
+class ShuffledSequenceLoader:
+    def __init__(self, h, device):
+        self.world_size = h.world_size
+        self.seq_len = h.train_seq_len
+        self.device = device
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files[h.rank :: h.world_size]
+        self.rng = np.random.Generator(np.random.PCG64(h.rank))
+        self.num_tokens = [_read_num_tokens(f) for f in self.files]
+        self.start_inds = [[] for _ in self.files]
+        for si in range(len(self.files)):
+            self._reset_shard(si)
+
+    def _reset_shard(self, si):
+        max_phase = min(
+            self.seq_len - 1, max(0, self.num_tokens[si] - self.seq_len - 1)
+        )
+        phase = int(self.rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        num_sequences = (self.num_tokens[si] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[si] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for bi in range(device_batch_size):
+            total = remaining.sum()
+            if total <= 0:
+                for si in range(len(self.files)):
+                    self._reset_shard(si)
+                remaining = np.array(
+                    [len(s) for s in self.start_inds], dtype=np.float64
+                )
+                total = remaining.sum()
+            probs = remaining / total
+            si = int(self.rng.choice(len(self.files), p=probs))
+            start_ind = self.start_inds[si].pop()
+            remaining[si] -= 1
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[bi] = window[:-1]
+            y[bi] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x):
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+@triton.jit
+def linear_leaky_relu_square_kernel(
+    a_desc,
+    b_desc,
+    c_desc,
+    aux_desc,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    FORWARD: tl.constexpr,
+):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+    tile_id_c = start_pid - NUM_SMS
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+        tile_id_c += NUM_SMS
+        offs_am_c = offs_am
+        offs_bn_c = offs_bn
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+        c0 = acc0.to(dtype)
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            pre0 = aux_desc.load([offs_am_c, offs_bn_c])
+            pre1 = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c0 = c0 * tl.where(pre0 > 0, 2.0 * pre0, 0.5 * pre0)
+            c1 = c1 * tl.where(pre1 > 0, 2.0 * pre1, 0.5 * pre1)
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+        if FORWARD:
+            aux0 = tl.where(c0 > 0, c0, 0.5 * c0)
+            aux1 = tl.where(c1 > 0, c1, 0.5 * c1)
+            aux_desc.store([offs_am_c, offs_bn_c], aux0 * aux0)
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], aux1 * aux1)
+
+
+def linear_leaky_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K2 = b.shape
+    assert K == K2
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    forward = aux is None
+    if aux is None:
+        aux = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 256, 64
+    num_stages = 4 if forward else 3
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    grid = lambda _meta: (
+        min(num_sms, triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N)),
+    )
+    linear_leaky_relu_square_kernel[grid](
+        a_desc,
+        b_desc,
+        c_desc,
+        aux_desc,
+        M,
+        N,
+        K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        NUM_SMS=num_sms,
+        FORWARD=forward,
+        num_stages=num_stages,
+        num_warps=8,
+    )
+    if forward:
+        return c, aux
+    return c
+
+
+class FusedLinearLeakyReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, w1, w2):
+        x_flat = x.reshape(-1, x.shape[-1])
+        pre, post = linear_leaky_relu_square(x_flat, w1)
+        out = F.linear(post, w2)
+        ctx.save_for_backward(x, w1, w2, pre, post)
+        return out.view(*x.shape[:-1], out.shape[-1])
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, w1, w2, pre, post = ctx.saved_tensors
+        x_flat = x.reshape(-1, x.shape[-1])
+        grad_output_flat = grad_output.reshape(-1, grad_output.shape[-1])
+        dw2 = grad_output_flat.T @ post
+        dpre = linear_leaky_relu_square(grad_output_flat, w2.T.contiguous(), aux=pre)
+        dw1 = dpre.T @ x_flat
+        dx = dpre @ w1
+        return dx.view_as(x), dw1, dw2
+
+
+FusedLeakyReLUSquareMLP = FusedLinearLeakyReLUSquareFunction.apply
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=1e4, train_seq_len=1024, rope_dims=0, yarn=True):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.yarn = yarn
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / base ** (
+            torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+
+    def forward(self, seq_len, device, dtype):
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached < seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if self.yarn and seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * scale ** (rd / (rd - 2))
+                inv_freq = 1.0 / new_base ** (
+                    torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd
+                )
+            else:
+                inv_freq = self.inv_freq.float().to(device)
+            t = torch.arange(seq_len, device=device, dtype=torch.float32)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached[:, :seq_len].to(dtype=dtype), self._sin_cached[:, :seq_len].to(dtype=dtype)
+
+
+def apply_rotary_emb(x, cos, sin, rope_dims=0):
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=True
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len, yarn=yarn)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x, q_w, k_w, v_w, out_w, cu_seqlens=None, max_seqlen=0):
+        bsz, seqlen, dim = x.shape
+        q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if cu_seqlens is not None:
+            y = flash_attn_varlen_func(
+                q[0],
+                k[0],
+                v[0],
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+                causal=True,
+                window_size=(-1, -1),
+            )[None]
+        else:
+            y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        self._last_proj_input = y.detach() if getattr(self, "_calib", False) else None
+        return F.linear(y, out_w.to(x.dtype))
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        self.use_fused = True
+
+    def forward(self, x, up_w, down_w):
+        if self.training and self.use_fused:
+            return FusedLeakyReLUSquareMLP(x, up_w.to(x.dtype), down_w.to(x.dtype))
+        hidden = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5).square()
+        self._last_down_input = hidden.detach() if getattr(self, "_calib", False) else None
+        return F.linear(hidden, down_w.to(x.dtype))
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        num_kv_heads,
+        mlp_mult,
+        rope_base,
+        qk_gain_init,
+        train_seq_len,
+        layer_idx=0,
+        ln_scale=False,
+        yarn=True,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=yarn
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(
+            torch.stack((torch.ones(dim), torch.zeros(dim))).float()
+        )
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+
+    def forward(self, x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=None, max_seqlen=0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(
+            self.attn_norm(x_in) * self.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[
+            None, None, :
+        ] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        return x_out
+
+class GPT(nn.Module):
+    def __init__(self, h):
+        super().__init__()
+        if h.logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {h.logit_softcap}")
+        self.tie_embeddings = h.tie_embeddings
+        self.tied_embed_init_std = h.tied_embed_init_std
+        self.logit_softcap = h.logit_softcap
+        self.tok_emb = nn.Embedding(h.vocab_size, h.embedding_dim)
+        if h.embedding_dim != h.model_dim:
+            self.embed_proj = CastedLinear(h.embedding_dim, h.model_dim, bias=False)
+            self.head_proj = CastedLinear(h.model_dim, h.embedding_dim, bias=False)
+        else:
+            self.embed_proj = None
+            self.head_proj = None
+        self.num_layers = h.num_layers
+        head_dim = h.model_dim // h.num_heads
+        kv_dim = h.num_kv_heads * head_dim
+        hidden_dim = int(h.mlp_mult * h.model_dim)
+        self.qo_bank = nn.Parameter(torch.empty(2 * h.num_layers, h.model_dim, h.model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * h.num_layers, kv_dim, h.model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(h.num_layers, hidden_dim, h.model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(h.num_layers, h.model_dim, hidden_dim))
+        self.num_encoder_layers = h.num_layers // 2
+        self.num_decoder_layers = h.num_layers - self.num_encoder_layers
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    h.model_dim,
+                    h.num_heads,
+                    h.num_kv_heads,
+                    h.mlp_mult,
+                    h.rope_base,
+                    h.qk_gain_init,
+                    h.train_seq_len,
+                    layer_idx=i,
+                    ln_scale=h.ln_scale,
+                    yarn=h.rope_yarn,
+                )
+                for i in range(h.num_layers)
+            ]
+        )
+        if h.rope_dims > 0:
+            head_dim = h.model_dim // h.num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = h.rope_dims
+                block.attn.rotary = Rotary(
+                    head_dim,
+                    base=h.rope_base,
+                    train_seq_len=h.train_seq_len,
+                    rope_dims=h.rope_dims,
+                    yarn=h.rope_yarn,
+                )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None
+            if h.tie_embeddings
+            else CastedLinear(h.embedding_dim, h.vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if h.xsa_last_n > 0:
+            for i in range(max(0, h.num_layers - h.xsa_last_n), h.num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self.looping_active = False
+        if h.num_loops > 0:
+            loop_seg = list(range(h.loop_start, h.loop_end + 1))
+            all_indices = list(range(h.loop_start))
+            for _ in range(h.num_loops + 1):
+                all_indices.extend(loop_seg)
+            all_indices.extend(range(h.loop_end + 1, h.num_layers))
+            num_enc = len(all_indices) // 2
+            self.encoder_indices = all_indices[:num_enc]
+            self.decoder_indices = all_indices[num_enc:]
+        else:
+            self.encoder_indices = list(range(self.num_encoder_layers))
+            self.decoder_indices = list(range(self.num_encoder_layers, h.num_layers))
+        self.num_skip_weights = min(
+            len(self.encoder_indices), len(self.decoder_indices)
+        )
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+        )
+        self.skip_gates = (
+            nn.Parameter(
+                torch.zeros(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+            )
+            if h.skip_gates_enabled
+            else None
+        )
+        self.parallel_start_layer = h.parallel_start_layer
+        self.parallel_final_lane = h.parallel_final_lane.lower()
+        self.parallel_post_lambdas = nn.Parameter(
+            torch.ones(h.num_layers, 2, 2, dtype=torch.float32)
+        )
+        self.parallel_resid_lambdas = nn.Parameter(
+            torch.full((h.num_layers, 2), 1.1, dtype=torch.float32)
+        )
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.qo_bank.data[n + i])
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.mlp_down_bank.data[i])
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _bank_weights(self, i):
+        n = self.num_layers
+        return (
+            self.qo_bank[i],
+            self.kv_bank[i],
+            self.kv_bank[n + i],
+            self.qo_bank[n + i],
+            self.mlp_up_bank[i],
+            self.mlp_down_bank[i],
+        )
+
+    def _parallel_block(
+        self, block_idx, lane0, lane1, x0,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+        cu_seqlens=None, max_seqlen=0,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        attn_out = block.attn(
+            block.attn_norm(attn_read) * block.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+        )
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * block.mlp(
+            block.mlp_norm(mlp_read) * block.ln_scale_factor, up_w, down_w
+        )
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+    def _final_parallel_hidden(self, lane0, lane1):
+        if self.parallel_final_lane == "mlp":
+            return lane1
+        if self.parallel_final_lane == "attn":
+            return lane0
+        return 0.5 * (lane0 + lane1)
+
+    def forward_logits(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else range(self.num_encoder_layers)
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else range(
+                self.num_encoder_layers,
+                self.num_encoder_layers + self.num_decoder_layers,
+            )
+        )
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block(
+                    i, lane0, lane1, x0, q_w, k_w, v_w, out_w, up_w, down_w,
+                    cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        if self.head_proj is not None:
+            x = self.head_proj(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(self, input_ids, target_ids, cu_seqlens=None, max_seqlen=0):
+        logits = self.forward_logits(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        return F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            target_ids.reshape(-1),
+            reduction="mean",
+        )
+
+    def forward_ttt(self, input_ids, target_ids, lora):
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else list(range(self.num_encoder_layers))
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else list(
+                range(
+                    self.num_encoder_layers,
+                    self.num_encoder_layers + self.num_decoder_layers,
+                )
+            )
+        )
+        slot = 0
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block_with_lora(
+                    i, lane0, lane1, x0, lora, slot,
+                    q_w, k_w, v_w, out_w, up_w, down_w,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        if self.head_proj is not None:
+            x = self.head_proj(x)
+        if self.tie_embeddings:
+            logits = F.linear(x, self.tok_emb.weight)
+        else:
+            logits = self.lm_head(x)
+        logits = logits + lora.lm_head_lora(x)
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        bsz, sl, V = logits.shape
+        return F.cross_entropy(
+            logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none"
+        ).reshape(bsz, sl)
+
+    def _block_with_lora(self, block, x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w):
+        mix = block.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = block.attn_norm(x_in) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q = (F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_heads, attn.head_dim
+        )
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        x_out = x_in + block.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        mlp_n = block.mlp_norm(x_out) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        x_out = x_out + block.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * mlp_out
+        return x_out
+
+    def _parallel_block_with_lora(
+        self, block_idx, lane0, lane1, x0, lora, slot,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        n = block.attn_norm(attn_read) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q = (F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_heads, attn.head_dim
+        )
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_n = block.mlp_norm(mlp_read) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * mlp_out
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+
+class BatchedLinearLoRA(nn.Module):
+    def __init__(self, bsz, in_features, out_features, rank):
+        super().__init__()
+        self._bound = 1.0 / math.sqrt(in_features)
+        self.A = nn.Parameter(
+            torch.empty(bsz, rank, in_features).uniform_(-self._bound, self._bound)
+        )
+        self.B = nn.Parameter(torch.zeros(bsz, out_features, rank))
+
+    def reset(self):
+        with torch.no_grad():
+            self.A.uniform_(-self._bound, self._bound)
+            self.B.zero_()
+
+    def forward(self, x):
+        return (x @ self.A.transpose(1, 2)) @ self.B.transpose(1, 2)
+
+
+class BatchedTTTLoRA(nn.Module):
+    def __init__(self, bsz, model, rank, k_lora=True, mlp_lora=True, o_lora=True):
+        super().__init__()
+        self.bsz = bsz
+        dim = model.qo_bank.shape[-1]
+        vocab = model.tok_emb.num_embeddings
+        if getattr(model, "looping_active", False):
+            num_slots = len(model.encoder_indices) + len(model.decoder_indices)
+        else:
+            num_slots = len(model.blocks)
+        kv_dim = model.blocks[0].attn.num_kv_heads * (
+            dim // model.blocks[0].attn.num_heads
+        )
+        embed_dim = model.tok_emb.embedding_dim
+        self.lm_head_lora = BatchedLinearLoRA(bsz, embed_dim, vocab, rank)
+        self.q_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+        )
+        self.v_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+        )
+        self.k_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+            )
+            if k_lora
+            else None
+        )
+        self.mlp_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if mlp_lora
+            else None
+        )
+        self.o_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if o_lora
+            else None
+        )
+
+    def reset(self):
+        with torch.no_grad():
+            self.lm_head_lora.reset()
+            for loras in [self.q_loras, self.v_loras, self.k_loras,
+                          self.mlp_loras, self.o_loras]:
+                if loras is not None:
+                    for lora in loras:
+                        lora.reset()
+
+
+def classify_param(name):
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or ".proj." in name and ".mlp." not in name:
+        return "attn"
+    return "other"
+
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps=10, eps=1e-07):
+    a, b, c = 3.4445, -4.775, 2.0315
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr,
+        momentum,
+        backend_steps,
+        nesterov=True,
+        weight_decay=0.0,
+        row_normalize=False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append({
+                    "p": p,
+                    "B": B,
+                    "padded_grad": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard_mom": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "full_update": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "scale": max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                })
+        self._bank_meta.sort(key=lambda m: -m["p"].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m["p"]
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m["padded_grad"]
+            pg[: m["B"]].copy_(p.grad.bfloat16())
+            if pg.shape[0] > m["B"]:
+                pg[m["B"] :].zero_()
+            fut = dist.reduce_scatter_tensor(
+                m["shard"], pg, op=dist.ReduceOp.AVG, async_op=True
+            )
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        if not self._built:
+            self._build()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+            row_normalize = group.get("row_normalize", False)
+            prev_ag_handle = None
+            prev_m = None
+            sharded = self._distributed and hasattr(self, "_rs_futures")
+            for idx, m in enumerate(self._bank_meta):
+                p = m["p"]
+                if p.grad is None:
+                    continue
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m["p"]
+                    upd = prev_m["full_update"][: prev_m["B"]]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+                if sharded and self._rs_futures[idx] is not None:
+                    self._rs_futures[idx].wait()
+                    g = m["shard"]
+                    buf = m["shard_mom"]
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+                if row_normalize:
+                    rn = update.float().norm(dim=-1, keepdim=True).clamp_min(1e-07)
+                    update = update / rn.to(update.dtype)
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m["full_update"], update, async_op=True
+                    )
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update.to(dtype=p.dtype), alpha=-lr * m["scale"])
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m["p"]
+                upd = prev_m["full_update"][: prev_m["B"]]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+            if hasattr(self, "_rs_futures"):
+                del self._rs_futures
+        return loss
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,parallel_post_lambdas,parallel_resid_lambdas",
+    ).split(",")
+    if pattern
+)
+
+
+PACKED_REPLICATED_GRAD_MAX_NUMEL = 1 << 15
+
+
+class Optimizers:
+    def __init__(self, h, base_model):
+        matrix_params = [
+            base_model.qo_bank,
+            base_model.kv_bank,
+            base_model.mlp_up_bank,
+            base_model.mlp_down_bank,
+        ]
+        block_named_params = list(base_model.blocks.named_parameters())
+        scalar_params = [
+            p
+            for (name, p) in block_named_params
+            if p.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        if base_model.skip_weights.numel() > 0:
+            scalar_params.append(base_model.skip_weights)
+        if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
+            scalar_params.append(base_model.skip_gates)
+        if base_model.parallel_post_lambdas is not None:
+            scalar_params.append(base_model.parallel_post_lambdas)
+        if base_model.parallel_resid_lambdas is not None:
+            scalar_params.append(base_model.parallel_resid_lambdas)
+        token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
+        tok_params = [
+            {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+        ]
+        self.optimizer_tok = torch.optim.AdamW(
+            tok_params,
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.embed_wd,
+            fused=True,
+        )
+        self.optimizer_muon = Muon(
+            matrix_params,
+            lr=h.matrix_lr,
+            momentum=h.muon_momentum,
+            backend_steps=h.muon_backend_steps,
+            weight_decay=h.muon_wd,
+            row_normalize=h.muon_row_normalize,
+        )
+        for group in self.optimizer_muon.param_groups:
+            group["base_lr"] = h.matrix_lr
+        self.optimizer_scalar = torch.optim.AdamW(
+            [{"params": scalar_params, "lr": h.scalar_lr, "base_lr": h.scalar_lr}],
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.adam_wd,
+            fused=True,
+        )
+        self.optimizers = [
+            self.optimizer_tok,
+            self.optimizer_muon,
+            self.optimizer_scalar,
+        ]
+        if base_model.lm_head is not None:
+            self.optimizer_head = torch.optim.Adam(
+                [
+                    {
+                        "params": [base_model.lm_head.weight],
+                        "lr": h.head_lr,
+                        "base_lr": h.head_lr,
+                    }
+                ],
+                betas=(h.beta1, h.beta2),
+                eps=h.adam_eps,
+                fused=True,
+            )
+            self.optimizers.insert(1, self.optimizer_head)
+        else:
+            self.optimizer_head = None
+        self.replicated_params = list(tok_params[0]["params"])
+        self.replicated_params.extend(scalar_params)
+        if base_model.lm_head is not None:
+            self.replicated_params.append(base_model.lm_head.weight)
+        self.replicated_large_params = []
+        self.replicated_packed_params = []
+        for p in self.replicated_params:
+            if p.numel() <= PACKED_REPLICATED_GRAD_MAX_NUMEL:
+                self.replicated_packed_params.append(p)
+            else:
+                self.replicated_large_params.append(p)
+
+    def __iter__(self):
+        return iter(self.optimizers)
+
+    def zero_grad_all(self):
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    def _all_reduce_packed_grads(self):
+        grads_by_key = collections.defaultdict(list)
+        for p in self.replicated_packed_params:
+            if p.grad is not None:
+                grads_by_key[(p.grad.device, p.grad.dtype)].append(p.grad)
+        for grads in grads_by_key.values():
+            flat = torch.empty(
+                sum(g.numel() for g in grads),
+                device=grads[0].device,
+                dtype=grads[0].dtype,
+            )
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                flat[offset : offset + n].copy_(g.contiguous().view(-1))
+                offset += n
+            dist.all_reduce(flat, op=dist.ReduceOp.AVG)
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                g.copy_(flat[offset : offset + n].view_as(g))
+                offset += n
+
+    def step(self, distributed=False):
+        self.optimizer_muon.launch_reduce_scatters()
+        if distributed:
+            reduce_handles = [
+                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG, async_op=True)
+                for p in self.replicated_large_params
+                if p.grad is not None
+            ]
+            self._all_reduce_packed_grads()
+            for handle in reduce_handles:
+                handle.wait()
+        self.optimizer_tok.step()
+        self.optimizer_scalar.step()
+        if self.optimizer_head is not None:
+            self.optimizer_head.step()
+        self.optimizer_muon.step()
+        self.zero_grad_all()
+
+
+def restore_fp32_params(model):
+    for module in model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    for name, param in model.named_parameters():
+        if (
+            param.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ) and param.dtype != torch.float32:
+            param.data = param.data.float()
+    if hasattr(model, "qo_bank"):
+        model.qo_bank.data = model.qo_bank.data.float()
+        model.kv_bank.data = model.kv_bank.data.float()
+        model.mlp_up_bank.data = model.mlp_up_bank.data.float()
+        model.mlp_down_bank.data = model.mlp_down_bank.data.float()
+
+
+def collect_hessians(model, train_loader, h, device, n_calibration_batches=64):
+    hessians = {}
+    hooks = []
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = True
+        block.mlp._calib = True
+        block.mlp.use_fused = False
+
+    def make_attn_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            for suffix in ["c_q", "c_k", "c_v"]:
+                name = f"blocks.{layer_idx}.attn.{suffix}.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            y = module._last_proj_input
+            if y is not None:
+                y = y.float()
+                if y.ndim == 3:
+                    y = y.reshape(-1, y.shape[-1])
+                name = f"blocks.{layer_idx}.attn.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        y.shape[1], y.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(y.T, y)
+        return hook_fn
+
+    def make_mlp_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            name = f"blocks.{layer_idx}.mlp.fc.weight"
+            if name not in hessians:
+                hessians[name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[name].addmm_(x.T, x)
+            h_act = module._last_down_input
+            if h_act is not None:
+                h_act = h_act.float()
+                if h_act.ndim == 3:
+                    h_act = h_act.reshape(-1, h_act.shape[-1])
+                name = f"blocks.{layer_idx}.mlp.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        h_act.shape[1], h_act.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(h_act.T, h_act)
+        return hook_fn
+
+    for i, block in enumerate(model.blocks):
+        hooks.append(block.attn.register_forward_hook(make_attn_hook(i)))
+        hooks.append(block.mlp.register_forward_hook(make_mlp_hook(i)))
+    if model.tie_embeddings:
+        hook_module = (
+            model.head_proj if model.head_proj is not None else model.final_norm
+        )
+
+        def make_output_hook(name):
+            def hook_fn(module, inp, out):
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            return hook_fn
+
+        hooks.append(
+            hook_module.register_forward_hook(make_output_hook("tok_emb.weight"))
+        )
+    model.eval()
+    with torch.no_grad():
+        for _ in range(n_calibration_batches):
+            x, _ = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+            model.forward_logits(x)
+    for hook in hooks:
+        hook.remove()
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = False
+        block.mlp._calib = False
+        block.mlp.use_fused = True
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / n_calibration_batches
+    return hessians
+
+
+def gptq_quantize_weight(w, H, clip_sigmas=3.0, clip_range=63, block_size=128):
+    W_orig = w.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * H.diag().mean()
+    H.diagonal().add_(damp)
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+    Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    row_std = W_orig.std(dim=1)
+    s = (clip_sigmas * row_std / clip_range).clamp_min(1e-10).to(torch.float16)
+    sf = s.float()
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    W_work = W_perm.clone()
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W_work[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros(rows, i2 - i1)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            d = Hinv_block[j, j]
+            q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - q_col.float() * sf) / d
+            Err[:, j] = err
+            W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+        if i2 < cols:
+            W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+    return Q[:, invperm], s
+
+
+def gptq_mixed_quantize(state_dict, hessians, h):
+    result = {}
+    meta = {}
+    for (name, tensor) in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough (float16)"
+            continue
+        cs = h.embed_clip_sigmas if "tok_emb" in name else h.matrix_clip_sigmas
+        bits = h.embed_bits if "tok_emb" in name else h.matrix_bits
+        q, s = gptq_quantize_weight(
+            t, hessians[name], clip_sigmas=cs, clip_range=2 ** (bits - 1) - 1
+        )
+        result[name + ".q"] = q
+        result[name + ".scale"] = s
+        meta[name] = f"gptq (int{bits})"
+    categories = collections.defaultdict(set)
+    for (name, cat) in meta.items():
+        short = re.sub("\\.\\d+$", "", re.sub("blocks\\.\\d+", "blocks", name))
+        categories[cat].add(short)
+    log("Quantized weights:")
+    for cat in sorted(categories):
+        log(f"  {cat}: {', '.join(sorted(categories[cat]))}")
+    return result, meta
+
+
+def dequantize_mixed(result, meta, template_sd):
+    out = {}
+    for (name, orig) in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if "passthrough" in info:
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (
+                q.float() * s.float().view(q.shape[0], *[1] * (q.ndim - 1))
+            ).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+_BSHF_MAGIC = b"BSHF"
+
+
+def _byte_shuffle(data, stride=2):
+    if stride <= 1 or len(data) < stride:
+        return data
+    src = np.frombuffer(data, dtype=np.uint8)
+    n = len(src)
+    out = np.empty(n, dtype=np.uint8)
+    dest_off = 0
+    for pos in range(stride):
+        chunk = src[pos::stride]
+        out[dest_off : dest_off + len(chunk)] = chunk
+        dest_off += len(chunk)
+    return _BSHF_MAGIC + bytes([stride]) + out.tobytes()
+
+
+def _byte_unshuffle(data):
+    if len(data) < 5 or data[:4] != _BSHF_MAGIC:
+        return data
+    stride = data[4]
+    if stride < 2:
+        return data[5:]
+    payload = np.frombuffer(data, dtype=np.uint8, offset=5)
+    n = len(payload)
+    out = np.empty(n, dtype=np.uint8)
+    src_off = 0
+    for pos in range(stride):
+        chunk_len = n // stride + (1 if pos < n % stride else 0)
+        out[pos::stride][:chunk_len] = payload[src_off : src_off + chunk_len]
+        src_off += chunk_len
+    return out.tobytes()
+
+
+def _compress(data, compressor):
+    data = _byte_shuffle(data)
+    if compressor == "lzma":
+        return lzma.compress(data, preset=6)
+    elif compressor == "brotli":
+        import brotli
+
+        return brotli.compress(data, quality=11)
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def _decompress(data, compressor):
+    if compressor == "lzma":
+        raw = lzma.decompress(data)
+    elif compressor == "brotli":
+        import brotli
+
+        raw = brotli.decompress(data)
+    else:
+        raise ValueError(f"Unknown compressor: {compressor!r}")
+    raw = _byte_unshuffle(raw)
+    return raw
+
+
+def _unbank_state_dict(state_dict, num_layers):
+    sd = {}
+    n = num_layers
+    for k, v in state_dict.items():
+        t = v.detach().cpu()
+        if k == "qo_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_q.weight"] = t[i]
+                sd[f"blocks.{i}.attn.proj.weight"] = t[n + i]
+        elif k == "kv_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_k.weight"] = t[i]
+                sd[f"blocks.{i}.attn.c_v.weight"] = t[n + i]
+        elif k == "mlp_up_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.fc.weight"] = t[i]
+        elif k == "mlp_down_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.proj.weight"] = t[i]
+        else:
+            sd[k] = t
+    return sd
+
+
+def _rebank_state_dict(flat_sd, num_layers, model_dim, kv_dim, hidden_dim):
+    sd = {}
+    n = num_layers
+    sd["qo_bank"] = torch.zeros(2 * n, model_dim, model_dim)
+    sd["kv_bank"] = torch.zeros(2 * n, kv_dim, model_dim)
+    sd["mlp_up_bank"] = torch.zeros(n, hidden_dim, model_dim)
+    sd["mlp_down_bank"] = torch.zeros(n, model_dim, hidden_dim)
+    for i in range(n):
+        sd["qo_bank"][i] = flat_sd[f"blocks.{i}.attn.c_q.weight"]
+        sd["qo_bank"][n + i] = flat_sd[f"blocks.{i}.attn.proj.weight"]
+        sd["kv_bank"][i] = flat_sd[f"blocks.{i}.attn.c_k.weight"]
+        sd["kv_bank"][n + i] = flat_sd[f"blocks.{i}.attn.c_v.weight"]
+        sd["mlp_up_bank"][i] = flat_sd[f"blocks.{i}.mlp.fc.weight"]
+        sd["mlp_down_bank"][i] = flat_sd[f"blocks.{i}.mlp.proj.weight"]
+    for k, v in flat_sd.items():
+        if not (
+            k.startswith("blocks.")
+            and any(
+                p in k
+                for p in [
+                    ".attn.c_q.", ".attn.c_k.", ".attn.c_v.",
+                    ".attn.proj.", ".mlp.fc.", ".mlp.proj.",
+                ]
+            )
+        ):
+            sd[k] = v
+    return sd
+
+
+def _compressed_code_size(code):
+    code_raw = code.encode("utf-8")
+    minified = subprocess.run(
+        ["pyminify", "--no-rename-locals", "--no-hoist-literals", "--remove-literal-statements", "-"],
+        input=code_raw, capture_output=True, check=True,
+    ).stdout
+    compressed = lzma.compress(minified)
+    encoded = base64.b85encode(compressed)
+    wrapper = b'import lzma as L,base64 as B\nexec(L.decompress(B.b85decode("' + encoded + b'")))\n'
+    return len(code_raw), len(wrapper)
+
+
+def serialize(h, base_model, code):
+    code_bytes_uncompressed, code_bytes = _compressed_code_size(code)
+    if h.is_main_process:
+        torch.save(base_model.state_dict(), h.model_path)
+        model_bytes = os.path.getsize(h.model_path)
+        log(f"Serialized model: {model_bytes} bytes")
+        log(f"Code size (uncompressed): {code_bytes_uncompressed} bytes")
+        log(f"Code size (compressed): {code_bytes} bytes")
+    sd_cpu = _unbank_state_dict(base_model.state_dict(), h.num_layers)
+    device = torch.device("cuda", h.local_rank)
+    log("GPTQ:collecting Hessians from calibration data...")
+    t0 = time.perf_counter()
+    calib_loader = ShuffledSequenceLoader(h, device)
+    hessians = collect_hessians(
+        base_model,
+        calib_loader,
+        h,
+        device,
+        n_calibration_batches=h.gptq_calibration_batches,
+    )
+    log(f"GPTQ:collected {len(hessians)} Hessians in {time.perf_counter()-t0:.1f}s")
+    quant_result, quant_meta = gptq_mixed_quantize(sd_cpu, hessians, h)
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = _compress(quant_raw, h.compressor)
+    quant_file_bytes = len(quant_blob)
+    bytes_total = quant_file_bytes + code_bytes
+    if h.is_main_process:
+        with open(h.quantized_model_path, "wb") as f:
+            f.write(quant_blob)
+        log(f"Serialized model quantized+{h.compressor}: {quant_file_bytes} bytes")
+        log(f"Total submission size quantized+{h.compressor}: {bytes_total} bytes")
+    return bytes_total, quant_file_bytes
+
+
+def deserialize(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    flat_template = _unbank_state_dict(eval_model.state_dict(), h.num_layers)
+    with open(h.quantized_model_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(_decompress(quant_blob_disk, h.compressor)), map_location="cpu"
+    )
+    deq_flat = dequantize_mixed(quant_state["w"], quant_state["m"], flat_template)
+    head_dim = h.model_dim // h.num_heads
+    kv_dim = h.num_kv_heads * head_dim
+    hidden_dim = int(h.mlp_mult * h.model_dim)
+    deq_state = _rebank_state_dict(deq_flat, h.num_layers, h.model_dim, kv_dim, hidden_dim)
+    eval_model.load_state_dict(deq_state, strict=True)
+    return eval_model
+
+
+def _loss_bpb(loss_sum, token_count, byte_count):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    return val_loss, val_bpb
+
+
+def eval_val(h, device, val_data, model, forward_logits_fn=None):
+    seq_len = h.eval_seq_len
+    local_batch_tokens = h.val_batch_tokens // (h.world_size * h.grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            f"VAL_BATCH_SIZE must provide at least one sequence per rank; got VAL_BATCH_SIZE={h.val_batch_tokens}, WORLD_SIZE={h.world_size}, GRAD_ACCUM_STEPS={h.grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = total_seqs * h.rank // h.world_size
+    seq_end = total_seqs * (h.rank + 1) // h.world_size
+
+    # TODO: Don't truncate this.
+    seq_end = seq_start + ((seq_end - seq_start) // local_batch_seqs) * local_batch_seqs
+
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    run_forward_logits = (
+        (model.module.forward_logits if hasattr(model, "module") else model.forward_logits)
+        if forward_logits_fn is None
+        else forward_logits_fn
+    )
+    model.eval()
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    with torch.no_grad():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_data.val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1]
+            y = local[1:]
+            bos_pos = (x == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                bos_pos, x.numel(), x.device, h.eval_seq_len, 64
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = run_forward_logits(
+                    x[None], cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                ).detach()
+            per_token_loss = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y.reshape(-1),
+                reduction="none",
+            )
+            val_loss_sum += per_token_loss.to(torch.float64).sum()
+            val_token_count += float(y.numel())
+            prev_ids = x
+            tgt_ids = y
+            token_bytes = val_data.base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (
+                val_data.has_leading_space_lut[tgt_ids]
+                & ~val_data.is_boundary_token_lut[prev_ids]
+            ).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    model.train()
+    return _loss_bpb(val_loss_sum, val_token_count, val_byte_count)
+
+
+def eval_val_sliding(h, device, val_data, base_model, forward_logits_fn=None, batch_seqs=32):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    run_forward_logits = base_model.forward_logits if forward_logits_fn is None else forward_logits_fn
+    seq_len = h.eval_seq_len
+    stride = h.eval_stride
+    total_tokens = val_data.val_tokens.numel() - 1
+    context_size = seq_len - stride
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if ws + context_size < total_tokens]
+    total_windows = len(window_starts)
+    my_s = (total_windows * h.rank) // h.world_size
+    my_e = (total_windows * (h.rank + 1)) // h.world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    total_batches = (len(my_windows) + batch_seqs - 1) // batch_seqs
+    is_master = h.rank == 0
+    cu_bucket = 64
+    t_sw_start = time.perf_counter()
+    with torch.no_grad():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_idx = bi // batch_seqs
+            if is_master and (batch_idx % 50 == 0 or batch_idx == total_batches - 1):
+                elapsed = time.perf_counter() - t_sw_start
+                rl = float(loss_sum.item() / token_count.item()) if token_count.item() > 0 else 0.0
+                rb = float((rl / math.log(2.0)) * token_count.item() / byte_count.item()) if byte_count.item() > 0 else 0.0
+                log(f"sliding_progress: batch {batch_idx+1}/{total_batches} "
+                    f"tokens:{int(token_count.item())} running_loss:{rl:.4f} running_bpb:{rb:.4f} "
+                    f"elapsed:{elapsed:.1f}s")
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            x_parts = []
+            y_parts = []
+            cu_starts = []
+            score_ranges = []
+            offset = 0
+            for ws in batch_ws:
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                chunk_cpu = val_data.val_tokens[ws:end + 1]
+                bos_pos = (chunk_cpu[:-1] == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+                if not bos_pos or bos_pos[0] != 0:
+                    bos_pos = [0] + bos_pos
+                cu_starts.extend(offset + pos for pos in bos_pos)
+                chunk = chunk_cpu.to(dtype=torch.int64, device=device)
+                x_parts.append(chunk[:-1])
+                y_parts.append(chunk[1:])
+                score_ranges.append((offset, wlen, ws))
+                offset += wlen
+            x_cat = torch.cat(x_parts, dim=0)[None]
+            y_cat = torch.cat(y_parts, dim=0)
+            boundaries = cu_starts + [offset]
+            padded_len = get_next_multiple_of_n(len(boundaries), cu_bucket)
+            cu_seqlens = torch.full((padded_len,), offset, dtype=torch.int32, device=device)
+            cu_seqlens[:len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = run_forward_logits(x_cat, cu_seqlens=cu_seqlens, max_seqlen=seq_len)
+            flat_nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_cat,
+                reduction="none",
+            )
+            flat_x = x_cat.reshape(-1)
+            for off, wlen, ws in score_ranges:
+                s = 0 if ws == 0 else context_size
+                lo = off + s
+                hi = off + wlen
+                scored_nll = flat_nll[lo:hi].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(hi - lo)
+                tgt = y_cat[lo:hi]
+                prev = flat_x[lo:hi]
+                tb = val_data.base_bytes_lut[tgt].to(torch.float64)
+                tb += (val_data.has_leading_space_lut[tgt] & ~val_data.is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    base_model.train()
+    return _loss_bpb(loss_sum, token_count, byte_count)
+
+
+def _find_docs(all_tokens):
+    bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0].numpy()
+    docs = []
+    for i in range(len(bos_positions)):
+        start = int(bos_positions[i])
+        end = (
+            int(bos_positions[i + 1])
+            if i + 1 < len(bos_positions)
+            else all_tokens.numel()
+        )
+        if i + 1 < len(bos_positions):
+            end += 1
+        assert end - start >= 2
+        docs.append((start, end - start))
+    return docs
+
+
+def _build_ttt_global_batches(doc_entries, h, ascending=False):
+    batch_size = h.ttt_batch_size
+    global_doc_entries = sorted(doc_entries, key=lambda x: x[1][1])
+    global_batches = [
+        global_doc_entries[i : i + batch_size]
+        for i in range(0, len(global_doc_entries), batch_size)
+    ]
+    indexed = list(enumerate(global_batches))
+    if not ascending:
+        indexed.sort(key=lambda ib: -max(dl for _, (_, dl) in ib[1]))
+    return indexed
+
+
+def _init_batch_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(4, "little"))
+
+
+def _claim_next_batch(counter_path, queue_len):
+    try:
+        with open(counter_path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            idx = int.from_bytes(f.read(4), "little")
+            f.seek(0)
+            f.write((idx + 1).to_bytes(4, "little"))
+            f.flush()
+    except FileNotFoundError:
+        return queue_len
+    return idx
+
+
+def _compute_chunk_window(ci, pred_len, num_chunks, chunk_size, eval_seq_len):
+    chunk_end = pred_len if ci == num_chunks - 1 else (ci + 1) * chunk_size
+    win_start = max(0, chunk_end - eval_seq_len)
+    win_len = chunk_end - win_start
+    chunk_start = ci * chunk_size
+    chunk_offset = chunk_start - win_start
+    chunk_len = chunk_end - chunk_start
+    return win_start, win_len, chunk_offset, chunk_len
+
+
+def _accumulate_bpb(
+    ptl,
+    x,
+    y,
+    chunk_offsets,
+    chunk_lens,
+    pos_idx,
+    base_bytes_lut,
+    has_leading_space_lut,
+    is_boundary_token_lut,
+    loss_sum,
+    byte_sum,
+    token_count,
+):
+    pos = pos_idx[: x.size(1)].unsqueeze(0)
+    mask = (
+        (chunk_lens.unsqueeze(1) > 0)
+        & (pos >= chunk_offsets.unsqueeze(1))
+        & (pos < (chunk_offsets + chunk_lens).unsqueeze(1))
+    )
+    mask_f64 = mask.to(torch.float64)
+    tok_bytes = base_bytes_lut[y].to(torch.float64)
+    tok_bytes += (has_leading_space_lut[y] & ~is_boundary_token_lut[x]).to(
+        torch.float64
+    )
+    loss_sum += (ptl.to(torch.float64) * mask_f64).sum()
+    byte_sum += (tok_bytes * mask_f64).sum()
+    token_count += chunk_lens.to(torch.float64).sum()
+
+def eval_val_ttt_lora(h, base_model, device, val_data, forward_ttt_train):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+    all_tokens = val_data.val_tokens
+    all_tokens_idx = all_tokens.to(torch.int32)
+    docs = _find_docs(all_tokens)
+    doc_entries = list(enumerate(docs))
+    if h.val_doc_fraction < 1.0:
+        sample_n = max(1, int(round(len(docs) * h.val_doc_fraction)))
+        sampled_indices = sorted(
+            random.Random(h.seed).sample(range(len(docs)), sample_n)
+        )
+        doc_entries = [(i, docs[i]) for i in sampled_indices]
+    log(
+        f"ttt_lora:docs:{len(doc_entries)} rank:{h.ttt_lora_rank} lr:{h.ttt_lora_lr} chunk:{h.ttt_chunk_size}"
+    )
+    if os.environ.get("TTT_DEBUG_BYPASS") and h.rank == 0:
+        test_doc = doc_entries[0][1]
+        ds, dl = test_doc
+        log(f"DEBUG: test doc start={ds} len={dl}")
+        toks = all_tokens_idx[ds : ds + dl].to(device=device, dtype=torch.int64)
+        x_d = toks[:-1].unsqueeze(0)
+        y_d = toks[1:].unsqueeze(0)
+        with torch.no_grad(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            logits_d = base_model.forward_logits(x_d)
+        ptl_d = F.cross_entropy(
+            logits_d.float().reshape(-1, logits_d.size(-1)),
+            y_d.reshape(-1), reduction="none",
+        )
+        direct_loss = ptl_d.mean().item()
+        direct_bpb = direct_loss / math.log(2.0)
+        log(f"DEBUG: direct forward_logits loss={direct_loss:.6f} bpb={direct_bpb:.6f} ntokens={y_d.numel()}")
+        toks_first5 = toks[:5].tolist()
+        ptl_first5 = ptl_d[:5].tolist()
+        log(f"DEBUG: first 5 tokens={toks_first5} ptl={[f'{v:.4f}' for v in ptl_first5]}")
+    chunk_size, eval_seq_len = h.ttt_chunk_size, h.ttt_eval_seq_len
+    eval_batch_set = None
+    if h.ttt_eval_batches:
+        eval_batch_set = set(int(x) for x in h.ttt_eval_batches.split(",") if x.strip())
+    use_ascending = eval_batch_set is not None
+    global_batches_sorted = _build_ttt_global_batches(doc_entries, h, ascending=use_ascending)
+    queue_len = len(global_batches_sorted)
+    counter_path = f"/tmp/ttt_counter_{h.run_id}"
+    if h.rank == 0:
+        _init_batch_counter(counter_path)
+    if dist.is_available() and dist.is_initialized():
+        path_list = [counter_path]
+        dist.broadcast_object_list(path_list, src=0)
+        counter_path = path_list[0]
+        dist.barrier()
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    t_start = time.perf_counter()
+    reusable_lora = BatchedTTTLoRA(
+        h.ttt_batch_size, base_model, h.ttt_lora_rank,
+        k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+    ).to(device)
+
+    def _build_opt(lora):
+        if h.ttt_optimizer == "sgd":
+            return torch.optim.SGD(
+                lora.parameters(), lr=h.ttt_lora_lr,
+                momentum=h.ttt_beta1, weight_decay=h.ttt_weight_decay,
+            )
+        return torch.optim.AdamW(
+            lora.parameters(), lr=h.ttt_lora_lr,
+            betas=(h.ttt_beta1, h.ttt_beta2),
+            eps=1e-10, weight_decay=h.ttt_weight_decay, fused=True,
+        )
+
+    reusable_opt = _build_opt(reusable_lora)
+    progress_f = None
+    if h.ttt_output_dir and h.rank == 0:
+        os.makedirs(h.ttt_output_dir, exist_ok=True)
+        progress_f = open(os.path.join(h.ttt_output_dir, "progress.jsonl"), "w")
+    try:
+      while True:
+        queue_idx = _claim_next_batch(counter_path, queue_len)
+        if queue_idx >= queue_len:
+            break
+        orig_batch_idx, batch_entries = global_batches_sorted[queue_idx]
+        batch = [doc for _, doc in batch_entries]
+        bsz = len(batch)
+        prev_loss = loss_sum.item()
+        prev_bytes = byte_sum.item()
+        prev_tokens = token_count.item()
+        if bsz == reusable_lora.bsz:
+            reusable_lora.reset()
+            for s in reusable_opt.state.values():
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor):
+                        v.zero_()
+                    elif k == "step":
+                        s[k] = 0
+            cur_lora = reusable_lora
+            cur_opt = reusable_opt
+        else:
+            cur_lora = BatchedTTTLoRA(
+                bsz, base_model, h.ttt_lora_rank,
+                k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+            ).to(device)
+            cur_opt = _build_opt(cur_lora)
+        pred_lens = [doc_len - 1 for _, doc_len in batch]
+        num_chunks = [(pl + chunk_size - 1) // chunk_size for pl in pred_lens]
+        max_nc = max(num_chunks)
+        num_chunks_t = torch.tensor(num_chunks, dtype=torch.int64, device=device)
+        for ci in range(max_nc):
+            active = [ci < nc for nc in num_chunks]
+            needs_train = any(ci < nc - 1 for nc in num_chunks)
+            tok_starts = torch.zeros(bsz, dtype=torch.int64)
+            tok_wls = torch.zeros(bsz, dtype=torch.int64)
+            chunk_offsets_cpu = torch.zeros(bsz, dtype=torch.int64)
+            chunk_lens_cpu = torch.zeros(bsz, dtype=torch.int64)
+            for b in range(bsz):
+                if not active[b]:
+                    continue
+                doc_start, doc_len = batch[b]
+                win_start, win_len, chunk_offset, chunk_len = _compute_chunk_window(
+                    ci, pred_lens[b], num_chunks[b], chunk_size, eval_seq_len
+                )
+                tok_starts[b] = doc_start + win_start
+                tok_wls[b] = win_len
+                chunk_offsets_cpu[b] = chunk_offset
+                chunk_lens_cpu[b] = chunk_len
+            _, context_size, chunk_offset, _ = _compute_chunk_window(
+                ci, (ci + 1) * chunk_size, ci + 1, chunk_size, eval_seq_len
+            )
+            col_idx = torch.arange(context_size + 1)
+            idx = tok_starts.unsqueeze(1) + col_idx.unsqueeze(0)
+            idx.clamp_(max=all_tokens.numel() - 1)
+            gathered_gpu = all_tokens_idx[idx].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            valid = (col_idx[:context_size].unsqueeze(0) < tok_wls.unsqueeze(1)).to(
+                device, non_blocking=True
+            )
+            chunk_offsets = chunk_offsets_cpu.to(device, non_blocking=True)
+            chunk_lens = chunk_lens_cpu.to(device, non_blocking=True)
+            x = torch.where(valid, gathered_gpu[:, :context_size], 0)
+            y = torch.where(valid, gathered_gpu[:, 1 : context_size + 1], 0)
+            ctx_pos = torch.arange(context_size, device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+            with torch.no_grad():
+                _accumulate_bpb(
+                    per_tok_loss,
+                    x,
+                    y,
+                    chunk_offsets,
+                    chunk_lens,
+                    ctx_pos,
+                    val_data.base_bytes_lut,
+                    val_data.has_leading_space_lut,
+                    val_data.is_boundary_token_lut,
+                    loss_sum,
+                    byte_sum,
+                    token_count,
+                )
+            if needs_train:
+                activate_chunk_mask = (num_chunks_t - 1 > ci).float()
+                for gi in range(h.ttt_grad_steps):
+                    if gi > 0:
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+                    per_doc = per_tok_loss[
+                        :, chunk_offset : chunk_offset + chunk_size
+                    ].mean(dim=-1)
+                    cur_opt.zero_grad(set_to_none=True)
+                    (per_doc * activate_chunk_mask).sum().backward()
+                    cur_opt.step()
+            else:
+                del per_tok_loss
+        batch_num = orig_batch_idx + 1
+        doc_lens = [dl for _, dl in batch]
+        should_report = False
+        if eval_batch_set is not None:
+            should_report = batch_num in eval_batch_set
+        else:
+            # should_report = local_batch_count % 10 == 0
+            should_report = True
+        if should_report:
+            cur_tokens = token_count.item()
+            cur_loss_val = loss_sum.item()
+            cur_bytes_val = byte_sum.item()
+            dt = cur_tokens - prev_tokens
+            if dt > 0:
+                b_loss = (cur_loss_val - prev_loss) / dt
+                b_bpb = b_loss / math.log(2.0) * (dt / (cur_bytes_val - prev_bytes))
+            else:
+                b_loss = b_bpb = 0.0
+            r_loss = cur_loss_val / max(cur_tokens, 1)
+            r_bpb = r_loss / math.log(2.0) * (cur_tokens / max(cur_bytes_val, 1))
+            elapsed = time.perf_counter() - t_start
+            log(
+                f"ttt_progress: batch {batch_num}/{queue_len} batch_loss:{b_loss:.4f} "
+                f"batch_bpb:{b_bpb:.4f} running_loss:{r_loss:.4f} running_bpb:{r_bpb:.4f} "
+                f"doc_len:{min(doc_lens)}-{max(doc_lens)}"
+            )
+            if progress_f is not None:
+                progress_f.write(
+                    json.dumps({
+                        "batch": batch_num, "total_batches": queue_len,
+                        "batch_loss": round(b_loss, 8), "batch_bpb": round(b_bpb, 8),
+                        "running_loss": round(r_loss, 8), "running_bpb": round(r_bpb, 8),
+                        "doc_len_min": min(doc_lens), "doc_len_max": max(doc_lens),
+                        "chunk_size": chunk_size,
+                        "elapsed_s": round(elapsed, 3),
+                        "batch_t_s": round(elapsed, 3),
+                    }) + "\n"
+                )
+                progress_f.flush()
+        del cur_lora, cur_opt
+    finally:
+        if progress_f is not None:
+            progress_f.close()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.train()
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_sum.item())
+    return val_loss, val_bpb
+
+
+def timed_eval(label, fn, *args, **kwargs):
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    val_loss, val_bpb = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    elapsed_ms = 1e3 * (time.perf_counter() - t0)
+    log(
+        f"{label} val_loss:{val_loss:.8f} val_bpb:{val_bpb:.8f} eval_time:{elapsed_ms:.0f}ms"
+    )
+    return val_loss, val_bpb
+
+
+def train_model(h, device, val_data):
+    base_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        base_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    model = compiled_model
+    log(f"model_params:{sum(p.numel()for p in base_model.parameters())}")
+    optimizers = Optimizers(h, base_model)
+    train_loader = DocumentPackingLoader(h, device)
+    max_wallclock_ms = (
+        1e3 * h.max_wallclock_seconds if h.max_wallclock_seconds > 0 else None
+    )
+    if max_wallclock_ms is not None:
+        max_wallclock_ms -= h.gptq_reserve_seconds * 1e3
+        log(
+            f"gptq:reserving {h.gptq_reserve_seconds:.0f}s, effective={max_wallclock_ms:.0f}ms"
+        )
+
+    def training_frac(step, elapsed_ms):
+        if max_wallclock_ms is None:
+            return step / max(h.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-09)
+
+    def lr_mul(frac):
+        if h.warmdown_frac <= 0:
+            return 1.0
+        if frac >= 1.0 - h.warmdown_frac:
+            return max((1.0 - frac) / h.warmdown_frac, h.min_lr)
+        return 1.0
+
+    def step_fn(step, lr_scale):
+        optimizers.zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(h.grad_accum_steps):
+            x, y, cu_seqlens, _max_seqlen = train_loader.next_batch(
+                h.train_batch_tokens, h.grad_accum_steps
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y, cu_seqlens=cu_seqlens, max_seqlen=h.train_seq_len)
+            train_loss += loss.detach()
+            (loss / h.grad_accum_steps).backward()
+        train_loss /= h.grad_accum_steps
+        frac = (
+            min(step / h.muon_momentum_warmup_steps, 1.0)
+            if h.muon_momentum_warmup_steps > 0
+            else 1.0
+        )
+        muon_momentum = (
+            1 - frac
+        ) * h.muon_momentum_warmup_start + frac * h.muon_momentum
+        for group in optimizers.optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * lr_scale
+        if h.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), h.grad_clip_norm)
+        optimizers.step(distributed=h.distributed)
+        return train_loss
+
+    if h.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for (name, tensor) in base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in optimizers
+        ]
+        model.train()
+        num_tokens_local = h.train_batch_tokens // h.world_size
+        for blk in base_model.blocks:
+            blk.attn.rotary(num_tokens_local, device, torch.bfloat16)
+        cu_bucket_size = train_loader.cu_bucket_size
+        warmup_cu_buckets = tuple(cu_bucket_size * i for i in range(1, 5))
+        warmup_cu_iters = 3
+        x, y, cu_seqlens, _ = train_loader.next_batch(
+            h.train_batch_tokens, h.grad_accum_steps
+        )
+        log(f"warmup_cu_buckets:{','.join(str(b) for b in warmup_cu_buckets)} iters_each:{warmup_cu_iters}")
+        def _run_cu_bucket_warmup():
+            for bucket_len in warmup_cu_buckets:
+                boundaries = list(range(0, x.size(1), max(h.train_seq_len, 1)))
+                if boundaries[-1] != x.size(1):
+                    boundaries.append(x.size(1))
+                cu = torch.full((bucket_len,), x.size(1), dtype=torch.int32, device=device)
+                cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+                for _ in range(warmup_cu_iters):
+                    optimizers.zero_grad_all()
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                        wloss = model(x, y, cu_seqlens=cu, max_seqlen=h.train_seq_len)
+                    (wloss / h.grad_accum_steps).backward()
+            optimizers.zero_grad_all()
+        _run_cu_bucket_warmup()
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            _run_cu_bucket_warmup()
+            base_model.looping_active = False
+        for warmup_step in range(h.warmup_steps):
+            step_fn(warmup_step, 1.0)
+            if (
+                warmup_step <= 5
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == h.warmup_steps
+            ):
+                log(f"warmup_step: {warmup_step+1}/{h.warmup_steps}")
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            log(
+                f"loop_warmup:enabled encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            for warmup_step in range(h.warmup_steps):
+                step_fn(warmup_step, 1.0)
+                if (
+                    warmup_step <= 5
+                    or (warmup_step + 1) % 10 == 0
+                    or warmup_step + 1 == h.warmup_steps
+                ):
+                    log(f"loop_warmup_step: {warmup_step+1}/{h.warmup_steps}")
+            base_model.looping_active = False
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for (opt, state) in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        optimizers.zero_grad_all()
+        train_loader = DocumentPackingLoader(h, device)
+    ema_state = {
+        name: t.detach().float().clone()
+        for (name, t) in base_model.state_dict().items()
+    }
+    ema_decay = h.ema_decay
+    training_time_ms = 0.0
+    stop_after_step = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = (
+            step == h.iterations
+            or stop_after_step is not None
+            and step >= stop_after_step
+        )
+        should_validate = (
+            last_step or h.val_loss_every > 0 and step % h.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1e3 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                h, device, val_data, model, compiled_forward_logits
+            )
+            log(
+                f"{step}/{h.iterations} val_loss: {val_loss:.4f} val_bpb: {val_bpb:.4f}"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < h.iterations:
+                log(
+                    f"stopping_early: wallclock_cap train_time: {training_time_ms:.0f}ms step: {step}/{h.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        frac = training_frac(step, elapsed_ms)
+        scale = lr_mul(frac)
+        if (
+            h.num_loops > 0
+            and not base_model.looping_active
+            and frac >= h.enable_looping_at
+        ):
+            base_model.looping_active = True
+            log(
+                f"layer_loop:enabled step:{step} frac:{frac:.3f} encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+        train_loss = step_fn(step, scale)
+        with torch.no_grad():
+            for (name, t) in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(
+                    t.detach().float(), alpha=1.0 - ema_decay
+                )
+        step += 1
+        approx_training_time_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        should_log_train = h.train_log_every > 0 and (
+            step <= 5 or step % h.train_log_every == 0 or stop_after_step is not None
+        )
+        if should_log_train:
+            tok_per_sec = step * h.train_batch_tokens / (approx_training_time_ms / 1e3)
+            log(
+                f"{step}/{h.iterations} train_loss: {train_loss.item():.4f} train_time: {approx_training_time_ms/60000:.1f}m tok/s: {tok_per_sec:.0f}"
+            )
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if h.distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated()//1024//1024} MiB reserved: {torch.cuda.max_memory_reserved()//1024//1024} MiB"
+    )
+    log("ema:applying EMA weights")
+    current_state = base_model.state_dict()
+    avg_state = {
+        name: t.to(dtype=current_state[name].dtype) for (name, t) in ema_state.items()
+    }
+    base_model.load_state_dict(avg_state, strict=True)
+    return base_model, compiled_model, compiled_forward_logits
+
+
+def train_and_eval(h, device):
+    random.seed(h.seed)
+    np.random.seed(h.seed)
+    torch.manual_seed(h.seed)
+    torch.cuda.manual_seed_all(h.seed)
+    if h.artifact_dir and h.is_main_process:
+        os.makedirs(h.artifact_dir, exist_ok=True)
+    val_data = ValidationData(h, device)
+    if h.eval_only_path:
+        log(f"eval_only:loading checkpoint from {h.eval_only_path}")
+        base_model = GPT(h).to(device).bfloat16()
+        restore_fp32_params(base_model)
+        base_model.load_state_dict(torch.load(h.eval_only_path, map_location=device))
+        if h.num_loops > 0:
+            base_model.looping_active = True
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+        compiled_forward_logits = torch.compile(
+            base_model.forward_logits, dynamic=False, fullgraph=True
+        )
+    else:
+        log(
+            f"train_shards: {len(list(Path(h.datasets_dir).resolve().glob('fineweb_train_*.bin')))}"
+        )
+        log(f"val_tokens: {val_data.val_tokens.numel()-1}")
+        base_model, compiled_model, compiled_forward_logits = train_model(
+            h, device, val_data
+        )
+    _skip_training = bool(h.eval_only_path)
+    torch._dynamo.reset()
+    timed_eval(
+        "diagnostic pre-quantization post-ema",
+        eval_val,
+        h,
+        device,
+        val_data,
+        compiled_model,
+        compiled_forward_logits,
+    )
+    if not _skip_training:
+        serialize(h, base_model, Path(__file__).read_text(encoding="utf-8"))
+    else:
+        log("eval_only: skipping serialize (already have quantized model)")
+        if not os.path.exists(h.quantized_model_path):
+            log("eval_only: no quantized model found, running serialize anyway")
+            serialize(h, base_model, Path(__file__).read_text(encoding="utf-8"))
+    if h.distributed:
+        dist.barrier()
+    eval_model = deserialize(h, device)
+    if h.num_loops > 0:
+        eval_model.looping_active = True
+    compiled_model = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        eval_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    timed_eval(
+        "diagnostic quantized",
+        eval_val,
+        h,
+        device,
+        val_data,
+        compiled_model,
+        compiled_forward_logits,
+    )
+    if h.sliding_window_enabled:
+        timed_eval(
+            "diagnostic quantized_sliding_window",
+            eval_val_sliding,
+            h,
+            device,
+            val_data,
+            eval_model,
+            forward_logits_fn=compiled_forward_logits,
+        )
+    if h.ttt_enabled:
+        del eval_model, compiled_model
+        torch._dynamo.reset()
+        torch.cuda.empty_cache()
+        ttt_model = deserialize(h, device)
+        if h.num_loops > 0:
+            ttt_model.looping_active = True
+        for p in ttt_model.parameters():
+            p.requires_grad_(False)
+
+        if h.rope_yarn:
+            _yarn_seqlen = h.train_batch_tokens // h.grad_accum_steps
+            for block in ttt_model.blocks:
+                block.attn.rotary(_yarn_seqlen, device, torch.bfloat16)
+        else:
+            for block in ttt_model.blocks:
+                block.attn.rotary._cos_cached = None
+                block.attn.rotary._sin_cached = None
+                block.attn.rotary._seq_len_cached = 0
+                block.attn.rotary(h.ttt_eval_seq_len, device, torch.bfloat16)
+
+        def _fwd_ttt_inner(input_ids, target_ids, lora):
+            return ttt_model.forward_ttt(input_ids, target_ids, lora=lora)
+
+        _fwd_ttt_compiled_inner = None
+
+        def _fwd_ttt(input_ids, target_ids, lora):
+            nonlocal _fwd_ttt_compiled_inner
+            if _fwd_ttt_compiled_inner is None:
+                _fwd_ttt_compiled_inner = torch.compile(_fwd_ttt_inner, dynamic=True)
+            return _fwd_ttt_compiled_inner(input_ids, target_ids, lora=lora)
+
+        _ttt_debug_bypass = bool(os.environ.get("TTT_DEBUG_BYPASS"))
+        if _ttt_debug_bypass:
+            def _fwd_ttt_bypass(input_ids, target_ids, lora):
+                logits = ttt_model.forward_logits(input_ids)
+                dummy = lora.q_loras[0].B.sum() * 0
+                logits = logits + dummy
+                bsz, sl, V = logits.shape
+                return F.cross_entropy(
+                    logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none"
+                ).reshape(bsz, sl)
+            fwd_ttt_compiled = _fwd_ttt_bypass
+            log("ttt_lora:DEBUG BYPASS active - using forward_logits directly (no compile warmup)")
+        else:
+            fwd_ttt_compiled = _fwd_ttt
+            log(f"ttt_lora:warming up compile")
+            global BOS_ID
+            if BOS_ID is None:
+                BOS_ID = 1
+            ds0 = 0
+            val_tokens_idx = val_data.val_tokens.to(torch.int32)
+            t_warmup = time.perf_counter()
+            warmup_bszes = [h.ttt_batch_size]
+            for bsz in warmup_bszes:
+                wl = BatchedTTTLoRA(
+                    bsz, ttt_model, h.ttt_lora_rank,
+                    k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+                ).to(device)
+                wo = torch.optim.AdamW(
+                    wl.parameters(),
+                    lr=h.ttt_lora_lr,
+                    betas=(h.ttt_beta1, h.ttt_beta2),
+                    eps=1e-10,
+                    weight_decay=h.ttt_weight_decay,
+                    fused=True,
+                )
+                for ctx_len in (h.ttt_chunk_size, h.ttt_eval_seq_len):
+                    col_w = torch.arange(ctx_len + 1)
+                    idx_w = (ds0 + col_w).clamp_(max=val_data.val_tokens.numel() - 1)
+                    row_w = val_tokens_idx[idx_w].to(device=device, dtype=torch.int64)
+                    xw = row_w[:ctx_len].unsqueeze(0).expand(bsz, -1).contiguous()
+                    yw = row_w[1 : ctx_len + 1].unsqueeze(0).expand(bsz, -1).contiguous()
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        ptl = fwd_ttt_compiled(xw, yw, lora=wl)
+                    ptl[:, : min(h.ttt_chunk_size, ctx_len)].mean(dim=-1).sum().backward()
+                    wo.step()
+                    wo.zero_grad(set_to_none=True)
+                del wl, wo
+            del val_tokens_idx
+            torch.cuda.empty_cache()
+            compile_elapsed = time.perf_counter() - t_warmup
+            log(f"ttt_lora:compile warmup done ({compile_elapsed:.1f}s)")
+        log("\nbeginning TTT eval timer")
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_val_loss, ttt_val_bpb = eval_val_ttt_lora(
+            h, ttt_model, device, val_data, forward_ttt_train=fwd_ttt_compiled
+        )
+        torch.cuda.synchronize()
+        ttt_eval_elapsed = time.perf_counter() - t_ttt
+        log(
+            f"quantized_ttt_lora val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f} eval_time:{1e3*ttt_eval_elapsed:.0f}ms"
+        )
+        log(f"total_eval_time:{ttt_eval_elapsed:.1f}s")
+        del ttt_model
+
+
+def main():
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    torch._dynamo.config.optimize_ddp = False
+    torch._dynamo.config.cache_size_limit = 16
+    h = Hyperparameters()
+    set_logging_hparams(h)
+    if h.is_main_process:
+        os.makedirs(h.artifact_dir if h.artifact_dir else "logs", exist_ok=True)
+        log(100 * "=", console=False)
+        log("Hyperparameters:", console=True)
+        for (k, v) in sorted(vars(type(h)).items()):
+            if not k.startswith("_"):
+                log(f"  {k}: {v}", console=True)
+        log("=" * 100, console=False)
+        log("Source code:", console=False)
+        log("=" * 100, console=False)
+        with open(__file__, "r", encoding="utf-8") as _src:
+            log(_src.read(), console=False)
+        log("=" * 100, console=False)
+        log(f"Running Python {sys.version}", console=False)
+        log(f"Running PyTorch {torch.__version__}", console=False)
+        log(
+            subprocess.run(
+                ["nvidia-smi"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            ).stdout,
+            console=False,
+        )
+        log("=" * 100, console=False)
+    train_and_eval(h, device)
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
 Running Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0]
 Running PyTorch 2.9.1+cu128
-Fri Apr 10 22:48:52 2026       
+Sat Apr 11 17:19:07 2026       
 +-----------------------------------------------------------------------------------------+
 | NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
 |-----------------------------------------+------------------------+----------------------+
@@ -112,35 +2963,35 @@ Fri Apr 10 22:48:52 2026
 |                                         |                        |               MIG M. |
 |=========================================+========================+======================|
 |   0  NVIDIA H100 80GB HBM3          On  |   00000000:04:00.0 Off |                    0 |
-| N/A   52C    P0            128W /  700W |    1519MiB /  81559MiB |      1%      Default |
+| N/A   47C    P0            127W /  700W |    1519MiB /  81559MiB |      3%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   1  NVIDIA H100 80GB HBM3          On  |   00000000:05:00.0 Off |                    0 |
-| N/A   40C    P0            122W /  700W |    1519MiB /  81559MiB |      0%      Default |
+| N/A   43C    P0            129W /  700W |    1519MiB /  81559MiB |      1%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   2  NVIDIA H100 80GB HBM3          On  |   00000000:0A:00.0 Off |                    0 |
-| N/A   43C    P0            121W /  700W |    1519MiB /  81559MiB |      2%      Default |
+| N/A   48C    P0            139W /  700W |    1519MiB /  81559MiB |      4%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   3  NVIDIA H100 80GB HBM3          On  |   00000000:0B:00.0 Off |                    0 |
-| N/A   39C    P0            122W /  700W |    1519MiB /  81559MiB |      2%      Default |
+| N/A   43C    P0            125W /  700W |    1519MiB /  81559MiB |      2%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   4  NVIDIA H100 80GB HBM3          On  |   00000000:84:00.0 Off |                    0 |
-| N/A   45C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+| N/A   47C    P0            129W /  700W |    1519MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   5  NVIDIA H100 80GB HBM3          On  |   00000000:85:00.0 Off |                    0 |
-| N/A   38C    P0            116W /  700W |    1519MiB /  81559MiB |      0%      Default |
+| N/A   40C    P0            117W /  700W |    1519MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   6  NVIDIA H100 80GB HBM3          On  |   00000000:8A:00.0 Off |                    0 |
-| N/A   41C    P0            120W /  700W |    1519MiB /  81559MiB |      0%      Default |
+| N/A   44C    P0            132W /  700W |    1519MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
 |   7  NVIDIA H100 80GB HBM3          On  |   00000000:8B:00.0 Off |                    0 |
-| N/A   38C    P0            119W /  700W |    1519MiB /  81559MiB |      0%      Default |
+| N/A   43C    P0            123W /  700W |    1519MiB /  81559MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
                                                                                          
@@ -149,21 +3000,21 @@ Fri Apr 10 22:48:52 2026
 |  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
 |        ID   ID                                                               Usage      |
 |=========================================================================================|
-|    0   N/A  N/A         1923701      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    1   N/A  N/A         1923702      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    2   N/A  N/A         1923703      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    3   N/A  N/A         1923704      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    4   N/A  N/A         1923705      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    5   N/A  N/A         1923706      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    6   N/A  N/A         1923707      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
-|    7   N/A  N/A         1923708      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    0   N/A  N/A          508516      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    1   N/A  N/A          508517      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    2   N/A  N/A          508518      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    3   N/A  N/A          508519      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    4   N/A  N/A          508520      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    5   N/A  N/A          508521      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    6   N/A  N/A          508522      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
+|    7   N/A  N/A          508523      C   ...ai-codegolf/.venv/bin/python3       1510MiB |
 +-----------------------------------------------------------------------------------------+
 
 ====================================================================================================
 train_shards: 128
 val_tokens: 40540160
-model_params:35944537
-gptq:reserving 12s, effective=588000ms
+model_params:35944602
+gptq:reserving 13s, effective=587000ms
 warmup_cu_buckets:64,128,192,256 iters_each:3
 warmup_step: 1/20
 warmup_step: 2/20
@@ -183,146 +3034,138 @@ loop_warmup_step: 6/20
 loop_warmup_step: 10/20
 loop_warmup_step: 20/20
 0/20000 val_loss: 9.0048 val_bpb: 3.4859
-1/20000 train_loss: 9.0044 train_time: 0.0m tok/s: 17402505
-2/20000 train_loss: 12.1620 train_time: 0.0m tok/s: 13572479
-3/20000 train_loss: 11.1394 train_time: 0.0m tok/s: 11442657
-4/20000 train_loss: 9.5694 train_time: 0.0m tok/s: 10548433
-5/20000 train_loss: 8.2082 train_time: 0.0m tok/s: 10099152
-500/20000 train_loss: 3.2840 train_time: 0.8m tok/s: 8332231
-1000/20000 train_loss: 3.0429 train_time: 1.6m tok/s: 8322705
-1500/20000 train_loss: 3.0440 train_time: 2.4m tok/s: 8321366
-2000/20000 train_loss: 3.0130 train_time: 3.2m tok/s: 8319692
-layer_loop:enabled step:2175 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
-2500/20000 train_loss: 3.0937 train_time: 4.2m tok/s: 7837630
-3000/20000 train_loss: 2.9311 train_time: 5.4m tok/s: 7339753
-3500/20000 train_loss: 2.9924 train_time: 6.5m tok/s: 7041994
-4000/20000 train_loss: 2.9201 train_time: 7.7m tok/s: 6832657
-4000/20000 val_loss: 2.8967 val_bpb: 1.1214
-4500/20000 train_loss: 2.8723 train_time: 8.8m tok/s: 6679533
-4920/20000 val_loss: 2.7790 val_bpb: 1.0758
-stopping_early: wallclock_cap train_time: 588111ms step: 4920/20000
-peak memory allocated: 40019 MiB reserved: 44088 MiB
+1/20000 train_loss: 9.0044 train_time: 0.0m tok/s: 16425431
+2/20000 train_loss: 12.2150 train_time: 0.0m tok/s: 12965631
+3/20000 train_loss: 11.2432 train_time: 0.0m tok/s: 11070404
+4/20000 train_loss: 9.6802 train_time: 0.0m tok/s: 10232173
+5/20000 train_loss: 8.2696 train_time: 0.0m tok/s: 9827797
+500/20000 train_loss: 3.2671 train_time: 0.8m tok/s: 8223330
+1000/20000 train_loss: 3.0232 train_time: 1.6m tok/s: 8206667
+1500/20000 train_loss: 3.0223 train_time: 2.4m tok/s: 8202260
+2000/20000 train_loss: 2.9821 train_time: 3.2m tok/s: 8202015
+layer_loop:enabled step:2143 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2500/20000 train_loss: 3.0644 train_time: 4.3m tok/s: 7691712
+3000/20000 train_loss: 2.9052 train_time: 5.4m tok/s: 7242710
+3500/20000 train_loss: 2.9726 train_time: 6.6m tok/s: 6953361
+4000/20000 train_loss: 2.9041 train_time: 7.8m tok/s: 6717442
+4000/20000 val_loss: 2.8757 val_bpb: 1.1132
+4500/20000 train_loss: 2.8499 train_time: 9.0m tok/s: 6573516
+4847/20000 val_loss: 2.7735 val_bpb: 1.0737
+stopping_early: wallclock_cap train_time: 587072ms step: 4847/20000
+peak memory allocated: 40019 MiB reserved: 44090 MiB
 ema:applying EMA weights
-
-beginning eval timer
-pre-quantization post-ema val_loss:2.77937808 val_bpb:1.07594919 eval_time:7704ms
-Serialized model: 135408623 bytes
-Code size (uncompressed): 124045 bytes
-Code size (compressed): 27085 bytes
+diagnostic pre-quantization post-ema val_loss:2.77237193 val_bpb:1.07323698 eval_time:5942ms
+Serialized model: 135409136 bytes
+Code size (uncompressed): 116694 bytes
+Code size (compressed): 26845 bytes
 GPTQ:collecting Hessians from calibration data...
-GPTQ:collected 67 Hessians in 12.5s
+GPTQ:collected 67 Hessians in 12.6s
 Quantized weights:
   gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
   gptq (int8): tok_emb.weight
-  passthrough (float16): blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, lane_merge, skip_gates, skip_weights
-Serialized model quantized+brotli: 15967464 bytes
-Total submission size quantized+brotli: 15994549 bytes
-quantized val_loss:2.80668282 val_bpb:1.08651937 eval_time:8814ms
+  passthrough (float16): blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, skip_gates, skip_weights
+Serialized model quantized+brotli: 15957953 bytes
+Total submission size quantized+brotli: 15984798 bytes
+diagnostic quantized val_loss:2.80266675 val_bpb:1.08496467 eval_time:9308ms
 ttt_lora:warming up compile
-ttt_lora:compile warmup done (90.9s)
-ttt_lora:docs:50000 rank:96 lr:0.0001 chunk:64
-ttt_progress: batch 778/782 batch_loss:2.7965 batch_bpb:1.1187 running_loss:2.7965 running_bpb:1.1187 doc_len:7961-8997
-ttt_progress: batch 772/782 batch_loss:2.7752 batch_bpb:1.1100 running_loss:2.7885 running_bpb:1.1155 doc_len:4937-5193
-ttt_progress: batch 768/782 batch_loss:2.7112 batch_bpb:1.0880 running_loss:2.7702 running_bpb:1.1090 doc_len:4128-4306
-ttt_progress: batch 762/782 batch_loss:2.8330 batch_bpb:1.0783 running_loss:2.7805 running_bpb:1.1037 doc_len:3431-3533
-ttt_progress: batch 756/782 batch_loss:2.7914 batch_bpb:1.0819 running_loss:2.7819 running_bpb:1.1010 doc_len:2973-3032
-ttt_progress: batch 750/782 batch_loss:2.8335 batch_bpb:1.0690 running_loss:2.7870 running_bpb:1.0977 doc_len:2638-2688
-ttt_progress: batch 744/782 batch_loss:2.6622 batch_bpb:1.0606 running_loss:2.7767 running_bpb:1.0946 doc_len:2388-2419
-ttt_progress: batch 737/782 batch_loss:2.8045 batch_bpb:1.0694 running_loss:2.7787 running_bpb:1.0928 doc_len:2165-2193
-ttt_progress: batch 732/782 batch_loss:2.8301 batch_bpb:1.1015 running_loss:2.7818 running_bpb:1.0934 doc_len:2041-2062
-ttt_progress: batch 725/782 batch_loss:2.7653 batch_bpb:1.0718 running_loss:2.7809 running_bpb:1.0922 doc_len:1900-1915
-ttt_progress: batch 718/782 batch_loss:2.7829 batch_bpb:1.0727 running_loss:2.7810 running_bpb:1.0912 doc_len:1773-1792
-ttt_progress: batch 711/782 batch_loss:2.7812 batch_bpb:1.0473 running_loss:2.7810 running_bpb:1.0893 doc_len:1673-1683
-ttt_progress: batch 704/782 batch_loss:2.7515 batch_bpb:1.0262 running_loss:2.7799 running_bpb:1.0867 doc_len:1595-1606
-ttt_progress: batch 697/782 batch_loss:2.7701 batch_bpb:1.0437 running_loss:2.7795 running_bpb:1.0850 doc_len:1522-1534
-ttt_progress: batch 691/782 batch_loss:2.7102 batch_bpb:1.0465 running_loss:2.7772 running_bpb:1.0837 doc_len:1467-1476
-ttt_progress: batch 683/782 batch_loss:2.7750 batch_bpb:1.0684 running_loss:2.7771 running_bpb:1.0832 doc_len:1400-1406
-ttt_progress: batch 679/782 batch_loss:2.8602 batch_bpb:1.0897 running_loss:2.7796 running_bpb:1.0834 doc_len:1368-1374
-ttt_progress: batch 672/782 batch_loss:2.9098 batch_bpb:1.1101 running_loss:2.7832 running_bpb:1.0842 doc_len:1321-1327
-ttt_progress: batch 665/782 batch_loss:2.7475 batch_bpb:1.0354 running_loss:2.7822 running_bpb:1.0829 doc_len:1275-1282
-ttt_progress: batch 653/782 batch_loss:2.7689 batch_bpb:1.0388 running_loss:2.7819 running_bpb:1.0818 doc_len:1203-1209
-ttt_progress: batch 651/782 batch_loss:2.7266 batch_bpb:1.0472 running_loss:2.7806 running_bpb:1.0809 doc_len:1193-1198
-ttt_progress: batch 644/782 batch_loss:2.7398 batch_bpb:1.0338 running_loss:2.7797 running_bpb:1.0799 doc_len:1155-1160
-ttt_progress: batch 633/782 batch_loss:2.8306 batch_bpb:1.1044 running_loss:2.7808 running_bpb:1.0804 doc_len:1101-1105
-ttt_progress: batch 626/782 batch_loss:2.8189 batch_bpb:1.0474 running_loss:2.7815 running_bpb:1.0797 doc_len:1068-1073
-ttt_progress: batch 619/782 batch_loss:2.7980 batch_bpb:1.0600 running_loss:2.7818 running_bpb:1.0793 doc_len:1037-1041
-ttt_progress: batch 612/782 batch_loss:2.8287 batch_bpb:1.0449 running_loss:2.7827 running_bpb:1.0787 doc_len:1007-1012
-ttt_progress: batch 606/782 batch_loss:2.8219 batch_bpb:1.0857 running_loss:2.7833 running_bpb:1.0788 doc_len:982-986
-ttt_progress: batch 599/782 batch_loss:2.7464 batch_bpb:1.0548 running_loss:2.7827 running_bpb:1.0784 doc_len:954-958
-ttt_progress: batch 595/782 batch_loss:2.7360 batch_bpb:1.0578 running_loss:2.7820 running_bpb:1.0781 doc_len:940-943
-ttt_progress: batch 588/782 batch_loss:2.7471 batch_bpb:1.0481 running_loss:2.7815 running_bpb:1.0776 doc_len:917-921
-ttt_progress: batch 580/782 batch_loss:2.7370 batch_bpb:1.0399 running_loss:2.7808 running_bpb:1.0771 doc_len:891-894
-ttt_progress: batch 571/782 batch_loss:2.7185 batch_bpb:1.0370 running_loss:2.7800 running_bpb:1.0765 doc_len:862-865
-ttt_progress: batch 563/782 batch_loss:2.8080 batch_bpb:1.0652 running_loss:2.7803 running_bpb:1.0763 doc_len:837-840
-ttt_progress: batch 553/782 batch_loss:2.7710 batch_bpb:1.0616 running_loss:2.7802 running_bpb:1.0762 doc_len:806-809
-ttt_progress: batch 545/782 batch_loss:2.7933 batch_bpb:1.0563 running_loss:2.7804 running_bpb:1.0759 doc_len:785-788
-ttt_progress: batch 537/782 batch_loss:2.7176 batch_bpb:1.0276 running_loss:2.7796 running_bpb:1.0753 doc_len:764-767
-ttt_progress: batch 531/782 batch_loss:2.7756 batch_bpb:1.0527 running_loss:2.7796 running_bpb:1.0751 doc_len:750-752
-ttt_progress: batch 523/782 batch_loss:2.8180 batch_bpb:1.0583 running_loss:2.7800 running_bpb:1.0749 doc_len:730-732
-ttt_progress: batch 515/782 batch_loss:2.7897 batch_bpb:1.0753 running_loss:2.7801 running_bpb:1.0749 doc_len:710-713
-ttt_progress: batch 504/782 batch_loss:2.8790 batch_bpb:1.1031 running_loss:2.7811 running_bpb:1.0752 doc_len:685-686
-ttt_progress: batch 495/782 batch_loss:2.7713 batch_bpb:1.0581 running_loss:2.7810 running_bpb:1.0750 doc_len:664-666
-ttt_progress: batch 487/782 batch_loss:2.8226 batch_bpb:1.0783 running_loss:2.7814 running_bpb:1.0750 doc_len:647-649
-ttt_progress: batch 479/782 batch_loss:2.7187 batch_bpb:1.0376 running_loss:2.7808 running_bpb:1.0747 doc_len:630-632
-ttt_progress: batch 472/782 batch_loss:2.8031 batch_bpb:1.0715 running_loss:2.7810 running_bpb:1.0747 doc_len:616-618
-ttt_progress: batch 463/782 batch_loss:2.8044 batch_bpb:1.0765 running_loss:2.7812 running_bpb:1.0747 doc_len:599-600
-ttt_progress: batch 454/782 batch_loss:2.8381 batch_bpb:1.0747 running_loss:2.7817 running_bpb:1.0747 doc_len:582-584
-ttt_progress: batch 446/782 batch_loss:2.8338 batch_bpb:1.0938 running_loss:2.7821 running_bpb:1.0748 doc_len:568-569
-ttt_progress: batch 441/782 batch_loss:2.7168 batch_bpb:1.0458 running_loss:2.7816 running_bpb:1.0746 doc_len:559-560
-ttt_progress: batch 433/782 batch_loss:2.7800 batch_bpb:1.0670 running_loss:2.7816 running_bpb:1.0746 doc_len:544-545
-ttt_progress: batch 425/782 batch_loss:2.7652 batch_bpb:1.0520 running_loss:2.7815 running_bpb:1.0744 doc_len:530-532
-ttt_progress: batch 416/782 batch_loss:2.7647 batch_bpb:1.0378 running_loss:2.7813 running_bpb:1.0741 doc_len:514-516
-ttt_progress: batch 407/782 batch_loss:2.7793 batch_bpb:1.0580 running_loss:2.7813 running_bpb:1.0740 doc_len:500-501
-ttt_progress: batch 399/782 batch_loss:2.7529 batch_bpb:1.0428 running_loss:2.7811 running_bpb:1.0738 doc_len:487-489
-ttt_progress: batch 391/782 batch_loss:2.8292 batch_bpb:1.1018 running_loss:2.7814 running_bpb:1.0740 doc_len:475-476
-ttt_progress: batch 383/782 batch_loss:2.8504 batch_bpb:1.0916 running_loss:2.7819 running_bpb:1.0741 doc_len:463-464
-ttt_progress: batch 375/782 batch_loss:2.8067 batch_bpb:1.1060 running_loss:2.7820 running_bpb:1.0743 doc_len:452-453
-ttt_progress: batch 367/782 batch_loss:2.8356 batch_bpb:1.0650 running_loss:2.7823 running_bpb:1.0742 doc_len:440-441
-ttt_progress: batch 359/782 batch_loss:2.8013 batch_bpb:1.0827 running_loss:2.7824 running_bpb:1.0743 doc_len:429-430
-ttt_progress: batch 351/782 batch_loss:2.8400 batch_bpb:1.0931 running_loss:2.7827 running_bpb:1.0744 doc_len:418-419
-ttt_progress: batch 343/782 batch_loss:2.8061 batch_bpb:1.0707 running_loss:2.7828 running_bpb:1.0744 doc_len:407-408
-ttt_progress: batch 335/782 batch_loss:2.7215 batch_bpb:1.0907 running_loss:2.7825 running_bpb:1.0744 doc_len:396-398
-ttt_progress: batch 327/782 batch_loss:2.7794 batch_bpb:1.0790 running_loss:2.7825 running_bpb:1.0745 doc_len:387-388
-ttt_progress: batch 319/782 batch_loss:2.8373 batch_bpb:1.1131 running_loss:2.7828 running_bpb:1.0746 doc_len:376-377
-ttt_progress: batch 311/782 batch_loss:2.8603 batch_bpb:1.0957 running_loss:2.7831 running_bpb:1.0747 doc_len:365-367
-ttt_progress: batch 303/782 batch_loss:2.8183 batch_bpb:1.0918 running_loss:2.7833 running_bpb:1.0748 doc_len:355-357
-ttt_progress: batch 295/782 batch_loss:2.8592 batch_bpb:1.1273 running_loss:2.7836 running_bpb:1.0750 doc_len:345-347
-ttt_progress: batch 287/782 batch_loss:2.8730 batch_bpb:1.1207 running_loss:2.7840 running_bpb:1.0752 doc_len:336-337
-ttt_progress: batch 280/782 batch_loss:2.8281 batch_bpb:1.0976 running_loss:2.7842 running_bpb:1.0753 doc_len:329-329
-ttt_progress: batch 271/782 batch_loss:2.7804 batch_bpb:1.0715 running_loss:2.7841 running_bpb:1.0753 doc_len:319-320
-ttt_progress: batch 264/782 batch_loss:2.9074 batch_bpb:1.1508 running_loss:2.7846 running_bpb:1.0756 doc_len:311-312
-ttt_progress: batch 256/782 batch_loss:2.8897 batch_bpb:1.1327 running_loss:2.7850 running_bpb:1.0758 doc_len:301-302
-ttt_progress: batch 248/782 batch_loss:2.8891 batch_bpb:1.1025 running_loss:2.7854 running_bpb:1.0759 doc_len:293-294
-ttt_progress: batch 240/782 batch_loss:2.9109 batch_bpb:1.1553 running_loss:2.7858 running_bpb:1.0761 doc_len:285-286
-ttt_progress: batch 231/782 batch_loss:2.8292 batch_bpb:1.1035 running_loss:2.7859 running_bpb:1.0762 doc_len:276-277
-ttt_progress: batch 223/782 batch_loss:2.8367 batch_bpb:1.0921 running_loss:2.7861 running_bpb:1.0763 doc_len:268-269
-ttt_progress: batch 215/782 batch_loss:2.8555 batch_bpb:1.1458 running_loss:2.7863 running_bpb:1.0765 doc_len:260-261
-ttt_progress: batch 208/782 batch_loss:2.8251 batch_bpb:1.1155 running_loss:2.7864 running_bpb:1.0766 doc_len:254-254
-ttt_progress: batch 200/782 batch_loss:2.8611 batch_bpb:1.0996 running_loss:2.7866 running_bpb:1.0767 doc_len:247-247
-ttt_progress: batch 191/782 batch_loss:2.9412 batch_bpb:1.1485 running_loss:2.7871 running_bpb:1.0769 doc_len:238-239
-ttt_progress: batch 183/782 batch_loss:2.8787 batch_bpb:1.1491 running_loss:2.7873 running_bpb:1.0770 doc_len:231-232
-ttt_progress: batch 175/782 batch_loss:2.8480 batch_bpb:1.1164 running_loss:2.7875 running_bpb:1.0772 doc_len:225-225
-ttt_progress: batch 166/782 batch_loss:2.9806 batch_bpb:1.1491 running_loss:2.7880 running_bpb:1.0773 doc_len:217-218
-ttt_progress: batch 160/782 batch_loss:2.8727 batch_bpb:1.1290 running_loss:2.7882 running_bpb:1.0775 doc_len:212-212
-ttt_progress: batch 151/782 batch_loss:2.7982 batch_bpb:1.1028 running_loss:2.7882 running_bpb:1.0775 doc_len:204-205
-ttt_progress: batch 143/782 batch_loss:3.0176 batch_bpb:1.1953 running_loss:2.7887 running_bpb:1.0778 doc_len:198-199
-ttt_progress: batch 135/782 batch_loss:2.9396 batch_bpb:1.1452 running_loss:2.7891 running_bpb:1.0779 doc_len:191-192
-ttt_progress: batch 129/782 batch_loss:2.9416 batch_bpb:1.1809 running_loss:2.7894 running_bpb:1.0781 doc_len:187-187
-ttt_progress: batch 121/782 batch_loss:2.8553 batch_bpb:1.1312 running_loss:2.7895 running_bpb:1.0783 doc_len:181-181
-ttt_progress: batch 112/782 batch_loss:3.0043 batch_bpb:1.1620 running_loss:2.7900 running_bpb:1.0784 doc_len:174-175
-ttt_progress: batch 104/782 batch_loss:2.9984 batch_bpb:1.1667 running_loss:2.7904 running_bpb:1.0786 doc_len:168-169
-ttt_progress: batch 96/782 batch_loss:2.9433 batch_bpb:1.1504 running_loss:2.7907 running_bpb:1.0787 doc_len:162-163
-ttt_progress: batch 88/782 batch_loss:3.1064 batch_bpb:1.2095 running_loss:2.7912 running_bpb:1.0790 doc_len:156-157
-ttt_progress: batch 79/782 batch_loss:3.0381 batch_bpb:1.2062 running_loss:2.7916 running_bpb:1.0792 doc_len:149-150
-ttt_progress: batch 72/782 batch_loss:2.9425 batch_bpb:1.1958 running_loss:2.7919 running_bpb:1.0793 doc_len:144-144
-ttt_progress: batch 63/782 batch_loss:3.0106 batch_bpb:1.2142 running_loss:2.7922 running_bpb:1.0795 doc_len:137-138
-ttt_progress: batch 53/782 batch_loss:3.1383 batch_bpb:1.2372 running_loss:2.7927 running_bpb:1.0798 doc_len:129-130
-ttt_progress: batch 44/782 batch_loss:3.1521 batch_bpb:1.2283 running_loss:2.7932 running_bpb:1.0800 doc_len:122-122
-ttt_progress: batch 34/782 batch_loss:3.0834 batch_bpb:1.2482 running_loss:2.7936 running_bpb:1.0802 doc_len:114-115
-ttt_progress: batch 27/782 batch_loss:3.0995 batch_bpb:1.2374 running_loss:2.7940 running_bpb:1.0804 doc_len:107-108
-ttt_progress: batch 19/782 batch_loss:3.1425 batch_bpb:1.2273 running_loss:2.7944 running_bpb:1.0805 doc_len:100-101
-ttt_progress: batch 11/782 batch_loss:3.2323 batch_bpb:1.2632 running_loss:2.7948 running_bpb:1.0807 doc_len:90-92
-ttt_progress: batch 3/782 batch_loss:3.3365 batch_bpb:1.2654 running_loss:2.7953 running_bpb:1.0809 doc_len:75-78
-quantized_ttt_lora val_loss:2.77993034 val_bpb:1.07619767 eval_time:177562ms
-total_eval_time:274.7s
-total_eval_time_with_compile:365.6s
+ttt_lora:compile warmup done (135.0s)
+
+beginning TTT eval timer
+ttt_lora:docs:50000 rank:96 lr:0.0001 chunk:32
+ttt_progress: batch 781/782 batch_loss:2.5674 batch_bpb:1.0599 running_loss:2.5674 running_bpb:1.0599 doc_len:14510-25988
+ttt_progress: batch 730/782 batch_loss:2.7662 batch_bpb:1.0890 running_loss:2.5866 running_bpb:1.0628 doc_len:1995-2016
+ttt_progress: batch 723/782 batch_loss:2.7813 batch_bpb:1.0611 running_loss:2.6026 running_bpb:1.0627 doc_len:1861-1885
+ttt_progress: batch 715/782 batch_loss:2.6473 batch_bpb:1.0401 running_loss:2.6058 running_bpb:1.0610 doc_len:1725-1739
+ttt_progress: batch 708/782 batch_loss:2.7226 batch_bpb:1.0463 running_loss:2.6132 running_bpb:1.0600 doc_len:1639-1649
+ttt_progress: batch 701/782 batch_loss:2.7600 batch_bpb:1.0497 running_loss:2.6215 running_bpb:1.0594 doc_len:1562-1572
+ttt_progress: batch 694/782 batch_loss:2.7653 batch_bpb:1.0673 running_loss:2.6289 running_bpb:1.0598 doc_len:1494-1504
+ttt_progress: batch 687/782 batch_loss:2.7194 batch_bpb:1.0502 running_loss:2.6332 running_bpb:1.0593 doc_len:1432-1441
+ttt_progress: batch 680/782 batch_loss:2.8091 batch_bpb:1.0567 running_loss:2.6408 running_bpb:1.0592 doc_len:1375-1383
+ttt_progress: batch 673/782 batch_loss:2.8132 batch_bpb:1.0564 running_loss:2.6477 running_bpb:1.0591 doc_len:1327-1334
+ttt_progress: batch 666/782 batch_loss:2.8218 batch_bpb:1.0605 running_loss:2.6542 running_bpb:1.0592 doc_len:1282-1288
+ttt_progress: batch 659/782 batch_loss:2.7194 batch_bpb:1.0241 running_loss:2.6564 running_bpb:1.0579 doc_len:1239-1245
+ttt_progress: batch 655/782 batch_loss:2.6837 batch_bpb:1.0208 running_loss:2.6573 running_bpb:1.0566 doc_len:1215-1220
+ttt_progress: batch 648/782 batch_loss:2.7488 batch_bpb:1.0419 running_loss:2.6601 running_bpb:1.0561 doc_len:1177-1182
+ttt_progress: batch 642/782 batch_loss:2.7803 batch_bpb:1.0816 running_loss:2.6636 running_bpb:1.0569 doc_len:1144-1150
+ttt_progress: batch 635/782 batch_loss:2.7419 batch_bpb:1.0614 running_loss:2.6658 running_bpb:1.0570 doc_len:1111-1116
+ttt_progress: batch 628/782 batch_loss:2.7699 batch_bpb:1.0475 running_loss:2.6685 running_bpb:1.0568 doc_len:1078-1082
+ttt_progress: batch 615/782 batch_loss:2.8417 batch_bpb:1.0670 running_loss:2.6727 running_bpb:1.0570 doc_len:1020-1023
+ttt_progress: batch 608/782 batch_loss:2.7325 batch_bpb:1.0313 running_loss:2.6740 running_bpb:1.0564 doc_len:990-994
+ttt_progress: batch 601/782 batch_loss:2.7631 batch_bpb:1.0619 running_loss:2.6760 running_bpb:1.0565 doc_len:963-966
+ttt_progress: batch 593/782 batch_loss:2.7982 batch_bpb:1.0465 running_loss:2.6785 running_bpb:1.0563 doc_len:933-937
+ttt_progress: batch 585/782 batch_loss:2.7680 batch_bpb:1.0672 running_loss:2.6802 running_bpb:1.0565 doc_len:908-911
+ttt_progress: batch 580/782 batch_loss:2.7309 batch_bpb:1.0376 running_loss:2.6812 running_bpb:1.0562 doc_len:891-894
+ttt_progress: batch 573/782 batch_loss:2.9297 batch_bpb:1.0723 running_loss:2.6857 running_bpb:1.0565 doc_len:868-871
+ttt_progress: batch 564/782 batch_loss:2.8735 batch_bpb:1.1117 running_loss:2.6889 running_bpb:1.0574 doc_len:840-843
+ttt_progress: batch 557/782 batch_loss:2.7937 batch_bpb:1.0416 running_loss:2.6906 running_bpb:1.0572 doc_len:818-821
+ttt_progress: batch 550/782 batch_loss:2.8080 batch_bpb:1.0774 running_loss:2.6925 running_bpb:1.0575 doc_len:798-801
+ttt_progress: batch 546/782 batch_loss:2.8367 batch_bpb:1.0771 running_loss:2.6947 running_bpb:1.0578 doc_len:788-790
+ttt_progress: batch 539/782 batch_loss:2.7326 batch_bpb:1.0462 running_loss:2.6953 running_bpb:1.0576 doc_len:769-771
+ttt_progress: batch 528/782 batch_loss:2.7584 batch_bpb:1.0333 running_loss:2.6961 running_bpb:1.0573 doc_len:742-745
+ttt_progress: batch 521/782 batch_loss:2.7692 batch_bpb:1.0507 running_loss:2.6971 running_bpb:1.0572 doc_len:725-727
+ttt_progress: batch 514/782 batch_loss:2.9122 batch_bpb:1.0984 running_loss:2.6999 running_bpb:1.0577 doc_len:707-710
+ttt_progress: batch 507/782 batch_loss:2.7638 batch_bpb:1.0433 running_loss:2.7007 running_bpb:1.0575 doc_len:690-693
+ttt_progress: batch 500/782 batch_loss:2.8371 batch_bpb:1.0837 running_loss:2.7024 running_bpb:1.0579 doc_len:675-677
+ttt_progress: batch 493/782 batch_loss:2.8469 batch_bpb:1.1164 running_loss:2.7041 running_bpb:1.0586 doc_len:659-661
+ttt_progress: batch 486/782 batch_loss:2.8017 batch_bpb:1.0634 running_loss:2.7052 running_bpb:1.0586 doc_len:645-646
+ttt_progress: batch 479/782 batch_loss:2.7134 batch_bpb:1.0356 running_loss:2.7053 running_bpb:1.0583 doc_len:630-632
+ttt_progress: batch 471/782 batch_loss:2.8437 batch_bpb:1.0715 running_loss:2.7067 running_bpb:1.0585 doc_len:614-616
+ttt_progress: batch 463/782 batch_loss:2.7993 batch_bpb:1.0746 running_loss:2.7077 running_bpb:1.0587 doc_len:599-600
+ttt_progress: batch 456/782 batch_loss:2.8118 batch_bpb:1.0679 running_loss:2.7087 running_bpb:1.0588 doc_len:586-587
+ttt_progress: batch 448/782 batch_loss:2.7256 batch_bpb:1.0355 running_loss:2.7089 running_bpb:1.0585 doc_len:571-573
+ttt_progress: batch 441/782 batch_loss:2.7140 batch_bpb:1.0447 running_loss:2.7089 running_bpb:1.0584 doc_len:559-560
+ttt_progress: batch 433/782 batch_loss:2.7804 batch_bpb:1.0671 running_loss:2.7096 running_bpb:1.0585 doc_len:544-545
+ttt_progress: batch 428/782 batch_loss:2.8228 batch_bpb:1.0680 running_loss:2.7105 running_bpb:1.0586 doc_len:535-537
+ttt_progress: batch 420/782 batch_loss:2.7842 batch_bpb:1.0604 running_loss:2.7112 running_bpb:1.0586 doc_len:521-522
+ttt_progress: batch 411/782 batch_loss:2.8164 batch_bpb:1.0738 running_loss:2.7120 running_bpb:1.0587 doc_len:507-508
+ttt_progress: batch 403/782 batch_loss:2.8202 batch_bpb:1.0539 running_loss:2.7129 running_bpb:1.0587 doc_len:493-495
+ttt_progress: batch 394/782 batch_loss:2.8910 batch_bpb:1.1149 running_loss:2.7142 running_bpb:1.0591 doc_len:479-481
+ttt_progress: batch 387/782 batch_loss:2.8320 batch_bpb:1.0720 running_loss:2.7151 running_bpb:1.0592 doc_len:468-470
+ttt_progress: batch 379/782 batch_loss:2.7702 batch_bpb:1.0608 running_loss:2.7155 running_bpb:1.0592 doc_len:457-459
+ttt_progress: batch 371/782 batch_loss:2.8170 batch_bpb:1.0767 running_loss:2.7161 running_bpb:1.0593 doc_len:446-447
+ttt_progress: batch 362/782 batch_loss:2.8133 batch_bpb:1.0637 running_loss:2.7168 running_bpb:1.0594 doc_len:433-434
+ttt_progress: batch 354/782 batch_loss:2.7959 batch_bpb:1.0848 running_loss:2.7173 running_bpb:1.0595 doc_len:422-423
+ttt_progress: batch 346/782 batch_loss:2.8511 batch_bpb:1.0880 running_loss:2.7181 running_bpb:1.0597 doc_len:412-413
+ttt_progress: batch 338/782 batch_loss:2.8560 batch_bpb:1.1139 running_loss:2.7190 running_bpb:1.0600 doc_len:400-402
+ttt_progress: batch 330/782 batch_loss:2.8678 batch_bpb:1.0933 running_loss:2.7198 running_bpb:1.0602 doc_len:390-392
+ttt_progress: batch 322/782 batch_loss:2.7596 batch_bpb:1.0783 running_loss:2.7200 running_bpb:1.0603 doc_len:380-381
+ttt_progress: batch 313/782 batch_loss:2.8297 batch_bpb:1.0898 running_loss:2.7206 running_bpb:1.0605 doc_len:368-369
+ttt_progress: batch 305/782 batch_loss:2.8652 batch_bpb:1.0870 running_loss:2.7214 running_bpb:1.0606 doc_len:358-359
+ttt_progress: batch 297/782 batch_loss:2.8017 batch_bpb:1.0614 running_loss:2.7218 running_bpb:1.0606 doc_len:348-349
+ttt_progress: batch 289/782 batch_loss:2.8460 batch_bpb:1.1266 running_loss:2.7224 running_bpb:1.0610 doc_len:339-340
+ttt_progress: batch 281/782 batch_loss:2.9225 batch_bpb:1.1523 running_loss:2.7234 running_bpb:1.0614 doc_len:329-330
+ttt_progress: batch 273/782 batch_loss:2.7746 batch_bpb:1.0628 running_loss:2.7236 running_bpb:1.0614 doc_len:321-322
+ttt_progress: batch 265/782 batch_loss:2.8264 batch_bpb:1.0879 running_loss:2.7241 running_bpb:1.0615 doc_len:312-313
+ttt_progress: batch 257/782 batch_loss:2.9222 batch_bpb:1.1126 running_loss:2.7249 running_bpb:1.0617 doc_len:302-304
+ttt_progress: batch 248/782 batch_loss:2.8998 batch_bpb:1.1066 running_loss:2.7257 running_bpb:1.0619 doc_len:293-294
+ttt_progress: batch 240/782 batch_loss:2.9097 batch_bpb:1.1548 running_loss:2.7264 running_bpb:1.0623 doc_len:285-286
+ttt_progress: batch 232/782 batch_loss:2.9284 batch_bpb:1.1327 running_loss:2.7272 running_bpb:1.0626 doc_len:277-278
+ttt_progress: batch 224/782 batch_loss:2.8293 batch_bpb:1.1114 running_loss:2.7276 running_bpb:1.0628 doc_len:269-270
+ttt_progress: batch 216/782 batch_loss:2.9315 batch_bpb:1.1155 running_loss:2.7283 running_bpb:1.0629 doc_len:261-262
+ttt_progress: batch 207/782 batch_loss:2.8353 batch_bpb:1.1154 running_loss:2.7287 running_bpb:1.0631 doc_len:253-254
+ttt_progress: batch 199/782 batch_loss:2.9513 batch_bpb:1.1312 running_loss:2.7294 running_bpb:1.0634 doc_len:246-247
+ttt_progress: batch 192/782 batch_loss:2.9058 batch_bpb:1.1454 running_loss:2.7300 running_bpb:1.0636 doc_len:239-240
+ttt_progress: batch 184/782 batch_loss:2.9111 batch_bpb:1.1559 running_loss:2.7306 running_bpb:1.0639 doc_len:232-233
+ttt_progress: batch 176/782 batch_loss:2.8252 batch_bpb:1.1084 running_loss:2.7309 running_bpb:1.0641 doc_len:225-226
+ttt_progress: batch 168/782 batch_loss:2.9139 batch_bpb:1.1419 running_loss:2.7314 running_bpb:1.0643 doc_len:218-219
+ttt_progress: batch 159/782 batch_loss:2.9903 batch_bpb:1.1780 running_loss:2.7322 running_bpb:1.0646 doc_len:211-212
+ttt_progress: batch 149/782 batch_loss:2.9752 batch_bpb:1.1729 running_loss:2.7329 running_bpb:1.0649 doc_len:203-204
+ttt_progress: batch 141/782 batch_loss:2.9002 batch_bpb:1.1434 running_loss:2.7333 running_bpb:1.0651 doc_len:196-197
+ttt_progress: batch 133/782 batch_loss:3.0312 batch_bpb:1.1974 running_loss:2.7341 running_bpb:1.0655 doc_len:189-190
+ttt_progress: batch 126/782 batch_loss:2.9280 batch_bpb:1.1897 running_loss:2.7346 running_bpb:1.0658 doc_len:185-185
+ttt_progress: batch 116/782 batch_loss:3.0091 batch_bpb:1.1899 running_loss:2.7352 running_bpb:1.0660 doc_len:177-178
+ttt_progress: batch 108/782 batch_loss:2.8667 batch_bpb:1.1010 running_loss:2.7355 running_bpb:1.0661 doc_len:171-172
+ttt_progress: batch 99/782 batch_loss:2.9884 batch_bpb:1.1882 running_loss:2.7361 running_bpb:1.0664 doc_len:164-165
+ttt_progress: batch 91/782 batch_loss:3.0299 batch_bpb:1.2127 running_loss:2.7367 running_bpb:1.0667 doc_len:158-159
+ttt_progress: batch 83/782 batch_loss:3.0425 batch_bpb:1.2158 running_loss:2.7373 running_bpb:1.0670 doc_len:152-153
+ttt_progress: batch 75/782 batch_loss:3.0920 batch_bpb:1.2140 running_loss:2.7380 running_bpb:1.0673 doc_len:146-147
+ttt_progress: batch 67/782 batch_loss:3.0595 batch_bpb:1.2367 running_loss:2.7386 running_bpb:1.0676 doc_len:140-141
+ttt_progress: batch 58/782 batch_loss:2.9807 batch_bpb:1.2294 running_loss:2.7390 running_bpb:1.0678 doc_len:133-134
+ttt_progress: batch 51/782 batch_loss:3.0290 batch_bpb:1.2107 running_loss:2.7395 running_bpb:1.0681 doc_len:127-128
+ttt_progress: batch 44/782 batch_loss:3.1356 batch_bpb:1.2219 running_loss:2.7402 running_bpb:1.0683 doc_len:122-122
+ttt_progress: batch 34/782 batch_loss:3.0900 batch_bpb:1.2509 running_loss:2.7407 running_bpb:1.0686 doc_len:114-115
+ttt_progress: batch 27/782 batch_loss:3.1059 batch_bpb:1.2399 running_loss:2.7412 running_bpb:1.0688 doc_len:107-108
+ttt_progress: batch 17/782 batch_loss:3.1299 batch_bpb:1.2406 running_loss:2.7417 running_bpb:1.0690 doc_len:98-99
+ttt_progress: batch 8/782 batch_loss:3.2591 batch_bpb:1.2599 running_loss:2.7423 running_bpb:1.0693 doc_len:86-87
+quantized_ttt_lora val_loss:2.77493185 val_bpb:1.07426259 eval_time:312976ms
+total_eval_time:313.0s

--- a/records/track_10min_16mb/2026-04-10_VarLenAttn/requirements.txt
+++ b/records/track_10min_16mb/2026-04-10_VarLenAttn/requirements.txt
@@ -13,3 +13,4 @@ tiktoken
 sentencepiece
 zstandard
 brotli
+python-minifier

--- a/records/track_10min_16mb/2026-04-10_VarLenAttn/requirements.txt
+++ b/records/track_10min_16mb/2026-04-10_VarLenAttn/requirements.txt
@@ -1,0 +1,15 @@
+# FlashAttention 3 must be installed separately; see README.md
+# PyTorch 2.9.1+cu128 required; install using:
+# uv pip install torch==2.9.1+cu128 --extra-index-url https://download.pytorch.org/whl/cu128
+numpy
+tqdm
+torch
+huggingface-hub
+kernels
+setuptools
+typing-extensions==4.15.0
+datasets
+tiktoken
+sentencepiece
+zstandard
+brotli

--- a/records/track_10min_16mb/2026-04-10_VarLenAttn/submission.json
+++ b/records/track_10min_16mb/2026-04-10_VarLenAttn/submission.json
@@ -1,0 +1,35 @@
+{
+    "author": "samacqua",
+    "github_id": "samacqua",
+    "name": "Varlen Attention + Fused MLP + doc-independent TTT",
+    "date": "2026-04-10",
+    "track": "10min_16mb",
+    "val_loss": 2.7806,
+    "val_bpb": 1.07643,
+    "val_bpb_std": 0.000291,
+    "seeds": [0, 1, 2],
+    "seed_results": {
+      "0": {
+        "val_bpb": 1.07676194, "artifact_bytes": 15992240
+      },
+      "1": {
+        "val_bpb": 1.07635404, "artifact_bytes": 15989679
+      },
+      "2": {
+        "val_bpb": 1.07619767, "artifact_bytes": 15994549
+      }
+    },
+    "compliance": {
+      "train_under_600s": true,
+      "artifact_under_16mb": true,
+      "eval_under_600s": true,
+      "no_slot": true,
+      "no_pre_quant_ttt": true,
+      "no_etlb": true,
+      "no_ngram_cache": true,
+      "score_first_ttt": true,
+      "three_seeds": true
+    },
+    "hardware": "8xH100 80GB SXM",
+    "pytorch_version": "2.9.1+cu128"
+  }

--- a/records/track_10min_16mb/2026-04-10_VarLenAttn/submission.json
+++ b/records/track_10min_16mb/2026-04-10_VarLenAttn/submission.json
@@ -2,21 +2,21 @@
     "author": "samacqua",
     "github_id": "samacqua",
     "name": "Varlen Attention + Fused MLP + doc-independent TTT",
-    "date": "2026-04-10",
+    "date": "2026-04-11",
     "track": "10min_16mb",
-    "val_loss": 2.7806,
-    "val_bpb": 1.07643,
-    "val_bpb_std": 0.000291,
+    "val_loss": 2.77261037,
+    "val_bpb": 1.07336388,
+    "val_bpb_std": 0.00084633,
     "seeds": [0, 1, 2],
     "seed_results": {
       "0": {
-        "val_bpb": 1.07676194, "artifact_bytes": 15992240
+        "val_bpb": 1.07258208, "artifact_bytes": 15996664
       },
       "1": {
-        "val_bpb": 1.07635404, "artifact_bytes": 15989679
+        "val_bpb": 1.07324696, "artifact_bytes": 15993874
       },
       "2": {
-        "val_bpb": 1.07619767, "artifact_bytes": 15994549
+        "val_bpb": 1.07426259, "artifact_bytes": 15984798
       }
     },
     "compliance": {

--- a/records/track_10min_16mb/2026-04-10_VarLenAttn/train_gpt.py
+++ b/records/track_10min_16mb/2026-04-10_VarLenAttn/train_gpt.py
@@ -1,0 +1,2830 @@
+import base64, collections, copy, fcntl, glob, io, json, lzma, math, os
+from pathlib import Path
+import random, re, subprocess, sys, time, uuid, numpy as np, sentencepiece as spm, torch, torch.distributed as dist, torch.nn.functional as F
+from torch import nn
+from flash_attn_interface import (
+    flash_attn_func as flash_attn_3_func,
+    flash_attn_varlen_func,
+)
+from concurrent.futures import ThreadPoolExecutor
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+class Hyperparameters:
+    data_dir = os.environ.get("DATA_DIR", "./data/")
+    seed = int(os.environ.get("SEED", 1337))
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.667))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 6e2))
+    val_batch_tokens = int(os.environ.get("VAL_BATCH_TOKENS", 524288))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    sliding_window_enabled = bool(int(os.environ.get("SLIDING_WINDOW_ENABLED", "0")))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 8192))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    embedding_dim = int(os.environ.get("EMBEDDING_DIM", 512))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 4.0))
+    skip_gates_enabled = bool(int(os.environ.get("SKIP_GATES_ENABLED", "1")))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 3e1))
+    rope_base = float(os.environ.get("ROPE_BASE", 1e4))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    rope_train_seq_len = int(os.environ.get("ROPE_TRAIN_SEQ_LEN", 2048))
+    rope_yarn = bool(int(os.environ.get("ROPE_YARN", "0")))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 5.0))
+    num_loops = int(os.environ.get("NUM_LOOPS", 2))
+    loop_start = int(os.environ.get("LOOP_START", 3))
+    loop_end = int(os.environ.get("LOOP_END", 5))
+    enable_looping_at = float(os.environ.get("ENABLE_LOOPING_AT", 0.35))
+    parallel_start_layer = int(os.environ.get("PARALLEL_START_LAYER", 7))
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.022))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.97))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-08))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.02))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.095))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_lora_rank = int(os.environ.get("TTT_LORA_RANK", 96))
+    ttt_lora_lr = float(os.environ.get("TTT_LORA_LR", 0.0001))
+    ttt_chunk_size = int(os.environ.get("TTT_CHUNK_SIZE", 64))
+    ttt_eval_seq_len = int(os.environ.get("TTT_EVAL_SEQ_LEN", 2048))
+    ttt_batch_size = int(os.environ.get("TTT_BATCH_SIZE", 64))
+    ttt_grad_steps = int(os.environ.get("TTT_GRAD_STEPS", 1))
+    ttt_weight_decay = float(os.environ.get("TTT_WEIGHT_DECAY", 0.5))
+    ttt_beta1 = float(os.environ.get("TTT_BETA1", 0))
+    ttt_beta2 = float(os.environ.get("TTT_BETA2", 0.999))
+    ttt_k_lora = bool(int(os.environ.get("TTT_K_LORA", "1")))
+    ttt_mlp_lora = bool(int(os.environ.get("TTT_MLP_LORA", "1")))
+    ttt_o_lora = bool(int(os.environ.get("TTT_O_LORA", "1")))
+    ttt_optimizer = os.environ.get("TTT_OPTIMIZER", "adam")
+    ttt_eval_batches = os.environ.get("TTT_EVAL_BATCHES", "")
+    ttt_output_dir = os.environ.get("TTT_OUTPUT_DIR", "")
+    val_doc_fraction = float(os.environ.get("VAL_DOC_FRACTION", 1.0))
+    etlb_lr = float(os.environ.get("ETLB_LR", 0.05))
+    etlb_steps = int(os.environ.get("ETLB_STEPS", 5))
+    etlb_clip = float(os.environ.get("ETLB_CLIP", 3.0))
+    compressor = os.environ.get("COMPRESSOR", "brotli")
+    gptq_calibration_batches = int(os.environ.get("GPTQ_CALIBRATION_BATCHES", 64))
+    gptq_reserve_seconds = float(os.environ.get("GPTQ_RESERVE_SECONDS", 12.0))
+    matrix_bits = int(os.environ.get("MATRIX_BITS", 6))
+    embed_bits = int(os.environ.get("EMBED_BITS", 8))
+    matrix_clip_sigmas = float(os.environ.get("MATRIX_CLIP_SIGMAS", 12.85))
+    embed_clip_sigmas = float(os.environ.get("EMBED_CLIP_SIGMAS", 2e1))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_main_process = rank == 0
+    grad_accum_steps = 8 // world_size
+    datasets_dir = os.path.join(data_dir, "datasets", f"fineweb10B_sp{vocab_size}")
+    train_files = os.path.join(datasets_dir, "fineweb_train_*.bin")
+    val_files = os.path.join(datasets_dir, "fineweb_val_*.bin")
+    tokenizer_path = os.path.join(
+        data_dir, "tokenizers", f"fineweb_{vocab_size}_bpe.model"
+    )
+    artifact_dir = os.environ.get("ARTIFACT_DIR", "")
+    eval_only_path = os.environ.get("EVAL_ONLY_PATH", "")
+    logfile = (
+        os.path.join(artifact_dir, f"{run_id}.txt")
+        if artifact_dir
+        else f"logs/{run_id}.txt"
+    )
+    model_path = (
+        os.path.join(artifact_dir, "final_model.pt")
+        if artifact_dir
+        else "final_model.pt"
+    )
+    quantized_model_path = (
+        os.path.join(artifact_dir, "final_model.int6.ptz")
+        if artifact_dir
+        else "final_model.int6.ptz"
+    )
+
+
+_logger_hparams = None
+
+
+def set_logging_hparams(h):
+    global _logger_hparams
+    _logger_hparams = h
+
+
+def log(msg, console=True):
+    if _logger_hparams is None:
+        print(msg)
+        return
+    if _logger_hparams.is_main_process:
+        if console:
+            print(msg)
+        if _logger_hparams.logfile is not None:
+            with open(_logger_hparams.logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+
+class ValidationData:
+    def __init__(self, h, device):
+        self.sp = spm.SentencePieceProcessor(model_file=h.tokenizer_path)
+        if int(self.sp.vocab_size()) != h.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={h.vocab_size} does not match tokenizer vocab_size={int(self.sp.vocab_size())}"
+            )
+        self.val_tokens = load_validation_tokens(h.val_files, h.eval_seq_len)
+        (
+            self.base_bytes_lut,
+            self.has_leading_space_lut,
+            self.is_boundary_token_lut,
+        ) = build_sentencepiece_luts(self.sp, h.vocab_size, device)
+
+
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sp_vocab_size = int(sp.vocab_size())
+    assert (
+        sp.piece_to_id("▁") != sp.unk_id()
+    ), "Tokenizer must have '▁' (space) as its own token for correct BPB byte counting"
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = (tokens.numel() - 1) // seq_len * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def load_data_shard(file):
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE = {}
+_MMAP_CACHE = {}
+
+
+def _read_num_tokens(file):
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+
+def _get_shard_memmap(file):
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode="r", dtype="<u2", offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+BOS_ID = None
+
+
+def get_next_multiple_of_n(v, n):
+    return ((v + n - 1) // n) * n
+
+
+def _build_cu_seqlens(bos_pos, total_len, device, max_doc_len=0, bucket_size=64):
+    if not bos_pos or bos_pos[0] != 0:
+        bos_pos = [0] + bos_pos
+    seg_starts = []
+    starts_with_end = bos_pos + [total_len]
+    for i in range(len(starts_with_end) - 1):
+        start = starts_with_end[i]
+        end = starts_with_end[i + 1]
+        if max_doc_len > 0:
+            pos = start
+            while pos < end:
+                seg_starts.append(pos)
+                pos += max_doc_len
+        else:
+            seg_starts.append(start)
+    boundaries = seg_starts + [total_len]
+    padded_len = get_next_multiple_of_n(len(boundaries), bucket_size)
+    cu = torch.full((padded_len,), total_len, dtype=torch.int32, device=device)
+    cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+    seg_ends = seg_starts[1:] + [total_len]
+    max_seqlen = max(end - start for start, end in zip(seg_starts, seg_ends))
+    return cu, max_seqlen
+
+class DocumentPackingLoader:
+    _shard_pool = ThreadPoolExecutor(1)
+
+    def __init__(self, h, device, cu_bucket_size=64):
+        self.rank = h.rank
+        self.world_size = h.world_size
+        self.device = device
+        self.cu_bucket_size = cu_bucket_size
+        self.max_seq_len = h.train_seq_len
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files
+        self.file_iter = iter(self.files)
+        self._init_shard(load_data_shard(next(self.file_iter)))
+        self._next_shard = self._submit_next_shard()
+        self._batch_pool = ThreadPoolExecutor(1)
+        self._next_batch = None
+
+    def _init_shard(self, tokens):
+        global BOS_ID
+        self.tokens = tokens
+        self.shard_size = tokens.numel()
+        if BOS_ID is None:
+            BOS_ID = 1
+        self.bos_idx = (
+            (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        )
+        if self.bos_idx.size == 0:
+            self.bos_idx = np.array([0], dtype=np.int64)
+        self.cursor = int(self.bos_idx[0])
+
+    def _submit_next_shard(self):
+        try:
+            path = next(self.file_iter)
+            return self._shard_pool.submit(load_data_shard, path)
+        except StopIteration:
+            return None
+
+    def _advance_shard(self):
+        if self._next_shard is None:
+            self.file_iter = iter(self.files)
+            self._next_shard = self._shard_pool.submit(
+                load_data_shard, next(self.file_iter)
+            )
+        self._init_shard(self._next_shard.result())
+        self._next_shard = self._submit_next_shard()
+
+    def _local_doc_starts(self, local_start, total_len):
+        lo = np.searchsorted(self.bos_idx, local_start, side="left")
+        hi = np.searchsorted(self.bos_idx, local_start + total_len, side="left")
+        return (self.bos_idx[lo:hi] - local_start).tolist()
+
+    def _prepare_batch(self, num_tokens_local, max_seq_len):
+        per_rank_span = num_tokens_local + 1
+        global_span = per_rank_span * self.world_size
+        while self.cursor + global_span > self.shard_size:
+            self._advance_shard()
+        local_start = self.cursor + self.rank * per_rank_span
+        buf = self.tokens[local_start : local_start + per_rank_span]
+        inputs = buf[:-1].to(dtype=torch.int64).pin_memory()
+        targets = buf[1:].to(dtype=torch.int64).pin_memory()
+        starts = self._local_doc_starts(local_start, inputs.numel())
+        cu_seqlens, max_seqlen = _build_cu_seqlens(
+            starts, inputs.numel(), inputs.device, max_seq_len, self.cu_bucket_size
+        )
+        cu_seqlens = cu_seqlens.pin_memory()
+        self.cursor += global_span
+        return inputs, targets, cu_seqlens, max_seqlen
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        num_tokens_local = global_tokens // (self.world_size * grad_accum_steps)
+        if self._next_batch is not None:
+            inputs, targets, cu_seqlens, max_seqlen = self._next_batch.result()
+        else:
+            inputs, targets, cu_seqlens, max_seqlen = self._prepare_batch(
+                num_tokens_local, self.max_seq_len
+            )
+        self._next_batch = self._batch_pool.submit(
+            self._prepare_batch, num_tokens_local, self.max_seq_len
+        )
+        return (
+            inputs[None].to(self.device, non_blocking=True),
+            targets[None].to(self.device, non_blocking=True),
+            cu_seqlens.to(self.device, non_blocking=True),
+            max_seqlen,
+        )
+
+
+class ShuffledSequenceLoader:
+    def __init__(self, h, device):
+        self.world_size = h.world_size
+        self.seq_len = h.train_seq_len
+        self.device = device
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files[h.rank :: h.world_size]
+        self.rng = np.random.Generator(np.random.PCG64(h.rank))
+        self.num_tokens = [_read_num_tokens(f) for f in self.files]
+        self.start_inds = [[] for _ in self.files]
+        for si in range(len(self.files)):
+            self._reset_shard(si)
+
+    def _reset_shard(self, si):
+        max_phase = min(
+            self.seq_len - 1, max(0, self.num_tokens[si] - self.seq_len - 1)
+        )
+        phase = int(self.rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        num_sequences = (self.num_tokens[si] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[si] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for bi in range(device_batch_size):
+            total = remaining.sum()
+            if total <= 0:
+                for si in range(len(self.files)):
+                    self._reset_shard(si)
+                remaining = np.array(
+                    [len(s) for s in self.start_inds], dtype=np.float64
+                )
+                total = remaining.sum()
+            probs = remaining / total
+            si = int(self.rng.choice(len(self.files), p=probs))
+            start_ind = self.start_inds[si].pop()
+            remaining[si] -= 1
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[bi] = window[:-1]
+            y[bi] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x):
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+@triton.jit
+def linear_leaky_relu_square_kernel(
+    a_desc,
+    b_desc,
+    c_desc,
+    aux_desc,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    FORWARD: tl.constexpr,
+):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+    tile_id_c = start_pid - NUM_SMS
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+        tile_id_c += NUM_SMS
+        offs_am_c = offs_am
+        offs_bn_c = offs_bn
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+        c0 = acc0.to(dtype)
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            pre0 = aux_desc.load([offs_am_c, offs_bn_c])
+            pre1 = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c0 = c0 * tl.where(pre0 > 0, 2.0 * pre0, 0.5 * pre0)
+            c1 = c1 * tl.where(pre1 > 0, 2.0 * pre1, 0.5 * pre1)
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+        if FORWARD:
+            aux0 = tl.where(c0 > 0, c0, 0.5 * c0)
+            aux1 = tl.where(c1 > 0, c1, 0.5 * c1)
+            aux_desc.store([offs_am_c, offs_bn_c], aux0 * aux0)
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], aux1 * aux1)
+
+
+def linear_leaky_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K2 = b.shape
+    assert K == K2
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    forward = aux is None
+    if aux is None:
+        aux = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 256, 64
+    num_stages = 4 if forward else 3
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    grid = lambda _meta: (
+        min(num_sms, triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N)),
+    )
+    linear_leaky_relu_square_kernel[grid](
+        a_desc,
+        b_desc,
+        c_desc,
+        aux_desc,
+        M,
+        N,
+        K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        NUM_SMS=num_sms,
+        FORWARD=forward,
+        num_stages=num_stages,
+        num_warps=8,
+    )
+    if forward:
+        return c, aux
+    return c
+
+
+class FusedLinearLeakyReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, w1, w2):
+        x_flat = x.reshape(-1, x.shape[-1])
+        pre, post = linear_leaky_relu_square(x_flat, w1)
+        out = F.linear(post, w2)
+        ctx.save_for_backward(x, w1, w2, pre, post)
+        return out.view(*x.shape[:-1], out.shape[-1])
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, w1, w2, pre, post = ctx.saved_tensors
+        x_flat = x.reshape(-1, x.shape[-1])
+        grad_output_flat = grad_output.reshape(-1, grad_output.shape[-1])
+        dw2 = grad_output_flat.T @ post
+        dpre = linear_leaky_relu_square(grad_output_flat, w2.T.contiguous(), aux=pre)
+        dw1 = dpre.T @ x_flat
+        dx = dpre @ w1
+        return dx.view_as(x), dw1, dw2
+
+
+FusedLeakyReLUSquareMLP = FusedLinearLeakyReLUSquareFunction.apply
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=1e4, train_seq_len=1024, rope_dims=0, yarn=True):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.yarn = yarn
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / base ** (
+            torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+
+    def forward(self, seq_len, device, dtype):
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached < seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if self.yarn and seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * scale ** (rd / (rd - 2))
+                inv_freq = 1.0 / new_base ** (
+                    torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd
+                )
+            else:
+                inv_freq = self.inv_freq.float().to(device)
+            t = torch.arange(seq_len, device=device, dtype=torch.float32)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached[:, :seq_len].to(dtype=dtype), self._sin_cached[:, :seq_len].to(dtype=dtype)
+
+
+def apply_rotary_emb(x, cos, sin, rope_dims=0):
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=True
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len, yarn=yarn)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x, q_w, k_w, v_w, out_w, cu_seqlens=None, max_seqlen=0):
+        bsz, seqlen, dim = x.shape
+        q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if cu_seqlens is not None:
+            y = flash_attn_varlen_func(
+                q[0],
+                k[0],
+                v[0],
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+                causal=True,
+                window_size=(-1, -1),
+            )[None]
+        else:
+            y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        self._last_proj_input = y.detach() if getattr(self, "_calib", False) else None
+        return F.linear(y, out_w.to(x.dtype))
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        self.use_fused = True
+
+    def forward(self, x, up_w, down_w):
+        if self.training and self.use_fused:
+            return FusedLeakyReLUSquareMLP(x, up_w.to(x.dtype), down_w.to(x.dtype))
+        hidden = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5).square()
+        self._last_down_input = hidden.detach() if getattr(self, "_calib", False) else None
+        return F.linear(hidden, down_w.to(x.dtype))
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        num_kv_heads,
+        mlp_mult,
+        rope_base,
+        qk_gain_init,
+        train_seq_len,
+        layer_idx=0,
+        ln_scale=False,
+        yarn=True,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=yarn
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(
+            torch.stack((torch.ones(dim), torch.zeros(dim))).float()
+        )
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+
+    def forward(self, x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=None, max_seqlen=0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(
+            self.attn_norm(x_in) * self.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[
+            None, None, :
+        ] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        return x_out
+
+    def forward_attn(self, x, x0, q_w, k_w, v_w, out_w, cu_seqlens=None, max_seqlen=0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(
+            self.attn_norm(x_in) * self.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        return x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+
+    def forward_mlp(self, x, up_w, down_w):
+        return x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(
+            self.mlp_norm(x) * self.ln_scale_factor, up_w, down_w
+        )
+
+
+class GPT(nn.Module):
+    def __init__(self, h):
+        super().__init__()
+        if h.logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {h.logit_softcap}")
+        self.tie_embeddings = h.tie_embeddings
+        self.tied_embed_init_std = h.tied_embed_init_std
+        self.logit_softcap = h.logit_softcap
+        self.tok_emb = nn.Embedding(h.vocab_size, h.embedding_dim)
+        if h.embedding_dim != h.model_dim:
+            self.embed_proj = CastedLinear(h.embedding_dim, h.model_dim, bias=False)
+            self.head_proj = CastedLinear(h.model_dim, h.embedding_dim, bias=False)
+        else:
+            self.embed_proj = None
+            self.head_proj = None
+        self.num_layers = h.num_layers
+        head_dim = h.model_dim // h.num_heads
+        kv_dim = h.num_kv_heads * head_dim
+        hidden_dim = int(h.mlp_mult * h.model_dim)
+        self.qo_bank = nn.Parameter(torch.empty(2 * h.num_layers, h.model_dim, h.model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * h.num_layers, kv_dim, h.model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(h.num_layers, hidden_dim, h.model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(h.num_layers, h.model_dim, hidden_dim))
+        self.num_encoder_layers = h.num_layers // 2
+        self.num_decoder_layers = h.num_layers - self.num_encoder_layers
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    h.model_dim,
+                    h.num_heads,
+                    h.num_kv_heads,
+                    h.mlp_mult,
+                    h.rope_base,
+                    h.qk_gain_init,
+                    h.train_seq_len,
+                    layer_idx=i,
+                    ln_scale=h.ln_scale,
+                    yarn=h.rope_yarn,
+                )
+                for i in range(h.num_layers)
+            ]
+        )
+        if h.rope_dims > 0:
+            head_dim = h.model_dim // h.num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = h.rope_dims
+                block.attn.rotary = Rotary(
+                    head_dim,
+                    base=h.rope_base,
+                    train_seq_len=h.train_seq_len,
+                    rope_dims=h.rope_dims,
+                    yarn=h.rope_yarn,
+                )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None
+            if h.tie_embeddings
+            else CastedLinear(h.embedding_dim, h.vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if h.xsa_last_n > 0:
+            for i in range(max(0, h.num_layers - h.xsa_last_n), h.num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self.looping_active = False
+        if h.num_loops > 0:
+            loop_seg = list(range(h.loop_start, h.loop_end + 1))
+            all_indices = list(range(h.loop_start))
+            for _ in range(h.num_loops + 1):
+                all_indices.extend(loop_seg)
+            all_indices.extend(range(h.loop_end + 1, h.num_layers))
+            num_enc = len(all_indices) // 2
+            self.encoder_indices = all_indices[:num_enc]
+            self.decoder_indices = all_indices[num_enc:]
+        else:
+            self.encoder_indices = list(range(self.num_encoder_layers))
+            self.decoder_indices = list(range(self.num_encoder_layers, h.num_layers))
+        self.num_skip_weights = min(
+            len(self.encoder_indices), len(self.decoder_indices)
+        )
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+        )
+        self.skip_gates = (
+            nn.Parameter(
+                torch.zeros(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+            )
+            if h.skip_gates_enabled
+            else None
+        )
+        self.parallel_start_layer = h.parallel_start_layer
+        self.lane_merge = (
+            nn.Parameter(torch.tensor(0.5)) if self.parallel_start_layer > 0 else None
+        )
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.qo_bank.data[n + i])
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.mlp_down_bank.data[i])
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _bank_weights(self, i):
+        n = self.num_layers
+        return (
+            self.qo_bank[i],
+            self.kv_bank[i],
+            self.kv_bank[n + i],
+            self.qo_bank[n + i],
+            self.mlp_up_bank[i],
+            self.mlp_down_bank[i],
+        )
+
+    def forward_logits(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else range(self.num_encoder_layers)
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else range(
+                self.num_encoder_layers,
+                self.num_encoder_layers + self.num_decoder_layers,
+            )
+        )
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if lane0 is None:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[
+                            None, None, :
+                        ]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                if i >= psl and psl > 0:
+                    lane0 = x
+                    lane1 = x.clone()
+                    lane0 = self.blocks[i].forward_attn(lane0, x0, q_w, k_w, v_w, out_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+                    lane1 = self.blocks[i].forward_mlp(lane1, up_w, down_w)
+                else:
+                    x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[
+                            None, None, :
+                        ]
+                        lane0 = torch.lerp(scaled_skip, lane0, g)
+                    else:
+                        lane0 = lane0 + scaled_skip
+                lane0 = self.blocks[i].forward_attn(lane0, x0, q_w, k_w, v_w, out_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+                lane1 = self.blocks[i].forward_mlp(lane1, up_w, down_w)
+        if lane0 is not None:
+            lm = self.lane_merge.to(dtype=lane0.dtype)
+            x = lm * lane0 + (1.0 - lm) * lane1
+        x = self.final_norm(x)
+        if self.head_proj is not None:
+            x = self.head_proj(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(self, input_ids, target_ids, cu_seqlens=None, max_seqlen=0):
+        logits = self.forward_logits(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        return F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            target_ids.reshape(-1),
+            reduction="mean",
+        )
+
+    def forward_ttt(self, input_ids, target_ids, lora):
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else list(range(self.num_encoder_layers))
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else list(
+                range(
+                    self.num_encoder_layers,
+                    self.num_encoder_layers + self.num_decoder_layers,
+                )
+            )
+        )
+        slot = 0
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if lane0 is None:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[
+                            None, None, :
+                        ]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                if i >= psl and psl > 0:
+                    lane0 = x
+                    lane1 = x.clone()
+                    lane0 = self._block_with_lora_attn(self.blocks[i], lane0, x0, lora, slot, q_w, k_w, v_w, out_w)
+                    lane1 = self._block_with_lora_mlp(self.blocks[i], lane1, lora, slot, up_w, down_w)
+                else:
+                    x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[
+                            None, None, :
+                        ]
+                        lane0 = torch.lerp(scaled_skip, lane0, g)
+                    else:
+                        lane0 = lane0 + scaled_skip
+                lane0 = self._block_with_lora_attn(self.blocks[i], lane0, x0, lora, slot, q_w, k_w, v_w, out_w)
+                lane1 = self._block_with_lora_mlp(self.blocks[i], lane1, lora, slot, up_w, down_w)
+            slot += 1
+        if lane0 is not None:
+            lm = self.lane_merge.to(dtype=lane0.dtype)
+            x = lm * lane0 + (1.0 - lm) * lane1
+        x = self.final_norm(x)
+        if self.head_proj is not None:
+            x = self.head_proj(x)
+        if self.tie_embeddings:
+            logits = F.linear(x, self.tok_emb.weight)
+        else:
+            logits = self.lm_head(x)
+        logits = logits + lora.lm_head_lora(x)
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        bsz, sl, V = logits.shape
+        return F.cross_entropy(
+            logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none"
+        ).reshape(bsz, sl)
+
+    def _block_with_lora(self, block, x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w):
+        mix = block.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = block.attn_norm(x_in) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q = (F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_heads, attn.head_dim
+        )
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        x_out = x_in + block.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        mlp_n = block.mlp_norm(x_out) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        x_out = x_out + block.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * mlp_out
+        return x_out
+
+    def _block_with_lora_attn(self, block, x, x0, lora, slot, q_w, k_w, v_w, out_w):
+        mix = block.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = block.attn_norm(x_in) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q = (F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_heads, attn.head_dim
+        )
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        return x_in + block.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+
+    def _block_with_lora_mlp(self, block, x, lora, slot, up_w, down_w):
+        mlp_n = block.mlp_norm(x) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        return x + block.mlp_scale.to(dtype=x.dtype)[None, None, :] * mlp_out
+
+
+class BatchedLinearLoRA(nn.Module):
+    def __init__(self, bsz, in_features, out_features, rank):
+        super().__init__()
+        self._bound = 1.0 / math.sqrt(in_features)
+        self.A = nn.Parameter(
+            torch.empty(bsz, rank, in_features).uniform_(-self._bound, self._bound)
+        )
+        self.B = nn.Parameter(torch.zeros(bsz, out_features, rank))
+
+    def reset(self):
+        with torch.no_grad():
+            self.A.uniform_(-self._bound, self._bound)
+            self.B.zero_()
+
+    def forward(self, x):
+        return (x @ self.A.transpose(1, 2)) @ self.B.transpose(1, 2)
+
+
+class BatchedTTTLoRA(nn.Module):
+    def __init__(self, bsz, model, rank, k_lora=True, mlp_lora=True, o_lora=True):
+        super().__init__()
+        self.bsz = bsz
+        dim = model.qo_bank.shape[-1]
+        vocab = model.tok_emb.num_embeddings
+        if getattr(model, "looping_active", False):
+            num_slots = len(model.encoder_indices) + len(model.decoder_indices)
+        else:
+            num_slots = len(model.blocks)
+        kv_dim = model.blocks[0].attn.num_kv_heads * (
+            dim // model.blocks[0].attn.num_heads
+        )
+        embed_dim = model.tok_emb.embedding_dim
+        self.lm_head_lora = BatchedLinearLoRA(bsz, embed_dim, vocab, rank)
+        self.q_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+        )
+        self.v_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+        )
+        self.k_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+            )
+            if k_lora
+            else None
+        )
+        self.mlp_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if mlp_lora
+            else None
+        )
+        self.o_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if o_lora
+            else None
+        )
+
+    def reset(self):
+        with torch.no_grad():
+            self.lm_head_lora.reset()
+            for loras in [self.q_loras, self.v_loras, self.k_loras,
+                          self.mlp_loras, self.o_loras]:
+                if loras is not None:
+                    for lora in loras:
+                        lora.reset()
+
+
+def classify_param(name):
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or ".proj." in name and ".mlp." not in name:
+        return "attn"
+    return "other"
+
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps=10, eps=1e-07):
+    a, b, c = 3.4445, -4.775, 2.0315
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr,
+        momentum,
+        backend_steps,
+        nesterov=True,
+        weight_decay=0.0,
+        row_normalize=False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append({
+                    "p": p,
+                    "B": B,
+                    "padded_grad": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard_mom": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "full_update": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "scale": max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                })
+        self._bank_meta.sort(key=lambda m: -m["p"].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m["p"]
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m["padded_grad"]
+            pg[: m["B"]].copy_(p.grad.bfloat16())
+            if pg.shape[0] > m["B"]:
+                pg[m["B"] :].zero_()
+            fut = dist.reduce_scatter_tensor(
+                m["shard"], pg, op=dist.ReduceOp.AVG, async_op=True
+            )
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        if not self._built:
+            self._build()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+            row_normalize = group.get("row_normalize", False)
+            prev_ag_handle = None
+            prev_m = None
+            sharded = self._distributed and hasattr(self, "_rs_futures")
+            for idx, m in enumerate(self._bank_meta):
+                p = m["p"]
+                if p.grad is None:
+                    continue
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m["p"]
+                    upd = prev_m["full_update"][: prev_m["B"]]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+                if sharded and self._rs_futures[idx] is not None:
+                    self._rs_futures[idx].wait()
+                    g = m["shard"]
+                    buf = m["shard_mom"]
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+                if row_normalize:
+                    rn = update.float().norm(dim=-1, keepdim=True).clamp_min(1e-07)
+                    update = update / rn.to(update.dtype)
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m["full_update"], update, async_op=True
+                    )
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update.to(dtype=p.dtype), alpha=-lr * m["scale"])
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m["p"]
+                upd = prev_m["full_update"][: prev_m["B"]]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+            if hasattr(self, "_rs_futures"):
+                del self._rs_futures
+        return loss
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,lane_merge",
+    ).split(",")
+    if pattern
+)
+
+
+PACKED_REPLICATED_GRAD_MAX_NUMEL = 1 << 15
+
+
+class Optimizers:
+    def __init__(self, h, base_model):
+        matrix_params = [
+            base_model.qo_bank,
+            base_model.kv_bank,
+            base_model.mlp_up_bank,
+            base_model.mlp_down_bank,
+        ]
+        block_named_params = list(base_model.blocks.named_parameters())
+        scalar_params = [
+            p
+            for (name, p) in block_named_params
+            if p.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        if base_model.skip_weights.numel() > 0:
+            scalar_params.append(base_model.skip_weights)
+        if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
+            scalar_params.append(base_model.skip_gates)
+        if base_model.lane_merge is not None:
+            scalar_params.append(base_model.lane_merge)
+        token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
+        tok_params = [
+            {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+        ]
+        self.optimizer_tok = torch.optim.AdamW(
+            tok_params,
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.embed_wd,
+            fused=True,
+        )
+        self.optimizer_muon = Muon(
+            matrix_params,
+            lr=h.matrix_lr,
+            momentum=h.muon_momentum,
+            backend_steps=h.muon_backend_steps,
+            weight_decay=h.muon_wd,
+            row_normalize=h.muon_row_normalize,
+        )
+        for group in self.optimizer_muon.param_groups:
+            group["base_lr"] = h.matrix_lr
+        self.optimizer_scalar = torch.optim.AdamW(
+            [{"params": scalar_params, "lr": h.scalar_lr, "base_lr": h.scalar_lr}],
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.adam_wd,
+            fused=True,
+        )
+        self.optimizers = [
+            self.optimizer_tok,
+            self.optimizer_muon,
+            self.optimizer_scalar,
+        ]
+        if base_model.lm_head is not None:
+            self.optimizer_head = torch.optim.Adam(
+                [
+                    {
+                        "params": [base_model.lm_head.weight],
+                        "lr": h.head_lr,
+                        "base_lr": h.head_lr,
+                    }
+                ],
+                betas=(h.beta1, h.beta2),
+                eps=h.adam_eps,
+                fused=True,
+            )
+            self.optimizers.insert(1, self.optimizer_head)
+        else:
+            self.optimizer_head = None
+        self.replicated_params = list(tok_params[0]["params"])
+        self.replicated_params.extend(scalar_params)
+        if base_model.lm_head is not None:
+            self.replicated_params.append(base_model.lm_head.weight)
+        self.replicated_large_params = []
+        self.replicated_packed_params = []
+        for p in self.replicated_params:
+            if p.numel() <= PACKED_REPLICATED_GRAD_MAX_NUMEL:
+                self.replicated_packed_params.append(p)
+            else:
+                self.replicated_large_params.append(p)
+
+    def __iter__(self):
+        return iter(self.optimizers)
+
+    def zero_grad_all(self):
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    def _all_reduce_packed_grads(self):
+        grads_by_key = collections.defaultdict(list)
+        for p in self.replicated_packed_params:
+            if p.grad is not None:
+                grads_by_key[(p.grad.device, p.grad.dtype)].append(p.grad)
+        for grads in grads_by_key.values():
+            flat = torch.empty(
+                sum(g.numel() for g in grads),
+                device=grads[0].device,
+                dtype=grads[0].dtype,
+            )
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                flat[offset : offset + n].copy_(g.contiguous().view(-1))
+                offset += n
+            dist.all_reduce(flat, op=dist.ReduceOp.AVG)
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                g.copy_(flat[offset : offset + n].view_as(g))
+                offset += n
+
+    def step(self, distributed=False):
+        self.optimizer_muon.launch_reduce_scatters()
+        if distributed:
+            reduce_handles = [
+                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG, async_op=True)
+                for p in self.replicated_large_params
+                if p.grad is not None
+            ]
+            self._all_reduce_packed_grads()
+            for handle in reduce_handles:
+                handle.wait()
+        self.optimizer_tok.step()
+        self.optimizer_scalar.step()
+        if self.optimizer_head is not None:
+            self.optimizer_head.step()
+        self.optimizer_muon.step()
+        self.zero_grad_all()
+
+
+def restore_fp32_params(model):
+    for module in model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    for name, param in model.named_parameters():
+        if (
+            param.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ) and param.dtype != torch.float32:
+            param.data = param.data.float()
+    if hasattr(model, "qo_bank"):
+        model.qo_bank.data = model.qo_bank.data.float()
+        model.kv_bank.data = model.kv_bank.data.float()
+        model.mlp_up_bank.data = model.mlp_up_bank.data.float()
+        model.mlp_down_bank.data = model.mlp_down_bank.data.float()
+
+
+def collect_hessians(model, train_loader, h, device, n_calibration_batches=64):
+    hessians = {}
+    hooks = []
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = True
+        block.mlp._calib = True
+        block.mlp.use_fused = False
+
+    def make_attn_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            for suffix in ["c_q", "c_k", "c_v"]:
+                name = f"blocks.{layer_idx}.attn.{suffix}.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            y = module._last_proj_input
+            if y is not None:
+                y = y.float()
+                if y.ndim == 3:
+                    y = y.reshape(-1, y.shape[-1])
+                name = f"blocks.{layer_idx}.attn.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        y.shape[1], y.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(y.T, y)
+        return hook_fn
+
+    def make_mlp_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            name = f"blocks.{layer_idx}.mlp.fc.weight"
+            if name not in hessians:
+                hessians[name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[name].addmm_(x.T, x)
+            h_act = module._last_down_input
+            if h_act is not None:
+                h_act = h_act.float()
+                if h_act.ndim == 3:
+                    h_act = h_act.reshape(-1, h_act.shape[-1])
+                name = f"blocks.{layer_idx}.mlp.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        h_act.shape[1], h_act.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(h_act.T, h_act)
+        return hook_fn
+
+    for i, block in enumerate(model.blocks):
+        hooks.append(block.attn.register_forward_hook(make_attn_hook(i)))
+        hooks.append(block.mlp.register_forward_hook(make_mlp_hook(i)))
+    if model.tie_embeddings:
+        hook_module = (
+            model.head_proj if model.head_proj is not None else model.final_norm
+        )
+
+        def make_output_hook(name):
+            def hook_fn(module, inp, out):
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            return hook_fn
+
+        hooks.append(
+            hook_module.register_forward_hook(make_output_hook("tok_emb.weight"))
+        )
+    model.eval()
+    with torch.no_grad():
+        for _ in range(n_calibration_batches):
+            x, _ = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+            model.forward_logits(x)
+    for hook in hooks:
+        hook.remove()
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = False
+        block.mlp._calib = False
+        block.mlp.use_fused = True
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / n_calibration_batches
+    return hessians
+
+
+def gptq_quantize_weight(w, H, clip_sigmas=3.0, clip_range=63, block_size=128):
+    W_orig = w.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * H.diag().mean()
+    H.diagonal().add_(damp)
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+    Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    row_std = W_orig.std(dim=1)
+    s = (clip_sigmas * row_std / clip_range).clamp_min(1e-10).to(torch.float16)
+    sf = s.float()
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    W_work = W_perm.clone()
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W_work[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros(rows, i2 - i1)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            d = Hinv_block[j, j]
+            q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - q_col.float() * sf) / d
+            Err[:, j] = err
+            W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+        if i2 < cols:
+            W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+    return Q[:, invperm], s
+
+
+def gptq_mixed_quantize(state_dict, hessians, h):
+    result = {}
+    meta = {}
+    for (name, tensor) in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough (float16)"
+            continue
+        cs = h.embed_clip_sigmas if "tok_emb" in name else h.matrix_clip_sigmas
+        bits = h.embed_bits if "tok_emb" in name else h.matrix_bits
+        q, s = gptq_quantize_weight(
+            t, hessians[name], clip_sigmas=cs, clip_range=2 ** (bits - 1) - 1
+        )
+        result[name + ".q"] = q
+        result[name + ".scale"] = s
+        meta[name] = f"gptq (int{bits})"
+    categories = collections.defaultdict(set)
+    for (name, cat) in meta.items():
+        short = re.sub("\\.\\d+$", "", re.sub("blocks\\.\\d+", "blocks", name))
+        categories[cat].add(short)
+    log("Quantized weights:")
+    for cat in sorted(categories):
+        log(f"  {cat}: {', '.join(sorted(categories[cat]))}")
+    return result, meta
+
+
+def dequantize_mixed(result, meta, template_sd):
+    out = {}
+    for (name, orig) in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if "passthrough" in info:
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (
+                q.float() * s.float().view(q.shape[0], *[1] * (q.ndim - 1))
+            ).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+_BSHF_MAGIC = b"BSHF"
+
+
+def _byte_shuffle(data, stride=2):
+    if stride <= 1 or len(data) < stride:
+        return data
+    src = np.frombuffer(data, dtype=np.uint8)
+    n = len(src)
+    out = np.empty(n, dtype=np.uint8)
+    dest_off = 0
+    for pos in range(stride):
+        chunk = src[pos::stride]
+        out[dest_off : dest_off + len(chunk)] = chunk
+        dest_off += len(chunk)
+    return _BSHF_MAGIC + bytes([stride]) + out.tobytes()
+
+
+def _byte_unshuffle(data):
+    if len(data) < 5 or data[:4] != _BSHF_MAGIC:
+        return data
+    stride = data[4]
+    if stride < 2:
+        return data[5:]
+    payload = np.frombuffer(data, dtype=np.uint8, offset=5)
+    n = len(payload)
+    out = np.empty(n, dtype=np.uint8)
+    src_off = 0
+    for pos in range(stride):
+        chunk_len = n // stride + (1 if pos < n % stride else 0)
+        out[pos::stride][:chunk_len] = payload[src_off : src_off + chunk_len]
+        src_off += chunk_len
+    return out.tobytes()
+
+
+def _compress(data, compressor):
+    data = _byte_shuffle(data)
+    if compressor == "lzma":
+        return lzma.compress(data, preset=6)
+    elif compressor == "brotli":
+        import brotli
+
+        return brotli.compress(data, quality=11)
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def _decompress(data, compressor):
+    if compressor == "lzma":
+        raw = lzma.decompress(data)
+    elif compressor == "brotli":
+        import brotli
+
+        raw = brotli.decompress(data)
+    else:
+        raise ValueError(f"Unknown compressor: {compressor!r}")
+    raw = _byte_unshuffle(raw)
+    return raw
+
+
+def _unbank_state_dict(state_dict, num_layers):
+    sd = {}
+    n = num_layers
+    for k, v in state_dict.items():
+        t = v.detach().cpu()
+        if k == "qo_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_q.weight"] = t[i]
+                sd[f"blocks.{i}.attn.proj.weight"] = t[n + i]
+        elif k == "kv_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_k.weight"] = t[i]
+                sd[f"blocks.{i}.attn.c_v.weight"] = t[n + i]
+        elif k == "mlp_up_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.fc.weight"] = t[i]
+        elif k == "mlp_down_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.proj.weight"] = t[i]
+        else:
+            sd[k] = t
+    return sd
+
+
+def _rebank_state_dict(flat_sd, num_layers, model_dim, kv_dim, hidden_dim):
+    sd = {}
+    n = num_layers
+    sd["qo_bank"] = torch.zeros(2 * n, model_dim, model_dim)
+    sd["kv_bank"] = torch.zeros(2 * n, kv_dim, model_dim)
+    sd["mlp_up_bank"] = torch.zeros(n, hidden_dim, model_dim)
+    sd["mlp_down_bank"] = torch.zeros(n, model_dim, hidden_dim)
+    for i in range(n):
+        sd["qo_bank"][i] = flat_sd[f"blocks.{i}.attn.c_q.weight"]
+        sd["qo_bank"][n + i] = flat_sd[f"blocks.{i}.attn.proj.weight"]
+        sd["kv_bank"][i] = flat_sd[f"blocks.{i}.attn.c_k.weight"]
+        sd["kv_bank"][n + i] = flat_sd[f"blocks.{i}.attn.c_v.weight"]
+        sd["mlp_up_bank"][i] = flat_sd[f"blocks.{i}.mlp.fc.weight"]
+        sd["mlp_down_bank"][i] = flat_sd[f"blocks.{i}.mlp.proj.weight"]
+    for k, v in flat_sd.items():
+        if not (
+            k.startswith("blocks.")
+            and any(
+                p in k
+                for p in [
+                    ".attn.c_q.", ".attn.c_k.", ".attn.c_v.",
+                    ".attn.proj.", ".mlp.fc.", ".mlp.proj.",
+                ]
+            )
+        ):
+            sd[k] = v
+    return sd
+
+
+def _compressed_code_size(code):
+    code_raw = code.encode("utf-8")
+    minified = subprocess.run(
+        ["pyminify", "--no-rename-locals", "--no-hoist-literals", "--remove-literal-statements", "-"],
+        input=code_raw, capture_output=True, check=True,
+    ).stdout
+    compressed = lzma.compress(minified)
+    encoded = base64.b85encode(compressed)
+    wrapper = b'import lzma as L,base64 as B\nexec(L.decompress(B.b85decode("' + encoded + b'")))\n'
+    return len(code_raw), len(wrapper)
+
+
+def serialize(h, base_model, code):
+    code_bytes_uncompressed, code_bytes = _compressed_code_size(code)
+    if h.is_main_process:
+        torch.save(base_model.state_dict(), h.model_path)
+        model_bytes = os.path.getsize(h.model_path)
+        log(f"Serialized model: {model_bytes} bytes")
+        log(f"Code size (uncompressed): {code_bytes_uncompressed} bytes")
+        log(f"Code size (compressed): {code_bytes} bytes")
+    sd_cpu = _unbank_state_dict(base_model.state_dict(), h.num_layers)
+    device = torch.device("cuda", h.local_rank)
+    log("GPTQ:collecting Hessians from calibration data...")
+    t0 = time.perf_counter()
+    calib_loader = ShuffledSequenceLoader(h, device)
+    hessians = collect_hessians(
+        base_model,
+        calib_loader,
+        h,
+        device,
+        n_calibration_batches=h.gptq_calibration_batches,
+    )
+    log(f"GPTQ:collected {len(hessians)} Hessians in {time.perf_counter()-t0:.1f}s")
+    quant_result, quant_meta = gptq_mixed_quantize(sd_cpu, hessians, h)
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = _compress(quant_raw, h.compressor)
+    quant_file_bytes = len(quant_blob)
+    bytes_total = quant_file_bytes + code_bytes
+    if h.is_main_process:
+        with open(h.quantized_model_path, "wb") as f:
+            f.write(quant_blob)
+        log(f"Serialized model quantized+{h.compressor}: {quant_file_bytes} bytes")
+        log(f"Total submission size quantized+{h.compressor}: {bytes_total} bytes")
+    return bytes_total, quant_file_bytes
+
+
+def deserialize(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    flat_template = _unbank_state_dict(eval_model.state_dict(), h.num_layers)
+    with open(h.quantized_model_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(_decompress(quant_blob_disk, h.compressor)), map_location="cpu"
+    )
+    deq_flat = dequantize_mixed(quant_state["w"], quant_state["m"], flat_template)
+    head_dim = h.model_dim // h.num_heads
+    kv_dim = h.num_kv_heads * head_dim
+    hidden_dim = int(h.mlp_mult * h.model_dim)
+    deq_state = _rebank_state_dict(deq_flat, h.num_layers, h.model_dim, kv_dim, hidden_dim)
+    eval_model.load_state_dict(deq_state, strict=True)
+    return eval_model
+
+
+def _loss_bpb(loss_sum, token_count, byte_count):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    return val_loss, val_bpb
+
+
+def eval_val(h, device, val_data, model, forward_logits_fn=None):
+    seq_len = h.eval_seq_len
+    local_batch_tokens = h.val_batch_tokens // (h.world_size * h.grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            f"VAL_BATCH_SIZE must provide at least one sequence per rank; got VAL_BATCH_SIZE={h.val_batch_tokens}, WORLD_SIZE={h.world_size}, GRAD_ACCUM_STEPS={h.grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = total_seqs * h.rank // h.world_size
+    seq_end = total_seqs * (h.rank + 1) // h.world_size
+
+    # TODO: Don't truncate this.
+    seq_end = seq_start + ((seq_end - seq_start) // local_batch_seqs) * local_batch_seqs
+
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    run_forward_logits = (
+        (model.module.forward_logits if hasattr(model, "module") else model.forward_logits)
+        if forward_logits_fn is None
+        else forward_logits_fn
+    )
+    model.eval()
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    with torch.no_grad():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_data.val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1]
+            y = local[1:]
+            bos_pos = (x == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                bos_pos, x.numel(), x.device, h.eval_seq_len, 64
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = run_forward_logits(
+                    x[None], cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                ).detach()
+            per_token_loss = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y.reshape(-1),
+                reduction="none",
+            )
+            val_loss_sum += per_token_loss.to(torch.float64).sum()
+            val_token_count += float(y.numel())
+            prev_ids = x
+            tgt_ids = y
+            token_bytes = val_data.base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (
+                val_data.has_leading_space_lut[tgt_ids]
+                & ~val_data.is_boundary_token_lut[prev_ids]
+            ).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    model.train()
+    return _loss_bpb(val_loss_sum, val_token_count, val_byte_count)
+
+
+def eval_val_sliding(h, device, val_data, base_model, forward_logits_fn=None, batch_seqs=32):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    run_forward_logits = base_model.forward_logits if forward_logits_fn is None else forward_logits_fn
+    seq_len = h.eval_seq_len
+    stride = h.eval_stride
+    total_tokens = val_data.val_tokens.numel() - 1
+    context_size = seq_len - stride
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if ws + context_size < total_tokens]
+    total_windows = len(window_starts)
+    my_s = (total_windows * h.rank) // h.world_size
+    my_e = (total_windows * (h.rank + 1)) // h.world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    total_batches = (len(my_windows) + batch_seqs - 1) // batch_seqs
+    is_master = h.rank == 0
+    cu_bucket = 64
+    t_sw_start = time.perf_counter()
+    with torch.no_grad():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_idx = bi // batch_seqs
+            if is_master and (batch_idx % 50 == 0 or batch_idx == total_batches - 1):
+                elapsed = time.perf_counter() - t_sw_start
+                rl = float(loss_sum.item() / token_count.item()) if token_count.item() > 0 else 0.0
+                rb = float((rl / math.log(2.0)) * token_count.item() / byte_count.item()) if byte_count.item() > 0 else 0.0
+                log(f"sliding_progress: batch {batch_idx+1}/{total_batches} "
+                    f"tokens:{int(token_count.item())} running_loss:{rl:.4f} running_bpb:{rb:.4f} "
+                    f"elapsed:{elapsed:.1f}s")
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            x_parts = []
+            y_parts = []
+            cu_starts = []
+            score_ranges = []
+            offset = 0
+            for ws in batch_ws:
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                chunk_cpu = val_data.val_tokens[ws:end + 1]
+                bos_pos = (chunk_cpu[:-1] == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+                if not bos_pos or bos_pos[0] != 0:
+                    bos_pos = [0] + bos_pos
+                cu_starts.extend(offset + pos for pos in bos_pos)
+                chunk = chunk_cpu.to(dtype=torch.int64, device=device)
+                x_parts.append(chunk[:-1])
+                y_parts.append(chunk[1:])
+                score_ranges.append((offset, wlen, ws))
+                offset += wlen
+            x_cat = torch.cat(x_parts, dim=0)[None]
+            y_cat = torch.cat(y_parts, dim=0)
+            boundaries = cu_starts + [offset]
+            padded_len = get_next_multiple_of_n(len(boundaries), cu_bucket)
+            cu_seqlens = torch.full((padded_len,), offset, dtype=torch.int32, device=device)
+            cu_seqlens[:len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = run_forward_logits(x_cat, cu_seqlens=cu_seqlens, max_seqlen=seq_len)
+            flat_nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_cat,
+                reduction="none",
+            )
+            flat_x = x_cat.reshape(-1)
+            for off, wlen, ws in score_ranges:
+                s = 0 if ws == 0 else context_size
+                lo = off + s
+                hi = off + wlen
+                scored_nll = flat_nll[lo:hi].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(hi - lo)
+                tgt = y_cat[lo:hi]
+                prev = flat_x[lo:hi]
+                tb = val_data.base_bytes_lut[tgt].to(torch.float64)
+                tb += (val_data.has_leading_space_lut[tgt] & ~val_data.is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    base_model.train()
+    return _loss_bpb(loss_sum, token_count, byte_count)
+
+
+def _find_docs(all_tokens):
+    bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0].numpy()
+    docs = []
+    for i in range(len(bos_positions)):
+        start = int(bos_positions[i])
+        end = (
+            int(bos_positions[i + 1])
+            if i + 1 < len(bos_positions)
+            else all_tokens.numel()
+        )
+        if i + 1 < len(bos_positions):
+            end += 1
+        assert end - start >= 2
+        docs.append((start, end - start))
+    return docs
+
+
+def _build_ttt_global_batches(doc_entries, h, ascending=False):
+    batch_size = h.ttt_batch_size
+    global_doc_entries = sorted(doc_entries, key=lambda x: x[1][1])
+    global_batches = [
+        global_doc_entries[i : i + batch_size]
+        for i in range(0, len(global_doc_entries), batch_size)
+    ]
+    indexed = list(enumerate(global_batches))
+    if not ascending:
+        indexed.sort(key=lambda ib: -max(dl for _, (_, dl) in ib[1]))
+    return indexed
+
+
+def _init_batch_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(4, "little"))
+
+
+def _claim_next_batch(counter_path, queue_len):
+    try:
+        with open(counter_path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            idx = int.from_bytes(f.read(4), "little")
+            f.seek(0)
+            f.write((idx + 1).to_bytes(4, "little"))
+            f.flush()
+    except FileNotFoundError:
+        return queue_len
+    return idx
+
+
+def _compute_chunk_window(ci, pred_len, num_chunks, chunk_size, eval_seq_len):
+    chunk_end = pred_len if ci == num_chunks - 1 else (ci + 1) * chunk_size
+    win_start = max(0, chunk_end - eval_seq_len)
+    win_len = chunk_end - win_start
+    chunk_start = ci * chunk_size
+    chunk_offset = chunk_start - win_start
+    chunk_len = chunk_end - chunk_start
+    return win_start, win_len, chunk_offset, chunk_len
+
+
+def _accumulate_bpb(
+    ptl,
+    x,
+    y,
+    chunk_offsets,
+    chunk_lens,
+    pos_idx,
+    base_bytes_lut,
+    has_leading_space_lut,
+    is_boundary_token_lut,
+    loss_sum,
+    byte_sum,
+    token_count,
+):
+    pos = pos_idx[: x.size(1)].unsqueeze(0)
+    mask = (
+        (chunk_lens.unsqueeze(1) > 0)
+        & (pos >= chunk_offsets.unsqueeze(1))
+        & (pos < (chunk_offsets + chunk_lens).unsqueeze(1))
+    )
+    mask_f64 = mask.to(torch.float64)
+    tok_bytes = base_bytes_lut[y].to(torch.float64)
+    tok_bytes += (has_leading_space_lut[y] & ~is_boundary_token_lut[x]).to(
+        torch.float64
+    )
+    loss_sum += (ptl.to(torch.float64) * mask_f64).sum()
+    byte_sum += (tok_bytes * mask_f64).sum()
+    token_count += chunk_lens.to(torch.float64).sum()
+
+def eval_val_ttt_lora(h, base_model, device, val_data, forward_ttt_train):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+    all_tokens = val_data.val_tokens
+    all_tokens_idx = all_tokens.to(torch.int32)
+    docs = _find_docs(all_tokens)
+    doc_entries = list(enumerate(docs))
+    if h.val_doc_fraction < 1.0:
+        sample_n = max(1, int(round(len(docs) * h.val_doc_fraction)))
+        sampled_indices = sorted(
+            random.Random(h.seed).sample(range(len(docs)), sample_n)
+        )
+        doc_entries = [(i, docs[i]) for i in sampled_indices]
+    log(
+        f"ttt_lora:docs:{len(doc_entries)} rank:{h.ttt_lora_rank} lr:{h.ttt_lora_lr} chunk:{h.ttt_chunk_size}"
+    )
+    if os.environ.get("TTT_DEBUG_BYPASS") and h.rank == 0:
+        test_doc = doc_entries[0][1]
+        ds, dl = test_doc
+        log(f"DEBUG: test doc start={ds} len={dl}")
+        toks = all_tokens_idx[ds : ds + dl].to(device=device, dtype=torch.int64)
+        x_d = toks[:-1].unsqueeze(0)
+        y_d = toks[1:].unsqueeze(0)
+        with torch.no_grad(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+            logits_d = base_model.forward_logits(x_d)
+        ptl_d = F.cross_entropy(
+            logits_d.float().reshape(-1, logits_d.size(-1)),
+            y_d.reshape(-1), reduction="none",
+        )
+        direct_loss = ptl_d.mean().item()
+        direct_bpb = direct_loss / math.log(2.0)
+        log(f"DEBUG: direct forward_logits loss={direct_loss:.6f} bpb={direct_bpb:.6f} ntokens={y_d.numel()}")
+        toks_first5 = toks[:5].tolist()
+        ptl_first5 = ptl_d[:5].tolist()
+        log(f"DEBUG: first 5 tokens={toks_first5} ptl={[f'{v:.4f}' for v in ptl_first5]}")
+    chunk_size, eval_seq_len = h.ttt_chunk_size, h.ttt_eval_seq_len
+    eval_batch_set = None
+    if h.ttt_eval_batches:
+        eval_batch_set = set(int(x) for x in h.ttt_eval_batches.split(",") if x.strip())
+    use_ascending = eval_batch_set is not None
+    global_batches_sorted = _build_ttt_global_batches(doc_entries, h, ascending=use_ascending)
+    queue_len = len(global_batches_sorted)
+    counter_path = f"/tmp/ttt_counter_{h.run_id}"
+    if h.rank == 0:
+        _init_batch_counter(counter_path)
+    if dist.is_available() and dist.is_initialized():
+        path_list = [counter_path]
+        dist.broadcast_object_list(path_list, src=0)
+        counter_path = path_list[0]
+        dist.barrier()
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    t_start = time.perf_counter()
+    local_batch_count = 0
+    reusable_lora = BatchedTTTLoRA(
+        h.ttt_batch_size, base_model, h.ttt_lora_rank,
+        k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+    ).to(device)
+
+    def _build_opt(lora):
+        if h.ttt_optimizer == "sgd":
+            return torch.optim.SGD(
+                lora.parameters(), lr=h.ttt_lora_lr,
+                momentum=h.ttt_beta1, weight_decay=h.ttt_weight_decay,
+            )
+        return torch.optim.AdamW(
+            lora.parameters(), lr=h.ttt_lora_lr,
+            betas=(h.ttt_beta1, h.ttt_beta2),
+            eps=1e-10, weight_decay=h.ttt_weight_decay, fused=True,
+        )
+
+    reusable_opt = _build_opt(reusable_lora)
+    progress_f = None
+    if h.ttt_output_dir and h.rank == 0:
+        os.makedirs(h.ttt_output_dir, exist_ok=True)
+        progress_f = open(os.path.join(h.ttt_output_dir, "progress.jsonl"), "w")
+    try:
+      while True:
+        queue_idx = _claim_next_batch(counter_path, queue_len)
+        if queue_idx >= queue_len:
+            break
+        orig_batch_idx, batch_entries = global_batches_sorted[queue_idx]
+        batch = [doc for _, doc in batch_entries]
+        bsz = len(batch)
+        prev_loss = loss_sum.item()
+        prev_bytes = byte_sum.item()
+        prev_tokens = token_count.item()
+        if bsz == reusable_lora.bsz:
+            reusable_lora.reset()
+            for s in reusable_opt.state.values():
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor):
+                        v.zero_()
+                    elif k == "step":
+                        s[k] = 0
+            cur_lora = reusable_lora
+            cur_opt = reusable_opt
+        else:
+            cur_lora = BatchedTTTLoRA(
+                bsz, base_model, h.ttt_lora_rank,
+                k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+            ).to(device)
+            cur_opt = _build_opt(cur_lora)
+        pred_lens = [doc_len - 1 for _, doc_len in batch]
+        num_chunks = [(pl + chunk_size - 1) // chunk_size for pl in pred_lens]
+        max_nc = max(num_chunks)
+        num_chunks_t = torch.tensor(num_chunks, dtype=torch.int64, device=device)
+        for ci in range(max_nc):
+            active = [ci < nc for nc in num_chunks]
+            needs_train = any(ci < nc - 1 for nc in num_chunks)
+            tok_starts = torch.zeros(bsz, dtype=torch.int64)
+            tok_wls = torch.zeros(bsz, dtype=torch.int64)
+            chunk_offsets_cpu = torch.zeros(bsz, dtype=torch.int64)
+            chunk_lens_cpu = torch.zeros(bsz, dtype=torch.int64)
+            for b in range(bsz):
+                if not active[b]:
+                    continue
+                doc_start, doc_len = batch[b]
+                win_start, win_len, chunk_offset, chunk_len = _compute_chunk_window(
+                    ci, pred_lens[b], num_chunks[b], chunk_size, eval_seq_len
+                )
+                tok_starts[b] = doc_start + win_start
+                tok_wls[b] = win_len
+                chunk_offsets_cpu[b] = chunk_offset
+                chunk_lens_cpu[b] = chunk_len
+            _, context_size, chunk_offset, _ = _compute_chunk_window(
+                ci, (ci + 1) * chunk_size, ci + 1, chunk_size, eval_seq_len
+            )
+            col_idx = torch.arange(context_size + 1)
+            idx = tok_starts.unsqueeze(1) + col_idx.unsqueeze(0)
+            idx.clamp_(max=all_tokens.numel() - 1)
+            gathered_gpu = all_tokens_idx[idx].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            valid = (col_idx[:context_size].unsqueeze(0) < tok_wls.unsqueeze(1)).to(
+                device, non_blocking=True
+            )
+            chunk_offsets = chunk_offsets_cpu.to(device, non_blocking=True)
+            chunk_lens = chunk_lens_cpu.to(device, non_blocking=True)
+            x = torch.where(valid, gathered_gpu[:, :context_size], 0)
+            y = torch.where(valid, gathered_gpu[:, 1 : context_size + 1], 0)
+            ctx_pos = torch.arange(context_size, device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+            with torch.no_grad():
+                _accumulate_bpb(
+                    per_tok_loss,
+                    x,
+                    y,
+                    chunk_offsets,
+                    chunk_lens,
+                    ctx_pos,
+                    val_data.base_bytes_lut,
+                    val_data.has_leading_space_lut,
+                    val_data.is_boundary_token_lut,
+                    loss_sum,
+                    byte_sum,
+                    token_count,
+                )
+            if needs_train:
+                activate_chunk_mask = (num_chunks_t - 1 > ci).float()
+                for gi in range(h.ttt_grad_steps):
+                    if gi > 0:
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+                    per_doc = per_tok_loss[
+                        :, chunk_offset : chunk_offset + chunk_size
+                    ].mean(dim=-1)
+                    cur_opt.zero_grad(set_to_none=True)
+                    (per_doc * activate_chunk_mask).sum().backward()
+                    cur_opt.step()
+            else:
+                del per_tok_loss
+        local_batch_count += 1
+        batch_num = orig_batch_idx + 1
+        doc_lens = [dl for _, dl in batch]
+        should_report = False
+        if eval_batch_set is not None:
+            should_report = batch_num in eval_batch_set
+        else:
+            # should_report = local_batch_count % 10 == 0
+            should_report = True
+        if should_report:
+            cur_tokens = token_count.item()
+            cur_loss_val = loss_sum.item()
+            cur_bytes_val = byte_sum.item()
+            dt = cur_tokens - prev_tokens
+            if dt > 0:
+                b_loss = (cur_loss_val - prev_loss) / dt
+                b_bpb = b_loss / math.log(2.0) * (dt / (cur_bytes_val - prev_bytes))
+            else:
+                b_loss = b_bpb = 0.0
+            r_loss = cur_loss_val / max(cur_tokens, 1)
+            r_bpb = r_loss / math.log(2.0) * (cur_tokens / max(cur_bytes_val, 1))
+            elapsed = time.perf_counter() - t_start
+            log(
+                f"ttt_progress: batch {batch_num}/{queue_len} batch_loss:{b_loss:.4f} "
+                f"batch_bpb:{b_bpb:.4f} running_loss:{r_loss:.4f} running_bpb:{r_bpb:.4f} "
+                f"doc_len:{min(doc_lens)}-{max(doc_lens)}"
+            )
+            if progress_f is not None:
+                progress_f.write(
+                    json.dumps({
+                        "batch": batch_num, "total_batches": queue_len,
+                        "batch_loss": round(b_loss, 8), "batch_bpb": round(b_bpb, 8),
+                        "running_loss": round(r_loss, 8), "running_bpb": round(r_bpb, 8),
+                        "doc_len_min": min(doc_lens), "doc_len_max": max(doc_lens),
+                        "chunk_size": chunk_size,
+                        "elapsed_s": round(elapsed, 3),
+                        "batch_t_s": round(elapsed, 3),
+                    }) + "\n"
+                )
+                progress_f.flush()
+        del cur_lora, cur_opt
+    finally:
+        if progress_f is not None:
+            progress_f.close()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.train()
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_sum.item())
+    return val_loss, val_bpb
+
+
+def timed_eval(label, fn, *args, **kwargs):
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    val_loss, val_bpb = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    elapsed_ms = 1e3 * (time.perf_counter() - t0)
+    log(
+        f"{label} val_loss:{val_loss:.8f} val_bpb:{val_bpb:.8f} eval_time:{elapsed_ms:.0f}ms"
+    )
+    return val_loss, val_bpb
+
+
+def train_model(h, device, val_data):
+    base_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        base_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    model = compiled_model
+    log(f"model_params:{sum(p.numel()for p in base_model.parameters())}")
+    optimizers = Optimizers(h, base_model)
+    train_loader = DocumentPackingLoader(h, device)
+    max_wallclock_ms = (
+        1e3 * h.max_wallclock_seconds if h.max_wallclock_seconds > 0 else None
+    )
+    if max_wallclock_ms is not None:
+        max_wallclock_ms -= h.gptq_reserve_seconds * 1e3
+        log(
+            f"gptq:reserving {h.gptq_reserve_seconds:.0f}s, effective={max_wallclock_ms:.0f}ms"
+        )
+
+    def training_frac(step, elapsed_ms):
+        if max_wallclock_ms is None:
+            return step / max(h.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-09)
+
+    def lr_mul(frac):
+        if h.warmdown_frac <= 0:
+            return 1.0
+        if frac >= 1.0 - h.warmdown_frac:
+            return max((1.0 - frac) / h.warmdown_frac, h.min_lr)
+        return 1.0
+
+    def step_fn(step, lr_scale):
+        optimizers.zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(h.grad_accum_steps):
+            x, y, cu_seqlens, _max_seqlen = train_loader.next_batch(
+                h.train_batch_tokens, h.grad_accum_steps
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y, cu_seqlens=cu_seqlens, max_seqlen=h.train_seq_len)
+            train_loss += loss.detach()
+            (loss / h.grad_accum_steps).backward()
+        train_loss /= h.grad_accum_steps
+        frac = (
+            min(step / h.muon_momentum_warmup_steps, 1.0)
+            if h.muon_momentum_warmup_steps > 0
+            else 1.0
+        )
+        muon_momentum = (
+            1 - frac
+        ) * h.muon_momentum_warmup_start + frac * h.muon_momentum
+        for group in optimizers.optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * lr_scale
+        if h.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), h.grad_clip_norm)
+        optimizers.step(distributed=h.distributed)
+        return train_loss
+
+    if h.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for (name, tensor) in base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in optimizers
+        ]
+        model.train()
+        num_tokens_local = h.train_batch_tokens // h.world_size
+        for blk in base_model.blocks:
+            blk.attn.rotary(num_tokens_local, device, torch.bfloat16)
+        cu_bucket_size = train_loader.cu_bucket_size
+        warmup_cu_buckets = tuple(cu_bucket_size * i for i in range(1, 5))
+        warmup_cu_iters = 3
+        x, y, cu_seqlens, _ = train_loader.next_batch(
+            h.train_batch_tokens, h.grad_accum_steps
+        )
+        log(f"warmup_cu_buckets:{','.join(str(b) for b in warmup_cu_buckets)} iters_each:{warmup_cu_iters}")
+        def _run_cu_bucket_warmup():
+            for bucket_len in warmup_cu_buckets:
+                boundaries = list(range(0, x.size(1), max(h.train_seq_len, 1)))
+                if boundaries[-1] != x.size(1):
+                    boundaries.append(x.size(1))
+                cu = torch.full((bucket_len,), x.size(1), dtype=torch.int32, device=device)
+                cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+                for _ in range(warmup_cu_iters):
+                    optimizers.zero_grad_all()
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                        wloss = model(x, y, cu_seqlens=cu, max_seqlen=h.train_seq_len)
+                    (wloss / h.grad_accum_steps).backward()
+            optimizers.zero_grad_all()
+        _run_cu_bucket_warmup()
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            _run_cu_bucket_warmup()
+            base_model.looping_active = False
+        for warmup_step in range(h.warmup_steps):
+            step_fn(warmup_step, 1.0)
+            if (
+                warmup_step <= 5
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == h.warmup_steps
+            ):
+                log(f"warmup_step: {warmup_step+1}/{h.warmup_steps}")
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            log(
+                f"loop_warmup:enabled encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            for warmup_step in range(h.warmup_steps):
+                step_fn(warmup_step, 1.0)
+                if (
+                    warmup_step <= 5
+                    or (warmup_step + 1) % 10 == 0
+                    or warmup_step + 1 == h.warmup_steps
+                ):
+                    log(f"loop_warmup_step: {warmup_step+1}/{h.warmup_steps}")
+            base_model.looping_active = False
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for (opt, state) in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        optimizers.zero_grad_all()
+        train_loader = DocumentPackingLoader(h, device)
+    ema_state = {
+        name: t.detach().float().clone()
+        for (name, t) in base_model.state_dict().items()
+    }
+    ema_decay = h.ema_decay
+    training_time_ms = 0.0
+    stop_after_step = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = (
+            step == h.iterations
+            or stop_after_step is not None
+            and step >= stop_after_step
+        )
+        should_validate = (
+            last_step or h.val_loss_every > 0 and step % h.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1e3 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                h, device, val_data, model, compiled_forward_logits
+            )
+            log(
+                f"{step}/{h.iterations} val_loss: {val_loss:.4f} val_bpb: {val_bpb:.4f}"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < h.iterations:
+                log(
+                    f"stopping_early: wallclock_cap train_time: {training_time_ms:.0f}ms step: {step}/{h.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        frac = training_frac(step, elapsed_ms)
+        scale = lr_mul(frac)
+        if (
+            h.num_loops > 0
+            and not base_model.looping_active
+            and frac >= h.enable_looping_at
+        ):
+            base_model.looping_active = True
+            log(
+                f"layer_loop:enabled step:{step} frac:{frac:.3f} encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+        train_loss = step_fn(step, scale)
+        with torch.no_grad():
+            for (name, t) in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(
+                    t.detach().float(), alpha=1.0 - ema_decay
+                )
+        step += 1
+        approx_training_time_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        should_log_train = h.train_log_every > 0 and (
+            step <= 5 or step % h.train_log_every == 0 or stop_after_step is not None
+        )
+        if should_log_train:
+            tok_per_sec = step * h.train_batch_tokens / (approx_training_time_ms / 1e3)
+            log(
+                f"{step}/{h.iterations} train_loss: {train_loss.item():.4f} train_time: {approx_training_time_ms/60000:.1f}m tok/s: {tok_per_sec:.0f}"
+            )
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if h.distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated()//1024//1024} MiB reserved: {torch.cuda.max_memory_reserved()//1024//1024} MiB"
+    )
+    log("ema:applying EMA weights")
+    current_state = base_model.state_dict()
+    avg_state = {
+        name: t.to(dtype=current_state[name].dtype) for (name, t) in ema_state.items()
+    }
+    base_model.load_state_dict(avg_state, strict=True)
+    return base_model, compiled_model, compiled_forward_logits
+
+
+def train_and_eval(h, device):
+    random.seed(h.seed)
+    np.random.seed(h.seed)
+    torch.manual_seed(h.seed)
+    torch.cuda.manual_seed_all(h.seed)
+    if h.artifact_dir and h.is_main_process:
+        os.makedirs(h.artifact_dir, exist_ok=True)
+    val_data = ValidationData(h, device)
+    if h.eval_only_path:
+        log(f"eval_only:loading checkpoint from {h.eval_only_path}")
+        base_model = GPT(h).to(device).bfloat16()
+        restore_fp32_params(base_model)
+        base_model.load_state_dict(torch.load(h.eval_only_path, map_location=device))
+        if h.num_loops > 0:
+            base_model.looping_active = True
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+        compiled_forward_logits = torch.compile(
+            base_model.forward_logits, dynamic=False, fullgraph=True
+        )
+    else:
+        log(
+            f"train_shards: {len(list(Path(h.datasets_dir).resolve().glob('fineweb_train_*.bin')))}"
+        )
+        log(f"val_tokens: {val_data.val_tokens.numel()-1}")
+        base_model, compiled_model, compiled_forward_logits = train_model(
+            h, device, val_data
+        )
+    _skip_training = bool(h.eval_only_path)
+    log("\nbeginning eval timer")
+    t_all_eval = time.perf_counter()
+
+    torch._dynamo.reset()
+    timed_eval(
+        "pre-quantization post-ema",
+        eval_val,
+        h,
+        device,
+        val_data,
+        compiled_model,
+        compiled_forward_logits,
+    )
+    if not _skip_training:
+        serialize(h, base_model, Path(__file__).read_text(encoding="utf-8"))
+    else:
+        log("eval_only: skipping serialize (already have quantized model)")
+        if not os.path.exists(h.quantized_model_path):
+            log("eval_only: no quantized model found, running serialize anyway")
+            serialize(h, base_model, Path(__file__).read_text(encoding="utf-8"))
+    if h.distributed:
+        dist.barrier()
+    eval_model = deserialize(h, device)
+    if h.num_loops > 0:
+        eval_model.looping_active = True
+    compiled_model = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        eval_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    timed_eval(
+        "quantized",
+        eval_val,
+        h,
+        device,
+        val_data,
+        compiled_model,
+        compiled_forward_logits,
+    )
+    if h.sliding_window_enabled:
+        timed_eval(
+            "quantized_sliding_window",
+            eval_val_sliding,
+            h,
+            device,
+            val_data,
+            eval_model,
+            forward_logits_fn=compiled_forward_logits,
+        )
+    ttt_compile_time = 0.0
+    if h.ttt_enabled:
+        del eval_model, compiled_model
+        torch._dynamo.reset()
+        torch.cuda.empty_cache()
+        ttt_model = deserialize(h, device)
+        if h.num_loops > 0:
+            ttt_model.looping_active = True
+        for p in ttt_model.parameters():
+            p.requires_grad_(False)
+
+        if h.rope_yarn:
+            _yarn_seqlen = h.train_batch_tokens // h.grad_accum_steps
+            for block in ttt_model.blocks:
+                block.attn.rotary(_yarn_seqlen, device, torch.bfloat16)
+        else:
+            for block in ttt_model.blocks:
+                block.attn.rotary._cos_cached = None
+                block.attn.rotary._sin_cached = None
+                block.attn.rotary._seq_len_cached = 0
+                block.attn.rotary(h.ttt_eval_seq_len, device, torch.bfloat16)
+
+        def _fwd_ttt(input_ids, target_ids, lora):
+            return ttt_model.forward_ttt(input_ids, target_ids, lora=lora)
+
+        _ttt_debug_bypass = bool(os.environ.get("TTT_DEBUG_BYPASS"))
+        if _ttt_debug_bypass:
+            def _fwd_ttt_bypass(input_ids, target_ids, lora):
+                logits = ttt_model.forward_logits(input_ids)
+                dummy = lora.q_loras[0].B.sum() * 0
+                logits = logits + dummy
+                bsz, sl, V = logits.shape
+                return F.cross_entropy(
+                    logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none"
+                ).reshape(bsz, sl)
+            fwd_ttt_compiled = _fwd_ttt_bypass
+            log("ttt_lora:DEBUG BYPASS active - using forward_logits directly (no compile warmup)")
+            ttt_compile_time = 0.0
+        else:
+            fwd_ttt_compiled = torch.compile(_fwd_ttt, dynamic=True)
+            log(f"ttt_lora:warming up compile")
+            global BOS_ID
+            if BOS_ID is None:
+                BOS_ID = 1
+            ds0 = 0
+            val_tokens_idx = val_data.val_tokens.to(torch.int32)
+            t_warmup = time.perf_counter()
+            warmup_bszes = [h.ttt_batch_size]
+            for bsz in warmup_bszes:
+                wl = BatchedTTTLoRA(
+                    bsz, ttt_model, h.ttt_lora_rank,
+                    k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+                ).to(device)
+                wo = torch.optim.AdamW(
+                    wl.parameters(),
+                    lr=h.ttt_lora_lr,
+                    betas=(h.ttt_beta1, h.ttt_beta2),
+                    eps=1e-10,
+                    weight_decay=h.ttt_weight_decay,
+                    fused=True,
+                )
+                for ctx_len in (h.ttt_chunk_size, h.ttt_eval_seq_len):
+                    col_w = torch.arange(ctx_len + 1)
+                    idx_w = (ds0 + col_w).clamp_(max=val_data.val_tokens.numel() - 1)
+                    row_w = val_tokens_idx[idx_w].to(device=device, dtype=torch.int64)
+                    xw = row_w[:ctx_len].unsqueeze(0).expand(bsz, -1).contiguous()
+                    yw = row_w[1 : ctx_len + 1].unsqueeze(0).expand(bsz, -1).contiguous()
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        ptl = fwd_ttt_compiled(xw, yw, lora=wl)
+                    ptl[:, : min(h.ttt_chunk_size, ctx_len)].mean(dim=-1).sum().backward()
+                    wo.step()
+                    wo.zero_grad(set_to_none=True)
+                del wl, wo
+            del val_tokens_idx
+            torch.cuda.empty_cache()
+            ttt_compile_time = time.perf_counter() - t_warmup
+            log(f"ttt_lora:compile warmup done ({ttt_compile_time:.1f}s)")
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_val_loss, ttt_val_bpb = eval_val_ttt_lora(
+            h, ttt_model, device, val_data, forward_ttt_train=fwd_ttt_compiled
+        )
+        torch.cuda.synchronize()
+        log(
+            f"quantized_ttt_lora val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f} eval_time:{1e3*(time.perf_counter()-t_ttt):.0f}ms"
+        )
+        del ttt_model
+
+    total_eval = time.perf_counter() - t_all_eval
+    log(f"total_eval_time:{total_eval - ttt_compile_time:.1f}s")
+    log(f"total_eval_time_with_compile:{total_eval:.1f}s")
+
+
+def main():
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    torch._dynamo.config.optimize_ddp = False
+    torch._dynamo.config.cache_size_limit = 16
+    h = Hyperparameters()
+    set_logging_hparams(h)
+    if h.is_main_process:
+        os.makedirs(h.artifact_dir if h.artifact_dir else "logs", exist_ok=True)
+        log(100 * "=", console=False)
+        log("Hyperparameters:", console=True)
+        for (k, v) in sorted(vars(type(h)).items()):
+            if not k.startswith("_"):
+                log(f"  {k}: {v}", console=True)
+        log("=" * 100, console=False)
+        log(f"Running Python {sys.version}", console=False)
+        log(f"Running PyTorch {torch.__version__}", console=False)
+        log(
+            subprocess.run(
+                ["nvidia-smi"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            ).stdout,
+            console=False,
+        )
+        log("=" * 100, console=False)
+    train_and_eval(h, device)
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-04-10_VarLenAttn/train_gpt.py
+++ b/records/track_10min_16mb/2026-04-10_VarLenAttn/train_gpt.py
@@ -17,7 +17,7 @@ class Hyperparameters:
     seed = int(os.environ.get("SEED", 1337))
     run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
     iterations = int(os.environ.get("ITERATIONS", 20000))
-    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.667))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.72))
     warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
     train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786432))
     train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
@@ -48,7 +48,8 @@ class Hyperparameters:
     loop_start = int(os.environ.get("LOOP_START", 3))
     loop_end = int(os.environ.get("LOOP_END", 5))
     enable_looping_at = float(os.environ.get("ENABLE_LOOPING_AT", 0.35))
-    parallel_start_layer = int(os.environ.get("PARALLEL_START_LAYER", 7))
+    parallel_start_layer = int(os.environ.get("PARALLEL_START_LAYER", 8))
+    parallel_final_lane = os.environ.get("PARALLEL_FINAL_LANE", "mean")
     min_lr = float(os.environ.get("MIN_LR", 0.0))
     embed_lr = float(os.environ.get("EMBED_LR", 0.6))
     head_lr = float(os.environ.get("HEAD_LR", 0.008))
@@ -71,12 +72,12 @@ class Hyperparameters:
     muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
     adam_wd = float(os.environ.get("ADAM_WD", 0.02))
     muon_wd = float(os.environ.get("MUON_WD", 0.095))
-    embed_wd = float(os.environ.get("EMBED_WD", 0.095))
-    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
     ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
     ttt_lora_rank = int(os.environ.get("TTT_LORA_RANK", 96))
     ttt_lora_lr = float(os.environ.get("TTT_LORA_LR", 0.0001))
-    ttt_chunk_size = int(os.environ.get("TTT_CHUNK_SIZE", 64))
+    ttt_chunk_size = int(os.environ.get("TTT_CHUNK_SIZE", 32))
     ttt_eval_seq_len = int(os.environ.get("TTT_EVAL_SEQ_LEN", 2048))
     ttt_batch_size = int(os.environ.get("TTT_BATCH_SIZE", 64))
     ttt_grad_steps = int(os.environ.get("TTT_GRAD_STEPS", 1))
@@ -90,12 +91,9 @@ class Hyperparameters:
     ttt_eval_batches = os.environ.get("TTT_EVAL_BATCHES", "")
     ttt_output_dir = os.environ.get("TTT_OUTPUT_DIR", "")
     val_doc_fraction = float(os.environ.get("VAL_DOC_FRACTION", 1.0))
-    etlb_lr = float(os.environ.get("ETLB_LR", 0.05))
-    etlb_steps = int(os.environ.get("ETLB_STEPS", 5))
-    etlb_clip = float(os.environ.get("ETLB_CLIP", 3.0))
     compressor = os.environ.get("COMPRESSOR", "brotli")
     gptq_calibration_batches = int(os.environ.get("GPTQ_CALIBRATION_BATCHES", 64))
-    gptq_reserve_seconds = float(os.environ.get("GPTQ_RESERVE_SECONDS", 12.0))
+    gptq_reserve_seconds = float(os.environ.get("GPTQ_RESERVE_SECONDS", 13.0))
     matrix_bits = int(os.environ.get("MATRIX_BITS", 6))
     embed_bits = int(os.environ.get("EMBED_BITS", 8))
     matrix_clip_sigmas = float(os.environ.get("MATRIX_CLIP_SIGMAS", 12.85))
@@ -729,23 +727,6 @@ class Block(nn.Module):
         ] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
         return x_out
 
-    def forward_attn(self, x, x0, q_w, k_w, v_w, out_w, cu_seqlens=None, max_seqlen=0):
-        mix = self.resid_mix.to(dtype=x.dtype)
-        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
-        attn_out = self.attn(
-            self.attn_norm(x_in) * self.ln_scale_factor,
-            q_w, k_w, v_w, out_w,
-            cu_seqlens=cu_seqlens,
-            max_seqlen=max_seqlen,
-        )
-        return x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
-
-    def forward_mlp(self, x, up_w, down_w):
-        return x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(
-            self.mlp_norm(x) * self.ln_scale_factor, up_w, down_w
-        )
-
-
 class GPT(nn.Module):
     def __init__(self, h):
         super().__init__()
@@ -837,8 +818,12 @@ class GPT(nn.Module):
             else None
         )
         self.parallel_start_layer = h.parallel_start_layer
-        self.lane_merge = (
-            nn.Parameter(torch.tensor(0.5)) if self.parallel_start_layer > 0 else None
+        self.parallel_final_lane = h.parallel_final_lane.lower()
+        self.parallel_post_lambdas = nn.Parameter(
+            torch.ones(h.num_layers, 2, 2, dtype=torch.float32)
+        )
+        self.parallel_resid_lambdas = nn.Parameter(
+            torch.full((h.num_layers, 2), 1.1, dtype=torch.float32)
         )
         self._init_weights()
 
@@ -878,6 +863,39 @@ class GPT(nn.Module):
             self.mlp_down_bank[i],
         )
 
+    def _parallel_block(
+        self, block_idx, lane0, lane1, x0,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+        cu_seqlens=None, max_seqlen=0,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        attn_out = block.attn(
+            block.attn_norm(attn_read) * block.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+        )
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * block.mlp(
+            block.mlp_norm(mlp_read) * block.ln_scale_factor, up_w, down_w
+        )
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+    def _final_parallel_hidden(self, lane0, lane1):
+        if self.parallel_final_lane == "mlp":
+            return lane1
+        if self.parallel_final_lane == "attn":
+            return lane0
+        return 0.5 * (lane0 + lane1)
+
     def forward_logits(self, input_ids, cu_seqlens=None, max_seqlen=0):
         x = self.tok_emb(input_ids)
         x = F.rms_norm(x, (x.size(-1),))
@@ -907,44 +925,36 @@ class GPT(nn.Module):
         lane1 = None
         for skip_idx, i in enumerate(dec_iter):
             q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
-            if lane0 is None:
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block(
+                    i, lane0, lane1, x0, q_w, k_w, v_w, out_w, up_w, down_w,
+                    cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+                )
+            else:
                 if skip_idx < self.num_skip_weights and skips:
                     scaled_skip = (
                         self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
                         * skips.pop()
                     )
                     if self.skip_gates is not None:
-                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[
-                            None, None, :
-                        ]
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
                         x = torch.lerp(scaled_skip, x, g)
                     else:
                         x = x + scaled_skip
-                if i >= psl and psl > 0:
-                    lane0 = x
-                    lane1 = x.clone()
-                    lane0 = self.blocks[i].forward_attn(lane0, x0, q_w, k_w, v_w, out_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
-                    lane1 = self.blocks[i].forward_mlp(lane1, up_w, down_w)
-                else:
-                    x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
-            else:
-                if skip_idx < self.num_skip_weights and skips:
-                    scaled_skip = (
-                        self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
-                        * skips.pop()
-                    )
-                    if self.skip_gates is not None:
-                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[
-                            None, None, :
-                        ]
-                        lane0 = torch.lerp(scaled_skip, lane0, g)
-                    else:
-                        lane0 = lane0 + scaled_skip
-                lane0 = self.blocks[i].forward_attn(lane0, x0, q_w, k_w, v_w, out_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
-                lane1 = self.blocks[i].forward_mlp(lane1, up_w, down_w)
+                x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
         if lane0 is not None:
-            lm = self.lane_merge.to(dtype=lane0.dtype)
-            x = lm * lane0 + (1.0 - lm) * lane1
+            x = self._final_parallel_hidden(lane0, lane1)
         x = self.final_norm(x)
         if self.head_proj is not None:
             x = self.head_proj(x)
@@ -997,45 +1007,37 @@ class GPT(nn.Module):
         lane1 = None
         for skip_idx, i in enumerate(dec_iter):
             q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
-            if lane0 is None:
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block_with_lora(
+                    i, lane0, lane1, x0, lora, slot,
+                    q_w, k_w, v_w, out_w, up_w, down_w,
+                )
+            else:
                 if skip_idx < self.num_skip_weights and skips:
                     scaled_skip = (
                         self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
                         * skips.pop()
                     )
                     if self.skip_gates is not None:
-                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[
-                            None, None, :
-                        ]
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
                         x = torch.lerp(scaled_skip, x, g)
                     else:
                         x = x + scaled_skip
-                if i >= psl and psl > 0:
-                    lane0 = x
-                    lane1 = x.clone()
-                    lane0 = self._block_with_lora_attn(self.blocks[i], lane0, x0, lora, slot, q_w, k_w, v_w, out_w)
-                    lane1 = self._block_with_lora_mlp(self.blocks[i], lane1, lora, slot, up_w, down_w)
-                else:
-                    x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
-            else:
-                if skip_idx < self.num_skip_weights and skips:
-                    scaled_skip = (
-                        self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
-                        * skips.pop()
-                    )
-                    if self.skip_gates is not None:
-                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[
-                            None, None, :
-                        ]
-                        lane0 = torch.lerp(scaled_skip, lane0, g)
-                    else:
-                        lane0 = lane0 + scaled_skip
-                lane0 = self._block_with_lora_attn(self.blocks[i], lane0, x0, lora, slot, q_w, k_w, v_w, out_w)
-                lane1 = self._block_with_lora_mlp(self.blocks[i], lane1, lora, slot, up_w, down_w)
+                x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
             slot += 1
         if lane0 is not None:
-            lm = self.lane_merge.to(dtype=lane0.dtype)
-            x = lm * lane0 + (1.0 - lm) * lane1
+            x = self._final_parallel_hidden(lane0, lane1)
         x = self.final_norm(x)
         if self.head_proj is not None:
             x = self.head_proj(x)
@@ -1087,10 +1089,14 @@ class GPT(nn.Module):
         x_out = x_out + block.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * mlp_out
         return x_out
 
-    def _block_with_lora_attn(self, block, x, x0, lora, slot, q_w, k_w, v_w, out_w):
-        mix = block.resid_mix.to(dtype=x.dtype)
-        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
-        n = block.attn_norm(x_in) * block.ln_scale_factor
+    def _parallel_block_with_lora(
+        self, block_idx, lane0, lane1, x0, lora, slot,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        n = block.attn_norm(attn_read) * block.ln_scale_factor
         attn = block.attn
         bsz, seqlen, dim = n.shape
         q = (F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)).reshape(
@@ -1116,14 +1122,20 @@ class GPT(nn.Module):
         attn_out = F.linear(y, out_w.to(n.dtype))
         if lora.o_loras is not None:
             attn_out = attn_out + lora.o_loras[slot](n)
-        return x_in + block.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
-
-    def _block_with_lora_mlp(self, block, x, lora, slot, up_w, down_w):
-        mlp_n = block.mlp_norm(x) * block.ln_scale_factor
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_n = block.mlp_norm(mlp_read) * block.ln_scale_factor
         mlp_out = block.mlp(mlp_n, up_w, down_w)
         if lora.mlp_loras is not None:
             mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
-        return x + block.mlp_scale.to(dtype=x.dtype)[None, None, :] * mlp_out
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * mlp_out
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
 
 
 class BatchedLinearLoRA(nn.Module):
@@ -1371,7 +1383,7 @@ CONTROL_TENSOR_NAME_PATTERNS = tuple(
     pattern
     for pattern in os.environ.get(
         "CONTROL_TENSOR_NAME_PATTERNS",
-        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,lane_merge",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,parallel_post_lambdas,parallel_resid_lambdas",
     ).split(",")
     if pattern
 )
@@ -1399,8 +1411,10 @@ class Optimizers:
             scalar_params.append(base_model.skip_weights)
         if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
             scalar_params.append(base_model.skip_gates)
-        if base_model.lane_merge is not None:
-            scalar_params.append(base_model.lane_merge)
+        if base_model.parallel_post_lambdas is not None:
+            scalar_params.append(base_model.parallel_post_lambdas)
+        if base_model.parallel_resid_lambdas is not None:
+            scalar_params.append(base_model.parallel_resid_lambdas)
         token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
         tok_params = [
             {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
@@ -2197,7 +2211,6 @@ def eval_val_ttt_lora(h, base_model, device, val_data, forward_ttt_train):
     byte_sum = torch.zeros((), device=device, dtype=torch.float64)
     token_count = torch.zeros((), device=device, dtype=torch.float64)
     t_start = time.perf_counter()
-    local_batch_count = 0
     reusable_lora = BatchedTTTLoRA(
         h.ttt_batch_size, base_model, h.ttt_lora_rank,
         k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
@@ -2317,7 +2330,6 @@ def eval_val_ttt_lora(h, base_model, device, val_data, forward_ttt_train):
                     cur_opt.step()
             else:
                 del per_tok_loss
-        local_batch_count += 1
         batch_num = orig_batch_idx + 1
         doc_lens = [dl for _, dl in batch]
         should_report = False
@@ -2624,12 +2636,9 @@ def train_and_eval(h, device):
             h, device, val_data
         )
     _skip_training = bool(h.eval_only_path)
-    log("\nbeginning eval timer")
-    t_all_eval = time.perf_counter()
-
     torch._dynamo.reset()
     timed_eval(
-        "pre-quantization post-ema",
+        "diagnostic pre-quantization post-ema",
         eval_val,
         h,
         device,
@@ -2654,7 +2663,7 @@ def train_and_eval(h, device):
         eval_model.forward_logits, dynamic=False, fullgraph=True
     )
     timed_eval(
-        "quantized",
+        "diagnostic quantized",
         eval_val,
         h,
         device,
@@ -2664,7 +2673,7 @@ def train_and_eval(h, device):
     )
     if h.sliding_window_enabled:
         timed_eval(
-            "quantized_sliding_window",
+            "diagnostic quantized_sliding_window",
             eval_val_sliding,
             h,
             device,
@@ -2672,7 +2681,6 @@ def train_and_eval(h, device):
             eval_model,
             forward_logits_fn=compiled_forward_logits,
         )
-    ttt_compile_time = 0.0
     if h.ttt_enabled:
         del eval_model, compiled_model
         torch._dynamo.reset()
@@ -2694,8 +2702,16 @@ def train_and_eval(h, device):
                 block.attn.rotary._seq_len_cached = 0
                 block.attn.rotary(h.ttt_eval_seq_len, device, torch.bfloat16)
 
-        def _fwd_ttt(input_ids, target_ids, lora):
+        def _fwd_ttt_inner(input_ids, target_ids, lora):
             return ttt_model.forward_ttt(input_ids, target_ids, lora=lora)
+
+        _fwd_ttt_compiled_inner = None
+
+        def _fwd_ttt(input_ids, target_ids, lora):
+            nonlocal _fwd_ttt_compiled_inner
+            if _fwd_ttt_compiled_inner is None:
+                _fwd_ttt_compiled_inner = torch.compile(_fwd_ttt_inner, dynamic=True)
+            return _fwd_ttt_compiled_inner(input_ids, target_ids, lora=lora)
 
         _ttt_debug_bypass = bool(os.environ.get("TTT_DEBUG_BYPASS"))
         if _ttt_debug_bypass:
@@ -2709,9 +2725,8 @@ def train_and_eval(h, device):
                 ).reshape(bsz, sl)
             fwd_ttt_compiled = _fwd_ttt_bypass
             log("ttt_lora:DEBUG BYPASS active - using forward_logits directly (no compile warmup)")
-            ttt_compile_time = 0.0
         else:
-            fwd_ttt_compiled = torch.compile(_fwd_ttt, dynamic=True)
+            fwd_ttt_compiled = _fwd_ttt
             log(f"ttt_lora:warming up compile")
             global BOS_ID
             if BOS_ID is None:
@@ -2747,22 +2762,21 @@ def train_and_eval(h, device):
                 del wl, wo
             del val_tokens_idx
             torch.cuda.empty_cache()
-            ttt_compile_time = time.perf_counter() - t_warmup
-            log(f"ttt_lora:compile warmup done ({ttt_compile_time:.1f}s)")
+            compile_elapsed = time.perf_counter() - t_warmup
+            log(f"ttt_lora:compile warmup done ({compile_elapsed:.1f}s)")
+        log("\nbeginning TTT eval timer")
         torch.cuda.synchronize()
         t_ttt = time.perf_counter()
         ttt_val_loss, ttt_val_bpb = eval_val_ttt_lora(
             h, ttt_model, device, val_data, forward_ttt_train=fwd_ttt_compiled
         )
         torch.cuda.synchronize()
+        ttt_eval_elapsed = time.perf_counter() - t_ttt
         log(
-            f"quantized_ttt_lora val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f} eval_time:{1e3*(time.perf_counter()-t_ttt):.0f}ms"
+            f"quantized_ttt_lora val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f} eval_time:{1e3*ttt_eval_elapsed:.0f}ms"
         )
+        log(f"total_eval_time:{ttt_eval_elapsed:.1f}s")
         del ttt_model
-
-    total_eval = time.perf_counter() - t_all_eval
-    log(f"total_eval_time:{total_eval - ttt_compile_time:.1f}s")
-    log(f"total_eval_time_with_compile:{total_eval:.1f}s")
 
 
 def main():
@@ -2807,6 +2821,11 @@ def main():
         for (k, v) in sorted(vars(type(h)).items()):
             if not k.startswith("_"):
                 log(f"  {k}: {v}", console=True)
+        log("=" * 100, console=False)
+        log("Source code:", console=False)
+        log("=" * 100, console=False)
+        with open(__file__, "r", encoding="utf-8") as _src:
+            log(_src.read(), console=False)
         log("=" * 100, console=False)
         log(f"Running Python {sys.version}", console=False)
         log(f"Running PyTorch {torch.__version__}", console=False)


### PR DESCRIPTION
# Record: Varlen attention + fused MLP + TTT

**val_loss: 2.77261 | val_bpb: 1.07336** | **~15.99 MB** | 8×H100 SXM, 587s train + ~340s TTT eval
| Seed | BPB | Loss |
|------|-----|------|
| 0 | 1.07258208 | 2.77059090 |
| 1 | 1.07324696 | 2.77230836 |
| 2 | 1.07426259 | 2.77493185 |
| **Mean** | **1.07336388** | **2.77261037** |
| **Std** | **0.00084633** | **0.00218618** |

Best PR bpb ([PR #1529](https://github.com/openai/parameter-golf/pull/1529)): bpb=1.0753 (**delta=0.0019**), loss=2.7776 (**delta=0.0050**)

Merged record bpb ([PR #1493](https://github.com/openai/parameter-golf/pull/1493)): bpb=1.0810 (**delta=0.0076**), loss=2.7923 (**delta=0.0197**)

Increased training speed ~5% via variable length attention, a fused MLP triton kernel (no `cutlass_evt_fusion` dep), and grouping together small parameters, yielding ~.002 nats when comparing sliding window eval. Re-added document-based LoRA TTT which has *no inter-sequence dependence* and improves over strided evaluation by ~.008 nats.

Based on a hackathon last weekend with @aldopareja, @sestinj, and @chrishamblin7 :)

## Main changes

Applied changes from [my old PR](https://github.com/openai/parameter-golf/pull/1354) to a recent record PR: [#1523](https://github.com/openai/parameter-golf/pull/1523). But [PR #1552](https://github.com/openai/parameter-golf/pull/1552) beat my previous bpb before I submitted the PR, so I incorporated their (orthogonal) improvements. Most of below is copied from my previous PR [#1354](https://github.com/openai/parameter-golf/pull/1354).

This involves 3 things:

### 1. Variable length attention (~2% faster training, ~0.001 nats)

Replaced dense causal attention with Flash Attention 3's `flash_attn_varlen_func`. During training, documents are packed into flat token buffers with `cu_seqlens` boundaries so attention is computed within documents only — the model never attends across unrelated documents that happen to be adjacent in a batch.

This does two things:
- Removes the need for the model to learn to ignore pre-BOS content from unrelated documents
- Reduces wasted FLOPs: e.g. 10 short (100-token) docs packed into a 1k-token buffer cost proportional to `100 * 100**2 = 1M` attention FLOPs vs `10 * 1000**2 = 10M` with dense attention.

### 2. Fused MLP + grouped small params (~3% faster training, ~0.001 nats)

A custom Triton kernel (`linear_leaky_relu_square_kernel`) fuses the up-projection, LeakyReLU(0.5)² activation, and squaring into a single kernel. Based on similar kernels from [modded-nanogpt](https://github.com/KellerJordan/modded-nanogpt/blob/master/triton_kernels.py). I also group the many tiny replicated scalar/control gradients into a single all-reduce to avoid a pile of tiny collectives.

### 3. Doc-based test-time training (TTT) (~0.008 nats over sliding window)

> [Blog explaining LoRA-based TTT from past record](https://samacquaviva.com/projects/parameter-golf/)

Although it is technically legal in this competition to train on tokens from previous documents in the dataset, I am spiritually opposed to this. Under the current formulation, if the eval set was bigger, the expectation of the loss would be lower which seems broken. So in this implementation, there is score-first TTT applied to each sequence in the validation set *independently* (and efficiently using batched LoRAs), which is strictly harder.

Re-adds LoRA-based TTT, based on [my old implementation](https://github.com/openai/parameter-golf/blob/main/records/track_10min_16mb/2026-03-17_LoRA_TTT/README.md), but > 2x faster which allows for using smaller chunk sizes which leads to better performance. This is an instance of "Case 3" according to [this classification](https://samacquaviva.com/projects/ttt-clarification/).

It's interesting to note that adding test-time training improves loss more than adding ~215 steps. These 215 steps train on `786432*215=169,082,880` tokens to gain ~.002 nats. The average sequence length in the validation set is ~200 tokens which means test-time training here gains ~.003 nats / 800 tokens on average (valid bc sequences are trained independently). So, in a way, TTT is `~(.003/800) / (.002/169082880) >= 300k` times more token efficient than pre-training: it helps to be in distribution :)

## Other small changes

Made some changes to make replication and dev based on this PR easier:

- Load from a checkpoint just for eval
- Didn't submit minified code, instead wrote that utility into the script when calculating file size so that it is easier for people to build off of this
- Store unminified code in logs

## Replicating runs + dev

```bash
# setup
uv venv
source .venv/bin/activate
uv pip install -r records/track_10min_16mb/2026-04-10_VarLenAttn/requirements.txt
uv pip install --break-system-packages flash_attn_3 --find-links https://windreamer.github.io/flash-attention3-wheels/cu128_torch291
uv pip install torch==2.9.1+cu128 --extra-index-url https://download.pytorch.org/whl/cu128

MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf \
  python3 data/cached_challenge_fineweb.py --variant sp8192 --train-shards  128

# train + eval
SEED=0
ARTIFACT_DIR="runs/varlen${SEED}" SEED=$SEED \
    torchrun --standalone --nproc_per_node=8 \
    records/track_10min_16mb/2026-04-10_VarLenAttn/train_gpt.py

# eval saved checkpoint w/ TTT (useful for dev)
EVAL_ONLY_PATH="runs/varlen${SEED}/final_model.pt" SEED=$SEED \
    torchrun --standalone --nproc_per_node=8 \
    records/track_10min_16mb/2026-04-10_VarLenAttn/train_gpt.py
```
