### PR TITLE
[notable non record] Train-Time Overparameterization: Better Models Through Transient Expansion

### DIFF
--- a/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/README.md
+++ b/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/README.md
@@ -1,4 +1,4 @@
-# Train-Time Overparameterization (TTO)
+# Train-Time Overparameterization
 
 ## Overview
 

--- a/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/README.md
+++ b/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/README.md
@@ -29,9 +29,65 @@ TTO is applied over the course of training using a simple staged schedule:
 
 After 25% of training, the model is functionally identical in size and structure to the baseline, and the remaining training proceeds normally.
 
+## Pseudocode
+
+```python
+class TTOLinear:
+    # start wider than the final exported layer
+    weight = learned_matrix(expanded_width, d_in)
+
+    # one learned keep logit per expanded neuron
+    keep_logits = learned_vector(expanded_width)
+
+    def forward(x):
+        h = linear(x, weight)
+
+        if gates_are_enabled:
+            p = sigmoid(keep_logits)
+
+            # hard stochastic gate in forward pass
+            mask = bernoulli(p)
+
+            # straight-through style gradient to keep_logits
+            h = hard_gate_with_logit_gradient(h, mask, p)
+
+        return h
+```
+
+```python
+def tto_aux_loss(layer, target_active_neurons):
+    p = sigmoid(layer.keep_logits)
+
+    # keep expected active neurons near the current budget
+    budget_loss = (sum(p) - target_active_neurons) ** 2
+
+    # encourage probabilities to become decisive, near 0 or 1
+    separation_loss = sum(p * (1 - p))
+
+    return budget_loss + separation_loss
+```
+
+```python
+def consolidate(layer, final_width):
+    p = sigmoid(layer.keep_logits)
+
+    # keep the neurons the model learned to rely on
+    keep = topk(p, final_width)
+
+    # prune the expansion projection
+    layer.weight = layer.weight[keep]
+
+    # prune the matching input dimension of the down projection
+    next_layer.weight = next_layer.weight[:, keep]
+
+    # remove gates; the layer is now a normal dense layer
+    layer.keep_logits = None
+    layer.gates_are_enabled = False
+```
+
 ## Results
 
-All runs are trained for 10k steps under identical settings across three seeds.
+All runs are trained for 10k steps under identical settings across three seeds, building off of the original naive baseline.
 
 To keep the final model within the same parameter budget, the baseline uses a 2× MLP expansion, while TTO uses a 4× temporary expansion (8× effective width during training), followed by consolidation back to the original size before export.
 
@@ -48,6 +104,38 @@ To keep the final model within the same parameter budget, the baseline uses a 2�
 
 Train-Time Overparameterization consistently improves over the baseline across all three seeds. 
 
+## Stronger Baseline Validation
+
+To check whether TTO still helps beyond the naive baseline setting, I also ran a second validation experiment on a stronger stack.
+
+This setup ports over several components from the current SOTA-style configuration, including:
+
+- 11 layers
+- SP8192 vocabulary
+- stronger hyperparameters
+- larger baseline MLP expansion
+
+Here, the matched baseline uses a 4× MLP expansion. I also include a 4.5× MLP run as a rough calibration point for how much extra dense MLP capacity would be needed to match TTO.
+
+| Model | Seed | Val BPB ↓ |
+|-------|------|----------:|
+| 4× MLP baseline | 1337 | 1.1304 |
+| 4.5× MLP baseline | 1337 | 1.1250 |
+| TTO, final 4× MLP | 1337 | **1.1249** |
+| 4× MLP baseline | 42 | 1.1312 |
+| 4.5× MLP baseline | 42 | **1.1258** |
+| TTO, final 4× MLP | 42 | 1.1260 |
+| 4× MLP baseline | 2025 | 1.1318 |
+| 4.5× MLP baseline | 2025 | **1.1265** |
+| TTO, final 4× MLP | 2025 | 1.1287 |
+| **Average 4× MLP baseline** | — | 1.1311 |
+| **Average 4.5× MLP baseline** | — | **1.1258** |
+| **Average TTO, final 4× MLP** | — | 1.1265 |
+
+TTO substantially improves over the matched 4× MLP baseline, reducing average validation BPB from **1.1311** to **1.1265**.
+
+It also lands close to the 4.5× MLP baseline while retaining the final 4× MLP size. Interpolating between the 4× and 4.5× dense baselines, TTO behaves roughly like a **4.43× MLP** on average, despite consolidating back to 4×.
+
 ---
 
 ## How Train-Time Overparameterization Works
@@ -55,16 +143,6 @@ Train-Time Overparameterization consistently improves over the baseline across a
 ### Why temporary expansion can help
 
 The fundamental idea behind TTO is simple: a model may be fully capable of representing a good function, but still be bad at discovering it through gradient descent—training with a larger transient model both expands the space of available features and makes useful solutions easier to reach, before being compressed back down.
-
-### Why the MLP is a natural place to apply it
-
-The MLP is a natural place to apply TTO: it contains most of the model’s parameters and is relatively self-contained, making expansion and later pruning straightforward.
-
-The value projection is a plausible alternative, but is much smaller, so we prioritized the MLP as the highest-leverage target (though value-TTO could still be effective).
-
-Applying TTO to query/key projections is likely more challenging due to their tighter coupling and more global role, and may introduce more disruptive changes, though we have not explored this.
-
-One important consideration is that TTO introduces distributional shift during training. As the active neuron budget is reduced, earlier layers change their outputs, perturbing the inputs seen by later layers. When applied more broadly, this effect may compound, suggesting that more structured (e.g. layer- or module-aware) scheduling could help isolate and control these shifts.
 
 ### The core challenge: selecting which neurons survive
 
@@ -106,7 +184,7 @@ From this point onward, training proceeds normally with no additional overhead.
 
 A key observation is that consolidation can occur relatively early. Although the soft pruning is initially disruptive, the model quickly recovers—typically within a small fraction of the remaining training steps—and maintains a consistent performance advantage thereafter.
 
-This makes TTO practical: most of the training run is performed with the final, smaller model, while still benefiting from the improved optimization enabled by early overparameterization.
+This makes TTO practical (though not on the timed track): most of the training run is performed with the final, smaller model, while still benefiting from the improved optimization enabled by early overparameterization.
 
 ## Selection vs. optimization
 

--- a/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/README.md
+++ b/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/README.md
@@ -1,3 +1,5 @@
+# Train-Time Overparameterization (TTO)
+
 ## Overview
 
 Language models are typically trained at the same capacity they will ultimately use at inference. In this work, we explore a different question:

--- a/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/README.md
+++ b/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/README.md
@@ -1,0 +1,133 @@
+## Overview
+
+Language models are typically trained at the same capacity they will ultimately use at inference. In this work, we explore a different question:
+
+Should a small model be trained small from the start?
+
+We find that the answer appears to be no.
+
+This work introduces Train-Time Overparameterization (TTO): a simple strategy in which the model is given extra MLP capacity during training, and that excess capacity is later consolidated back down to the original inference budget. The final model remains the same size at deployment, but training proceeds through a larger feature space.
+
+The core idea is straightforward:
+
+- start from a target small model  
+- expand the MLP during training  
+- learn which neurons are most useful via stochastic gating  
+- consolidate back to the original width before export  
+
+Empirically, this produces a consistent improvements over training the same final-capacity model directly.
+
+### Training Schedule
+
+TTO is applied over the course of training using a simple staged schedule:
+
+- **0–5%**: train with the fully expanded MLP (no gating)  
+- **5–25%**: introduce stochastic gating with a learned, budget-aware objective  
+- **25–100%**: prune to the target width and continue training as a standard model  
+
+After 25% of training, the model is functionally identical in size and structure to the baseline, and the remaining training proceeds normally.
+
+## Results
+
+All runs are trained for 10k steps under identical settings across three seeds.
+
+To keep the final model within the same parameter budget, the baseline uses a 2× MLP expansion, while Train-Time Overparameterization (TTO) uses a 4× temporary expansion (8× effective width during training), followed by consolidation back to the original size before export.
+
+| Model | Seed | Pre-quant BPB ↓ | Post-quant BPB ↓ | Size (bytes) |
+|-------|------|----------------:|-----------------:|-------------:|
+| Baseline | 1337 | 1.2262 | 1.2328 | 15861272 |
+| TTO (4× expand) | 1337 | **1.2197** | **1.2264** | 15891679 |
+| Baseline | 42 | 1.2276 | 1.2343 | 15856563 |
+| TTO (4× expand) | 42 | **1.2197** | **1.2270** | 15886567 |
+| Baseline | 2025 | 1.2253 | 1.2321 | 15853892 |
+| TTO (4× expand) | 2025 | **1.2204** | **1.2273** | 15883534 |
+| **Average (Baseline)** | — | 1.2264 | 1.2331 | 15857242 |
+| **Average (TTO)** | — | **1.2199** | **1.2269** | 15887260 |
+
+Train-Time Overparameterization consistently improves over the baseline across all three seeds. 
+
+---
+
+## How Train-Time Overparameterization Works
+
+### Why temporary expansion can help
+
+The fundamental idea behind TTO is simple: a model may be fully capable of representing a good function, but still be bad at discovering it through gradient descent—training with a larger transient model both expands the space of available features and makes useful solutions easier to reach, before being compressed back down.
+
+### Why the MLP is a natural place to apply it
+
+The MLP is a natural place to apply TTO: it contains most of the model’s parameters and is relatively self-contained, making expansion and later pruning straightforward.
+
+The value projection is a plausible alternative, but is much smaller, so we prioritized the MLP as the highest-leverage target (though value-TTO could still be effective).
+
+Applying TTO to query/key projections is likely more challenging due to their tighter coupling and more global role, and may introduce more disruptive changes, though we have not explored this.
+
+One important consideration is that TTO introduces distributional shift during training. As the active neuron budget is reduced, earlier layers change their outputs, perturbing the inputs seen by later layers. When applied more broadly, this effect may compound, suggesting that more structured (e.g. layer- or module-aware) scheduling could help isolate and control these shifts.
+
+### The core challenge: selecting which neurons survive
+
+Expanding the MLP is straightforward. The real challenge is deciding which neurons should remain when we return to the target model.
+
+At a high level, TTO is built around a simple idea: enforce a **capacity budget** during training, and structure it so that the most useful neurons naturally emerge. Crucially, this budget must be applied *gradually*. Abruptly removing capacity would be highly disruptive, so instead we slowly reduce the number of active neurons over time, allowing the network to adapt as it is progressively “soft pruned” toward its final size.
+
+A natural first approach is to assign each neuron a learned continuous gate, and use an auxiliary objective to constrain the total activation mass to match a target budget. This allows the model to softly reallocate capacity and gradually shift importance across neurons.
+
+However, this approach runs into a fundamental issue: under a budget constraint alone, the model tends to distribute mass evenly across neurons, resulting in a “mushy” allocation where many neurons remain partially active. This is poorly aligned with the final top-k pruning step, where we need a clear separation between neurons that are used and those that are not.
+
+To address this, we introduce a simple **separation objective** that encourages gates to move toward the extremes of 0 or 1. This pushes the network to make more decisive allocations, and in practice is critical for obtaining a clean ranking of neurons prior to pruning.
+
+Even with this, however, the continuous formulation has a deeper problem: the network can *cheat*. Because the gates only scale activations, surrounding weights can simply increase in magnitude to compensate for reduced values. This allows the model to continue using its full effective capacity despite the imposed budget. As a result, when pruning is eventually applied, performance degrades sharply—the model was still relying on the neurons that are removed.
+
+While it may be possible to address this with additional constraints (e.g. coupling gates to weight norms), this quickly becomes complex and difficult to tune. Instead, we take a different approach: we make the selection process explicitly **discrete**.
+
+Each neuron is assigned a learned logit, which defines a Bernoulli probability via a sigmoid. During training, neurons are stochastically gated on or off using a hard binary mask. This eliminates the possibility of compensation through rescaling—when a neuron is off, it is truly unavailable.
+
+This discrete formulation has two key advantages. First, it aligns training with the final model: neurons are either present or absent, just as they will be after consolidation. Second, it produces a meaningful importance signal: the learned probability directly reflects how valuable it is for a neuron to remain active.
+
+To train these logits, we use a surrogate (straight-through) gradient estimator. Intuitively, this treats the hard gating operation as if it were a smooth scaling during backpropagation, allowing gradients to flow to the logits while preserving discrete behavior in the forward pass. This provides a stable signal for which neurons should be kept, while still enabling gradual adaptation as the budget is reduced.
+
+By the time consolidation occurs, the network has already adapted to operate under the target budget, with most neurons effectively either fully on or fully off. As a result, the explicit pruning via top-k selection itself becomes minimally disruptive.
+
+### Consolidation and training schedule
+
+TTO operates in three phases: expansion, controlled sparsification, and consolidation.
+
+We begin training with the fully expanded MLP, with all neurons active. This allows the model to take advantage of the larger feature space during the early stages of optimization.
+
+At 5% of training, stochastic gating is enabled. From this point onward, neurons are sampled according to their learned probabilities, and the auxiliary objectives begin to take effect.
+
+Between 5% and 15% of training, we **anneal the target budget** from the expanded width down to the final width. This gradually reduces the expected number of active neurons, allowing the model to adapt smoothly as capacity is removed.
+
+At 25% of training, we **consolidate** the model by selecting the top-k neurons (by learned probability) and permanently pruning the rest. The MLP is then replaced with a standard dense layer of the target size, making the model architecturally identical to the baseline.
+
+From this point onward, training proceeds normally with no additional overhead.
+
+A key observation is that consolidation can occur relatively early. Although the soft pruning is initially disruptive, the model quickly recovers—typically within a small fraction of the remaining training steps—and maintains a consistent performance advantage thereafter.
+
+This makes TTO practical even under tight compute constraints: most of the training run is performed with the final, smaller model, while still benefiting from the improved optimization enabled by early overparameterization.
+
+## Selection vs. optimization
+
+TTO raises a central question: *where does the improvement actually come from?*
+
+One possibility is **selection**. The expanded model exposes a much larger pool of neurons, and training identifies a particularly effective subset. From this perspective, overparameterization primarily acts as a search process, and the final performance is driven by the specific neurons that are retained after consolidation.
+
+An alternative (and not mutually exclusive) explanation is **optimization**. A larger model may be easier to train: it can represent intermediate solutions more flexibly and make it easier for gradient descent to discover useful representations. In this view, even temporary overparameterization can guide the model into regions of parameter space that a smaller model would be unlikely to reach on its own, with some of these improvements persisting after consolidation.
+
+To probe this, we ran a simple transfer experiment. We first trained a model with TTO and recorded the neurons selected during consolidation. We then trained a new model at the target size, initializing it with the same subset of neurons (i.e. same indices), but without using TTO during training.
+
+This did **not** recover the performance of the full TTO model.
+
+This suggests that the benefit is not solely explained by identifying a “lucky” subset of neurons at initialization, in contrast to interpretations similar to the lottery ticket hypothesis. While it is still possible that certain neurons become particularly important over the course of training, their usefulness does not appear to be fixed from the start in a way that can be trivially transferred.
+
+Instead, this points toward a more optimization-driven explanation: the transient overparameterized phase may enable the model to form representations that are simply not accessible when training at the final capacity from the outset.
+
+More broadly, it is unclear how localized this effect is. Although TTO is applied only to the MLP, changes in intermediate representations affect the entire network, and it is possible that attention layers also benefit indirectly from the improved feature space during early training.
+
+These questions remain open, and we view TTO primarily as an empirical result that highlights the potential importance of training dynamics, rather than as a fully understood mechanism.
+
+## Closing note
+
+While it is easy to overstate the similarities between biological and artificial neural networks, TTO bears a rather striking structural resemblance to early brain development, where synaptic overgrowth is followed by large-scale pruning.
+
+Perhaps this reflects something more fundamental: neural nets may simply learn better if you let them have a childhood.

--- a/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/README.md
+++ b/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/README.md
@@ -106,7 +106,7 @@ From this point onward, training proceeds normally with no additional overhead.
 
 A key observation is that consolidation can occur relatively early. Although the soft pruning is initially disruptive, the model quickly recovers—typically within a small fraction of the remaining training steps—and maintains a consistent performance advantage thereafter.
 
-This makes TTO practical even under tight compute constraints: most of the training run is performed with the final, smaller model, while still benefiting from the improved optimization enabled by early overparameterization.
+This makes TTO practical: most of the training run is performed with the final, smaller model, while still benefiting from the improved optimization enabled by early overparameterization.
 
 ## Selection vs. optimization
 

--- a/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/README.md
+++ b/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/README.md
@@ -33,7 +33,7 @@ After 25% of training, the model is functionally identical in size and structure
 
 All runs are trained for 10k steps under identical settings across three seeds.
 
-To keep the final model within the same parameter budget, the baseline uses a 2× MLP expansion, while Train-Time Overparameterization (TTO) uses a 4× temporary expansion (8× effective width during training), followed by consolidation back to the original size before export.
+To keep the final model within the same parameter budget, the baseline uses a 2× MLP expansion, while TTO uses a 4× temporary expansion (8× effective width during training), followed by consolidation back to the original size before export.
 
 | Model | Seed | Pre-quant BPB ↓ | Post-quant BPB ↓ | Size (bytes) |
 |-------|------|----------------:|-----------------:|-------------:|

--- a/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/submission.json
+++ b/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/submission.json
@@ -1,0 +1,9 @@
+{
+  "author": "Andrew Mouldon",
+  "github_id": "andrewmouldon",
+  "name": "Train-Time Overparameterization — Temporary MLP Expansion with Consolidation",
+  "blurb": "TTO temporarily expands MLP capacity during training, learns which neurons to keep using stochastic hard gates, then consolidates back to the original inference width. Directly builds on the initial naive baseline and is trained for a fixed 10k steps. Improves the final model without increasing inference size.",
+  "date": "2026-04-11T00:00:00Z",
+  "val_bpb": 1.2269,
+  "bytes_total": 15887260,
+}

--- a/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/train_gpt.py
+++ b/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/train_gpt.py
@@ -1,0 +1,1660 @@
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: `train_gpt.py` and `train_gpt_mlx.py` must never be longer than 1500 lines.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+os.environ["CUDA_VISIBLE_DEVICES"] = "1"
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from dataclasses import dataclass
+
+
+
+torch._dynamo.config.recompile_limit = 16
+
+
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 10000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 4))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+
+    # TTO 
+    tto_enable = bool(int(os.environ.get("TTO_ENABLE", "1")))
+    tto_init_logit = float(os.environ.get("TTO_INIT_LOGIT", 3.0))
+    tto_expand_ratio = float(os.environ.get("TTO_EXPAND_RATIO", 3.0))
+    tto_start = int(os.environ.get("TTO_START", 500))
+    tto_budget_duration = int(os.environ.get("TTO_BUDGET_DURATION", 1500))
+    tto_consolidate_step = int(os.environ.get("TTO_CONSOLIDATE_STEP", 2500)) 
+    tto_budget_lambda = float(os.environ.get("TTO_BUDGET_LAMBDA", 1e-3))
+    tto_sep_lambda = float(os.environ.get("TTO_SEP_LAMBDA", 1e-3))
+    
+
+# -----------------------------
+# MUON OPTIMIZER 
+# -----------------------------
+# 
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING 
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, self.weight.to(x.dtype), bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+
+
+class HardGateOnlyLogitGrad(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, h: Tensor, logits: Tensor) -> Tensor:
+        p = torch.sigmoid(logits) 
+
+        p_broadcast = p
+        while p_broadcast.ndim < h.ndim:
+            p_broadcast = p_broadcast.unsqueeze(0)
+
+        z_hard = (torch.rand_like(h) < p_broadcast).to(h.dtype)
+        ctx.save_for_backward(h, z_hard, p)
+
+        return h * z_hard
+
+    @staticmethod
+    def backward(ctx, grad_out: Tensor):
+        h, z_hard, p = ctx.saved_tensors
+
+        grad_h = grad_out * z_hard
+
+        reduce_dims = tuple(range(h.ndim - 1))
+        grad_logits = (grad_out * h).sum(dim=reduce_dims) * p * (1.0 - p)
+
+        return grad_h, grad_logits
+
+
+@dataclass
+class ParamReplacement:
+    old_param: nn.Parameter
+    new_param: nn.Parameter | None
+    action: str  # "replace" or "drop"
+    prune_axis: int | None = None
+    keep_idx: Tensor | None = None
+
+
+@dataclass
+class TTOMLPConsolidationPlan:
+    keep_idx: Tensor
+    new_up: nn.Module
+    new_down: nn.Module
+    replacements: list[ParamReplacement]
+
+
+
+class TTOLinear(nn.Module):
+    """
+    Expansion linear with learned stochastic gating over output neurons.
+
+    Training modes:
+      - gate_enabled=False: dense linear, no gating
+      - gate_enabled=True and gate_sample=True: hard Bernoulli mask with surrogate grad to logits
+      - gate_enabled=True and gate_sample=False: deterministic soft gate using probs
+    """
+
+    def __init__(self, d_in: int, d_out_start: int, d_out_final: int, bias: bool = False, init_logit: float = 3.0):
+        super().__init__()
+        if d_out_start < d_out_final:
+            raise ValueError(f"d_out_start ({d_out_start}) must be >= d_out_final ({d_out_final})")
+        self.d_in = d_in
+        self.d_out_start = d_out_start
+        self.d_out_final = d_out_final
+
+        self.weight = nn.Parameter(torch.empty(d_out_start, d_in))
+        bound = 1 / math.sqrt(d_in)
+        nn.init.uniform_(self.weight, a=-bound, b=bound)
+        self.bias = nn.Parameter(torch.zeros(d_out_start)) if bias else None
+        self.logits = nn.Parameter(torch.full((d_out_start,), init_logit))
+
+        self.gate_enabled = False
+        self.gate_sample = True
+
+    def gate_probs(self) -> Tensor:
+        return torch.sigmoid(self.logits)
+
+    def set_gate_mode(self, enabled: bool, sample: bool) -> None:
+        self.gate_enabled = enabled
+        self.gate_sample = sample
+
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        h = F.linear(x, self.weight.to(x.dtype), bias)
+        if not self.gate_enabled:
+            return h
+        if self.gate_sample and self.training:
+            return HardGateOnlyLogitGrad.apply(h, self.logits)
+        return h * self.gate_probs().to(dtype=h.dtype)
+
+    @torch.no_grad()
+    def topk_indices(self) -> Tensor:
+        k = self.d_out_final
+        p = self.gate_probs()
+        keep_idx = torch.topk(p, k=k, dim=0).indices
+        return keep_idx.sort().values
+
+class TTOMLP(nn.Module):
+    # relu^2 MLP with TTO on the expansion projection only.
+    def __init__(self, dim: int, mlp_mult: int, tto_expand_ratio: float, tto_init_logit: float):
+        super().__init__()
+        hidden_final = mlp_mult * dim
+        hidden_start = int(round(hidden_final * tto_expand_ratio))
+        if hidden_start < hidden_final:
+            raise ValueError(
+                f"tto_expand_ratio must give hidden_start >= hidden_final, "
+                f"got hidden_start={hidden_start}, hidden_final={hidden_final}"
+            )
+        self.hidden_start = hidden_start
+        self.hidden_final = hidden_final
+        self.is_consolidated = False
+
+        self.up_proj = TTOLinear(
+            dim,
+            hidden_start,
+            hidden_final,
+            bias=False,
+            init_logit=tto_init_logit,
+        )
+        self.down_proj = CastedLinear(hidden_start, dim, bias=False)
+        self.down_proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.up_proj(x))
+        return self.down_proj(x.square())
+
+    @torch.no_grad()
+    def build_consolidation_plan(self) -> TTOMLPConsolidationPlan:
+        if self.is_consolidated:
+            raise RuntimeError("TTOMLP is already consolidated")
+
+        if not isinstance(self.up_proj, TTOLinear):
+            raise RuntimeError("TTOMLP.up_proj is expected to be TTOLinear before consolidation")
+
+        keep_idx = self.up_proj.topk_indices()
+        device = self.up_proj.weight.device
+
+        new_up = CastedLinear(self.up_proj.d_in, self.hidden_final, bias=self.up_proj.bias is not None).to(device=device)
+        new_down = CastedLinear(self.hidden_final, self.down_proj.out_features, bias=self.down_proj.bias is not None).to(device=device)
+
+        new_up.weight.data.copy_(self.up_proj.weight[keep_idx].to(dtype=new_up.weight.dtype))
+        new_down.weight.data.copy_(self.down_proj.weight[:, keep_idx].to(dtype=new_down.weight.dtype))
+
+        replacements: list[ParamReplacement] = [
+            ParamReplacement(
+                old_param=self.up_proj.weight,
+                new_param=new_up.weight,
+                action="replace",
+                prune_axis=0,
+                keep_idx=keep_idx,
+            ),
+            ParamReplacement(
+                old_param=self.down_proj.weight,
+                new_param=new_down.weight,
+                action="replace",
+                prune_axis=1,
+                keep_idx=keep_idx,
+            ),
+            ParamReplacement(
+                old_param=self.up_proj.logits,
+                new_param=None,
+                action="drop",
+            ),
+        ]
+
+        if self.up_proj.bias is not None:
+            if new_up.bias is None:
+                raise RuntimeError("Expected new_up to have bias")
+            new_up.bias.data.copy_(self.up_proj.bias[keep_idx].to(dtype=new_up.bias.dtype))
+            replacements.append(
+                ParamReplacement(
+                    old_param=self.up_proj.bias,
+                    new_param=new_up.bias,
+                    action="replace",
+                    prune_axis=0,
+                    keep_idx=keep_idx,
+                )
+            )
+
+        if self.down_proj.bias is not None:
+            if new_down.bias is None:
+                raise RuntimeError("Expected new_down to have bias")
+            new_down.bias.data.copy_(self.down_proj.bias.to(dtype=new_down.bias.dtype))
+            replacements.append(
+                ParamReplacement(
+                    old_param=self.down_proj.bias,
+                    new_param=new_down.bias,
+                    action="replace",
+                    prune_axis=None,
+                    keep_idx=None,
+                )
+            )
+
+        return TTOMLPConsolidationPlan(
+            keep_idx=keep_idx,
+            new_up=new_up,
+            new_down=new_down,
+            replacements=replacements,
+        )
+
+    @torch.no_grad()
+    def apply_consolidation_plan(self, plan: TTOMLPConsolidationPlan) -> None:
+        if self.is_consolidated:
+            raise RuntimeError("TTOMLP is already consolidated")
+        self.up_proj = plan.new_up
+        self.down_proj = plan.new_down
+        self.is_consolidated = True
+
+    @torch.no_grad()
+    def apply_saved_keep_idx(self, keep_idx: Tensor) -> None:
+        if self.is_consolidated:
+            raise RuntimeError("TTOMLP is already consolidated")
+
+        keep_idx = keep_idx.to(self.up_proj.weight.device)
+
+        if not isinstance(self.up_proj, TTOLinear):
+            raise RuntimeError("Expected TTOLinear before applying saved keep_idx")
+
+        new_up = CastedLinear(
+            self.up_proj.d_in,
+            self.hidden_final,
+            bias=self.up_proj.bias is not None,
+        ).to(device=self.up_proj.weight.device)
+
+        new_down = CastedLinear(
+            self.hidden_final,
+            self.down_proj.out_features,
+            bias=self.down_proj.bias is not None,
+        ).to(device=self.down_proj.weight.device)
+
+        new_up.weight.data.copy_(self.up_proj.weight[keep_idx].to(dtype=new_up.weight.dtype))
+        new_down.weight.data.copy_(self.down_proj.weight[:, keep_idx].to(dtype=new_down.weight.dtype))
+
+        if self.up_proj.bias is not None:
+            new_up.bias.data.copy_(self.up_proj.bias[keep_idx].to(dtype=new_up.bias.dtype))
+
+        if self.down_proj.bias is not None:
+            new_down.bias.data.copy_(self.down_proj.bias.to(dtype=new_down.bias.dtype))
+
+        self.up_proj = new_up
+        self.down_proj = new_down
+        self.is_consolidated = True
+
+
+
+
+
+
+
+class TTODropManager:
+    def __init__(self, model: nn.Module, args: Hyperparameters):
+        self.args = args
+        self.layers = [m for m in model.modules() if isinstance(m, TTOLinear)]
+
+    def enabled(self) -> bool:
+        return self.args.tto_enable and len(self.layers) > 0
+
+    @staticmethod
+    def _linear_ramp(step: int, start: int, duration: int) -> float:
+        if step < start:
+            return 0.0
+        if duration <= 0:
+            return 1.0
+        return min((step - start) / duration, 1.0)
+
+    def current_budget_target(self, step: int, layer: TTOLinear) -> float:
+        alpha = self._linear_ramp(step, self.args.tto_start, self.args.tto_budget_duration)
+        start = float(layer.d_out_start)
+        end = float(layer.d_out_final)
+        return start + alpha * (end - start)
+
+    def set_train_mode(self, step: int) -> None:
+        if not self.enabled():
+            return
+        active = step >= self.args.tto_start
+        for layer in self.layers:
+            layer.set_gate_mode(enabled=active, sample=True)
+
+    def set_eval_mode(self, step: int) -> None:
+        if not self.enabled():
+            return
+        active = step >= self.args.tto_start
+        for layer in self.layers:
+            layer.set_gate_mode(enabled=active, sample=False)
+
+    def set_disabled(self) -> None:
+        for layer in self.layers:
+            layer.set_gate_mode(enabled=False, sample=False)
+
+    def compute_aux_loss(self, step: int, device: torch.device) -> tuple[Tensor, dict[str, float]]:
+        if not self.enabled():
+            zero = torch.zeros((), device=device)
+            return zero, {
+                "budget_loss": 0.0,
+                "sep_loss": 0.0,
+                "budget_target_total": 0.0,
+                "expected_kept_total": 0.0,
+                "keep_gap": 0.0,
+                "p_mean": 0.0,
+                "p_std": 0.0,
+                "p_min": 0.0,
+                "p_q10": 0.0,
+                "p_q50": 0.0,
+                "p_q90": 0.0,
+                "p_max": 0.0,
+                "p_mid_frac": 0.0,
+                "p_binary_frac": 0.0,
+            }
+
+        total_budget = torch.zeros((), device=device)
+        total_sep = torch.zeros((), device=device)
+        budget_target_total = 0.0
+        expected_kept_total = 0.0
+        all_p = []
+
+        for layer in self.layers:
+            p = layer.gate_probs()
+            all_p.append(p.detach())
+            target = self.current_budget_target(step, layer)
+            total_budget = total_budget + (p.sum() - target) ** 2
+            total_sep = total_sep + (p * (1.0 - p)).sum()
+            budget_target_total += target
+            expected_kept_total += float(p.sum().detach().item())
+
+        if step < self.args.tto_start:
+            aux = torch.zeros((), device=device)
+        else:
+            aux = self.args.tto_budget_lambda * total_budget + self.args.tto_sep_lambda * total_sep
+
+        all_p_cat = torch.cat(all_p)
+        p_mean = float(all_p_cat.mean().item())
+        p_std = float(all_p_cat.std(unbiased=False).item())
+        p_min = float(all_p_cat.min().item())
+        p_q10 = float(torch.quantile(all_p_cat, 0.10).item())
+        p_q50 = float(torch.quantile(all_p_cat, 0.50).item())
+        p_q90 = float(torch.quantile(all_p_cat, 0.90).item())
+        p_max = float(all_p_cat.max().item())
+        p_mid_frac = float(((all_p_cat > 0.2) & (all_p_cat < 0.8)).float().mean().item())
+        p_binary_frac = float(((all_p_cat < 0.05) | (all_p_cat > 0.95)).float().mean().item())
+
+        stats = {
+            "budget_loss": float(total_budget.detach().item()),
+            "sep_loss": float(total_sep.detach().item()),
+            "budget_target_total": budget_target_total,
+            "expected_kept_total": expected_kept_total,
+            "keep_gap": expected_kept_total - budget_target_total,
+            "p_mean": p_mean,
+            "p_std": p_std,
+            "p_min": p_min,
+            "p_q10": p_q10,
+            "p_q50": p_q50,
+            "p_q90": p_q90,
+            "p_max": p_max,
+            "p_mid_frac": p_mid_frac,
+            "p_binary_frac": p_binary_frac,
+        }
+        return aux, stats
+
+    @staticmethod
+    def _transform_state_tensor(t: Tensor, repl: ParamReplacement) -> Tensor:
+        if repl.action != "replace":
+            raise RuntimeError("State tensor transformation is only valid for replace actions")
+
+        out = t.detach().clone()
+        if repl.keep_idx is None or repl.prune_axis is None:
+            return out
+
+        if tuple(t.shape) != tuple(repl.old_param.shape):
+            return out
+
+        keep_idx = repl.keep_idx.to(device=t.device)
+        index = [slice(None)] * t.ndim
+        index[repl.prune_axis] = keep_idx
+        return t[tuple(index)].clone()
+
+    def _patch_single_optimizer(self, optimizer: torch.optim.Optimizer, repl: ParamReplacement) -> bool:
+        found = False
+
+        for group in optimizer.param_groups:
+            params = group["params"]
+            for i, p in enumerate(params):
+                if p is repl.old_param:
+                    found = True
+                    if repl.action == "drop":
+                        params.pop(i)
+                    elif repl.action == "replace":
+                        if repl.new_param is None:
+                            raise RuntimeError("replace action requires new_param")
+                        params[i] = repl.new_param
+                    else:
+                        raise ValueError(f"Unknown replacement action: {repl.action}")
+                    break
+
+        old_state = optimizer.state.pop(repl.old_param, None)
+
+        if repl.action == "replace" and repl.new_param is not None and old_state is not None:
+            new_state = {}
+            for key, value in old_state.items():
+                if torch.is_tensor(value):
+                    new_state[key] = self._transform_state_tensor(value, repl)
+                else:
+                    new_state[key] = copy.deepcopy(value)
+            optimizer.state[repl.new_param] = new_state
+
+        return found or (old_state is not None)
+
+    @torch.no_grad()
+    def consolidate_model(
+        self,
+        model: nn.Module,
+        optimizers: list[torch.optim.Optimizer] | None = None,
+    ) -> dict[str, Tensor]:
+        keep_map: dict[str, Tensor] = {}
+
+        for name, module in list(model.named_modules()):
+            if not isinstance(module, TTOMLP) or module.is_consolidated:
+                continue
+
+            plan = module.build_consolidation_plan()
+
+            if optimizers is not None:
+                for repl in plan.replacements:
+                    found_any = False
+                    for opt in optimizers:
+                        found_any = self._patch_single_optimizer(opt, repl) or found_any
+                    if not found_any:
+                        raise RuntimeError(
+                            f"Failed to find old parameter in any optimizer during consolidation: "
+                            f"shape={tuple(repl.old_param.shape)} action={repl.action}"
+                        )
+
+            module.apply_consolidation_plan(plan)
+            keep_map[name] = plan.keep_idx
+
+        self.layers = [m for m in model.modules() if isinstance(m, TTOLinear)]
+        return keep_map
+
+
+
+
+
+
+
+
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tto_expand_ratio: float,
+        tto_init_logit: float,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = TTOMLP(dim, mlp_mult, tto_expand_ratio, tto_init_logit)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tto_expand_ratio: float,
+        tto_init_logit: float,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    tto_expand_ratio,
+                    tto_init_logit,
+                    rope_base,
+                    qk_gain_init,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+
+        # First half stores skips; second half reuses them in reverse order.
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tto_expand_ratio=args.tto_expand_ratio,
+        tto_init_logit=args.tto_init_logit,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    tto_manager = TTODropManager(base_model, args)
+    def build_runtime_model(curr_base_model: nn.Module) -> tuple[nn.Module, nn.Module]:
+        compiled = torch.compile(curr_base_model, dynamic=False, fullgraph=True)
+        wrapped: nn.Module = DDP(compiled, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled
+        return compiled, wrapped
+
+    compiled_model, model = build_runtime_model(base_model)
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+    log0(
+        f"tto_enable:{args.tto_enable} "
+        f"tto_layers:{len(tto_manager.layers)} "
+        f"tto_expand_ratio:{args.tto_expand_ratio} "
+        f"tto_start:{args.tto_start} "
+        f"tto_budget_duration:{args.tto_budget_duration} "
+        f"tto_budget_lambda:{args.tto_budget_lambda} "
+        f"tto_sep_lambda:{args.tto_sep_lambda} "
+    )
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        tto_manager.set_train_mode(0)
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+        tto_manager.set_train_mode(0)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+
+            tto_manager.set_eval_mode(step)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            tto_manager.set_train_mode(step)
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        # --- TTO CONSOLIDATION HOOK (runs once at target step) ---
+        if (
+            args.tto_enable
+            and args.tto_consolidate_step > 0
+            and step == args.tto_consolidate_step
+            and any(isinstance(m, TTOMLP) and not m.is_consolidated for m in base_model.modules())
+        ):
+            zero_grad_all()
+            if distributed:
+                dist.barrier()
+            if master_process:
+                log0(f"tto_consolidation:begin step:{step}")
+
+            keep_map = tto_manager.consolidate_model(base_model, optimizers=optimizers)
+
+            restore_low_dim_params_to_fp32(base_model)
+
+            # rebuild compiled + DDP model
+            compiled_model, model = build_runtime_model(base_model)
+
+            # refresh manager (important!)
+            tto_manager = TTODropManager(base_model, args)
+
+            zero_grad_all()
+            if distributed:
+                dist.barrier()
+            if master_process:
+                kept_total = sum(int(v.numel()) for v in keep_map.values())
+                log0(
+                    f"tto_consolidation:done step:{step} "
+                    f"consolidated_mlps:{len(keep_map)} kept_total:{kept_total}"
+                )
+
+        tto_manager.set_train_mode(step)
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        aux_loss_detached = torch.zeros((), device=device)
+        aux_stats = {
+            "budget_loss": 0.0,
+            "sep_loss": 0.0,
+            "budget_target_total": 0.0,
+            "expected_kept_total": 0.0,
+        }
+
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        aux_loss, aux_stats = tto_manager.compute_aux_loss(step, device)
+        aux_loss_detached = aux_loss.detach()
+        if aux_loss.requires_grad:
+            aux_loss.backward()
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"aux_loss:{aux_loss_detached.item():.4f} "
+                f"budget_loss:{aux_stats['budget_loss']:.4f} "
+                f"sep_loss:{aux_stats['sep_loss']:.4f} "
+                f"expected_kept:{aux_stats['expected_kept_total']:.2f} "
+                f"target_kept:{aux_stats['budget_target_total']:.2f} "
+                f"p_mean:{aux_stats['p_mean']:.4f} "
+                f"p_std:{aux_stats['p_std']:.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed int8+zlib artifact and validate the round-tripped weights.
+
+    tto_manager.set_disabled()
+    eval_model: nn.Module = model
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        eval_model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/train_log_tto_1337.txt
+++ b/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/train_log_tto_1337.txt
@@ -1,0 +1,1831 @@
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: `train_gpt.py` and `train_gpt_mlx.py` must never be longer than 1500 lines.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from dataclasses import dataclass
+
+
+
+torch._dynamo.config.recompile_limit = 16
+
+
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 10000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 2))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+
+    # TTO 
+    tto_enable = bool(int(os.environ.get("TTO_ENABLE", "1")))
+    tto_init_logit = float(os.environ.get("TTO_INIT_LOGIT", 3.0))
+    tto_expand_ratio = float(os.environ.get("TTO_EXPAND_RATIO", 4.0))
+    tto_start = int(os.environ.get("TTO_START", 500))
+    tto_budget_duration = int(os.environ.get("TTO_BUDGET_DURATION", 1500))
+    tto_consolidate_step = int(os.environ.get("TTO_CONSOLIDATE_STEP", 2500)) 
+    tto_budget_lambda = float(os.environ.get("TTO_BUDGET_LAMBDA", 1e-3))
+    tto_sep_lambda = float(os.environ.get("TTO_SEP_LAMBDA", 1e-3))
+    
+
+# -----------------------------
+# MUON OPTIMIZER 
+# -----------------------------
+# 
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING 
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, self.weight.to(x.dtype), bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+
+
+class HardGateOnlyLogitGrad(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, h: Tensor, logits: Tensor) -> Tensor:
+        p = torch.sigmoid(logits) 
+
+        p_broadcast = p
+        while p_broadcast.ndim < h.ndim:
+            p_broadcast = p_broadcast.unsqueeze(0)
+
+        z_hard = (torch.rand_like(h) < p_broadcast).to(h.dtype)
+        ctx.save_for_backward(h, z_hard, p)
+
+        return h * z_hard
+
+    @staticmethod
+    def backward(ctx, grad_out: Tensor):
+        h, z_hard, p = ctx.saved_tensors
+
+        grad_h = grad_out * z_hard
+
+        reduce_dims = tuple(range(h.ndim - 1))
+        grad_logits = (grad_out * h).sum(dim=reduce_dims) * p * (1.0 - p)
+
+        return grad_h, grad_logits
+
+
+@dataclass
+class ParamReplacement:
+    old_param: nn.Parameter
+    new_param: nn.Parameter | None
+    action: str  # "replace" or "drop"
+    prune_axis: int | None = None
+    keep_idx: Tensor | None = None
+
+
+@dataclass
+class TTOMLPConsolidationPlan:
+    keep_idx: Tensor
+    new_up: nn.Module
+    new_down: nn.Module
+    replacements: list[ParamReplacement]
+
+
+
+class TTOLinear(nn.Module):
+    """
+    Expansion linear with learned stochastic gating over output neurons.
+
+    Training modes:
+      - gate_enabled=False: dense linear, no gating
+      - gate_enabled=True and gate_sample=True: hard Bernoulli mask with surrogate grad to logits
+      - gate_enabled=True and gate_sample=False: deterministic soft gate using probs
+    """
+
+    def __init__(self, d_in: int, d_out_start: int, d_out_final: int, bias: bool = False, init_logit: float = 3.0):
+        super().__init__()
+        if d_out_start < d_out_final:
+            raise ValueError(f"d_out_start ({d_out_start}) must be >= d_out_final ({d_out_final})")
+        self.d_in = d_in
+        self.d_out_start = d_out_start
+        self.d_out_final = d_out_final
+
+        self.weight = nn.Parameter(torch.empty(d_out_start, d_in))
+        bound = 1 / math.sqrt(d_in)
+        nn.init.uniform_(self.weight, a=-bound, b=bound)
+        self.bias = nn.Parameter(torch.zeros(d_out_start)) if bias else None
+        self.logits = nn.Parameter(torch.full((d_out_start,), init_logit))
+
+        self.gate_enabled = False
+        self.gate_sample = True
+
+    def gate_probs(self) -> Tensor:
+        return torch.sigmoid(self.logits)
+
+    def set_gate_mode(self, enabled: bool, sample: bool) -> None:
+        self.gate_enabled = enabled
+        self.gate_sample = sample
+
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        h = F.linear(x, self.weight.to(x.dtype), bias)
+        if not self.gate_enabled:
+            return h
+        if self.gate_sample and self.training:
+            return HardGateOnlyLogitGrad.apply(h, self.logits)
+        return h * self.gate_probs().to(dtype=h.dtype)
+
+    @torch.no_grad()
+    def topk_indices(self) -> Tensor:
+        k = self.d_out_final
+        p = self.gate_probs()
+        keep_idx = torch.topk(p, k=k, dim=0).indices
+        return keep_idx.sort().values
+
+class TTOMLP(nn.Module):
+    # relu^2 MLP with TTO on the expansion projection only.
+    def __init__(self, dim: int, mlp_mult: int, tto_expand_ratio: float, tto_init_logit: float):
+        super().__init__()
+        hidden_final = mlp_mult * dim
+        hidden_start = int(round(hidden_final * tto_expand_ratio))
+        if hidden_start < hidden_final:
+            raise ValueError(
+                f"tto_expand_ratio must give hidden_start >= hidden_final, "
+                f"got hidden_start={hidden_start}, hidden_final={hidden_final}"
+            )
+        self.hidden_start = hidden_start
+        self.hidden_final = hidden_final
+        self.is_consolidated = False
+
+        self.up_proj = TTOLinear(
+            dim,
+            hidden_start,
+            hidden_final,
+            bias=False,
+            init_logit=tto_init_logit,
+        )
+        self.down_proj = CastedLinear(hidden_start, dim, bias=False)
+        self.down_proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.up_proj(x))
+        return self.down_proj(x.square())
+
+    @torch.no_grad()
+    def build_consolidation_plan(self) -> TTOMLPConsolidationPlan:
+        if self.is_consolidated:
+            raise RuntimeError("TTOMLP is already consolidated")
+
+        if not isinstance(self.up_proj, TTOLinear):
+            raise RuntimeError("TTOMLP.up_proj is expected to be TTOLinear before consolidation")
+
+        keep_idx = self.up_proj.topk_indices()
+        device = self.up_proj.weight.device
+
+        new_up = CastedLinear(self.up_proj.d_in, self.hidden_final, bias=self.up_proj.bias is not None).to(device=device)
+        new_down = CastedLinear(self.hidden_final, self.down_proj.out_features, bias=self.down_proj.bias is not None).to(device=device)
+
+        new_up.weight.data.copy_(self.up_proj.weight[keep_idx].to(dtype=new_up.weight.dtype))
+        new_down.weight.data.copy_(self.down_proj.weight[:, keep_idx].to(dtype=new_down.weight.dtype))
+
+        replacements: list[ParamReplacement] = [
+            ParamReplacement(
+                old_param=self.up_proj.weight,
+                new_param=new_up.weight,
+                action="replace",
+                prune_axis=0,
+                keep_idx=keep_idx,
+            ),
+            ParamReplacement(
+                old_param=self.down_proj.weight,
+                new_param=new_down.weight,
+                action="replace",
+                prune_axis=1,
+                keep_idx=keep_idx,
+            ),
+            ParamReplacement(
+                old_param=self.up_proj.logits,
+                new_param=None,
+                action="drop",
+            ),
+        ]
+
+        if self.up_proj.bias is not None:
+            if new_up.bias is None:
+                raise RuntimeError("Expected new_up to have bias")
+            new_up.bias.data.copy_(self.up_proj.bias[keep_idx].to(dtype=new_up.bias.dtype))
+            replacements.append(
+                ParamReplacement(
+                    old_param=self.up_proj.bias,
+                    new_param=new_up.bias,
+                    action="replace",
+                    prune_axis=0,
+                    keep_idx=keep_idx,
+                )
+            )
+
+        if self.down_proj.bias is not None:
+            if new_down.bias is None:
+                raise RuntimeError("Expected new_down to have bias")
+            new_down.bias.data.copy_(self.down_proj.bias.to(dtype=new_down.bias.dtype))
+            replacements.append(
+                ParamReplacement(
+                    old_param=self.down_proj.bias,
+                    new_param=new_down.bias,
+                    action="replace",
+                    prune_axis=None,
+                    keep_idx=None,
+                )
+            )
+
+        return TTOMLPConsolidationPlan(
+            keep_idx=keep_idx,
+            new_up=new_up,
+            new_down=new_down,
+            replacements=replacements,
+        )
+
+    @torch.no_grad()
+    def apply_consolidation_plan(self, plan: TTOMLPConsolidationPlan) -> None:
+        if self.is_consolidated:
+            raise RuntimeError("TTOMLP is already consolidated")
+        self.up_proj = plan.new_up
+        self.down_proj = plan.new_down
+        self.is_consolidated = True
+
+    @torch.no_grad()
+    def apply_saved_keep_idx(self, keep_idx: Tensor) -> None:
+        if self.is_consolidated:
+            raise RuntimeError("TTOMLP is already consolidated")
+
+        keep_idx = keep_idx.to(self.up_proj.weight.device)
+
+        if not isinstance(self.up_proj, TTOLinear):
+            raise RuntimeError("Expected TTOLinear before applying saved keep_idx")
+
+        new_up = CastedLinear(
+            self.up_proj.d_in,
+            self.hidden_final,
+            bias=self.up_proj.bias is not None,
+        ).to(device=self.up_proj.weight.device)
+
+        new_down = CastedLinear(
+            self.hidden_final,
+            self.down_proj.out_features,
+            bias=self.down_proj.bias is not None,
+        ).to(device=self.down_proj.weight.device)
+
+        new_up.weight.data.copy_(self.up_proj.weight[keep_idx].to(dtype=new_up.weight.dtype))
+        new_down.weight.data.copy_(self.down_proj.weight[:, keep_idx].to(dtype=new_down.weight.dtype))
+
+        if self.up_proj.bias is not None:
+            new_up.bias.data.copy_(self.up_proj.bias[keep_idx].to(dtype=new_up.bias.dtype))
+
+        if self.down_proj.bias is not None:
+            new_down.bias.data.copy_(self.down_proj.bias.to(dtype=new_down.bias.dtype))
+
+        self.up_proj = new_up
+        self.down_proj = new_down
+        self.is_consolidated = True
+
+
+
+
+
+
+
+class TTODropManager:
+    def __init__(self, model: nn.Module, args: Hyperparameters):
+        self.args = args
+        self.layers = [m for m in model.modules() if isinstance(m, TTOLinear)]
+
+    def enabled(self) -> bool:
+        return self.args.tto_enable and len(self.layers) > 0
+
+    @staticmethod
+    def _linear_ramp(step: int, start: int, duration: int) -> float:
+        if step < start:
+            return 0.0
+        if duration <= 0:
+            return 1.0
+        return min((step - start) / duration, 1.0)
+
+    def current_budget_target(self, step: int, layer: TTOLinear) -> float:
+        alpha = self._linear_ramp(step, self.args.tto_start, self.args.tto_budget_duration)
+        start = float(layer.d_out_start)
+        end = float(layer.d_out_final)
+        return start + alpha * (end - start)
+
+    def set_train_mode(self, step: int) -> None:
+        if not self.enabled():
+            return
+        active = step >= self.args.tto_start
+        for layer in self.layers:
+            layer.set_gate_mode(enabled=active, sample=True)
+
+    def set_eval_mode(self, step: int) -> None:
+        if not self.enabled():
+            return
+        active = step >= self.args.tto_start
+        for layer in self.layers:
+            layer.set_gate_mode(enabled=active, sample=False)
+
+    def set_disabled(self) -> None:
+        for layer in self.layers:
+            layer.set_gate_mode(enabled=False, sample=False)
+
+    def compute_aux_loss(self, step: int, device: torch.device) -> tuple[Tensor, dict[str, float]]:
+        if not self.enabled():
+            zero = torch.zeros((), device=device)
+            return zero, {
+                "budget_loss": 0.0,
+                "sep_loss": 0.0,
+                "budget_target_total": 0.0,
+                "expected_kept_total": 0.0,
+                "keep_gap": 0.0,
+                "p_mean": 0.0,
+                "p_std": 0.0,
+                "p_min": 0.0,
+                "p_q10": 0.0,
+                "p_q50": 0.0,
+                "p_q90": 0.0,
+                "p_max": 0.0,
+                "p_mid_frac": 0.0,
+                "p_binary_frac": 0.0,
+            }
+
+        total_budget = torch.zeros((), device=device)
+        total_sep = torch.zeros((), device=device)
+        budget_target_total = 0.0
+        expected_kept_total = 0.0
+        all_p = []
+
+        for layer in self.layers:
+            p = layer.gate_probs()
+            all_p.append(p.detach())
+            target = self.current_budget_target(step, layer)
+            total_budget = total_budget + (p.sum() - target) ** 2
+            total_sep = total_sep + (p * (1.0 - p)).sum()
+            budget_target_total += target
+            expected_kept_total += float(p.sum().detach().item())
+
+        if step < self.args.tto_start:
+            aux = torch.zeros((), device=device)
+        else:
+            aux = self.args.tto_budget_lambda * total_budget + self.args.tto_sep_lambda * total_sep
+
+        all_p_cat = torch.cat(all_p)
+        p_mean = float(all_p_cat.mean().item())
+        p_std = float(all_p_cat.std(unbiased=False).item())
+        p_min = float(all_p_cat.min().item())
+        p_q10 = float(torch.quantile(all_p_cat, 0.10).item())
+        p_q50 = float(torch.quantile(all_p_cat, 0.50).item())
+        p_q90 = float(torch.quantile(all_p_cat, 0.90).item())
+        p_max = float(all_p_cat.max().item())
+        p_mid_frac = float(((all_p_cat > 0.2) & (all_p_cat < 0.8)).float().mean().item())
+        p_binary_frac = float(((all_p_cat < 0.05) | (all_p_cat > 0.95)).float().mean().item())
+
+        stats = {
+            "budget_loss": float(total_budget.detach().item()),
+            "sep_loss": float(total_sep.detach().item()),
+            "budget_target_total": budget_target_total,
+            "expected_kept_total": expected_kept_total,
+            "keep_gap": expected_kept_total - budget_target_total,
+            "p_mean": p_mean,
+            "p_std": p_std,
+            "p_min": p_min,
+            "p_q10": p_q10,
+            "p_q50": p_q50,
+            "p_q90": p_q90,
+            "p_max": p_max,
+            "p_mid_frac": p_mid_frac,
+            "p_binary_frac": p_binary_frac,
+        }
+        return aux, stats
+
+    @staticmethod
+    def _transform_state_tensor(t: Tensor, repl: ParamReplacement) -> Tensor:
+        if repl.action != "replace":
+            raise RuntimeError("State tensor transformation is only valid for replace actions")
+
+        out = t.detach().clone()
+        if repl.keep_idx is None or repl.prune_axis is None:
+            return out
+
+        if tuple(t.shape) != tuple(repl.old_param.shape):
+            return out
+
+        keep_idx = repl.keep_idx.to(device=t.device)
+        index = [slice(None)] * t.ndim
+        index[repl.prune_axis] = keep_idx
+        return t[tuple(index)].clone()
+
+    def _patch_single_optimizer(self, optimizer: torch.optim.Optimizer, repl: ParamReplacement) -> bool:
+        found = False
+
+        for group in optimizer.param_groups:
+            params = group["params"]
+            for i, p in enumerate(params):
+                if p is repl.old_param:
+                    found = True
+                    if repl.action == "drop":
+                        params.pop(i)
+                    elif repl.action == "replace":
+                        if repl.new_param is None:
+                            raise RuntimeError("replace action requires new_param")
+                        params[i] = repl.new_param
+                    else:
+                        raise ValueError(f"Unknown replacement action: {repl.action}")
+                    break
+
+        old_state = optimizer.state.pop(repl.old_param, None)
+
+        if repl.action == "replace" and repl.new_param is not None and old_state is not None:
+            new_state = {}
+            for key, value in old_state.items():
+                if torch.is_tensor(value):
+                    new_state[key] = self._transform_state_tensor(value, repl)
+                else:
+                    new_state[key] = copy.deepcopy(value)
+            optimizer.state[repl.new_param] = new_state
+
+        return found or (old_state is not None)
+
+    @torch.no_grad()
+    def consolidate_model(
+        self,
+        model: nn.Module,
+        optimizers: list[torch.optim.Optimizer] | None = None,
+    ) -> dict[str, Tensor]:
+        keep_map: dict[str, Tensor] = {}
+
+        for name, module in list(model.named_modules()):
+            if not isinstance(module, TTOMLP) or module.is_consolidated:
+                continue
+
+            plan = module.build_consolidation_plan()
+
+            if optimizers is not None:
+                for repl in plan.replacements:
+                    found_any = False
+                    for opt in optimizers:
+                        found_any = self._patch_single_optimizer(opt, repl) or found_any
+                    if not found_any:
+                        raise RuntimeError(
+                            f"Failed to find old parameter in any optimizer during consolidation: "
+                            f"shape={tuple(repl.old_param.shape)} action={repl.action}"
+                        )
+
+            module.apply_consolidation_plan(plan)
+            keep_map[name] = plan.keep_idx
+
+        self.layers = [m for m in model.modules() if isinstance(m, TTOLinear)]
+        return keep_map
+
+
+
+
+
+
+
+
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tto_expand_ratio: float,
+        tto_init_logit: float,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = TTOMLP(dim, mlp_mult, tto_expand_ratio, tto_init_logit)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tto_expand_ratio: float,
+        tto_init_logit: float,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    tto_expand_ratio,
+                    tto_init_logit,
+                    rope_base,
+                    qk_gain_init,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+
+        # First half stores skips; second half reuses them in reverse order.
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+
+
+def get_grad_norm(parameters, norm_type: float = 2.0) -> Tensor:
+    grads = [p.grad for p in parameters if p.grad is not None]
+    if not grads:
+        return torch.tensor(0.0)
+    device = grads[0].device
+    norms = torch.stack([torch.norm(g.detach(), norm_type).to(device) for g in grads])
+    return torch.norm(norms, norm_type)
+
+
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tto_expand_ratio=args.tto_expand_ratio,
+        tto_init_logit=args.tto_init_logit,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    tto_manager = TTODropManager(base_model, args)
+    def build_runtime_model(curr_base_model: nn.Module) -> tuple[nn.Module, nn.Module]:
+        compiled = torch.compile(curr_base_model, dynamic=False, fullgraph=True)
+        wrapped: nn.Module = DDP(compiled, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled
+        return compiled, wrapped
+
+    compiled_model, model = build_runtime_model(base_model)
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+    log0(
+        f"tto_enable:{args.tto_enable} "
+        f"tto_layers:{len(tto_manager.layers)} "
+        f"tto_expand_ratio:{args.tto_expand_ratio} "
+        f"tto_start:{args.tto_start} "
+        f"tto_budget_duration:{args.tto_budget_duration} "
+        f"tto_budget_lambda:{args.tto_budget_lambda} "
+        f"tto_sep_lambda:{args.tto_sep_lambda} "
+    )
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        tto_manager.set_train_mode(0)
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+        tto_manager.set_train_mode(0)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+
+            tto_manager.set_eval_mode(step)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            tto_manager.set_train_mode(step)
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        # --- TTO CONSOLIDATION HOOK (runs once at target step) ---
+        if (
+            args.tto_enable
+            and args.tto_consolidate_step > 0
+            and step == args.tto_consolidate_step
+            and any(isinstance(m, TTOMLP) and not m.is_consolidated for m in base_model.modules())
+        ):
+            zero_grad_all()
+            if distributed:
+                dist.barrier()
+            if master_process:
+                log0(f"tto_consolidation:begin step:{step}")
+
+            keep_map = tto_manager.consolidate_model(base_model, optimizers=optimizers)
+
+            restore_low_dim_params_to_fp32(base_model)
+
+            # rebuild compiled + DDP model
+            compiled_model, model = build_runtime_model(base_model)
+
+            # refresh manager (important!)
+            tto_manager = TTODropManager(base_model, args)
+
+            zero_grad_all()
+            if distributed:
+                dist.barrier()
+            if master_process:
+                kept_total = sum(int(v.numel()) for v in keep_map.values())
+                log0(
+                    f"tto_consolidation:done step:{step} "
+                    f"consolidated_mlps:{len(keep_map)} kept_total:{kept_total}"
+                )
+
+        tto_manager.set_train_mode(step)
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        aux_loss_detached = torch.zeros((), device=device)
+        aux_stats = {
+            "budget_loss": 0.0,
+            "sep_loss": 0.0,
+            "budget_target_total": 0.0,
+            "expected_kept_total": 0.0,
+        }
+
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        aux_loss, aux_stats = tto_manager.compute_aux_loss(step, device)
+        aux_loss_detached = aux_loss.detach()
+        if aux_loss.requires_grad:
+            aux_loss.backward()
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            grad_norm = torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        else:
+            grad_norm = get_grad_norm(base_model.parameters())
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            """ 
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"aux_loss:{aux_loss_detached.item():.4f} "
+                f"budget_loss:{aux_stats['budget_loss']:.4f} "
+                f"sep_loss:{aux_stats['sep_loss']:.4f} "
+                f"expected_kept:{aux_stats['expected_kept_total']:.2f} "
+                f"target_kept:{aux_stats['budget_target_total']:.2f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+            """
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"aux_loss:{aux_loss_detached.item():.4f} "
+                f"grad_norm:{float(grad_norm):.4f} "
+                f"budget_loss:{aux_stats['budget_loss']:.4f} "
+                f"sep_loss:{aux_stats['sep_loss']:.4f} "
+                f"expected_kept:{aux_stats['expected_kept_total']:.2f} "
+                f"target_kept:{aux_stats['budget_target_total']:.2f} "
+                f"p_mean:{aux_stats['p_mean']:.4f} "
+                f"p_std:{aux_stats['p_std']:.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed int8+zlib artifact and validate the round-tripped weights.
+
+    tto_manager.set_disabled()
+    eval_model: nn.Module = model
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        eval_model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+====================================================================================================
+Running Python 3.11.14 (main, Oct 21 2025, 18:31:21) [GCC 11.2.0]
+Running PyTorch 2.7.1+cu128
+Sat Apr 11 08:50:49 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA GeForce RTX 5090        Off |   00000000:09:00.0 Off |                  N/A |
+|100%   27C    P5             24W /  500W |      24MiB /  32607MiB |      0%      Default |
+|                                         |                        |                  N/A |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA GeForce RTX 5090        Off |   00000000:0A:00.0  On |                  N/A |
+|100%   25C    P8             23W /  500W |     755MiB /  32607MiB |      0%      Default |
+|                                         |                        |                  N/A |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A            1253      G   /usr/lib/xorg/Xorg                        9MiB |
+|    1   N/A  N/A            1253      G   /usr/lib/xorg/Xorg                      347MiB |
+|    1   N/A  N/A            2003      G   cinnamon                                 29MiB |
+|    1   N/A  N/A            2304      G   /usr/share/codium/codium                234MiB |
+|    1   N/A  N/A            4301      G   ...rack-uuid=3190708988185955192         67MiB |
+|    1   N/A  N/A         1718527      G   /usr/bin/nautilus                        20MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:45408328
+world_size:1 grad_accum_steps:8
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:524288 train_seq_len:1024 iterations:10000 warmup_steps:20 max_wallclock_seconds:0.000
+seed:1337
+tto_enable:True tto_layers:9 tto_expand_ratio:4.0 tto_start:500 tto_budget_duration:1500 tto_budget_lambda:0.001 tto_sep_lambda:0.001 
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/10000 val_loss:6.9354 val_bpb:4.1076 train_time:0ms step_avg:0.01ms
+step:1/10000 train_loss:6.9353 aux_loss:0.0000 grad_norm:0.3969 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:1315ms step_avg:1315.34ms
+step:2/10000 train_loss:16.5617 aux_loss:0.0000 grad_norm:5.6432 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:2428ms step_avg:1214.14ms
+step:3/10000 train_loss:8.4324 aux_loss:0.0000 grad_norm:5.1722 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:3551ms step_avg:1183.67ms
+step:4/10000 train_loss:6.6585 aux_loss:0.0000 grad_norm:1.4412 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:4669ms step_avg:1167.35ms
+step:5/10000 train_loss:6.8331 aux_loss:0.0000 grad_norm:1.4855 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:5790ms step_avg:1158.03ms
+step:6/10000 train_loss:6.7499 aux_loss:0.0000 grad_norm:1.0362 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:6909ms step_avg:1151.48ms
+step:7/10000 train_loss:6.3338 aux_loss:0.0000 grad_norm:0.8744 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:8028ms step_avg:1146.80ms
+step:8/10000 train_loss:6.1437 aux_loss:0.0000 grad_norm:0.4574 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:9148ms step_avg:1143.45ms
+step:9/10000 train_loss:6.0329 aux_loss:0.0000 grad_norm:0.4479 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:10269ms step_avg:1140.96ms
+step:10/10000 train_loss:5.9303 aux_loss:0.0000 grad_norm:0.4257 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:11390ms step_avg:1138.98ms
+step:200/10000 train_loss:2.7401 aux_loss:0.0000 grad_norm:0.2492 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:226851ms step_avg:1134.25ms
+step:400/10000 train_loss:2.3461 aux_loss:0.0000 grad_norm:0.1436 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:454689ms step_avg:1136.72ms
+step:600/10000 train_loss:2.4709 aux_loss:2.6983 grad_norm:0.2209 budget_loss:883.7266 sep_loss:1814.5798 expected_kept:34950.05 target_kept:35039.23 p_mean:0.9481 p_std:0.0000 train_time:698122ms step_avg:1163.54ms
+step:800/10000 train_loss:2.3482 aux_loss:4.6897 grad_norm:0.0704 budget_loss:2.4618 sep_loss:4687.2227 expected_kept:31352.83 target_kept:31352.83 p_mean:0.8505 p_std:0.0008 train_time:943992ms step_avg:1179.99ms
+step:1000/10000 train_loss:2.4000 aux_loss:6.9111 grad_norm:0.1052 budget_loss:7.9698 sep_loss:6903.1494 expected_kept:27661.26 target_kept:27666.43 p_mean:0.7504 p_std:0.0078 train_time:1189357ms step_avg:1189.36ms
+step:1000/10000 val_loss:2.3523 val_bpb:1.3932 train_time:1189358ms step_avg:1189.36ms
+step:1200/10000 train_loss:2.3659 aux_loss:8.2970 grad_norm:0.0808 budget_loss:5.6042 sep_loss:8291.3926 expected_kept:23985.17 target_kept:23980.03 p_mean:0.6506 p_std:0.0489 train_time:1434179ms step_avg:1195.15ms
+step:1400/10000 train_loss:2.4247 aux_loss:7.4728 grad_norm:0.0933 budget_loss:5.9430 sep_loss:7466.9038 expected_kept:20288.82 target_kept:20293.63 p_mean:0.5504 p_std:0.2119 train_time:1678709ms step_avg:1199.08ms
+step:1600/10000 train_loss:2.2458 aux_loss:1.1969 grad_norm:0.0641 budget_loss:1.4537 sep_loss:1195.3990 expected_kept:16610.52 target_kept:16607.23 p_mean:0.4506 p_std:0.4638 train_time:1922681ms step_avg:1201.68ms
+step:1800/10000 train_loss:2.2958 aux_loss:0.7237 grad_norm:0.0552 budget_loss:1.7563 sep_loss:721.8950 expected_kept:12924.75 target_kept:12920.83 p_mean:0.3506 p_std:0.4562 train_time:2166019ms step_avg:1203.34ms
+step:2000/10000 train_loss:2.3094 aux_loss:1.2662 grad_norm:0.0508 budget_loss:3.7149 sep_loss:1262.4731 expected_kept:9239.62 target_kept:9234.43 p_mean:0.2506 p_std:0.3919 train_time:2408852ms step_avg:1204.43ms
+step:2000/10000 val_loss:2.2921 val_bpb:1.3575 train_time:2408852ms step_avg:1204.43ms
+step:2200/10000 train_loss:2.1859 aux_loss:0.0810 grad_norm:0.0522 budget_loss:0.3489 sep_loss:80.6759 expected_kept:9217.25 target_kept:9216.00 p_mean:0.2500 p_std:0.4305 train_time:2651437ms step_avg:1205.20ms
+step:2400/10000 train_loss:2.2161 aux_loss:0.0060 grad_norm:0.0504 budget_loss:1.7240 sep_loss:4.3130 expected_kept:9218.49 target_kept:9216.00 p_mean:0.2501 p_std:0.4329 train_time:2893863ms step_avg:1205.78ms
+tto_consolidation:begin step:2500
+tto_consolidation:done step:2500 consolidated_mlps:9 kept_total:9216
+step:2600/10000 train_loss:2.2705 aux_loss:0.0000 grad_norm:0.0542 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3078181ms step_avg:1183.92ms
+step:2800/10000 train_loss:2.2143 aux_loss:0.0000 grad_norm:0.0408 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3201756ms step_avg:1143.48ms
+step:3000/10000 train_loss:2.1393 aux_loss:0.0000 grad_norm:0.0388 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3325422ms step_avg:1108.47ms
+step:3000/10000 val_loss:2.1872 val_bpb:1.2954 train_time:3325422ms step_avg:1108.47ms
+step:3200/10000 train_loss:2.2131 aux_loss:0.0000 grad_norm:0.0424 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3449003ms step_avg:1077.81ms
+step:3400/10000 train_loss:2.1974 aux_loss:0.0000 grad_norm:0.0420 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3572734ms step_avg:1050.80ms
+step:3600/10000 train_loss:2.1429 aux_loss:0.0000 grad_norm:0.0389 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3696444ms step_avg:1026.79ms
+step:3800/10000 train_loss:2.2235 aux_loss:0.0000 grad_norm:0.0369 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3820151ms step_avg:1005.30ms
+step:4000/10000 train_loss:2.1223 aux_loss:0.0000 grad_norm:0.0393 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3943901ms step_avg:985.98ms
+step:4000/10000 val_loss:2.1578 val_bpb:1.2779 train_time:3943901ms step_avg:985.98ms
+step:4200/10000 train_loss:2.1947 aux_loss:0.0000 grad_norm:0.0411 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4067651ms step_avg:968.49ms
+step:4400/10000 train_loss:2.2001 aux_loss:0.0000 grad_norm:0.0382 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4191413ms step_avg:952.59ms
+step:4600/10000 train_loss:2.0360 aux_loss:0.0000 grad_norm:0.0379 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4315108ms step_avg:938.07ms
+step:4800/10000 train_loss:2.1450 aux_loss:0.0000 grad_norm:0.0379 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4438775ms step_avg:924.74ms
+step:5000/10000 train_loss:2.1414 aux_loss:0.0000 grad_norm:0.0392 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4562468ms step_avg:912.49ms
+step:5000/10000 val_loss:2.1398 val_bpb:1.2673 train_time:4562468ms step_avg:912.49ms
+step:5200/10000 train_loss:2.1574 aux_loss:0.0000 grad_norm:0.0363 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4686052ms step_avg:901.16ms
+step:5400/10000 train_loss:2.1652 aux_loss:0.0000 grad_norm:0.0355 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4809644ms step_avg:890.67ms
+step:5600/10000 train_loss:2.1667 aux_loss:0.0000 grad_norm:0.0419 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4933281ms step_avg:880.94ms
+step:5800/10000 train_loss:2.1445 aux_loss:0.0000 grad_norm:0.0389 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5056863ms step_avg:871.87ms
+step:6000/10000 train_loss:2.2692 aux_loss:0.0000 grad_norm:0.0383 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5180474ms step_avg:863.41ms
+step:6000/10000 val_loss:2.1292 val_bpb:1.2610 train_time:5180474ms step_avg:863.41ms
+step:6200/10000 train_loss:2.1310 aux_loss:0.0000 grad_norm:0.0365 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5304119ms step_avg:855.50ms
+step:6400/10000 train_loss:2.1487 aux_loss:0.0000 grad_norm:0.0385 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5427778ms step_avg:848.09ms
+step:6600/10000 train_loss:2.1002 aux_loss:0.0000 grad_norm:0.0362 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5551412ms step_avg:841.12ms
+step:6800/10000 train_loss:2.2422 aux_loss:0.0000 grad_norm:0.0434 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5675069ms step_avg:834.57ms
+step:7000/10000 train_loss:2.1199 aux_loss:0.0000 grad_norm:0.0359 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5798670ms step_avg:828.38ms
+step:7000/10000 val_loss:2.1184 val_bpb:1.2546 train_time:5798670ms step_avg:828.38ms
+step:7200/10000 train_loss:2.1306 aux_loss:0.0000 grad_norm:0.0552 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5922292ms step_avg:822.54ms
+step:7400/10000 train_loss:2.1210 aux_loss:0.0000 grad_norm:0.0402 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6045961ms step_avg:817.02ms
+step:7600/10000 train_loss:2.0604 aux_loss:0.0000 grad_norm:0.0384 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6169630ms step_avg:811.79ms
+step:7800/10000 train_loss:2.1158 aux_loss:0.0000 grad_norm:0.0371 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6293270ms step_avg:806.83ms
+step:8000/10000 train_loss:2.1026 aux_loss:0.0000 grad_norm:0.0345 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6417008ms step_avg:802.13ms
+step:8000/10000 val_loss:2.1089 val_bpb:1.2490 train_time:6417009ms step_avg:802.13ms
+step:8200/10000 train_loss:2.0830 aux_loss:0.0000 grad_norm:0.0340 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6540746ms step_avg:797.65ms
+step:8400/10000 train_loss:2.0727 aux_loss:0.0000 grad_norm:0.0343 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6664483ms step_avg:793.39ms
+step:8600/10000 train_loss:2.1191 aux_loss:0.0000 grad_norm:0.0365 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6788232ms step_avg:789.33ms
+step:8800/10000 train_loss:2.0978 aux_loss:0.0000 grad_norm:0.0355 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6911935ms step_avg:785.45ms
+step:9000/10000 train_loss:2.0770 aux_loss:0.0000 grad_norm:0.0317 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7035583ms step_avg:781.73ms
+step:9000/10000 val_loss:2.0984 val_bpb:1.2428 train_time:7035583ms step_avg:781.73ms
+step:9200/10000 train_loss:2.0505 aux_loss:0.0000 grad_norm:0.0310 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7159363ms step_avg:778.19ms
+step:9400/10000 train_loss:2.0751 aux_loss:0.0000 grad_norm:0.0336 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7283110ms step_avg:774.80ms
+step:9600/10000 train_loss:2.1339 aux_loss:0.0000 grad_norm:0.0309 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7406894ms step_avg:771.55ms
+step:9800/10000 train_loss:2.0446 aux_loss:0.0000 grad_norm:0.0288 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7530677ms step_avg:768.44ms
+step:10000/10000 train_loss:1.9715 aux_loss:0.0000 grad_norm:0.0231 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7654436ms step_avg:765.44ms
+step:10000/10000 val_loss:2.0595 val_bpb:1.2197 train_time:7654436ms step_avg:765.44ms
+peak memory allocated: 20145 MiB reserved: 20218 MiB
+Serialized model: 67225175 bytes
+Code size: 68112 bytes
+Total submission size: 67293287 bytes
+Serialized model int8+zlib: 15823567 bytes (payload:17178912 raw_torch:17224089 payload_ratio:3.91x)
+Total submission size int8+zlib: 15891679 bytes
+final_int8_zlib_roundtrip val_loss:2.0707 val_bpb:1.2264 eval_time:21458ms
+final_int8_zlib_roundtrip_exact val_loss:2.07066148 val_bpb:1.22636236

--- a/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/train_log_tto_2025.txt
+++ b/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/train_log_tto_2025.txt
@@ -1,0 +1,1832 @@
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: `train_gpt.py` and `train_gpt_mlx.py` must never be longer than 1500 lines.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from dataclasses import dataclass
+
+
+
+torch._dynamo.config.recompile_limit = 16
+
+
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 2025))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 10000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 2))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+
+    # TTO 
+    tto_enable = bool(int(os.environ.get("TTO_ENABLE", "1")))
+    tto_init_logit = float(os.environ.get("TTO_INIT_LOGIT", 3.0))
+    tto_expand_ratio = float(os.environ.get("TTO_EXPAND_RATIO", 4.0))
+    tto_start = int(os.environ.get("TTO_START", 500))
+    tto_budget_duration = int(os.environ.get("TTO_BUDGET_DURATION", 1500))
+    tto_consolidate_step = int(os.environ.get("TTO_CONSOLIDATE_STEP", 2500)) 
+    tto_budget_lambda = float(os.environ.get("TTO_BUDGET_LAMBDA", 1e-3))
+    tto_sep_lambda = float(os.environ.get("TTO_SEP_LAMBDA", 1e-3))
+    
+
+# -----------------------------
+# MUON OPTIMIZER 
+# -----------------------------
+# 
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING 
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, self.weight.to(x.dtype), bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+
+
+class HardGateOnlyLogitGrad(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, h: Tensor, logits: Tensor) -> Tensor:
+        p = torch.sigmoid(logits) 
+
+        p_broadcast = p
+        while p_broadcast.ndim < h.ndim:
+            p_broadcast = p_broadcast.unsqueeze(0)
+
+        z_hard = (torch.rand_like(h) < p_broadcast).to(h.dtype)
+        ctx.save_for_backward(h, z_hard, p)
+
+        return h * z_hard
+
+    @staticmethod
+    def backward(ctx, grad_out: Tensor):
+        h, z_hard, p = ctx.saved_tensors
+
+        grad_h = grad_out * z_hard
+
+        reduce_dims = tuple(range(h.ndim - 1))
+        grad_logits = (grad_out * h).sum(dim=reduce_dims) * p * (1.0 - p)
+
+        return grad_h, grad_logits
+
+
+@dataclass
+class ParamReplacement:
+    old_param: nn.Parameter
+    new_param: nn.Parameter | None
+    action: str  # "replace" or "drop"
+    prune_axis: int | None = None
+    keep_idx: Tensor | None = None
+
+
+@dataclass
+class TTOMLPConsolidationPlan:
+    keep_idx: Tensor
+    new_up: nn.Module
+    new_down: nn.Module
+    replacements: list[ParamReplacement]
+
+
+
+class TTOLinear(nn.Module):
+    """
+    Expansion linear with learned stochastic gating over output neurons.
+
+    Training modes:
+      - gate_enabled=False: dense linear, no gating
+      - gate_enabled=True and gate_sample=True: hard Bernoulli mask with surrogate grad to logits
+      - gate_enabled=True and gate_sample=False: deterministic soft gate using probs
+    """
+
+    def __init__(self, d_in: int, d_out_start: int, d_out_final: int, bias: bool = False, init_logit: float = 3.0):
+        super().__init__()
+        if d_out_start < d_out_final:
+            raise ValueError(f"d_out_start ({d_out_start}) must be >= d_out_final ({d_out_final})")
+        self.d_in = d_in
+        self.d_out_start = d_out_start
+        self.d_out_final = d_out_final
+
+        self.weight = nn.Parameter(torch.empty(d_out_start, d_in))
+        bound = 1 / math.sqrt(d_in)
+        nn.init.uniform_(self.weight, a=-bound, b=bound)
+        self.bias = nn.Parameter(torch.zeros(d_out_start)) if bias else None
+        self.logits = nn.Parameter(torch.full((d_out_start,), init_logit))
+
+        self.gate_enabled = False
+        self.gate_sample = True
+
+    def gate_probs(self) -> Tensor:
+        return torch.sigmoid(self.logits)
+
+    def set_gate_mode(self, enabled: bool, sample: bool) -> None:
+        self.gate_enabled = enabled
+        self.gate_sample = sample
+
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        h = F.linear(x, self.weight.to(x.dtype), bias)
+        if not self.gate_enabled:
+            return h
+        if self.gate_sample and self.training:
+            return HardGateOnlyLogitGrad.apply(h, self.logits)
+        return h * self.gate_probs().to(dtype=h.dtype)
+
+    @torch.no_grad()
+    def topk_indices(self) -> Tensor:
+        k = self.d_out_final
+        p = self.gate_probs()
+        keep_idx = torch.topk(p, k=k, dim=0).indices
+        return keep_idx.sort().values
+
+class TTOMLP(nn.Module):
+    # relu^2 MLP with TTO on the expansion projection only.
+    def __init__(self, dim: int, mlp_mult: int, tto_expand_ratio: float, tto_init_logit: float):
+        super().__init__()
+        hidden_final = mlp_mult * dim
+        hidden_start = int(round(hidden_final * tto_expand_ratio))
+        if hidden_start < hidden_final:
+            raise ValueError(
+                f"tto_expand_ratio must give hidden_start >= hidden_final, "
+                f"got hidden_start={hidden_start}, hidden_final={hidden_final}"
+            )
+        self.hidden_start = hidden_start
+        self.hidden_final = hidden_final
+        self.is_consolidated = False
+
+        self.up_proj = TTOLinear(
+            dim,
+            hidden_start,
+            hidden_final,
+            bias=False,
+            init_logit=tto_init_logit,
+        )
+        self.down_proj = CastedLinear(hidden_start, dim, bias=False)
+        self.down_proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.up_proj(x))
+        return self.down_proj(x.square())
+
+    @torch.no_grad()
+    def build_consolidation_plan(self) -> TTOMLPConsolidationPlan:
+        if self.is_consolidated:
+            raise RuntimeError("TTOMLP is already consolidated")
+
+        if not isinstance(self.up_proj, TTOLinear):
+            raise RuntimeError("TTOMLP.up_proj is expected to be TTOLinear before consolidation")
+
+        keep_idx = self.up_proj.topk_indices()
+        device = self.up_proj.weight.device
+
+        new_up = CastedLinear(self.up_proj.d_in, self.hidden_final, bias=self.up_proj.bias is not None).to(device=device)
+        new_down = CastedLinear(self.hidden_final, self.down_proj.out_features, bias=self.down_proj.bias is not None).to(device=device)
+
+        new_up.weight.data.copy_(self.up_proj.weight[keep_idx].to(dtype=new_up.weight.dtype))
+        new_down.weight.data.copy_(self.down_proj.weight[:, keep_idx].to(dtype=new_down.weight.dtype))
+
+        replacements: list[ParamReplacement] = [
+            ParamReplacement(
+                old_param=self.up_proj.weight,
+                new_param=new_up.weight,
+                action="replace",
+                prune_axis=0,
+                keep_idx=keep_idx,
+            ),
+            ParamReplacement(
+                old_param=self.down_proj.weight,
+                new_param=new_down.weight,
+                action="replace",
+                prune_axis=1,
+                keep_idx=keep_idx,
+            ),
+            ParamReplacement(
+                old_param=self.up_proj.logits,
+                new_param=None,
+                action="drop",
+            ),
+        ]
+
+        if self.up_proj.bias is not None:
+            if new_up.bias is None:
+                raise RuntimeError("Expected new_up to have bias")
+            new_up.bias.data.copy_(self.up_proj.bias[keep_idx].to(dtype=new_up.bias.dtype))
+            replacements.append(
+                ParamReplacement(
+                    old_param=self.up_proj.bias,
+                    new_param=new_up.bias,
+                    action="replace",
+                    prune_axis=0,
+                    keep_idx=keep_idx,
+                )
+            )
+
+        if self.down_proj.bias is not None:
+            if new_down.bias is None:
+                raise RuntimeError("Expected new_down to have bias")
+            new_down.bias.data.copy_(self.down_proj.bias.to(dtype=new_down.bias.dtype))
+            replacements.append(
+                ParamReplacement(
+                    old_param=self.down_proj.bias,
+                    new_param=new_down.bias,
+                    action="replace",
+                    prune_axis=None,
+                    keep_idx=None,
+                )
+            )
+
+        return TTOMLPConsolidationPlan(
+            keep_idx=keep_idx,
+            new_up=new_up,
+            new_down=new_down,
+            replacements=replacements,
+        )
+
+    @torch.no_grad()
+    def apply_consolidation_plan(self, plan: TTOMLPConsolidationPlan) -> None:
+        if self.is_consolidated:
+            raise RuntimeError("TTOMLP is already consolidated")
+        self.up_proj = plan.new_up
+        self.down_proj = plan.new_down
+        self.is_consolidated = True
+
+    @torch.no_grad()
+    def apply_saved_keep_idx(self, keep_idx: Tensor) -> None:
+        if self.is_consolidated:
+            raise RuntimeError("TTOMLP is already consolidated")
+
+        keep_idx = keep_idx.to(self.up_proj.weight.device)
+
+        if not isinstance(self.up_proj, TTOLinear):
+            raise RuntimeError("Expected TTOLinear before applying saved keep_idx")
+
+        new_up = CastedLinear(
+            self.up_proj.d_in,
+            self.hidden_final,
+            bias=self.up_proj.bias is not None,
+        ).to(device=self.up_proj.weight.device)
+
+        new_down = CastedLinear(
+            self.hidden_final,
+            self.down_proj.out_features,
+            bias=self.down_proj.bias is not None,
+        ).to(device=self.down_proj.weight.device)
+
+        new_up.weight.data.copy_(self.up_proj.weight[keep_idx].to(dtype=new_up.weight.dtype))
+        new_down.weight.data.copy_(self.down_proj.weight[:, keep_idx].to(dtype=new_down.weight.dtype))
+
+        if self.up_proj.bias is not None:
+            new_up.bias.data.copy_(self.up_proj.bias[keep_idx].to(dtype=new_up.bias.dtype))
+
+        if self.down_proj.bias is not None:
+            new_down.bias.data.copy_(self.down_proj.bias.to(dtype=new_down.bias.dtype))
+
+        self.up_proj = new_up
+        self.down_proj = new_down
+        self.is_consolidated = True
+
+
+
+
+
+
+
+class TTODropManager:
+    def __init__(self, model: nn.Module, args: Hyperparameters):
+        self.args = args
+        self.layers = [m for m in model.modules() if isinstance(m, TTOLinear)]
+
+    def enabled(self) -> bool:
+        return self.args.tto_enable and len(self.layers) > 0
+
+    @staticmethod
+    def _linear_ramp(step: int, start: int, duration: int) -> float:
+        if step < start:
+            return 0.0
+        if duration <= 0:
+            return 1.0
+        return min((step - start) / duration, 1.0)
+
+    def current_budget_target(self, step: int, layer: TTOLinear) -> float:
+        alpha = self._linear_ramp(step, self.args.tto_start, self.args.tto_budget_duration)
+        start = float(layer.d_out_start)
+        end = float(layer.d_out_final)
+        return start + alpha * (end - start)
+
+    def set_train_mode(self, step: int) -> None:
+        if not self.enabled():
+            return
+        active = step >= self.args.tto_start
+        for layer in self.layers:
+            layer.set_gate_mode(enabled=active, sample=True)
+
+    def set_eval_mode(self, step: int) -> None:
+        if not self.enabled():
+            return
+        active = step >= self.args.tto_start
+        for layer in self.layers:
+            layer.set_gate_mode(enabled=active, sample=False)
+
+    def set_disabled(self) -> None:
+        for layer in self.layers:
+            layer.set_gate_mode(enabled=False, sample=False)
+
+    def compute_aux_loss(self, step: int, device: torch.device) -> tuple[Tensor, dict[str, float]]:
+        if not self.enabled():
+            zero = torch.zeros((), device=device)
+            return zero, {
+                "budget_loss": 0.0,
+                "sep_loss": 0.0,
+                "budget_target_total": 0.0,
+                "expected_kept_total": 0.0,
+                "keep_gap": 0.0,
+                "p_mean": 0.0,
+                "p_std": 0.0,
+                "p_min": 0.0,
+                "p_q10": 0.0,
+                "p_q50": 0.0,
+                "p_q90": 0.0,
+                "p_max": 0.0,
+                "p_mid_frac": 0.0,
+                "p_binary_frac": 0.0,
+            }
+
+        total_budget = torch.zeros((), device=device)
+        total_sep = torch.zeros((), device=device)
+        budget_target_total = 0.0
+        expected_kept_total = 0.0
+        all_p = []
+
+        for layer in self.layers:
+            p = layer.gate_probs()
+            all_p.append(p.detach())
+            target = self.current_budget_target(step, layer)
+            total_budget = total_budget + (p.sum() - target) ** 2
+            total_sep = total_sep + (p * (1.0 - p)).sum()
+            budget_target_total += target
+            expected_kept_total += float(p.sum().detach().item())
+
+        if step < self.args.tto_start:
+            aux = torch.zeros((), device=device)
+        else:
+            aux = self.args.tto_budget_lambda * total_budget + self.args.tto_sep_lambda * total_sep
+
+        all_p_cat = torch.cat(all_p)
+        p_mean = float(all_p_cat.mean().item())
+        p_std = float(all_p_cat.std(unbiased=False).item())
+        p_min = float(all_p_cat.min().item())
+        p_q10 = float(torch.quantile(all_p_cat, 0.10).item())
+        p_q50 = float(torch.quantile(all_p_cat, 0.50).item())
+        p_q90 = float(torch.quantile(all_p_cat, 0.90).item())
+        p_max = float(all_p_cat.max().item())
+        p_mid_frac = float(((all_p_cat > 0.2) & (all_p_cat < 0.8)).float().mean().item())
+        p_binary_frac = float(((all_p_cat < 0.05) | (all_p_cat > 0.95)).float().mean().item())
+
+        stats = {
+            "budget_loss": float(total_budget.detach().item()),
+            "sep_loss": float(total_sep.detach().item()),
+            "budget_target_total": budget_target_total,
+            "expected_kept_total": expected_kept_total,
+            "keep_gap": expected_kept_total - budget_target_total,
+            "p_mean": p_mean,
+            "p_std": p_std,
+            "p_min": p_min,
+            "p_q10": p_q10,
+            "p_q50": p_q50,
+            "p_q90": p_q90,
+            "p_max": p_max,
+            "p_mid_frac": p_mid_frac,
+            "p_binary_frac": p_binary_frac,
+        }
+        return aux, stats
+
+    @staticmethod
+    def _transform_state_tensor(t: Tensor, repl: ParamReplacement) -> Tensor:
+        if repl.action != "replace":
+            raise RuntimeError("State tensor transformation is only valid for replace actions")
+
+        out = t.detach().clone()
+        if repl.keep_idx is None or repl.prune_axis is None:
+            return out
+
+        if tuple(t.shape) != tuple(repl.old_param.shape):
+            return out
+
+        keep_idx = repl.keep_idx.to(device=t.device)
+        index = [slice(None)] * t.ndim
+        index[repl.prune_axis] = keep_idx
+        return t[tuple(index)].clone()
+
+    def _patch_single_optimizer(self, optimizer: torch.optim.Optimizer, repl: ParamReplacement) -> bool:
+        found = False
+
+        for group in optimizer.param_groups:
+            params = group["params"]
+            for i, p in enumerate(params):
+                if p is repl.old_param:
+                    found = True
+                    if repl.action == "drop":
+                        params.pop(i)
+                    elif repl.action == "replace":
+                        if repl.new_param is None:
+                            raise RuntimeError("replace action requires new_param")
+                        params[i] = repl.new_param
+                    else:
+                        raise ValueError(f"Unknown replacement action: {repl.action}")
+                    break
+
+        old_state = optimizer.state.pop(repl.old_param, None)
+
+        if repl.action == "replace" and repl.new_param is not None and old_state is not None:
+            new_state = {}
+            for key, value in old_state.items():
+                if torch.is_tensor(value):
+                    new_state[key] = self._transform_state_tensor(value, repl)
+                else:
+                    new_state[key] = copy.deepcopy(value)
+            optimizer.state[repl.new_param] = new_state
+
+        return found or (old_state is not None)
+
+    @torch.no_grad()
+    def consolidate_model(
+        self,
+        model: nn.Module,
+        optimizers: list[torch.optim.Optimizer] | None = None,
+    ) -> dict[str, Tensor]:
+        keep_map: dict[str, Tensor] = {}
+
+        for name, module in list(model.named_modules()):
+            if not isinstance(module, TTOMLP) or module.is_consolidated:
+                continue
+
+            plan = module.build_consolidation_plan()
+
+            if optimizers is not None:
+                for repl in plan.replacements:
+                    found_any = False
+                    for opt in optimizers:
+                        found_any = self._patch_single_optimizer(opt, repl) or found_any
+                    if not found_any:
+                        raise RuntimeError(
+                            f"Failed to find old parameter in any optimizer during consolidation: "
+                            f"shape={tuple(repl.old_param.shape)} action={repl.action}"
+                        )
+
+            module.apply_consolidation_plan(plan)
+            keep_map[name] = plan.keep_idx
+
+        self.layers = [m for m in model.modules() if isinstance(m, TTOLinear)]
+        return keep_map
+
+
+
+
+
+
+
+
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tto_expand_ratio: float,
+        tto_init_logit: float,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = TTOMLP(dim, mlp_mult, tto_expand_ratio, tto_init_logit)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tto_expand_ratio: float,
+        tto_init_logit: float,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    tto_expand_ratio,
+                    tto_init_logit,
+                    rope_base,
+                    qk_gain_init,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+
+        # First half stores skips; second half reuses them in reverse order.
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+
+
+def get_grad_norm(parameters, norm_type: float = 2.0) -> Tensor:
+    grads = [p.grad for p in parameters if p.grad is not None]
+    if not grads:
+        return torch.tensor(0.0)
+    device = grads[0].device
+    norms = torch.stack([torch.norm(g.detach(), norm_type).to(device) for g in grads])
+    return torch.norm(norms, norm_type)
+
+
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tto_expand_ratio=args.tto_expand_ratio,
+        tto_init_logit=args.tto_init_logit,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    tto_manager = TTODropManager(base_model, args)
+    def build_runtime_model(curr_base_model: nn.Module) -> tuple[nn.Module, nn.Module]:
+        compiled = torch.compile(curr_base_model, dynamic=False, fullgraph=True)
+        wrapped: nn.Module = DDP(compiled, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled
+        return compiled, wrapped
+
+    compiled_model, model = build_runtime_model(base_model)
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+    log0(
+        f"tto_enable:{args.tto_enable} "
+        f"tto_layers:{len(tto_manager.layers)} "
+        f"tto_expand_ratio:{args.tto_expand_ratio} "
+        f"tto_start:{args.tto_start} "
+        f"tto_budget_duration:{args.tto_budget_duration} "
+        f"tto_budget_lambda:{args.tto_budget_lambda} "
+        f"tto_sep_lambda:{args.tto_sep_lambda} "
+    )
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        tto_manager.set_train_mode(0)
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+        tto_manager.set_train_mode(0)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+
+            tto_manager.set_eval_mode(step)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            tto_manager.set_train_mode(step)
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        # --- TTO CONSOLIDATION HOOK (runs once at target step) ---
+        if (
+            args.tto_enable
+            and args.tto_consolidate_step > 0
+            and step == args.tto_consolidate_step
+            and any(isinstance(m, TTOMLP) and not m.is_consolidated for m in base_model.modules())
+        ):
+            zero_grad_all()
+            if distributed:
+                dist.barrier()
+            if master_process:
+                log0(f"tto_consolidation:begin step:{step}")
+
+            keep_map = tto_manager.consolidate_model(base_model, optimizers=optimizers)
+
+            restore_low_dim_params_to_fp32(base_model)
+
+            # rebuild compiled + DDP model
+            compiled_model, model = build_runtime_model(base_model)
+
+            # refresh manager (important!)
+            tto_manager = TTODropManager(base_model, args)
+
+            zero_grad_all()
+            if distributed:
+                dist.barrier()
+            if master_process:
+                kept_total = sum(int(v.numel()) for v in keep_map.values())
+                log0(
+                    f"tto_consolidation:done step:{step} "
+                    f"consolidated_mlps:{len(keep_map)} kept_total:{kept_total}"
+                )
+
+        tto_manager.set_train_mode(step)
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        aux_loss_detached = torch.zeros((), device=device)
+        aux_stats = {
+            "budget_loss": 0.0,
+            "sep_loss": 0.0,
+            "budget_target_total": 0.0,
+            "expected_kept_total": 0.0,
+        }
+
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        aux_loss, aux_stats = tto_manager.compute_aux_loss(step, device)
+        aux_loss_detached = aux_loss.detach()
+        if aux_loss.requires_grad:
+            aux_loss.backward()
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            grad_norm = torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        else:
+            grad_norm = get_grad_norm(base_model.parameters())
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            """ 
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"aux_loss:{aux_loss_detached.item():.4f} "
+                f"budget_loss:{aux_stats['budget_loss']:.4f} "
+                f"sep_loss:{aux_stats['sep_loss']:.4f} "
+                f"expected_kept:{aux_stats['expected_kept_total']:.2f} "
+                f"target_kept:{aux_stats['budget_target_total']:.2f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+            """
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"aux_loss:{aux_loss_detached.item():.4f} "
+                f"grad_norm:{float(grad_norm):.4f} "
+                f"budget_loss:{aux_stats['budget_loss']:.4f} "
+                f"sep_loss:{aux_stats['sep_loss']:.4f} "
+                f"expected_kept:{aux_stats['expected_kept_total']:.2f} "
+                f"target_kept:{aux_stats['budget_target_total']:.2f} "
+                f"p_mean:{aux_stats['p_mean']:.4f} "
+                f"p_std:{aux_stats['p_std']:.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed int8+zlib artifact and validate the round-tripped weights.
+
+    tto_manager.set_disabled()
+    eval_model: nn.Module = model
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        eval_model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+====================================================================================================
+Running Python 3.11.14 (main, Oct 21 2025, 18:31:21) [GCC 11.2.0]
+Running PyTorch 2.7.1+cu128
+Sat Apr 11 01:26:48 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA GeForce RTX 5090        Off |   00000000:09:00.0 Off |                  N/A |
+|100%   39C    P8             27W /  500W |      24MiB /  32607MiB |      0%      Default |
+|                                         |                        |                  N/A |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA GeForce RTX 5090        Off |   00000000:0A:00.0  On |                  N/A |
+|100%   63C    P1            493W /  500W |   21473MiB /  32607MiB |     99%      Default |
+|                                         |                        |                  N/A |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A            1253      G   /usr/lib/xorg/Xorg                        9MiB |
+|    1   N/A  N/A            1253      G   /usr/lib/xorg/Xorg                      347MiB |
+|    1   N/A  N/A            2003      G   cinnamon                                 31MiB |
+|    1   N/A  N/A            2304      G   /usr/share/codium/codium                140MiB |
+|    1   N/A  N/A            4301      G   ...rack-uuid=3190708988185955192         53MiB |
+|    1   N/A  N/A          590633      C   python                                20820MiB |
+|    1   N/A  N/A         1718527      G   /usr/bin/nautilus                        16MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:45408328
+world_size:1 grad_accum_steps:8
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:524288 train_seq_len:1024 iterations:10000 warmup_steps:20 max_wallclock_seconds:0.000
+seed:2025
+tto_enable:True tto_layers:9 tto_expand_ratio:4.0 tto_start:500 tto_budget_duration:1500 tto_budget_lambda:0.001 tto_sep_lambda:0.001 
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/10000 val_loss:6.9365 val_bpb:4.1082 train_time:0ms step_avg:0.01ms
+step:1/10000 train_loss:6.9372 aux_loss:0.0000 grad_norm:0.3959 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:1319ms step_avg:1318.80ms
+step:2/10000 train_loss:16.7744 aux_loss:0.0000 grad_norm:5.5178 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:2443ms step_avg:1221.56ms
+step:3/10000 train_loss:8.5944 aux_loss:0.0000 grad_norm:5.4404 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:3578ms step_avg:1192.56ms
+step:4/10000 train_loss:6.6126 aux_loss:0.0000 grad_norm:1.3422 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:4712ms step_avg:1177.90ms
+step:5/10000 train_loss:6.8246 aux_loss:0.0000 grad_norm:1.5377 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:5845ms step_avg:1168.91ms
+step:6/10000 train_loss:6.7781 aux_loss:0.0000 grad_norm:0.9833 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:6985ms step_avg:1164.19ms
+step:7/10000 train_loss:6.3997 aux_loss:0.0000 grad_norm:0.7574 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:8124ms step_avg:1160.51ms
+step:8/10000 train_loss:6.2033 aux_loss:0.0000 grad_norm:0.4455 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:9254ms step_avg:1156.71ms
+step:9/10000 train_loss:6.0548 aux_loss:0.0000 grad_norm:0.4357 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:10387ms step_avg:1154.11ms
+step:10/10000 train_loss:5.9330 aux_loss:0.0000 grad_norm:0.4084 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:11523ms step_avg:1152.31ms
+step:200/10000 train_loss:2.7548 aux_loss:0.0000 grad_norm:0.2659 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:228401ms step_avg:1142.01ms
+step:400/10000 train_loss:2.3524 aux_loss:0.0000 grad_norm:0.1478 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:456831ms step_avg:1142.08ms
+step:600/10000 train_loss:2.4713 aux_loss:2.6983 grad_norm:0.2127 budget_loss:883.7314 sep_loss:1814.5798 expected_kept:34950.05 target_kept:35039.23 p_mean:0.9481 p_std:0.0000 train_time:700847ms step_avg:1168.08ms
+step:800/10000 train_loss:2.3508 aux_loss:4.6921 grad_norm:0.0750 budget_loss:6.4674 sep_loss:4685.6616 expected_kept:31355.05 target_kept:31352.83 p_mean:0.8506 p_std:0.0009 train_time:946854ms step_avg:1183.57ms
+step:1000/10000 train_loss:2.4001 aux_loss:6.9061 grad_norm:0.0861 budget_loss:7.0082 sep_loss:6899.0659 expected_kept:27669.01 target_kept:27666.43 p_mean:0.7506 p_std:0.0081 train_time:1192420ms step_avg:1192.42ms
+step:1000/10000 val_loss:2.3560 val_bpb:1.3954 train_time:1192420ms step_avg:1192.42ms
+step:1200/10000 train_loss:2.3668 aux_loss:8.2911 grad_norm:0.0818 budget_loss:3.2645 sep_loss:8287.8662 expected_kept:23978.13 target_kept:23980.03 p_mean:0.6504 p_std:0.0504 train_time:1437407ms step_avg:1197.84ms
+step:1400/10000 train_loss:2.4220 aux_loss:7.4164 grad_norm:0.0837 budget_loss:4.2253 sep_loss:7412.1626 expected_kept:20294.89 target_kept:20293.63 p_mean:0.5505 p_std:0.2154 train_time:1681931ms step_avg:1201.38ms
+step:1600/10000 train_loss:2.2460 aux_loss:1.1377 grad_norm:0.0749 budget_loss:1.8075 sep_loss:1135.9167 expected_kept:16610.95 target_kept:16607.23 p_mean:0.4506 p_std:0.4656 train_time:1925869ms step_avg:1203.67ms
+step:1800/10000 train_loss:2.3018 aux_loss:0.7690 grad_norm:0.0592 budget_loss:2.2780 sep_loss:766.7197 expected_kept:12925.21 target_kept:12920.83 p_mean:0.3506 p_std:0.4548 train_time:2169246ms step_avg:1205.14ms
+step:2000/10000 train_loss:2.2994 aux_loss:0.9820 grad_norm:0.0589 budget_loss:2.0135 sep_loss:979.9820 expected_kept:9237.83 target_kept:9234.43 p_mean:0.2506 p_std:0.4015 train_time:2412212ms step_avg:1206.11ms
+step:2000/10000 val_loss:2.2915 val_bpb:1.3572 train_time:2412212ms step_avg:1206.11ms
+step:2200/10000 train_loss:2.1826 aux_loss:0.0520 grad_norm:0.0554 budget_loss:0.2107 sep_loss:51.8105 expected_kept:9216.46 target_kept:9216.00 p_mean:0.2500 p_std:0.4314 train_time:2654924ms step_avg:1206.78ms
+step:2400/10000 train_loss:2.2151 aux_loss:0.0047 grad_norm:0.0494 budget_loss:0.7119 sep_loss:3.9767 expected_kept:9216.50 target_kept:9216.00 p_mean:0.2500 p_std:0.4329 train_time:2897403ms step_avg:1207.25ms
+tto_consolidation:begin step:2500
+tto_consolidation:done step:2500 consolidated_mlps:9 kept_total:9216
+step:2600/10000 train_loss:2.2741 aux_loss:0.0000 grad_norm:0.0554 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3081549ms step_avg:1185.21ms
+step:2800/10000 train_loss:2.2169 aux_loss:0.0000 grad_norm:0.0461 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3205087ms step_avg:1144.67ms
+step:3000/10000 train_loss:2.1398 aux_loss:0.0000 grad_norm:0.0488 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3328610ms step_avg:1109.54ms
+step:3000/10000 val_loss:2.1878 val_bpb:1.2957 train_time:3328610ms step_avg:1109.54ms
+step:3200/10000 train_loss:2.2136 aux_loss:0.0000 grad_norm:0.0422 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3452084ms step_avg:1078.78ms
+step:3400/10000 train_loss:2.1979 aux_loss:0.0000 grad_norm:0.0437 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3575633ms step_avg:1051.66ms
+step:3600/10000 train_loss:2.1427 aux_loss:0.0000 grad_norm:0.0369 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3698529ms step_avg:1027.37ms
+step:3800/10000 train_loss:2.2236 aux_loss:0.0000 grad_norm:0.0389 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3820362ms step_avg:1005.36ms
+step:4000/10000 train_loss:2.1216 aux_loss:0.0000 grad_norm:0.0379 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3942008ms step_avg:985.50ms
+step:4000/10000 val_loss:2.1576 val_bpb:1.2778 train_time:3942008ms step_avg:985.50ms
+step:4200/10000 train_loss:2.1942 aux_loss:0.0000 grad_norm:0.0435 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4063597ms step_avg:967.52ms
+step:4400/10000 train_loss:2.2016 aux_loss:0.0000 grad_norm:0.0382 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4185154ms step_avg:951.17ms
+step:4600/10000 train_loss:2.0376 aux_loss:0.0000 grad_norm:0.0373 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4306689ms step_avg:936.24ms
+step:4800/10000 train_loss:2.1464 aux_loss:0.0000 grad_norm:0.0364 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4428232ms step_avg:922.55ms
+step:5000/10000 train_loss:2.1427 aux_loss:0.0000 grad_norm:0.0377 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4549783ms step_avg:909.96ms
+step:5000/10000 val_loss:2.1402 val_bpb:1.2675 train_time:4549784ms step_avg:909.96ms
+step:5200/10000 train_loss:2.1568 aux_loss:0.0000 grad_norm:0.0364 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4671314ms step_avg:898.33ms
+step:5400/10000 train_loss:2.1648 aux_loss:0.0000 grad_norm:0.0356 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4792852ms step_avg:887.57ms
+step:5600/10000 train_loss:2.1685 aux_loss:0.0000 grad_norm:0.0405 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4914391ms step_avg:877.57ms
+step:5800/10000 train_loss:2.1451 aux_loss:0.0000 grad_norm:0.0400 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5035868ms step_avg:868.25ms
+step:6000/10000 train_loss:2.2706 aux_loss:0.0000 grad_norm:0.0367 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5157405ms step_avg:859.57ms
+step:6000/10000 val_loss:2.1296 val_bpb:1.2613 train_time:5157405ms step_avg:859.57ms
+step:6200/10000 train_loss:2.1319 aux_loss:0.0000 grad_norm:0.0354 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5278941ms step_avg:851.44ms
+step:6400/10000 train_loss:2.1464 aux_loss:0.0000 grad_norm:0.0394 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5400477ms step_avg:843.82ms
+step:6600/10000 train_loss:2.0995 aux_loss:0.0000 grad_norm:0.0331 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5522020ms step_avg:836.67ms
+step:6800/10000 train_loss:2.2411 aux_loss:0.0000 grad_norm:0.0438 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5643578ms step_avg:829.94ms
+step:7000/10000 train_loss:2.1226 aux_loss:0.0000 grad_norm:0.0387 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5765088ms step_avg:823.58ms
+step:7000/10000 val_loss:2.1194 val_bpb:1.2552 train_time:5765089ms step_avg:823.58ms
+step:7200/10000 train_loss:2.1321 aux_loss:0.0000 grad_norm:0.0531 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5886664ms step_avg:817.59ms
+step:7400/10000 train_loss:2.1214 aux_loss:0.0000 grad_norm:0.0393 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6008224ms step_avg:811.92ms
+step:7600/10000 train_loss:2.0630 aux_loss:0.0000 grad_norm:0.0387 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6129765ms step_avg:806.55ms
+step:7800/10000 train_loss:2.1187 aux_loss:0.0000 grad_norm:0.0365 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6251300ms step_avg:801.45ms
+step:8000/10000 train_loss:2.1023 aux_loss:0.0000 grad_norm:0.0321 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6372887ms step_avg:796.61ms
+step:8000/10000 val_loss:2.1098 val_bpb:1.2496 train_time:6372887ms step_avg:796.61ms
+step:8200/10000 train_loss:2.0845 aux_loss:0.0000 grad_norm:0.0348 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6494479ms step_avg:792.01ms
+step:8400/10000 train_loss:2.0738 aux_loss:0.0000 grad_norm:0.0339 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6616014ms step_avg:787.62ms
+step:8600/10000 train_loss:2.1209 aux_loss:0.0000 grad_norm:0.0369 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6737540ms step_avg:783.43ms
+step:8800/10000 train_loss:2.0999 aux_loss:0.0000 grad_norm:0.0379 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6859078ms step_avg:779.44ms
+step:9000/10000 train_loss:2.0766 aux_loss:0.0000 grad_norm:0.0339 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6980614ms step_avg:775.62ms
+step:9000/10000 val_loss:2.0991 val_bpb:1.2432 train_time:6980614ms step_avg:775.62ms
+step:9200/10000 train_loss:2.0498 aux_loss:0.0000 grad_norm:0.0306 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7102150ms step_avg:771.97ms
+step:9400/10000 train_loss:2.0736 aux_loss:0.0000 grad_norm:0.0326 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7223665ms step_avg:768.48ms
+step:9600/10000 train_loss:2.1346 aux_loss:0.0000 grad_norm:0.0303 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7345178ms step_avg:765.12ms
+step:9800/10000 train_loss:2.0450 aux_loss:0.0000 grad_norm:0.0277 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7466702ms step_avg:761.91ms
+step:10000/10000 train_loss:1.9729 aux_loss:0.0000 grad_norm:0.0228 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7588270ms step_avg:758.83ms
+step:10000/10000 val_loss:2.0605 val_bpb:1.2204 train_time:7588270ms step_avg:758.83ms
+peak memory allocated: 20145 MiB reserved: 20218 MiB
+Serialized model: 67225175 bytes
+Code size: 68112 bytes
+Total submission size: 67293287 bytes
+Serialized model int8+zlib: 15815422 bytes (payload:17178912 raw_torch:17224089 payload_ratio:3.91x)
+Total submission size int8+zlib: 15883534 bytes
+final_int8_zlib_roundtrip val_loss:2.0722 val_bpb:1.2273 eval_time:21144ms
+final_int8_zlib_roundtrip_exact val_loss:2.07218127 val_bpb:1.22726247

--- a/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/train_log_tto_42.txt
+++ b/records/track_non_record_16mb/2026-04-11_Train_Time_Overparameterization/train_log_tto_42.txt
@@ -1,0 +1,1832 @@
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: `train_gpt.py` and `train_gpt_mlx.py` must never be longer than 1500 lines.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+os.environ["CUDA_VISIBLE_DEVICES"] = "1"
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from dataclasses import dataclass
+
+
+
+torch._dynamo.config.recompile_limit = 16
+
+
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 42))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 10000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 2))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+
+    # TTO 
+    tto_enable = bool(int(os.environ.get("TTO_ENABLE", "1")))
+    tto_init_logit = float(os.environ.get("TTO_INIT_LOGIT", 3.0))
+    tto_expand_ratio = float(os.environ.get("TTO_EXPAND_RATIO", 4.0))
+    tto_start = int(os.environ.get("TTO_START", 500))
+    tto_budget_duration = int(os.environ.get("TTO_BUDGET_DURATION", 1500))
+    tto_consolidate_step = int(os.environ.get("TTO_CONSOLIDATE_STEP", 2500)) 
+    tto_budget_lambda = float(os.environ.get("TTO_BUDGET_LAMBDA", 1e-3))
+    tto_sep_lambda = float(os.environ.get("TTO_SEP_LAMBDA", 1e-3))
+    
+
+# -----------------------------
+# MUON OPTIMIZER 
+# -----------------------------
+# 
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING 
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, self.weight.to(x.dtype), bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+
+
+class HardGateOnlyLogitGrad(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, h: Tensor, logits: Tensor) -> Tensor:
+        p = torch.sigmoid(logits) 
+
+        p_broadcast = p
+        while p_broadcast.ndim < h.ndim:
+            p_broadcast = p_broadcast.unsqueeze(0)
+
+        z_hard = (torch.rand_like(h) < p_broadcast).to(h.dtype)
+        ctx.save_for_backward(h, z_hard, p)
+
+        return h * z_hard
+
+    @staticmethod
+    def backward(ctx, grad_out: Tensor):
+        h, z_hard, p = ctx.saved_tensors
+
+        grad_h = grad_out * z_hard
+
+        reduce_dims = tuple(range(h.ndim - 1))
+        grad_logits = (grad_out * h).sum(dim=reduce_dims) * p * (1.0 - p)
+
+        return grad_h, grad_logits
+
+
+@dataclass
+class ParamReplacement:
+    old_param: nn.Parameter
+    new_param: nn.Parameter | None
+    action: str  # "replace" or "drop"
+    prune_axis: int | None = None
+    keep_idx: Tensor | None = None
+
+
+@dataclass
+class TTOMLPConsolidationPlan:
+    keep_idx: Tensor
+    new_up: nn.Module
+    new_down: nn.Module
+    replacements: list[ParamReplacement]
+
+
+
+class TTOLinear(nn.Module):
+    """
+    Expansion linear with learned stochastic gating over output neurons.
+
+    Training modes:
+      - gate_enabled=False: dense linear, no gating
+      - gate_enabled=True and gate_sample=True: hard Bernoulli mask with surrogate grad to logits
+      - gate_enabled=True and gate_sample=False: deterministic soft gate using probs
+    """
+
+    def __init__(self, d_in: int, d_out_start: int, d_out_final: int, bias: bool = False, init_logit: float = 3.0):
+        super().__init__()
+        if d_out_start < d_out_final:
+            raise ValueError(f"d_out_start ({d_out_start}) must be >= d_out_final ({d_out_final})")
+        self.d_in = d_in
+        self.d_out_start = d_out_start
+        self.d_out_final = d_out_final
+
+        self.weight = nn.Parameter(torch.empty(d_out_start, d_in))
+        bound = 1 / math.sqrt(d_in)
+        nn.init.uniform_(self.weight, a=-bound, b=bound)
+        self.bias = nn.Parameter(torch.zeros(d_out_start)) if bias else None
+        self.logits = nn.Parameter(torch.full((d_out_start,), init_logit))
+
+        self.gate_enabled = False
+        self.gate_sample = True
+
+    def gate_probs(self) -> Tensor:
+        return torch.sigmoid(self.logits)
+
+    def set_gate_mode(self, enabled: bool, sample: bool) -> None:
+        self.gate_enabled = enabled
+        self.gate_sample = sample
+
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        h = F.linear(x, self.weight.to(x.dtype), bias)
+        if not self.gate_enabled:
+            return h
+        if self.gate_sample and self.training:
+            return HardGateOnlyLogitGrad.apply(h, self.logits)
+        return h * self.gate_probs().to(dtype=h.dtype)
+
+    @torch.no_grad()
+    def topk_indices(self) -> Tensor:
+        k = self.d_out_final
+        p = self.gate_probs()
+        keep_idx = torch.topk(p, k=k, dim=0).indices
+        return keep_idx.sort().values
+
+class TTOMLP(nn.Module):
+    # relu^2 MLP with TTO on the expansion projection only.
+    def __init__(self, dim: int, mlp_mult: int, tto_expand_ratio: float, tto_init_logit: float):
+        super().__init__()
+        hidden_final = mlp_mult * dim
+        hidden_start = int(round(hidden_final * tto_expand_ratio))
+        if hidden_start < hidden_final:
+            raise ValueError(
+                f"tto_expand_ratio must give hidden_start >= hidden_final, "
+                f"got hidden_start={hidden_start}, hidden_final={hidden_final}"
+            )
+        self.hidden_start = hidden_start
+        self.hidden_final = hidden_final
+        self.is_consolidated = False
+
+        self.up_proj = TTOLinear(
+            dim,
+            hidden_start,
+            hidden_final,
+            bias=False,
+            init_logit=tto_init_logit,
+        )
+        self.down_proj = CastedLinear(hidden_start, dim, bias=False)
+        self.down_proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.up_proj(x))
+        return self.down_proj(x.square())
+
+    @torch.no_grad()
+    def build_consolidation_plan(self) -> TTOMLPConsolidationPlan:
+        if self.is_consolidated:
+            raise RuntimeError("TTOMLP is already consolidated")
+
+        if not isinstance(self.up_proj, TTOLinear):
+            raise RuntimeError("TTOMLP.up_proj is expected to be TTOLinear before consolidation")
+
+        keep_idx = self.up_proj.topk_indices()
+        device = self.up_proj.weight.device
+
+        new_up = CastedLinear(self.up_proj.d_in, self.hidden_final, bias=self.up_proj.bias is not None).to(device=device)
+        new_down = CastedLinear(self.hidden_final, self.down_proj.out_features, bias=self.down_proj.bias is not None).to(device=device)
+
+        new_up.weight.data.copy_(self.up_proj.weight[keep_idx].to(dtype=new_up.weight.dtype))
+        new_down.weight.data.copy_(self.down_proj.weight[:, keep_idx].to(dtype=new_down.weight.dtype))
+
+        replacements: list[ParamReplacement] = [
+            ParamReplacement(
+                old_param=self.up_proj.weight,
+                new_param=new_up.weight,
+                action="replace",
+                prune_axis=0,
+                keep_idx=keep_idx,
+            ),
+            ParamReplacement(
+                old_param=self.down_proj.weight,
+                new_param=new_down.weight,
+                action="replace",
+                prune_axis=1,
+                keep_idx=keep_idx,
+            ),
+            ParamReplacement(
+                old_param=self.up_proj.logits,
+                new_param=None,
+                action="drop",
+            ),
+        ]
+
+        if self.up_proj.bias is not None:
+            if new_up.bias is None:
+                raise RuntimeError("Expected new_up to have bias")
+            new_up.bias.data.copy_(self.up_proj.bias[keep_idx].to(dtype=new_up.bias.dtype))
+            replacements.append(
+                ParamReplacement(
+                    old_param=self.up_proj.bias,
+                    new_param=new_up.bias,
+                    action="replace",
+                    prune_axis=0,
+                    keep_idx=keep_idx,
+                )
+            )
+
+        if self.down_proj.bias is not None:
+            if new_down.bias is None:
+                raise RuntimeError("Expected new_down to have bias")
+            new_down.bias.data.copy_(self.down_proj.bias.to(dtype=new_down.bias.dtype))
+            replacements.append(
+                ParamReplacement(
+                    old_param=self.down_proj.bias,
+                    new_param=new_down.bias,
+                    action="replace",
+                    prune_axis=None,
+                    keep_idx=None,
+                )
+            )
+
+        return TTOMLPConsolidationPlan(
+            keep_idx=keep_idx,
+            new_up=new_up,
+            new_down=new_down,
+            replacements=replacements,
+        )
+
+    @torch.no_grad()
+    def apply_consolidation_plan(self, plan: TTOMLPConsolidationPlan) -> None:
+        if self.is_consolidated:
+            raise RuntimeError("TTOMLP is already consolidated")
+        self.up_proj = plan.new_up
+        self.down_proj = plan.new_down
+        self.is_consolidated = True
+
+    @torch.no_grad()
+    def apply_saved_keep_idx(self, keep_idx: Tensor) -> None:
+        if self.is_consolidated:
+            raise RuntimeError("TTOMLP is already consolidated")
+
+        keep_idx = keep_idx.to(self.up_proj.weight.device)
+
+        if not isinstance(self.up_proj, TTOLinear):
+            raise RuntimeError("Expected TTOLinear before applying saved keep_idx")
+
+        new_up = CastedLinear(
+            self.up_proj.d_in,
+            self.hidden_final,
+            bias=self.up_proj.bias is not None,
+        ).to(device=self.up_proj.weight.device)
+
+        new_down = CastedLinear(
+            self.hidden_final,
+            self.down_proj.out_features,
+            bias=self.down_proj.bias is not None,
+        ).to(device=self.down_proj.weight.device)
+
+        new_up.weight.data.copy_(self.up_proj.weight[keep_idx].to(dtype=new_up.weight.dtype))
+        new_down.weight.data.copy_(self.down_proj.weight[:, keep_idx].to(dtype=new_down.weight.dtype))
+
+        if self.up_proj.bias is not None:
+            new_up.bias.data.copy_(self.up_proj.bias[keep_idx].to(dtype=new_up.bias.dtype))
+
+        if self.down_proj.bias is not None:
+            new_down.bias.data.copy_(self.down_proj.bias.to(dtype=new_down.bias.dtype))
+
+        self.up_proj = new_up
+        self.down_proj = new_down
+        self.is_consolidated = True
+
+
+
+
+
+
+
+class TTODropManager:
+    def __init__(self, model: nn.Module, args: Hyperparameters):
+        self.args = args
+        self.layers = [m for m in model.modules() if isinstance(m, TTOLinear)]
+
+    def enabled(self) -> bool:
+        return self.args.tto_enable and len(self.layers) > 0
+
+    @staticmethod
+    def _linear_ramp(step: int, start: int, duration: int) -> float:
+        if step < start:
+            return 0.0
+        if duration <= 0:
+            return 1.0
+        return min((step - start) / duration, 1.0)
+
+    def current_budget_target(self, step: int, layer: TTOLinear) -> float:
+        alpha = self._linear_ramp(step, self.args.tto_start, self.args.tto_budget_duration)
+        start = float(layer.d_out_start)
+        end = float(layer.d_out_final)
+        return start + alpha * (end - start)
+
+    def set_train_mode(self, step: int) -> None:
+        if not self.enabled():
+            return
+        active = step >= self.args.tto_start
+        for layer in self.layers:
+            layer.set_gate_mode(enabled=active, sample=True)
+
+    def set_eval_mode(self, step: int) -> None:
+        if not self.enabled():
+            return
+        active = step >= self.args.tto_start
+        for layer in self.layers:
+            layer.set_gate_mode(enabled=active, sample=False)
+
+    def set_disabled(self) -> None:
+        for layer in self.layers:
+            layer.set_gate_mode(enabled=False, sample=False)
+
+    def compute_aux_loss(self, step: int, device: torch.device) -> tuple[Tensor, dict[str, float]]:
+        if not self.enabled():
+            zero = torch.zeros((), device=device)
+            return zero, {
+                "budget_loss": 0.0,
+                "sep_loss": 0.0,
+                "budget_target_total": 0.0,
+                "expected_kept_total": 0.0,
+                "keep_gap": 0.0,
+                "p_mean": 0.0,
+                "p_std": 0.0,
+                "p_min": 0.0,
+                "p_q10": 0.0,
+                "p_q50": 0.0,
+                "p_q90": 0.0,
+                "p_max": 0.0,
+                "p_mid_frac": 0.0,
+                "p_binary_frac": 0.0,
+            }
+
+        total_budget = torch.zeros((), device=device)
+        total_sep = torch.zeros((), device=device)
+        budget_target_total = 0.0
+        expected_kept_total = 0.0
+        all_p = []
+
+        for layer in self.layers:
+            p = layer.gate_probs()
+            all_p.append(p.detach())
+            target = self.current_budget_target(step, layer)
+            total_budget = total_budget + (p.sum() - target) ** 2
+            total_sep = total_sep + (p * (1.0 - p)).sum()
+            budget_target_total += target
+            expected_kept_total += float(p.sum().detach().item())
+
+        if step < self.args.tto_start:
+            aux = torch.zeros((), device=device)
+        else:
+            aux = self.args.tto_budget_lambda * total_budget + self.args.tto_sep_lambda * total_sep
+
+        all_p_cat = torch.cat(all_p)
+        p_mean = float(all_p_cat.mean().item())
+        p_std = float(all_p_cat.std(unbiased=False).item())
+        p_min = float(all_p_cat.min().item())
+        p_q10 = float(torch.quantile(all_p_cat, 0.10).item())
+        p_q50 = float(torch.quantile(all_p_cat, 0.50).item())
+        p_q90 = float(torch.quantile(all_p_cat, 0.90).item())
+        p_max = float(all_p_cat.max().item())
+        p_mid_frac = float(((all_p_cat > 0.2) & (all_p_cat < 0.8)).float().mean().item())
+        p_binary_frac = float(((all_p_cat < 0.05) | (all_p_cat > 0.95)).float().mean().item())
+
+        stats = {
+            "budget_loss": float(total_budget.detach().item()),
+            "sep_loss": float(total_sep.detach().item()),
+            "budget_target_total": budget_target_total,
+            "expected_kept_total": expected_kept_total,
+            "keep_gap": expected_kept_total - budget_target_total,
+            "p_mean": p_mean,
+            "p_std": p_std,
+            "p_min": p_min,
+            "p_q10": p_q10,
+            "p_q50": p_q50,
+            "p_q90": p_q90,
+            "p_max": p_max,
+            "p_mid_frac": p_mid_frac,
+            "p_binary_frac": p_binary_frac,
+        }
+        return aux, stats
+
+    @staticmethod
+    def _transform_state_tensor(t: Tensor, repl: ParamReplacement) -> Tensor:
+        if repl.action != "replace":
+            raise RuntimeError("State tensor transformation is only valid for replace actions")
+
+        out = t.detach().clone()
+        if repl.keep_idx is None or repl.prune_axis is None:
+            return out
+
+        if tuple(t.shape) != tuple(repl.old_param.shape):
+            return out
+
+        keep_idx = repl.keep_idx.to(device=t.device)
+        index = [slice(None)] * t.ndim
+        index[repl.prune_axis] = keep_idx
+        return t[tuple(index)].clone()
+
+    def _patch_single_optimizer(self, optimizer: torch.optim.Optimizer, repl: ParamReplacement) -> bool:
+        found = False
+
+        for group in optimizer.param_groups:
+            params = group["params"]
+            for i, p in enumerate(params):
+                if p is repl.old_param:
+                    found = True
+                    if repl.action == "drop":
+                        params.pop(i)
+                    elif repl.action == "replace":
+                        if repl.new_param is None:
+                            raise RuntimeError("replace action requires new_param")
+                        params[i] = repl.new_param
+                    else:
+                        raise ValueError(f"Unknown replacement action: {repl.action}")
+                    break
+
+        old_state = optimizer.state.pop(repl.old_param, None)
+
+        if repl.action == "replace" and repl.new_param is not None and old_state is not None:
+            new_state = {}
+            for key, value in old_state.items():
+                if torch.is_tensor(value):
+                    new_state[key] = self._transform_state_tensor(value, repl)
+                else:
+                    new_state[key] = copy.deepcopy(value)
+            optimizer.state[repl.new_param] = new_state
+
+        return found or (old_state is not None)
+
+    @torch.no_grad()
+    def consolidate_model(
+        self,
+        model: nn.Module,
+        optimizers: list[torch.optim.Optimizer] | None = None,
+    ) -> dict[str, Tensor]:
+        keep_map: dict[str, Tensor] = {}
+
+        for name, module in list(model.named_modules()):
+            if not isinstance(module, TTOMLP) or module.is_consolidated:
+                continue
+
+            plan = module.build_consolidation_plan()
+
+            if optimizers is not None:
+                for repl in plan.replacements:
+                    found_any = False
+                    for opt in optimizers:
+                        found_any = self._patch_single_optimizer(opt, repl) or found_any
+                    if not found_any:
+                        raise RuntimeError(
+                            f"Failed to find old parameter in any optimizer during consolidation: "
+                            f"shape={tuple(repl.old_param.shape)} action={repl.action}"
+                        )
+
+            module.apply_consolidation_plan(plan)
+            keep_map[name] = plan.keep_idx
+
+        self.layers = [m for m in model.modules() if isinstance(m, TTOLinear)]
+        return keep_map
+
+
+
+
+
+
+
+
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tto_expand_ratio: float,
+        tto_init_logit: float,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = TTOMLP(dim, mlp_mult, tto_expand_ratio, tto_init_logit)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tto_expand_ratio: float,
+        tto_init_logit: float,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    tto_expand_ratio,
+                    tto_init_logit,
+                    rope_base,
+                    qk_gain_init,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+
+        # First half stores skips; second half reuses them in reverse order.
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+
+
+def get_grad_norm(parameters, norm_type: float = 2.0) -> Tensor:
+    grads = [p.grad for p in parameters if p.grad is not None]
+    if not grads:
+        return torch.tensor(0.0)
+    device = grads[0].device
+    norms = torch.stack([torch.norm(g.detach(), norm_type).to(device) for g in grads])
+    return torch.norm(norms, norm_type)
+
+
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tto_expand_ratio=args.tto_expand_ratio,
+        tto_init_logit=args.tto_init_logit,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    tto_manager = TTODropManager(base_model, args)
+    def build_runtime_model(curr_base_model: nn.Module) -> tuple[nn.Module, nn.Module]:
+        compiled = torch.compile(curr_base_model, dynamic=False, fullgraph=True)
+        wrapped: nn.Module = DDP(compiled, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled
+        return compiled, wrapped
+
+    compiled_model, model = build_runtime_model(base_model)
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+    log0(
+        f"tto_enable:{args.tto_enable} "
+        f"tto_layers:{len(tto_manager.layers)} "
+        f"tto_expand_ratio:{args.tto_expand_ratio} "
+        f"tto_start:{args.tto_start} "
+        f"tto_budget_duration:{args.tto_budget_duration} "
+        f"tto_budget_lambda:{args.tto_budget_lambda} "
+        f"tto_sep_lambda:{args.tto_sep_lambda} "
+    )
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        tto_manager.set_train_mode(0)
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+        tto_manager.set_train_mode(0)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+
+            tto_manager.set_eval_mode(step)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            tto_manager.set_train_mode(step)
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        # --- TTO CONSOLIDATION HOOK (runs once at target step) ---
+        if (
+            args.tto_enable
+            and args.tto_consolidate_step > 0
+            and step == args.tto_consolidate_step
+            and any(isinstance(m, TTOMLP) and not m.is_consolidated for m in base_model.modules())
+        ):
+            zero_grad_all()
+            if distributed:
+                dist.barrier()
+            if master_process:
+                log0(f"tto_consolidation:begin step:{step}")
+
+            keep_map = tto_manager.consolidate_model(base_model, optimizers=optimizers)
+
+            restore_low_dim_params_to_fp32(base_model)
+
+            # rebuild compiled + DDP model
+            compiled_model, model = build_runtime_model(base_model)
+
+            # refresh manager (important!)
+            tto_manager = TTODropManager(base_model, args)
+
+            zero_grad_all()
+            if distributed:
+                dist.barrier()
+            if master_process:
+                kept_total = sum(int(v.numel()) for v in keep_map.values())
+                log0(
+                    f"tto_consolidation:done step:{step} "
+                    f"consolidated_mlps:{len(keep_map)} kept_total:{kept_total}"
+                )
+
+        tto_manager.set_train_mode(step)
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        aux_loss_detached = torch.zeros((), device=device)
+        aux_stats = {
+            "budget_loss": 0.0,
+            "sep_loss": 0.0,
+            "budget_target_total": 0.0,
+            "expected_kept_total": 0.0,
+        }
+
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        aux_loss, aux_stats = tto_manager.compute_aux_loss(step, device)
+        aux_loss_detached = aux_loss.detach()
+        if aux_loss.requires_grad:
+            aux_loss.backward()
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            grad_norm = torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        else:
+            grad_norm = get_grad_norm(base_model.parameters())
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            """ 
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"aux_loss:{aux_loss_detached.item():.4f} "
+                f"budget_loss:{aux_stats['budget_loss']:.4f} "
+                f"sep_loss:{aux_stats['sep_loss']:.4f} "
+                f"expected_kept:{aux_stats['expected_kept_total']:.2f} "
+                f"target_kept:{aux_stats['budget_target_total']:.2f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+            """
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"aux_loss:{aux_loss_detached.item():.4f} "
+                f"grad_norm:{float(grad_norm):.4f} "
+                f"budget_loss:{aux_stats['budget_loss']:.4f} "
+                f"sep_loss:{aux_stats['sep_loss']:.4f} "
+                f"expected_kept:{aux_stats['expected_kept_total']:.2f} "
+                f"target_kept:{aux_stats['budget_target_total']:.2f} "
+                f"p_mean:{aux_stats['p_mean']:.4f} "
+                f"p_std:{aux_stats['p_std']:.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed int8+zlib artifact and validate the round-tripped weights.
+
+    tto_manager.set_disabled()
+    eval_model: nn.Module = model
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        eval_model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+====================================================================================================
+Running Python 3.11.14 (main, Oct 21 2025, 18:31:21) [GCC 11.2.0]
+Running PyTorch 2.7.1+cu128
+Sat Apr 11 08:51:04 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.95.05              Driver Version: 580.95.05      CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA GeForce RTX 5090        Off |   00000000:09:00.0 Off |                  N/A |
+|100%   55C    P1            497W /  500W |   18521MiB /  32607MiB |    100%      Default |
+|                                         |                        |                  N/A |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA GeForce RTX 5090        Off |   00000000:0A:00.0  On |                  N/A |
+|100%   25C    P8             27W /  500W |     766MiB /  32607MiB |      0%      Default |
+|                                         |                        |                  N/A |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|    0   N/A  N/A            1253      G   /usr/lib/xorg/Xorg                        9MiB |
+|    0   N/A  N/A          713789      C   python                                18492MiB |
+|    1   N/A  N/A            1253      G   /usr/lib/xorg/Xorg                      347MiB |
+|    1   N/A  N/A            2003      G   cinnamon                                 29MiB |
+|    1   N/A  N/A            2304      G   /usr/share/codium/codium                241MiB |
+|    1   N/A  N/A            4301      G   ...rack-uuid=3190708988185955192         67MiB |
+|    1   N/A  N/A         1718527      G   /usr/bin/nautilus                        20MiB |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:45408328
+world_size:1 grad_accum_steps:8
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:524288 train_seq_len:1024 iterations:10000 warmup_steps:20 max_wallclock_seconds:0.000
+seed:42
+tto_enable:True tto_layers:9 tto_expand_ratio:4.0 tto_start:500 tto_budget_duration:1500 tto_budget_lambda:0.001 tto_sep_lambda:0.001 
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/10000 val_loss:6.9366 val_bpb:4.1082 train_time:0ms step_avg:0.02ms
+step:1/10000 train_loss:6.9366 aux_loss:0.0000 grad_norm:0.3957 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:1299ms step_avg:1298.75ms
+step:2/10000 train_loss:16.8088 aux_loss:0.0000 grad_norm:5.5176 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:2483ms step_avg:1241.34ms
+step:3/10000 train_loss:8.5466 aux_loss:0.0000 grad_norm:5.2886 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:3746ms step_avg:1248.51ms
+step:4/10000 train_loss:6.6328 aux_loss:0.0000 grad_norm:1.4730 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:4848ms step_avg:1212.06ms
+step:5/10000 train_loss:6.8799 aux_loss:0.0000 grad_norm:1.8622 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:5952ms step_avg:1190.46ms
+step:6/10000 train_loss:6.8496 aux_loss:0.0000 grad_norm:1.0322 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:7057ms step_avg:1176.09ms
+step:7/10000 train_loss:6.3539 aux_loss:0.0000 grad_norm:0.7354 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:8162ms step_avg:1165.98ms
+step:8/10000 train_loss:6.1391 aux_loss:0.0000 grad_norm:0.4470 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:9268ms step_avg:1158.51ms
+step:9/10000 train_loss:6.0106 aux_loss:0.0000 grad_norm:0.4242 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:10373ms step_avg:1152.51ms
+step:10/10000 train_loss:5.9170 aux_loss:0.0000 grad_norm:0.4100 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:11485ms step_avg:1148.48ms
+step:200/10000 train_loss:2.7450 aux_loss:0.0000 grad_norm:0.3170 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:228708ms step_avg:1143.54ms
+step:400/10000 train_loss:2.3436 aux_loss:0.0000 grad_norm:0.1430 budget_loss:339619.7500 sep_loss:1665.3922 expected_kept:35115.69 target_kept:36864.00 p_mean:0.9526 p_std:0.0000 train_time:459599ms step_avg:1149.00ms
+step:600/10000 train_loss:2.4650 aux_loss:2.6983 grad_norm:0.2126 budget_loss:883.7266 sep_loss:1814.5798 expected_kept:34950.05 target_kept:35039.23 p_mean:0.9481 p_std:0.0000 train_time:701911ms step_avg:1169.85ms
+step:800/10000 train_loss:2.3487 aux_loss:4.6887 grad_norm:0.0718 budget_loss:1.1587 sep_loss:4687.5376 expected_kept:31352.38 target_kept:31352.83 p_mean:0.8505 p_std:0.0008 train_time:949113ms step_avg:1186.39ms
+step:1000/10000 train_loss:2.3997 aux_loss:6.9119 grad_norm:0.1017 budget_loss:8.5202 sep_loss:6903.3457 expected_kept:27660.87 target_kept:27666.43 p_mean:0.7503 p_std:0.0078 train_time:1197105ms step_avg:1197.10ms
+step:1000/10000 val_loss:2.3693 val_bpb:1.4032 train_time:1197105ms step_avg:1197.10ms
+step:1200/10000 train_loss:2.3678 aux_loss:8.3042 grad_norm:0.1091 budget_loss:13.0309 sep_loss:8291.1797 expected_kept:23988.27 target_kept:23980.03 p_mean:0.6507 p_std:0.0487 train_time:1441684ms step_avg:1201.40ms
+step:1400/10000 train_loss:2.4246 aux_loss:7.4998 grad_norm:0.0934 budget_loss:6.3700 sep_loss:7493.4092 expected_kept:20291.67 target_kept:20293.63 p_mean:0.5504 p_std:0.2102 train_time:1691482ms step_avg:1208.20ms
+step:1600/10000 train_loss:2.2497 aux_loss:1.2032 grad_norm:0.0741 budget_loss:1.6825 sep_loss:1201.5315 expected_kept:16610.78 target_kept:16607.23 p_mean:0.4506 p_std:0.4636 train_time:1937918ms step_avg:1211.20ms
+step:1800/10000 train_loss:2.3015 aux_loss:0.7105 grad_norm:0.0577 budget_loss:1.7648 sep_loss:708.7484 expected_kept:12924.81 target_kept:12920.83 p_mean:0.3506 p_std:0.4566 train_time:2177012ms step_avg:1209.45ms
+step:2000/10000 train_loss:2.3057 aux_loss:1.1871 grad_norm:0.0581 budget_loss:3.1496 sep_loss:1183.9092 expected_kept:9238.86 target_kept:9234.43 p_mean:0.2506 p_std:0.3946 train_time:2415560ms step_avg:1207.78ms
+step:2000/10000 val_loss:2.2985 val_bpb:1.3613 train_time:2415561ms step_avg:1207.78ms
+step:2200/10000 train_loss:2.1853 aux_loss:0.0669 grad_norm:0.0541 budget_loss:0.3222 sep_loss:66.6122 expected_kept:9215.19 target_kept:9216.00 p_mean:0.2500 p_std:0.4309 train_time:2652761ms step_avg:1205.80ms
+step:2400/10000 train_loss:2.2171 aux_loss:0.0062 grad_norm:0.0456 budget_loss:1.4466 sep_loss:4.7077 expected_kept:9214.06 target_kept:9216.00 p_mean:0.2499 p_std:0.4328 train_time:2892864ms step_avg:1205.36ms
+tto_consolidation:begin step:2500
+tto_consolidation:done step:2500 consolidated_mlps:9 kept_total:9216
+step:2600/10000 train_loss:2.2728 aux_loss:0.0000 grad_norm:0.0532 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3077024ms step_avg:1183.47ms
+step:2800/10000 train_loss:2.2177 aux_loss:0.0000 grad_norm:0.0491 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3201094ms step_avg:1143.25ms
+step:3000/10000 train_loss:2.1384 aux_loss:0.0000 grad_norm:0.0376 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3327576ms step_avg:1109.19ms
+step:3000/10000 val_loss:2.1877 val_bpb:1.2957 train_time:3327576ms step_avg:1109.19ms
+step:3200/10000 train_loss:2.2123 aux_loss:0.0000 grad_norm:0.0409 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3450382ms step_avg:1078.24ms
+step:3400/10000 train_loss:2.1998 aux_loss:0.0000 grad_norm:0.0402 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3574954ms step_avg:1051.46ms
+step:3600/10000 train_loss:2.1441 aux_loss:0.0000 grad_norm:0.0382 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3698866ms step_avg:1027.46ms
+step:3800/10000 train_loss:2.2256 aux_loss:0.0000 grad_norm:0.0398 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3821734ms step_avg:1005.72ms
+step:4000/10000 train_loss:2.1218 aux_loss:0.0000 grad_norm:0.0395 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:3946133ms step_avg:986.53ms
+step:4000/10000 val_loss:2.1582 val_bpb:1.2782 train_time:3946133ms step_avg:986.53ms
+step:4200/10000 train_loss:2.1943 aux_loss:0.0000 grad_norm:0.0459 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4069912ms step_avg:969.03ms
+step:4400/10000 train_loss:2.2012 aux_loss:0.0000 grad_norm:0.0379 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4193035ms step_avg:952.96ms
+step:4600/10000 train_loss:2.0358 aux_loss:0.0000 grad_norm:0.0359 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4314857ms step_avg:938.01ms
+step:4800/10000 train_loss:2.1471 aux_loss:0.0000 grad_norm:0.0415 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4438731ms step_avg:924.74ms
+step:5000/10000 train_loss:2.1422 aux_loss:0.0000 grad_norm:0.0401 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4561386ms step_avg:912.28ms
+step:5000/10000 val_loss:2.1403 val_bpb:1.2676 train_time:4561386ms step_avg:912.28ms
+step:5200/10000 train_loss:2.1578 aux_loss:0.0000 grad_norm:0.0361 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4684477ms step_avg:900.86ms
+step:5400/10000 train_loss:2.1654 aux_loss:0.0000 grad_norm:0.0351 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4808540ms step_avg:890.47ms
+step:5600/10000 train_loss:2.1677 aux_loss:0.0000 grad_norm:0.0363 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:4931229ms step_avg:880.58ms
+step:5800/10000 train_loss:2.1449 aux_loss:0.0000 grad_norm:0.0378 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5054847ms step_avg:871.53ms
+step:6000/10000 train_loss:2.2707 aux_loss:0.0000 grad_norm:0.0375 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5178853ms step_avg:863.14ms
+step:6000/10000 val_loss:2.1294 val_bpb:1.2612 train_time:5178853ms step_avg:863.14ms
+step:6200/10000 train_loss:2.1321 aux_loss:0.0000 grad_norm:0.0369 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5301160ms step_avg:855.03ms
+step:6400/10000 train_loss:2.1477 aux_loss:0.0000 grad_norm:0.0396 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5423852ms step_avg:847.48ms
+step:6600/10000 train_loss:2.1005 aux_loss:0.0000 grad_norm:0.0342 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5548572ms step_avg:840.69ms
+step:6800/10000 train_loss:2.2412 aux_loss:0.0000 grad_norm:0.0428 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5672503ms step_avg:834.19ms
+step:7000/10000 train_loss:2.1201 aux_loss:0.0000 grad_norm:0.0375 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5796089ms step_avg:828.01ms
+step:7000/10000 val_loss:2.1187 val_bpb:1.2548 train_time:5796089ms step_avg:828.01ms
+step:7200/10000 train_loss:2.1297 aux_loss:0.0000 grad_norm:0.0487 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:5920607ms step_avg:822.31ms
+step:7400/10000 train_loss:2.1223 aux_loss:0.0000 grad_norm:0.0403 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6043483ms step_avg:816.69ms
+step:7600/10000 train_loss:2.0608 aux_loss:0.0000 grad_norm:0.0379 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6166223ms step_avg:811.35ms
+step:7800/10000 train_loss:2.1163 aux_loss:0.0000 grad_norm:0.0341 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6289647ms step_avg:806.36ms
+step:8000/10000 train_loss:2.1017 aux_loss:0.0000 grad_norm:0.0331 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6414816ms step_avg:801.85ms
+step:8000/10000 val_loss:2.1092 val_bpb:1.2492 train_time:6414816ms step_avg:801.85ms
+step:8200/10000 train_loss:2.0826 aux_loss:0.0000 grad_norm:0.0321 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6538214ms step_avg:797.34ms
+step:8400/10000 train_loss:2.0736 aux_loss:0.0000 grad_norm:0.0343 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6660618ms step_avg:792.93ms
+step:8600/10000 train_loss:2.1206 aux_loss:0.0000 grad_norm:0.0376 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6783645ms step_avg:788.80ms
+step:8800/10000 train_loss:2.0982 aux_loss:0.0000 grad_norm:0.0376 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:6907974ms step_avg:785.00ms
+step:9000/10000 train_loss:2.0769 aux_loss:0.0000 grad_norm:0.0313 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7029181ms step_avg:781.02ms
+step:9000/10000 val_loss:2.0983 val_bpb:1.2428 train_time:7029181ms step_avg:781.02ms
+step:9200/10000 train_loss:2.0504 aux_loss:0.0000 grad_norm:0.0305 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7152326ms step_avg:777.43ms
+step:9400/10000 train_loss:2.0743 aux_loss:0.0000 grad_norm:0.0326 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7275315ms step_avg:773.97ms
+step:9600/10000 train_loss:2.1336 aux_loss:0.0000 grad_norm:0.0307 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7397886ms step_avg:770.61ms
+step:9800/10000 train_loss:2.0439 aux_loss:0.0000 grad_norm:0.0279 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7521823ms step_avg:767.53ms
+step:10000/10000 train_loss:1.9711 aux_loss:0.0000 grad_norm:0.0229 budget_loss:0.0000 sep_loss:0.0000 expected_kept:0.00 target_kept:0.00 p_mean:0.0000 p_std:0.0000 train_time:7646255ms step_avg:764.63ms
+step:10000/10000 val_loss:2.0595 val_bpb:1.2197 train_time:7646255ms step_avg:764.63ms
+peak memory allocated: 20145 MiB reserved: 20218 MiB
+Serialized model: 67225175 bytes
+Code size: 68110 bytes
+Total submission size: 67293285 bytes
+Serialized model int8+zlib: 15818457 bytes (payload:17178912 raw_torch:17224089 payload_ratio:3.91x)
+Total submission size int8+zlib: 15886567 bytes
+final_int8_zlib_roundtrip val_loss:2.0717 val_bpb:1.2270 eval_time:21257ms
+final_int8_zlib_roundtrip_exact val_loss:2.07171897 val_bpb:1.22698867


### PR DESCRIPTION

This PR introduces **Train-Time Overparameterization (TTO)**, a method for improving language models by temporarily expanding MLP capacity during training and consolidating back to the original size before inference.

Across 3 seeds, TTO consistently improves over baseline at identical final model size, suggesting that transient overparameterization can meaningfully improve optimization and representation quality.

## Overview

Language models are typically trained at the same capacity they will ultimately use at inference. In this work, we explore a different question:

Should a small model be trained small from the start?

We find that the answer appears to be no.

TTO is a simple strategy in which the model is given extra MLP capacity during training, and that excess capacity is later consolidated back down to the original inference budget. The final model remains the same size at deployment, but training proceeds through a larger feature space.

The core idea is straightforward:

- start from a target small model  
- expand the MLP during training  
- learn which neurons are most useful via stochastic gating  
- consolidate back to the original width before export  

Empirically, this produces a consistent improvements over training the same final-capacity model directly.

### Training Schedule

TTO is applied over the course of training using a simple staged schedule:

- **0–5%**: train with the fully expanded MLP (no gating)  
- **5–25%**: introduce stochastic gating with a learned, budget-aware objective  
- **25–100%**: prune to the target width and continue training as a standard model  

After 25% of training, the model is functionally identical in size and structure to the baseline, and the remaining training proceeds normally.

## Pseudocode

```python
class TTOLinear:
    # start wider than the final exported layer
    weight = learned_matrix(expanded_width, d_in)

    # one learned keep logit per expanded neuron
    keep_logits = learned_vector(expanded_width)

    def forward(x):
        h = linear(x, weight)

        if gates_are_enabled:
            p = sigmoid(keep_logits)

            # hard stochastic gate in forward pass
            mask = bernoulli(p)

            # straight-through style gradient to keep_logits
            h = hard_gate_with_logit_gradient(h, mask, p)

        return h
```

```python
def tto_aux_loss(layer, target_active_neurons):
    p = sigmoid(layer.keep_logits)

    # keep expected active neurons near the current budget
    budget_loss = (sum(p) - target_active_neurons) ** 2

    # encourage probabilities to become decisive, near 0 or 1
    separation_loss = sum(p * (1 - p))

    return budget_loss + separation_loss
```

```python
def consolidate(layer, final_width):
    p = sigmoid(layer.keep_logits)

    # keep the neurons the model learned to rely on
    keep = topk(p, final_width)

    # prune the expansion projection
    layer.weight = layer.weight[keep]

    # prune the matching input dimension of the down projection
    next_layer.weight = next_layer.weight[:, keep]

    # remove gates; the layer is now a normal dense layer
    layer.keep_logits = None
    layer.gates_are_enabled = False
```

## Results

All runs are trained for 10k steps under identical settings across three seeds, building off of the original naive baseline.

To keep the final model within the same parameter budget, the baseline uses a 2× MLP expansion, while TTO uses a 4× temporary expansion (8× effective width during training), followed by consolidation back to the original size before export.

| Model | Seed | Pre-quant BPB ↓ | Post-quant BPB ↓ | Size (bytes) |
|-------|------|----------------:|-----------------:|-------------:|
| Baseline | 1337 | 1.2262 | 1.2328 | 15861272 |
| TTO (4× expand) | 1337 | **1.2197** | **1.2264** | 15891679 |
| Baseline | 42 | 1.2276 | 1.2343 | 15856563 |
| TTO (4× expand) | 42 | **1.2197** | **1.2270** | 15886567 |
| Baseline | 2025 | 1.2253 | 1.2321 | 15853892 |
| TTO (4× expand) | 2025 | **1.2204** | **1.2273** | 15883534 |
| **Average (Baseline)** | — | 1.2264 | 1.2331 | 15857242 |
| **Average (TTO)** | — | **1.2199** | **1.2269** | 15887260 |

Train-Time Overparameterization consistently improves over the baseline across all three seeds. 

## Stronger Baseline Validation

To check whether TTO still helps beyond the naive baseline setting, I also ran a second validation experiment on a stronger stack.

This setup ports over several components from the current SOTA-style configuration, including:

- 11 layers
- SP8192 vocabulary
- stronger hyperparameters
- larger baseline MLP expansion

Here, the matched baseline uses a 4× MLP expansion. I also include a 4.5× MLP run as a rough calibration point for how much extra dense MLP capacity would be needed to match TTO.

| Model | Seed | Val BPB ↓ |
|-------|------|----------:|
| 4× MLP baseline | 1337 | 1.1304 |
| 4.5× MLP baseline | 1337 | 1.1250 |
| TTO, final 4× MLP | 1337 | **1.1249** |
| 4× MLP baseline | 42 | 1.1312 |
| 4.5× MLP baseline | 42 | **1.1258** |
| TTO, final 4× MLP | 42 | 1.1260 |
| 4× MLP baseline | 2025 | 1.1318 |
| 4.5× MLP baseline | 2025 | **1.1265** |
| TTO, final 4× MLP | 2025 | 1.1287 |
| **Average 4× MLP baseline** | — | 1.1311 |
| **Average 4.5× MLP baseline** | — | **1.1258** |
| **Average TTO, final 4× MLP** | — | 1.1265 |

TTO substantially improves over the matched 4× MLP baseline, reducing average validation BPB from **1.1311** to **1.1265**.

It also lands close to the 4.5× MLP baseline while retaining the final 4× MLP size. Interpolating between the 4× and 4.5× dense baselines, TTO behaves roughly like a **4.43× MLP** on average, despite consolidating back to 4×.

---

## How Train-Time Overparameterization Works

### Why temporary expansion can help

The fundamental idea behind TTO is simple: a model may be fully capable of representing a good function, but still be bad at discovering it through gradient descent—training with a larger transient model both expands the space of available features and makes useful solutions easier to reach, before being compressed back down.

### The core challenge: selecting which neurons survive

Expanding the MLP is straightforward. The real challenge is deciding which neurons should remain when we return to the target model.

At a high level, TTO is built around a simple idea: enforce a **capacity budget** during training, and structure it so that the most useful neurons naturally emerge. Crucially, this budget must be applied *gradually*. Abruptly removing capacity would be highly disruptive, so instead we slowly reduce the number of active neurons over time, allowing the network to adapt as it is progressively “soft pruned” toward its final size.

A natural first approach is to assign each neuron a learned continuous gate, and use an auxiliary objective to constrain the total activation mass to match a target budget. This allows the model to softly reallocate capacity and gradually shift importance across neurons.

However, this approach runs into a fundamental issue: under a budget constraint alone, the model tends to distribute mass evenly across neurons, resulting in a “mushy” allocation where many neurons remain partially active. This is poorly aligned with the final top-k pruning step, where we need a clear separation between neurons that are used and those that are not.

To address this, we introduce a simple **separation objective** that encourages gates to move toward the extremes of 0 or 1. This pushes the network to make more decisive allocations, and in practice is critical for obtaining a clean ranking of neurons prior to pruning.

Even with this, however, the continuous formulation has a deeper problem: the network can *cheat*. Because the gates only scale activations, surrounding weights can simply increase in magnitude to compensate for reduced values. This allows the model to continue using its full effective capacity despite the imposed budget. As a result, when pruning is eventually applied, performance degrades sharply—the model was still relying on the neurons that are removed.

While it may be possible to address this with additional constraints (e.g. coupling gates to weight norms), this quickly becomes complex and difficult to tune. Instead, we take a different approach: we make the selection process explicitly **discrete**.

Each neuron is assigned a learned logit, which defines a Bernoulli probability via a sigmoid. During training, neurons are stochastically gated on or off using a hard binary mask. This eliminates the possibility of compensation through rescaling—when a neuron is off, it is truly unavailable.

This discrete formulation has two key advantages. First, it aligns training with the final model: neurons are either present or absent, just as they will be after consolidation. Second, it produces a meaningful importance signal: the learned probability directly reflects how valuable it is for a neuron to remain active.

To train these logits, we use a surrogate (straight-through) gradient estimator. Intuitively, this treats the hard gating operation as if it were a smooth scaling during backpropagation, allowing gradients to flow to the logits while preserving discrete behavior in the forward pass. This provides a stable signal for which neurons should be kept, while still enabling gradual adaptation as the budget is reduced.

By the time consolidation occurs, the network has already adapted to operate under the target budget, with most neurons effectively either fully on or fully off. As a result, the explicit pruning via top-k selection itself becomes minimally disruptive.

### Consolidation and training schedule

TTO operates in three phases: expansion, controlled sparsification, and consolidation.

We begin training with the fully expanded MLP, with all neurons active. This allows the model to take advantage of the larger feature space during the early stages of optimization.

At 5% of training, stochastic gating is enabled. From this point onward, neurons are sampled according to their learned probabilities, and the auxiliary objectives begin to take effect.

Between 5% and 15% of training, we **anneal the target budget** from the expanded width down to the final width. This gradually reduces the expected number of active neurons, allowing the model to adapt smoothly as capacity is removed.

At 25% of training, we **consolidate** the model by selecting the top-k neurons (by learned probability) and permanently pruning the rest. The MLP is then replaced with a standard dense layer of the target size, making the model architecturally identical to the baseline.

From this point onward, training proceeds normally with no additional overhead.

A key observation is that consolidation can occur relatively early. Although the soft pruning is initially disruptive, the model quickly recovers—typically within a small fraction of the remaining training steps—and maintains a consistent performance advantage thereafter.

This makes TTO practical (though not on the timed track): most of the training run is performed with the final, smaller model, while still benefiting from the improved optimization enabled by early overparameterization.

## Selection vs. optimization

TTO raises a central question: *where does the improvement actually come from?*

One possibility is **selection**. The expanded model exposes a much larger pool of neurons, and training identifies a particularly effective subset. From this perspective, overparameterization primarily acts as a search process, and the final performance is driven by the specific neurons that are retained after consolidation.

An alternative (and not mutually exclusive) explanation is **optimization**. A larger model may be easier to train: it can represent intermediate solutions more flexibly and make it easier for gradient descent to discover useful representations. In this view, even temporary overparameterization can guide the model into regions of parameter space that a smaller model would be unlikely to reach on its own, with some of these improvements persisting after consolidation.

To probe this, we ran a simple transfer experiment. We first trained a model with TTO and recorded the neurons selected during consolidation. We then trained a new model at the target size, initializing it with the same subset of neurons (i.e. same indices), but without using TTO during training.

This did **not** recover the performance of the full TTO model.

This suggests that the benefit is not solely explained by identifying a “lucky” subset of neurons at initialization, in contrast to interpretations similar to the lottery ticket hypothesis. While it is still possible that certain neurons become particularly important over the course of training, their usefulness does not appear to be fixed from the start in a way that can be trivially transferred.

Instead, this points toward a more optimization-driven explanation: the transient overparameterized phase may enable the model to form representations that are simply not accessible when training at the final capacity from the outset.

More broadly, it is unclear how localized this effect is. Although TTO is applied only to the MLP, changes in intermediate representations affect the entire network, and it is possible that attention layers also benefit indirectly from the improved feature space during early training.

These questions remain open, and we view TTO primarily as an empirical result that highlights the potential importance of training dynamics, rather than as a fully understood mechanism.

## Closing note

While it is easy to overstate the similarities between biological and artificial neural networks, TTO bears a rather striking structural resemblance to early brain development, where synaptic overgrowth is followed by large-scale pruning.

Perhaps this reflects something more fundamental: neural nets may simply learn better if you let them have a childhood.