### PR TITLE
Non-Record: JEPA-NTP Auxiliary Losses (Negative Result)

### DIFF
--- a/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/README.md
+++ b/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/README.md
@@ -1,0 +1,162 @@
+# JEPA-NTP: Auxiliary Latent Losses for Next-Token Prediction
+
+**Result: Negative.** JEPA-style auxiliary losses do not improve next-token prediction in the parameter golf regime.
+
+**Best JEPA variant post-quant val_bpb: 1.4352** (baseline: **1.4326**)
+
+## Motivation
+
+Can we improve language model representations by borrowing the two-loss recipe from LeCun's LeWorldModel (LeWM) paper? LeWM uses:
+1. **Spectral variance floor** — prevents dimensional collapse in hidden states
+2. **Cosine-MSE latent prediction** — predicts the next-position hidden state via a dedicated MLP head
+
+We adapted both losses for autoregressive language models and tested whether they improve `val_bpb` in the parameter golf setting (9-layer, 512-dim, ~17M param transformer).
+
+## The Compound Loss
+
+```
+L = L_CE + alpha * L_cosine_mse(h_hat_{t+1}, sg(h_{t+1})) + lambda * L_spectral(delta_h_t)
+```
+
+| Component | What it does | Hyperparameter |
+|-----------|-------------|----------------|
+| `L_CE` | Standard cross-entropy NTP | — |
+| `L_cosine_mse` | Predicts next-position latent via 2-layer MLP | alpha = 0.1 |
+| `L_spectral` | Penalizes eigenvalues of Cov(delta_h) below epsilon | lambda = 0.01, eps = 0.01 |
+
+Key adaptations for language (vs. LeWM's vision setting):
+- Applied to hidden-state **deltas** (delta_h = h_{t+1} - h_t), not absolute states
+- Only penalizes total dimensional collapse, not full isotropy (SIGReg would destroy language embedding structure)
+- L2-normalize before MSE (cosine distance — avoids magnitude conflicts with CE)
+- Stop-gradient on target prevents representational shortcuts
+
+## Hardware
+
+- 2x NVIDIA RTX PRO 6000 Blackwell (98 GB VRAM each)
+- RunPod cloud instance
+- 1 epoch of FineWeb-10B SP1024 (~1B tokens, 477 steps at 2M tokens/step)
+
+## Results
+
+All runs: torch.compile enabled, 1 epoch, identical data/hyperparameters.
+
+### JEPA Experiments (train_jepa_ntp.py)
+
+| Experiment | Config | val_bpb (pre-quant) | val_bpb (post-quant) | Quant gap | tok/s | Int8+zlib bytes |
+|-----------|--------|:-------------------:|:--------------------:|:---------:|------:|----------------:|
+| **Baseline** | L_CE only | **1.4152** | **1.4326** | 0.0174 | 2,119,557 | 9,900,240 |
+| Exp4 JEPA targeted | L_CE + spectral + cosine_mse (layers 2-5) | 1.4170 | 1.4352 | 0.0182 | 1,702,648 | 9,903,685 |
+
+### Architectural Experiments (train_modded.py)
+
+| Experiment | Config | Params | val_bpb (pre-quant) | val_bpb (post-quant) | tok/s | Int8+zlib bytes |
+|-----------|--------|-------:|:-------------------:|:--------------------:|------:|----------------:|
+| **Baseline** | Stock 9L/512d/4KV | 17.06M | **1.4152** | **1.4326** | 2,119,557 | 9,900,240 |
+| MQA + Value Embeds | 1 KV head + VE on first/last 2 layers | 15.42M | 1.4277 | 1.4439 | 2,201,000 | 9,680,000 |
+| MQA + VE + 3x MLP | Above + 3x MLP multiplier | 20.14M | 1.4190 | 1.4364 | 1,936,000 | 12,120,000 |
+
+### Verdict
+
+The baseline wins on every metric. At 1 epoch of training:
+- JEPA: +0.0018 BPB worse, 20% slower throughput
+- MQA+VE: +0.012 BPB worse (dropping from 4 to 1 KV head loses too much attention capacity)
+- MQA+VE+3xMLP: +0.004 BPB worse (3x MLP partially recovers but doesn't justify the size increase)
+
+## Key Findings
+
+### 1. JEPA auxiliary losses are orthogonal to quantization
+
+The spectral floor and cosine-MSE losses operate on **hidden-state geometry** (eigenvalue spectrum, latent prediction), but int8 quantization operates on **weight distributions** (per-row clipping, rounding error). These are nearly independent — JEPA cannot improve quantization robustness.
+
+### 2. Spectral floor works mechanically but doesn't help language modeling
+
+The spectral loss successfully prevents dimensional collapse:
+- Effective rank improved from 424 to 445 out of 512 dimensions (83% -> 87%)
+- Tail singular values (sv_058-063) stayed at ~2,300 (far from zero)
+- The loss spiked to 0.045 at step 25 (catching early collapse), then decayed to 0 by step 175
+
+But this improved dimension utilization didn't translate to better next-token prediction at 17M params. The model is too small for dimensional collapse to be the binding constraint.
+
+### 3. Cosine-MSE predictor was essentially inert
+
+The predictor MLP's loss values were tiny throughout training (0.001-0.003). With alpha=0.1, the actual gradient contribution was negligible. The predictor added ~1M parameters (not counted in submission size) and 20% throughput overhead for no benefit.
+
+### 4. Critical methodology lesson: torch.compile confound
+
+An initial apparent 0.02 BPB improvement from JEPA was traced to a **torch.compile confound** — the baseline ran uncompiled while JEPA ran compiled. Once both used torch.compile:
+
+| Run | Compile | val_bpb |
+|-----|---------|--------:|
+| Baseline (uncompiled) | off | 1.9496 |
+| JEPA exp4 (compiled) | on | 1.9065 |
+| **Baseline (compiled)** | **on** | **1.8990** |
+
+torch.compile alone provides ~0.05 BPB improvement beyond just speed — it affects optimization quality (likely via reduced numerical noise in fused kernels).
+
+### 5. MQA is harmful at this scale
+
+Going from 4 to 1 KV head in a 9-layer model loses too much attention capacity. Value embeddings (zero-compute-cost per-token V lookups shared between first/last layers) don't compensate. Even adding a 3x MLP multiplier to use the freed parameters doesn't fully recover quality.
+
+## Experiment Framework
+
+The submission includes a reusable experimental framework:
+
+```
+jepa_ntp/
+  config.py                  -- Experiment configurations (baseline, exp1-4)
+  train_jepa_ntp.py          -- JEPA training script (wraps train_gpt.py)
+  train_modded.py            -- MQA + Value Embeddings script
+  losses/
+    spectral_floor.py        -- Spectral variance floor loss
+    cosine_mse.py            -- Cosine-MSE prediction loss + LatentPredictor MLP
+  metrics/
+    effective_rank.py         -- Effective rank diagnostic
+    singular_spectrum.py      -- Full SV spectrum logging
+    latent_smoothness.py      -- Latent path curvature + cosine smoothness
+```
+
+### Running
+
+```bash
+# JEPA experiment (exp4 = best JEPA variant)
+EXPERIMENT=exp4_targeted RUN_ID=exp4_run1 \
+    torchrun --standalone --nproc_per_node=2 jepa_ntp/train_jepa_ntp.py
+
+# Modded architecture experiment
+EXPERIMENT=exp5_modded RUN_ID=modded_run1 \
+    torchrun --standalone --nproc_per_node=2 jepa_ntp/train_modded.py
+```
+
+### WandB Diagnostics
+
+The framework logs rich diagnostics to WandB:
+- `diagnostics/effective_rank_delta` — primary anti-collapse metric (should stay near model_dim)
+- `spectrum/sv_*` — full singular value spectrum (smooth decay = healthy, cliff to zero = collapse)
+- `loss/cosine_mse` — predictor loss (should decrease if predictor is learning)
+- `diagnostics/curvature` — latent path curvature (decreasing = path straightening)
+- `diagnostics/cosine_smoothness` — consecutive velocity cosine similarity
+
+## Design Decisions
+
+1. **Inline hidden state capture** (no hooks) — hooks break torch.compile. Instead, JEPAGPT subclasses GPT and returns captured hidden states from forward(). When capture_layers=None, branches are dead-code-eliminated by the compiler.
+
+2. **DDP before compile** — PyTorch requires DDP wrapping before torch.compile. The predictor MLP also needs DDP wrapping for weight synchronization across ranks.
+
+3. **Predictor weights excluded from submission** — the LatentPredictor MLP is only used during training. The serialized model is identical to baseline (same architecture, same param count).
+
+## What Would Be Worth Trying Next
+
+Based on leaderboard analysis, the winning approaches use fundamentally different strategies:
+1. **More training** — 3.7 epochs (not 1) to match competition baseline
+2. **QAT (quantization-aware training)** — fake int6 quantization with STE during warmdown
+3. **Better compression** — zstd-22 instead of zlib, int6 instead of int8
+4. **More layers** — 11 instead of 9 (all top entries use deeper models)
+
+These are orthogonal to auxiliary training losses and address the actual bottlenecks.
+
+## References
+
+- [LeWorldModel: Training JEPA Models with Two Loss Terms](https://arxiv.org/abs/2503.XXXXX) — Garrido, Bordes, Assran, Ballas, Bardes, Najman, LeCun (2026)
+- [SIGReg: Sketched Isotropic Gaussian Regularizer](https://arxiv.org/abs/2308.11809)
+- [modded-nanogpt](https://github.com/KellerJordan/modded-nanogpt) — Value Embeddings, MQA tricks
+- [OpenAI Parameter Golf](https://github.com/openai/parameter-golf)

--- a/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/config.py
+++ b/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/config.py
@@ -1,0 +1,155 @@
+"""
+Experiment Configuration
+=========================
+
+Defines the 5 experiment configurations discussed in the research plan:
+
+  Baseline   — Pure NTP (L_CE only), no auxiliary losses
+  Exp 1      — Spectral Variance Floor only (anti-collapse ablation)
+  Exp 2      — Cosine-MSE Auxiliary Head only (latent prediction ablation)
+  Exp 3      — Combined (Exp 1 + Exp 2) — mirrors LeWM's two-term structure
+  Exp 4      — Layer-Targeted (Exp 3 scoped to middle layers only)
+
+The compound loss formula for Exp 3/4:
+    L = L_CE + α · L_cosine-MSE(ĥ_{t+1}, sg(h_{t+1})) + λ · L_spec(Δh_t)
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class JEPAConfig:
+    """Configuration for JEPA-NTP auxiliary losses."""
+
+    # --- Experiment toggles ---
+    use_spectral: bool = False          # Enable spectral variance floor loss
+    use_cosine_mse: bool = False        # Enable cosine-MSE prediction loss
+
+    # --- Loss weights ---
+    alpha: float = 0.1                  # Weight for cosine-MSE loss
+    lambda_spec: float = 0.01          # Weight for spectral floor loss
+    spectral_eps: float = 0.01         # Eigenvalue floor threshold
+    spectral_use_deltas: bool = True   # Apply to Δh (True) or h (False)
+
+    # --- Alpha decay schedule ---
+    alpha_decay: bool = True            # Decay alpha over training
+    alpha_warmup_frac: float = 0.1     # Fraction of steps before decay starts
+    alpha_min: float = 0.01            # Minimum alpha after decay
+
+    # --- Layer targeting ---
+    target_layers: Optional[list[int]] = None  # Which layers to hook for aux losses
+    # If None, uses middle layers (25-60% of model depth) by default
+
+    # --- Predictor architecture ---
+    predictor_hidden_mult: int = 2     # Hidden dim multiplier for predictor MLP
+    predictor_dropout: float = 0.1     # Dropout in predictor head
+
+    # --- Logging ---
+    log_metrics_every: int = 200       # Steps between metric logging
+    log_spectrum: bool = True          # Log full singular value spectrum
+    spectrum_top_k: int = 64           # Number of SVs to log
+
+    # --- WandB ---
+    use_wandb: bool = True             # Enable WandB logging
+    wandb_project: str = "jepa-ntp-parameter-golf"
+    wandb_group: str = ""              # Set per experiment
+    wandb_tags: list[str] = field(default_factory=list)
+
+    def get_alpha(self, step: int, total_steps: int) -> float:
+        """Compute decayed alpha for current step."""
+        if not self.alpha_decay:
+            return self.alpha
+        warmup_steps = int(total_steps * self.alpha_warmup_frac)
+        if step < warmup_steps:
+            return self.alpha
+        decay_steps = total_steps - warmup_steps
+        progress = (step - warmup_steps) / max(decay_steps, 1)
+        # Logarithmic decay
+        import math
+        decay = 1.0 - math.log1p(progress * (math.e - 1))
+        decay = max(decay, 0.0)
+        return max(self.alpha_min, self.alpha * decay)
+
+
+# ============================
+# Pre-defined experiment configs
+# ============================
+
+def baseline_config() -> JEPAConfig:
+    """Exp 0: Pure NTP baseline — no auxiliary losses."""
+    return JEPAConfig(
+        use_spectral=False,
+        use_cosine_mse=False,
+        use_wandb=True,
+        wandb_group="baseline",
+        wandb_tags=["baseline", "pure-ntp"],
+    )
+
+
+def exp1_spectral_config() -> JEPAConfig:
+    """Exp 1: Spectral Variance Floor only — pure anti-collapse ablation."""
+    return JEPAConfig(
+        use_spectral=True,
+        use_cosine_mse=False,
+        lambda_spec=0.01,
+        spectral_eps=0.01,
+        use_wandb=True,
+        wandb_group="exp1_spectral",
+        wandb_tags=["exp1", "spectral-floor", "anti-collapse"],
+    )
+
+
+def exp2_cosine_mse_config() -> JEPAConfig:
+    """Exp 2: Cosine-MSE Auxiliary Head only — latent prediction ablation."""
+    return JEPAConfig(
+        use_spectral=False,
+        use_cosine_mse=True,
+        alpha=0.1,
+        alpha_decay=True,
+        use_wandb=True,
+        wandb_group="exp2_cosine_mse",
+        wandb_tags=["exp2", "cosine-mse", "latent-prediction"],
+    )
+
+
+def exp3_combined_config() -> JEPAConfig:
+    """Exp 3: Full Two-Term JEPA-NTP — mirrors LeWM's structure."""
+    return JEPAConfig(
+        use_spectral=True,
+        use_cosine_mse=True,
+        alpha=0.1,
+        lambda_spec=0.01,
+        alpha_decay=True,
+        use_wandb=True,
+        wandb_group="exp3_combined",
+        wandb_tags=["exp3", "combined", "jepa-ntp", "two-term"],
+    )
+
+
+def exp4_targeted_config(num_layers: int = 9) -> JEPAConfig:
+    """Exp 4: Layer-Targeted — auxiliary losses scoped to middle layers."""
+    # Target layers at 25-60% of model depth
+    start = max(1, int(num_layers * 0.25))
+    end = min(num_layers - 1, int(num_layers * 0.60))
+    layers = list(range(start, end + 1))
+    return JEPAConfig(
+        use_spectral=True,
+        use_cosine_mse=True,
+        alpha=0.1,
+        lambda_spec=0.01,
+        alpha_decay=True,
+        target_layers=layers,
+        use_wandb=True,
+        wandb_group="exp4_targeted",
+        wandb_tags=["exp4", "layer-targeted", "scoped"],
+    )
+
+
+EXPERIMENT_CONFIGS = {
+    "baseline": baseline_config,
+    "exp1_spectral": exp1_spectral_config,
+    "exp2_cosine_mse": exp2_cosine_mse_config,
+    "exp3_combined": exp3_combined_config,
+    "exp4_targeted": exp4_targeted_config,
+}

--- a/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/losses/__init__.py
+++ b/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/losses/__init__.py
@@ -1,0 +1,4 @@
+from .spectral_floor import spectral_variance_floor
+from .cosine_mse import cosine_mse_loss
+
+__all__ = ["spectral_variance_floor", "cosine_mse_loss"]

--- a/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/losses/cosine_mse.py
+++ b/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/losses/cosine_mse.py
@@ -1,0 +1,92 @@
+"""
+Cosine-MSE Auxiliary Prediction Loss
+=====================================
+
+Next-position latent prediction head inspired by LeWM's prediction loss,
+adapted for language models.
+
+Key design choices:
+  1. L2-normalize before MSE → effectively cosine distance, no magnitude pressure
+  2. Stop-gradient on target → gradients only flow through the predictor MLP
+  3. Dedicated projection head → isolates auxiliary gradients from the main trunk
+
+This avoids the Neural Collapse conflict where MSE pushes embeddings toward
+equal norms while cross-entropy pushes toward classifier-specific structure.
+
+Formula:
+    L_cosine_mse = || ĥ_{t+1}/||ĥ_{t+1}|| - sg(h_{t+1}/||h_{t+1}||) ||²
+
+where ĥ_{t+1} = predictor_mlp(h_t) and sg = stop_gradient.
+"""
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+
+class LatentPredictor(nn.Module):
+    """
+    2-layer MLP projection head for next-position latent prediction.
+    
+    Architecture mirrors SimCLR/BYOL projection heads — keeps auxiliary
+    loss gradients scoped to this head rather than leaking into the trunk.
+    
+    Input:  h_t  (batch, seq_len, dim)
+    Output: ĥ_{t+1} (batch, seq_len-1, dim) — predicted next-position embedding
+    """
+
+    def __init__(self, dim: int, hidden_mult: int = 2, dropout: float = 0.1):
+        super().__init__()
+        hidden = dim * hidden_mult
+        self.net = nn.Sequential(
+            nn.Linear(dim, hidden, bias=False),
+            nn.LayerNorm(hidden),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden, dim, bias=False),
+        )
+        # Initialize output layer to near-zero for stable training start
+        nn.init.normal_(self.net[-1].weight, std=0.01)
+
+    def forward(self, h: Tensor) -> Tensor:
+        """
+        Predict next-position latent from current-position hidden states.
+        
+        Args:
+            h: (batch, seq_len, dim)
+        Returns:
+            (batch, seq_len - 1, dim) — predicted h_{t+1} for positions 0..T-2
+        """
+        return self.net(h[:, :-1, :])
+
+
+def cosine_mse_loss(
+    predicted: Tensor,
+    target: Tensor,
+    eps: float = 1e-8,
+) -> Tensor:
+    """
+    Cosine-MSE loss with stop-gradient on target.
+    
+    L2-normalizes both predicted and target, then computes MSE.
+    This is equivalent to 2 * (1 - cosine_similarity) but with cleaner gradients.
+    
+    Args:
+        predicted: (batch, seq_len-1, dim) — from LatentPredictor
+        target: (batch, seq_len-1, dim) — actual h_{t+1}, will be detached
+        eps: Small constant for numerical stability in normalization
+        
+    Returns:
+        Scalar loss.
+    """
+    # Stop-gradient on target: gradients only flow through the predictor
+    target = target.detach()
+
+    # L2-normalize → cosine distance (no magnitude pressure)
+    pred_norm = predicted / (predicted.norm(dim=-1, keepdim=True) + eps)
+    tgt_norm = target / (target.norm(dim=-1, keepdim=True) + eps)
+
+    # MSE on normalized vectors = 2 * (1 - cos_sim)
+    loss = (pred_norm - tgt_norm).pow(2).mean()
+
+    return loss

--- a/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/losses/spectral_floor.py
+++ b/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/losses/spectral_floor.py
@@ -1,0 +1,95 @@
+"""
+Spectral Variance Floor Loss
+=============================
+
+Anti-collapse regularizer adapted from LeWM's SIGReg for language models.
+
+Key insight: We apply this to hidden-state *deltas* (Δh_t = h_{t+1} - h_t)
+rather than absolute states, because language embeddings are naturally anisotropic
+(this is load-bearing structure, not a bug). Transition deltas have less intrinsic
+semantic structure and benefit more from anti-collapse pressure.
+
+The loss penalizes only total dimensional collapse (singular values → 0), NOT
+full isotropy. This is the "minimal sufficient intervention" — it ensures the
+model uses all available embedding dimensions without destroying the natural
+cone structure of language representations.
+
+Formula:
+    L_spec = Σ max(0, ε - σ_i(Cov(ΔH)))
+    
+where σ_i are eigenvalues of the covariance matrix of hidden-state deltas,
+and ε is a small floor (default 0.01).
+"""
+
+import torch
+from torch import Tensor
+
+
+def spectral_variance_floor(
+    hidden_states: Tensor,
+    eps_floor: float = 0.01,
+    use_deltas: bool = True,
+) -> Tensor:
+    """
+    Compute the spectral variance floor loss on hidden states.
+
+    Args:
+        hidden_states: (batch, seq_len, dim) — hidden states from a target layer.
+        eps_floor: Minimum eigenvalue threshold. Dimensions with eigenvalue below
+                   this are penalized. Default 0.01.
+        use_deltas: If True (default), compute on Δh_t = h_{t+1} - h_t rather
+                    than raw h_t. Recommended for language models.
+
+    Returns:
+        Scalar loss — sum of max(0, eps - eigenvalue) over all dimensions.
+    """
+    if use_deltas:
+        # Δh_t = h_{t+1} - h_t : captures transition dynamics
+        h = hidden_states[:, 1:, :] - hidden_states[:, :-1, :]
+    else:
+        h = hidden_states
+
+    # Flatten batch and seq dims: (batch * seq, dim)
+    h_flat = h.reshape(-1, h.size(-1)).float()
+
+    # Center the embeddings
+    h_centered = h_flat - h_flat.mean(dim=0, keepdim=True)
+
+    # Covariance matrix: (dim, dim)
+    n = h_centered.size(0)
+    cov = (h_centered.T @ h_centered) / max(n - 1, 1)
+
+    # Eigenvalues of the covariance matrix (symmetric → use eigh)
+    eigenvalues = torch.linalg.eigvalsh(cov)  # sorted ascending
+
+    # Penalize any eigenvalue below the floor
+    # This catches total dimensional collapse without enforcing isotropy
+    violations = torch.clamp(eps_floor - eigenvalues, min=0.0)
+
+    return violations.sum()
+
+
+def effective_rank_from_cov(hidden_states: Tensor, use_deltas: bool = True) -> float:
+    """
+    Compute effective rank (entropy-based) of the hidden state covariance.
+    Useful as a diagnostic metric — NOT a loss.
+
+    Effective rank = exp(entropy of normalized singular values)
+    A value of d means the representation uses all d dimensions equally.
+    A value of 1 means all information is on a single axis (total collapse).
+    """
+    if use_deltas:
+        h = hidden_states[:, 1:, :] - hidden_states[:, :-1, :]
+    else:
+        h = hidden_states
+
+    h_flat = h.reshape(-1, h.size(-1)).float()
+    h_centered = h_flat - h_flat.mean(dim=0, keepdim=True)
+
+    # SVD for singular values
+    s = torch.linalg.svdvals(h_centered)
+    # Normalize to a probability distribution
+    p = s / s.sum()
+    p = p[p > 1e-12]  # avoid log(0)
+    entropy = -(p * p.log()).sum()
+    return float(torch.exp(entropy).item())

--- a/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/metrics/__init__.py
+++ b/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/metrics/__init__.py
@@ -1,0 +1,9 @@
+from .effective_rank import compute_effective_rank
+from .singular_spectrum import compute_singular_spectrum
+from .latent_smoothness import compute_latent_curvature
+
+__all__ = [
+    "compute_effective_rank",
+    "compute_singular_spectrum",
+    "compute_latent_curvature",
+]

--- a/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/metrics/effective_rank.py
+++ b/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/metrics/effective_rank.py
@@ -1,0 +1,51 @@
+"""
+Effective Rank Metric
+======================
+
+Measures how many embedding dimensions are actually being used.
+
+Effective rank = exp(entropy of normalized singular values)
+  - Value of d → all d dimensions used equally (perfect)
+  - Value of 1 → total collapse to a single axis
+  - Values between → partial dimensional usage
+
+This is the primary anti-collapse diagnostic. If spectral floor loss
+is working correctly, effective rank should stay close to d (the model dim)
+rather than collapsing over training.
+"""
+
+import torch
+from torch import Tensor
+
+
+@torch.no_grad()
+def compute_effective_rank(
+    hidden_states: Tensor,
+    use_deltas: bool = True,
+) -> float:
+    """
+    Compute effective rank of hidden state distribution.
+    
+    Args:
+        hidden_states: (batch, seq_len, dim)
+        use_deltas: If True, compute on Δh rather than h
+        
+    Returns:
+        Effective rank (float between 1 and dim).
+    """
+    if use_deltas:
+        h = hidden_states[:, 1:, :] - hidden_states[:, :-1, :]
+    else:
+        h = hidden_states
+
+    h_flat = h.reshape(-1, h.size(-1)).float()
+    h_centered = h_flat - h_flat.mean(dim=0, keepdim=True)
+
+    s = torch.linalg.svdvals(h_centered)
+
+    # Normalize to probability distribution
+    p = s / (s.sum() + 1e-12)
+    p = p[p > 1e-12]
+
+    entropy = -(p * p.log()).sum()
+    return float(torch.exp(entropy).item())

--- a/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/metrics/latent_smoothness.py
+++ b/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/metrics/latent_smoothness.py
@@ -1,0 +1,89 @@
+"""
+Latent Path Curvature / Smoothness
+====================================
+
+Measures how "straight" the latent trajectory is across sequence positions.
+
+In LeWM, one of the key emergent properties is "Temporal Latent Path Straightening" —
+latent trajectories become smoother/more linear over training without explicit
+regularization. We measure whether this emerges in LLMs too.
+
+Curvature is computed as the angular deviation of second-order differences:
+  - Low curvature → smooth, predictable trajectories (good)
+  - High curvature → erratic, unpredictable transitions (bad)
+
+A steadily decreasing curvature over training confirms the path-straightening effect.
+"""
+
+import torch
+from torch import Tensor
+
+
+@torch.no_grad()
+def compute_latent_curvature(
+    hidden_states: Tensor,
+    eps: float = 1e-8,
+) -> float:
+    """
+    Compute mean angular curvature of latent trajectories.
+    
+    Uses second-order finite differences:
+        d_t = h_{t+1} - h_t     (first difference / velocity)
+        dd_t = d_{t+1} - d_t    (second difference / acceleration)
+        curvature ≈ mean(||dd_t|| / ||d_t||)
+    
+    Args:
+        hidden_states: (batch, seq_len, dim) — must have seq_len >= 3
+        eps: Small constant for numerical stability
+        
+    Returns:
+        Mean curvature (float). Lower = smoother.
+    """
+    if hidden_states.size(1) < 3:
+        return 0.0
+
+    h = hidden_states.float()
+
+    # First differences (velocity): (batch, seq_len-1, dim)
+    d = h[:, 1:, :] - h[:, :-1, :]
+
+    # Second differences (acceleration): (batch, seq_len-2, dim)
+    dd = d[:, 1:, :] - d[:, :-1, :]
+
+    # Curvature = ||acceleration|| / ||velocity|| for each position
+    d_norm = d[:, :-1, :].norm(dim=-1) + eps  # align with dd
+    dd_norm = dd.norm(dim=-1)
+
+    curvature = (dd_norm / d_norm).mean()
+    return float(curvature.item())
+
+
+@torch.no_grad()
+def compute_cosine_smoothness(
+    hidden_states: Tensor,
+    eps: float = 1e-8,
+) -> float:
+    """
+    Alternative smoothness metric: mean cosine similarity between
+    consecutive velocity vectors.
+    
+    Values close to 1.0 mean nearly-straight trajectories.
+    Values close to 0.0 mean random-walk trajectories.
+    
+    Args:
+        hidden_states: (batch, seq_len, dim) — must have seq_len >= 3
+        
+    Returns:
+        Mean cosine similarity of consecutive velocities (float in [-1, 1]).
+    """
+    if hidden_states.size(1) < 3:
+        return 0.0
+
+    h = hidden_states.float()
+    d = h[:, 1:, :] - h[:, :-1, :]
+
+    d1 = d[:, :-1, :]  # velocity at t
+    d2 = d[:, 1:, :]   # velocity at t+1
+
+    cos_sim = torch.nn.functional.cosine_similarity(d1, d2, dim=-1, eps=eps)
+    return float(cos_sim.mean().item())

--- a/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/metrics/singular_spectrum.py
+++ b/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/metrics/singular_spectrum.py
@@ -1,0 +1,51 @@
+"""
+Singular Value Spectrum
+========================
+
+Logs the full singular value spectrum of hidden state covariance.
+Visualizing this as a line plot or histogram reveals:
+  - Healthy spectrum: smooth decay with no sharp cliff
+  - Collapsed spectrum: few large values, many near zero
+  - Over-regularized: flat spectrum (too isotropic — rare in practice)
+
+When plotted over training steps, you should see:
+  - Baseline: progressive collapse (tail drops to zero)
+  - With spectral floor: tail stays above the floor ε
+"""
+
+import torch
+from torch import Tensor
+import numpy as np
+
+
+@torch.no_grad()
+def compute_singular_spectrum(
+    hidden_states: Tensor,
+    use_deltas: bool = True,
+    top_k: int = 64,
+) -> np.ndarray:
+    """
+    Compute top-k singular values of hidden state distribution.
+    
+    Args:
+        hidden_states: (batch, seq_len, dim)
+        use_deltas: If True, compute on Δh
+        top_k: Number of singular values to return (default 64).
+               Set to dim for the full spectrum.
+        
+    Returns:
+        numpy array of top_k singular values (descending order).
+    """
+    if use_deltas:
+        h = hidden_states[:, 1:, :] - hidden_states[:, :-1, :]
+    else:
+        h = hidden_states
+
+    h_flat = h.reshape(-1, h.size(-1)).float()
+    h_centered = h_flat - h_flat.mean(dim=0, keepdim=True)
+
+    s = torch.linalg.svdvals(h_centered)
+    
+    k = min(top_k, s.numel())
+    # svdvals returns descending order
+    return s[:k].cpu().numpy()

--- a/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/submission.json
+++ b/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/submission.json
@@ -1,0 +1,14 @@
+{
+  "name": "JEPA-NTP: Auxiliary Latent Losses for Next-Token Prediction (Negative Result)",
+  "author": "Sidhanth Krishna",
+  "github_id": "sidhanth97",
+  "date": "2026-04-11",
+  "track": "non-record-unlimited-compute-16mb",
+  "val_bpb": 1.4352,
+  "val_loss": 2.4222,
+  "pre_quant_val_bpb": 1.4170,
+  "pre_quant_val_loss": 2.3915,
+  "bytes_total": 9903685,
+  "bytes_model_int8_zlib": 9903685,
+  "blurb": "Negative result: JEPA-style auxiliary losses (spectral variance floor + cosine-MSE latent prediction from LeWM/LeWorldModel) do not improve next-token prediction in the parameter golf regime. Across 6 experiments on 2xRTX PRO 6000 Blackwell GPUs, the compiled baseline (val_bpb 1.4152) beats all JEPA variants (best: 1.4170, +0.0018 worse) while being 20% faster. Also tested MQA + Value Embeddings from modded-nanogpt (1.4277, worse) and MQA+VE+3xMLP (1.4190, worse). Key finding: the spectral floor loss mechanically prevents dimensional collapse (effective rank 424->445/512) but this doesn't translate to better language modeling at 17M params. An initial apparent improvement was traced to a torch.compile confound. Includes full experimental framework with WandB diagnostics."
+}

--- a/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/train_jepa_ntp.py
+++ b/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/train_jepa_ntp.py
@@ -1,0 +1,768 @@
+"""
+JEPA-NTP Training Script
+=========================
+
+Wraps the baseline Parameter Golf train_gpt.py with JEPA-style auxiliary losses.
+
+This script:
+  1. Subclasses the baseline GPT model to return hidden states from the forward pass
+  2. Adds spectral floor and/or cosine-MSE losses as configured
+  3. Uses torch.compile for full training speed (no hooks!)
+  4. Logs JEPA-specific metrics (effective rank, spectrum, curvature) to WandB
+
+Key design: Hidden states are captured by returning them from forward() rather
+than using hooks. This keeps the full compute graph traceable by torch.compile.
+When capture_layers=None, the branches are dead-code-eliminated and you get
+the exact same compiled graph as the baseline.
+
+Usage:
+    # Single experiment
+    EXPERIMENT=exp3_combined RUN_ID=exp3_run1 \\
+        torchrun --standalone --nproc_per_node=1 jepa_ntp/train_jepa_ntp.py
+    
+    # All experiments
+    for exp in baseline exp1_spectral exp2_cosine_mse exp3_combined exp4_targeted; do
+        EXPERIMENT=$exp RUN_ID=${exp}_run1 \\
+            torchrun --standalone --nproc_per_node=1 jepa_ntp/train_jepa_ntp.py
+    done
+
+    # Full 8xH100 competition run
+    EXPERIMENT=exp3_combined RUN_ID=competition_run \\
+        torchrun --standalone --nproc_per_node=8 jepa_ntp/train_jepa_ntp.py
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+
+# --- Add parent directory to path so we can import train_gpt ---
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from train_gpt import (
+    GPT,
+    Hyperparameters,
+    Muon,
+    CastedLinear,
+    DistributedTokenLoader,
+    TokenStream,
+    build_sentencepiece_luts,
+    eval_val,
+    load_validation_tokens,
+    quantize_state_dict_int8,
+    dequantize_state_dict_int8,
+    restore_low_dim_params_to_fp32,
+    zeropower_via_newtonschulz5,
+    CONTROL_TENSOR_NAME_PATTERNS,
+)
+
+from config import (
+    JEPAConfig,
+    EXPERIMENT_CONFIGS,
+)
+from losses import spectral_variance_floor, cosine_mse_loss
+from losses.cosine_mse import LatentPredictor
+from metrics import compute_effective_rank, compute_singular_spectrum, compute_latent_curvature
+from metrics.latent_smoothness import compute_cosine_smoothness
+
+
+# ============================================================
+# JEPA-GPT: SUBCLASS WITH INLINE HIDDEN STATE CAPTURE
+# ============================================================
+# Instead of hooks (which break torch.compile), we override forward()
+# to optionally return intermediate hidden states as part of the output.
+# When capture_layers is None, the capture branches are all False and
+# torch.compile dead-code-eliminates them — same graph as baseline.
+
+class JEPAGPT(GPT):
+    """
+    GPT subclass that can return intermediate hidden states from forward().
+    Fully compatible with torch.compile — no hooks, no Python callbacks.
+
+    IMPORTANT: forward() always returns (loss, captured_dict). The baseline
+    eval_val() expects model(x, y) to return a single loss tensor, so we
+    provide an EvalWrapper for validation calls.
+    """
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        target_ids: Tensor,
+        capture_layers: set[int] | None = None,
+    ) -> tuple[Tensor, dict[int, Tensor]]:
+        """
+        Forward pass with optional hidden state capture.
+
+        Args:
+            input_ids: (batch, seq_len)
+            target_ids: (batch, seq_len)
+            capture_layers: Set of layer indices to capture. None = no capture.
+
+        Returns:
+            (ce_loss, captured) where captured is {layer_idx: (batch, seq, dim)}
+            When capture_layers is None, captured is empty dict.
+        """
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+        captured: dict[int, Tensor] = {}
+
+        # First half: encoder layers (store skips)
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+            if capture_layers is not None and i in capture_layers:
+                captured[i] = x
+
+        # Second half: decoder layers (consume skips in reverse)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            layer_idx = self.num_encoder_layers + i
+            x = self.blocks[layer_idx](x, x0)
+            if capture_layers is not None and layer_idx in capture_layers:
+                captured[layer_idx] = x
+
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        loss = F.cross_entropy(logits.float(), targets, reduction="mean")
+
+        return loss, captured
+
+
+class EvalWrapper(nn.Module):
+    """
+    Thin wrapper that makes JEPAGPT forward() compatible with eval_val().
+    eval_val() calls model(x, y).detach() — it expects a single tensor.
+    This wrapper unpacks the (loss, captured) tuple and returns just the loss.
+    """
+
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        loss, _captured = self.model(input_ids, target_ids)
+        return loss
+
+    def train(self, mode: bool = True):
+        self.model.train(mode)
+        return self
+
+    def eval(self):
+        self.model.eval()
+        return self
+
+
+def resolve_target_layers(
+    num_layers: int,
+    config_layers: list[int] | None,
+) -> list[int]:
+    """Compute target layer indices. Default: middle layers (25-60% of depth)."""
+    if config_layers is not None:
+        return config_layers
+    start = max(1, int(num_layers * 0.25))
+    end = min(num_layers - 1, int(num_layers * 0.60))
+    return list(range(start, end + 1))
+
+
+# ============================================================
+# JEPA-AUGMENTED FORWARD PASS
+# ============================================================
+
+def jepa_forward(
+    model: nn.Module,
+    x: Tensor,
+    y: Tensor,
+    jepa_cfg: JEPAConfig,
+    capture_layer_set: set[int] | None,
+    predictor: LatentPredictor | None,
+    step: int,
+    total_steps: int,
+) -> tuple[Tensor, dict[str, float], dict[int, Tensor]]:
+    """
+    Run forward pass with JEPA auxiliary losses.
+    
+    Returns:
+        (total_loss, metrics_dict, captured_hidden_states)
+    """
+    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+        ce_loss, captured = model(x, y, capture_layers=capture_layer_set)
+
+    total_loss = ce_loss
+    metrics = {"loss/ce": float(ce_loss.item())}
+
+    if not captured:
+        metrics["loss/total"] = float(total_loss.item())
+        return total_loss, metrics, captured
+
+    # Average across captured layers: (batch, seq, dim)
+    h = torch.stack(list(captured.values()), dim=0).mean(dim=0)
+
+    # --- Spectral Variance Floor ---
+    if jepa_cfg.use_spectral:
+        spec_loss = spectral_variance_floor(
+            h,
+            eps_floor=jepa_cfg.spectral_eps,
+            use_deltas=jepa_cfg.spectral_use_deltas,
+        )
+        total_loss = total_loss + jepa_cfg.lambda_spec * spec_loss
+        metrics["loss/spectral"] = float(spec_loss.item())
+
+    # --- Cosine-MSE Prediction ---
+    if jepa_cfg.use_cosine_mse and predictor is not None:
+        alpha = jepa_cfg.get_alpha(step, total_steps)
+        predicted = predictor(h)
+        target = h[:, 1:, :]  # actual h_{t+1}
+        cmse_loss = cosine_mse_loss(predicted, target)
+        total_loss = total_loss + alpha * cmse_loss
+        metrics["loss/cosine_mse"] = float(cmse_loss.item())
+        metrics["schedule/alpha"] = alpha
+
+    metrics["loss/total"] = float(total_loss.item())
+    return total_loss, metrics, captured
+
+
+# ============================================================
+# METRIC LOGGING
+# ============================================================
+
+def log_jepa_metrics(
+    captured: dict[int, Tensor],
+    jepa_cfg: JEPAConfig,
+    wandb_run,
+    step: int,
+):
+    """Compute and log JEPA-specific diagnostics."""
+    if not captured:
+        return
+
+    h = torch.stack(list(captured.values()), dim=0).mean(dim=0).detach()
+
+    metrics = {}
+
+    # Effective rank (primary anti-collapse metric)
+    eff_rank = compute_effective_rank(h, use_deltas=True)
+    metrics["diagnostics/effective_rank_delta"] = eff_rank
+    eff_rank_abs = compute_effective_rank(h, use_deltas=False)
+    metrics["diagnostics/effective_rank_abs"] = eff_rank_abs
+
+    # Latent path curvature
+    curvature = compute_latent_curvature(h)
+    metrics["diagnostics/curvature"] = curvature
+    cosine_smooth = compute_cosine_smoothness(h)
+    metrics["diagnostics/cosine_smoothness"] = cosine_smooth
+
+    # Singular value spectrum
+    if jepa_cfg.log_spectrum:
+        sv = compute_singular_spectrum(h, use_deltas=True, top_k=jepa_cfg.spectrum_top_k)
+        for i, v in enumerate(sv):
+            metrics[f"spectrum/sv_{i:03d}"] = float(v)
+
+    if wandb_run is not None:
+        wandb_run.log(metrics, step=step)
+    else:
+        # Fallback: print key metrics
+        print(
+            f"  [JEPA] eff_rank_Δ={eff_rank:.1f} eff_rank_abs={eff_rank_abs:.1f} "
+            f"curvature={curvature:.4f} cos_smooth={cosine_smooth:.4f}"
+        )
+
+
+# ============================================================
+# MAIN TRAINING LOOP
+# ============================================================
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    import sentencepiece as spm
+    import subprocess
+    import random
+    import glob as glob_mod
+    import io
+    import zlib
+    from torch.nn.parallel import DistributedDataParallel as DDP
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    _compile_disabled = (
+        os.environ.get("TORCH_COMPILE_DISABLE", "0") == "1"
+        or os.environ.get("TORCHDYNAMO_DISABLE", "0") == "1"
+    )
+    if not _compile_disabled:
+        zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # --- Load experiment config ---
+    exp_name = os.environ.get("EXPERIMENT", "baseline")
+    if exp_name not in EXPERIMENT_CONFIGS:
+        raise ValueError(
+            f"Unknown experiment '{exp_name}'. Choose from: {list(EXPERIMENT_CONFIGS.keys())}"
+        )
+    jepa_cfg = EXPERIMENT_CONFIGS[exp_name]()
+    print(f"[JEPA-NTP] Experiment: {exp_name}")
+    print(f"[JEPA-NTP] Config: spectral={jepa_cfg.use_spectral}, cosine_mse={jepa_cfg.use_cosine_mse}")
+    if jepa_cfg.target_layers:
+        print(f"[JEPA-NTP] Target layers: {jepa_cfg.target_layers}")
+
+    # --- Distributed + CUDA setup (same as baseline) ---
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+
+    # --- Seed ---
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    # --- Tokenizer + Validation ---
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+
+    # --- Model (JEPAGPT subclass with inline capture) ---
+    base_model = JEPAGPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+
+    # --- Resolve target layers ---
+    target_layers = resolve_target_layers(args.num_layers, jepa_cfg.target_layers)
+    needs_capture = jepa_cfg.use_spectral or jepa_cfg.use_cosine_mse
+    capture_layer_set: set[int] | None = set(target_layers) if needs_capture else None
+    log0(f"[JEPA-NTP] Target layers: {target_layers}, capture={'enabled' if needs_capture else 'disabled'}")
+
+    # Set up predictor MLP (if using cosine-MSE)
+    predictor: LatentPredictor | None = None
+    if jepa_cfg.use_cosine_mse:
+        predictor = LatentPredictor(
+            dim=args.model_dim,
+            hidden_mult=jepa_cfg.predictor_hidden_mult,
+            dropout=jepa_cfg.predictor_dropout,
+        ).to(device).bfloat16()
+        log0(f"[JEPA-NTP] Predictor params: {sum(p.numel() for p in predictor.parameters()):,}")
+
+    # --- DDP + Compile ---
+    # DDP must wrap the model BEFORE torch.compile (PyTorch DDP+compile guidance).
+    # Predictor also needs DDP wrapping to keep weights synchronized across ranks.
+    if distributed:
+        model: nn.Module = DDP(base_model, device_ids=[local_rank], broadcast_buffers=False)
+        if predictor is not None:
+            predictor = DDP(predictor, device_ids=[local_rank], broadcast_buffers=False)
+    else:
+        model = base_model
+
+    if not _compile_disabled:
+        log0("[JEPA-NTP] torch.compile enabled (fullgraph=False for DDP compatibility)")
+        model = torch.compile(model, dynamic=False, fullgraph=False)
+    else:
+        log0("[JEPA-NTP] torch.compile DISABLED")
+
+    # EvalWrapper for eval_val() compatibility — eval_val expects model(x,y)
+    # to return a single loss tensor, but JEPAGPT returns (loss, captured).
+    eval_model = EvalWrapper(model)
+
+    # --- Optimizers (same split as baseline) ---
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params, lr=args.matrix_lr, momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    # Predictor optimizer (separate Adam, higher LR for faster convergence)
+    if predictor is not None:
+        optimizer_pred = torch.optim.Adam(
+            predictor.parameters(), lr=args.scalar_lr * 2, betas=(args.beta1, args.beta2),
+        )
+        optimizers.append(optimizer_pred)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    pred_params = sum(p.numel() for p in predictor.parameters()) if predictor else 0
+    log0(f"model_params:{n_params} predictor_params:{pred_params} total:{n_params + pred_params}")
+
+    # --- WandB ---
+    wandb_run = None
+    if jepa_cfg.use_wandb and master_process:
+        try:
+            import wandb
+            wandb_run = wandb.init(
+                project=jepa_cfg.wandb_project,
+                group=jepa_cfg.wandb_group,
+                tags=jepa_cfg.wandb_tags,
+                name=f"{exp_name}_{args.run_id}",
+                config={
+                    "experiment": exp_name,
+                    "model_dim": args.model_dim,
+                    "num_layers": args.num_layers,
+                    "vocab_size": args.vocab_size,
+                    "use_spectral": jepa_cfg.use_spectral,
+                    "use_cosine_mse": jepa_cfg.use_cosine_mse,
+                    "alpha": jepa_cfg.alpha,
+                    "lambda_spec": jepa_cfg.lambda_spec,
+                    "target_layers": target_layers,
+                    "total_params": n_params + pred_params,
+                },
+            )
+            log0(f"[JEPA-NTP] WandB run: {wandb_run.url}")
+        except ImportError:
+            log0("[JEPA-NTP] wandb not installed, logging to stdout only")
+
+    # --- Data loader ---
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all():
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # --- Warmup (same as baseline, resets state after) ---
+    if args.warmup_steps > 0:
+        initial_model_state = {n: t.detach().cpu().clone() for n, t in base_model.state_dict().items()}
+        initial_pred_state = {n: t.detach().cpu().clone() for n, t in predictor.state_dict().items()} if predictor else None
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        if predictor:
+            predictor.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                    if predictor is not None and isinstance(predictor, DDP):
+                        predictor.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                loss, _, _ = jepa_forward(
+                    model, x, y, jepa_cfg, capture_layer_set, predictor,
+                    warmup_step, args.iterations,
+                )
+                (loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+        # Reset everything
+        base_model.load_state_dict(initial_model_state, strict=True)
+        if predictor and initial_pred_state:
+            predictor.load_state_dict(initial_pred_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+            if predictor is not None and isinstance(predictor, DDP):
+                predictor.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+        log0(f"[JEPA-NTP] Warmup complete ({args.warmup_steps} steps)")
+
+    # --- Main training loop ---
+    training_time_ms = 0.0
+    total_tokens_seen: int = 0  # Track tokens for Chinchilla-style loss curves
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    model.train()
+    if predictor:
+        predictor.train()
+
+    step = 0
+    last_captured: dict[int, Tensor] = {}  # Keep last captured states for metric logging
+
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        # --- Validation ---
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args, eval_model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"tokens:{total_tokens_seen:,} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            if wandb_run:
+                wandb_run.log({
+                    "val/loss": val_loss,
+                    "val/bpb": val_bpb,
+                    "throughput/tokens_seen": total_tokens_seen,
+                }, step=step)
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms step:{step}/{args.iterations}")
+            break
+
+        # --- Training step ---
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        step_metrics: dict[str, float] = {}
+
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                if predictor is not None and isinstance(predictor, DDP):
+                    predictor.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+
+            loss, metrics, captured = jepa_forward(
+                model, x, y, jepa_cfg, capture_layer_set, predictor,
+                step, args.iterations,
+            )
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+            step_metrics = metrics  # keep last micro-step metrics
+            last_captured = captured  # keep for diagnostic logging
+
+        train_loss /= grad_accum_steps
+
+        # Track cumulative tokens seen (the real currency for loss curve comparison)
+        total_tokens_seen += args.train_batch_tokens
+
+        # Muon momentum warmup
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        # LR schedule
+        for opt in optimizers:
+            for group in opt.param_groups:
+                if "base_lr" in group:
+                    group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+            if predictor:
+                torch.nn.utils.clip_grad_norm_(predictor.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+
+        # --- Logging ---
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            tokens_per_sec = total_tokens_seen / (approx_training_time_ms / 1000.0) if approx_training_time_ms > 0 else 0.0
+            parts = [f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f}"]
+            for k, v in step_metrics.items():
+                if k.startswith("loss/") and k != "loss/total":
+                    parts.append(f"{k.split('/')[-1]}:{v:.4f}")
+            parts.append(f"tokens:{total_tokens_seen:,} tok/s:{tokens_per_sec:,.0f}")
+            parts.append(f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms")
+            log0(" ".join(parts))
+
+            if wandb_run:
+                step_metrics["throughput/tokens_seen"] = total_tokens_seen
+                step_metrics["throughput/tokens_per_sec"] = tokens_per_sec
+                wandb_run.log(step_metrics, step=step)
+
+        # --- JEPA diagnostic metrics ---
+        should_log_jepa = (
+            jepa_cfg.log_metrics_every > 0
+            and step % jepa_cfg.log_metrics_every == 0
+            and needs_capture
+        )
+        if should_log_jepa:
+            log_jepa_metrics(last_captured, jepa_cfg, wandb_run, step)
+
+        # --- Wallclock cap ---
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # --- Serialization (same as baseline) ---
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_size = len(code.encode("utf-8"))
+        # NOTE: Predictor weights are NOT included in submission size —
+        # they are only used during training, not inference.
+        log0(f"Serialized model: {model_bytes} bytes (code: {code_size})")
+        log0(f"Total submission size: {model_bytes + code_size} bytes")
+        if predictor:
+            torch.save(predictor.state_dict(), "final_predictor.pt")
+            log0(f"Predictor saved (NOT part of submission): {os.path.getsize('final_predictor.pt')} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_size = len(code.encode("utf-8"))
+        log0(f"Int8+zlib model: {quant_file_bytes} bytes, total: {quant_file_bytes + code_size} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args, eval_model, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+
+    if wandb_run:
+        wandb_run.log({
+            "final/val_loss": q_val_loss,
+            "final/val_bpb": q_val_bpb,
+            "final/model_size_bytes": os.path.getsize("final_model.int8.ptz") if master_process else 0,
+        })
+        wandb_run.finish()
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/train_modded.py
+++ b/records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result/train_modded.py
@@ -1,0 +1,795 @@
+"""
+Modded-NanoGPT Tricks Training Script
+======================================
+
+Integrates proven techniques from the NanoGPT speedrun world record
+into the Parameter Golf baseline architecture:
+
+  1. Value Embeddings — Per-token V lookup added to first/last attention layers.
+     Shared pairwise (layer 0 <-> layer N-1, layer 1 <-> layer N-2) so gradients
+     flow from both early and late layers. Pure embedding lookup = zero compute cost.
+
+  2. MQA (1 KV head) — Reduces K,V projection from 4 KV heads to 1, freeing
+     ~1.8M params and reducing attention compute. The freed budget remains
+     unallocated for now (keeps model smaller / compresses better).
+
+The baseline already has x0-mixin via resid_mix and UNet skip connections
+via skip_weights, so those are not reimplemented here.
+
+Architecture: ModdedGPT subclasses GPT, adds value embeddings and overrides
+CausalSelfAttention to accept optional VE tensors. Fully torch.compile compatible.
+
+Usage:
+    # Baseline with modded tricks (no JEPA losses)
+    EXPERIMENT=exp5_modded RUN_ID=exp5_run1 \
+        torchrun --standalone --nproc_per_node=1 jepa_ntp/train_modded.py
+
+    # MQA only (no value embeddings)
+    EXPERIMENT=exp5_mqa_only RUN_ID=mqa_run1 \
+        torchrun --standalone --nproc_per_node=1 jepa_ntp/train_modded.py
+"""
+
+from __future__ import annotations
+
+import copy
+import io
+import math
+import os
+import random
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+
+# --- Add parent directory to path so we can import train_gpt ---
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from train_gpt import (
+    GPT,
+    Block,
+    CausalSelfAttention,
+    CastedLinear,
+    MLP,
+    RMSNorm,
+    Rotary,
+    apply_rotary_emb,
+    Hyperparameters,
+    Muon,
+    DistributedTokenLoader,
+    build_sentencepiece_luts,
+    eval_val,
+    load_validation_tokens,
+    quantize_state_dict_int8,
+    dequantize_state_dict_int8,
+    restore_low_dim_params_to_fp32,
+    zeropower_via_newtonschulz5,
+    CONTROL_TENSOR_NAME_PATTERNS,
+)
+
+# ============================================================
+# EXPERIMENT CONFIGS
+# ============================================================
+
+MODDED_CONFIGS = {
+    # Full modded tricks: MQA + value embeddings
+    "exp5_modded": {
+        "num_kv_heads": 1,
+        "use_value_embeds": True,
+        "ve_layers_each_side": 2,  # VE on first 2 and last 2 layers
+    },
+    # MQA only (ablation)
+    "exp5_mqa_only": {
+        "num_kv_heads": 1,
+        "use_value_embeds": False,
+        "ve_layers_each_side": 0,
+    },
+    # VE only, keep 4 KV heads (ablation)
+    "exp5_ve_only": {
+        "num_kv_heads": 4,
+        "use_value_embeds": True,
+        "ve_layers_each_side": 2,
+    },
+    # Full modded + 3x MLP (uses freed MQA params)
+    "exp5_modded_3x_mlp": {
+        "num_kv_heads": 1,
+        "use_value_embeds": True,
+        "ve_layers_each_side": 2,
+        "mlp_mult": 3,
+    },
+    # Baseline (pure, no changes — for fair comparison in this script)
+    "baseline": {
+        "num_kv_heads": 4,
+        "use_value_embeds": False,
+        "ve_layers_each_side": 0,
+    },
+}
+
+# ============================================================
+# ATTENTION WITH VALUE EMBEDDINGS
+# ============================================================
+
+class ModdedAttention(nn.Module):
+    """
+    CausalSelfAttention with optional value embedding injection.
+
+    When ve_table is provided during forward(), the looked-up value embeddings
+    are mixed into V via learned scalars: v = v_lambda * v + ve_lambda * ve
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+        has_value_embed: bool = False,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+        # Value embedding mixing scalars
+        self.has_value_embed = has_value_embed
+        if has_value_embed:
+            # v_lambda init=1 (keep projected V), ve_lambda init=0 (VE starts off)
+            self.v_lambda = nn.Parameter(torch.ones(1, dtype=torch.float32))
+            self.ve_lambda = nn.Parameter(torch.zeros(1, dtype=torch.float32))
+
+    def forward(self, x: Tensor, ve: Tensor | None = None) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+
+        # Inject value embeddings if present
+        if self.has_value_embed and ve is not None:
+            # ve shape: (bsz, seqlen, kv_dim) -> (bsz, num_kv_heads, seqlen, head_dim)
+            ve = ve.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+            v = self.v_lambda.to(dtype=v.dtype) * v + self.ve_lambda.to(dtype=v.dtype) * ve
+
+        y = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+# ============================================================
+# MODDED BLOCK (uses ModdedAttention)
+# ============================================================
+
+class ModdedBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+        has_value_embed: bool = False,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = ModdedAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init, has_value_embed)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor, ve: Tensor | None = None) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x), ve=ve)
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+# ============================================================
+# MODDED GPT
+# ============================================================
+
+class ModdedGPT(nn.Module):
+    """
+    GPT with value embeddings and configurable KV heads.
+
+    Value embeddings are shared pairwise between first/last layers:
+      Layer 0 <-> Layer N-1  (share VE table 0)
+      Layer 1 <-> Layer N-2  (share VE table 1)
+      ...
+
+    This ensures short gradient paths from both directions.
+    """
+
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        # Modded tricks
+        use_value_embeds: bool = False,
+        ve_layers_each_side: int = 2,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.use_value_embeds = use_value_embeds
+        self.ve_layers_each_side = ve_layers_each_side
+        self.num_layers = num_layers
+
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+
+        # UNet structure (same as baseline)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+
+        # Determine which layers get value embeddings
+        # ve_layer_map[i] = index into ve_tables, or -1 if no VE
+        self.ve_layer_map: list[int] = [-1] * num_layers
+        if use_value_embeds and ve_layers_each_side > 0:
+            n = min(ve_layers_each_side, num_layers // 2)
+            for k in range(n):
+                self.ve_layer_map[k] = k                    # first N layers
+                self.ve_layer_map[num_layers - 1 - k] = k   # last N layers (shared)
+
+        # Value embedding tables
+        kv_dim = num_kv_heads * (model_dim // num_heads)
+        num_ve_tables = max(0, max(self.ve_layer_map) + 1) if use_value_embeds else 0
+        if num_ve_tables > 0:
+            # Spherical Gaussian init (small scale, following modded-nanogpt)
+            self.ve_tables = nn.Parameter(
+                0.01 * torch.randn(num_ve_tables, vocab_size, kv_dim)
+            )
+        else:
+            self.register_parameter("ve_tables", None)
+
+        # Build blocks with ModdedAttention where VE is needed
+        self.blocks = nn.ModuleList()
+        for i in range(num_layers):
+            has_ve = self.ve_layer_map[i] >= 0
+            self.blocks.append(
+                ModdedBlock(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                    has_value_embed=has_ve,
+                )
+            )
+
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+
+        # Look up value embeddings once (pure embedding lookup, no matmul)
+        # ve_lookups[k] has shape (bsz, seq, kv_dim) for table k
+        ve_lookups: dict[int, Tensor] | None = None
+        if self.use_value_embeds and self.ve_tables is not None:
+            ve_lookups = {}
+            for k in range(self.ve_tables.size(0)):
+                # input_ids: (bsz, seq) -> index into ve_tables[k]: (vocab, kv_dim)
+                ve_lookups[k] = self.ve_tables[k][input_ids]  # (bsz, seq, kv_dim)
+
+        # Encoder half (stores skips)
+        for i in range(self.num_encoder_layers):
+            ve_k = self.ve_layer_map[i]
+            ve = ve_lookups[ve_k] if (ve_lookups is not None and ve_k >= 0) else None
+            x = self.blocks[i](x, x0, ve=ve)
+            skips.append(x)
+
+        # Decoder half (consumes skips in reverse)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            layer_idx = self.num_encoder_layers + i
+            ve_k = self.ve_layer_map[layer_idx]
+            ve = ve_lookups[ve_k] if (ve_lookups is not None and ve_k >= 0) else None
+            x = self.blocks[layer_idx](x, x0, ve=ve)
+
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+
+# ============================================================
+# MAIN TRAINING LOOP
+# ============================================================
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    import sentencepiece as spm
+    import subprocess
+    import glob as glob_mod
+    from torch.nn.parallel import DistributedDataParallel as DDP
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    _compile_disabled = (
+        os.environ.get("TORCH_COMPILE_DISABLE", "0") == "1"
+        or os.environ.get("TORCHDYNAMO_DISABLE", "0") == "1"
+    )
+    if not _compile_disabled:
+        zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # --- Load experiment config ---
+    exp_name = os.environ.get("EXPERIMENT", "exp5_modded")
+    if exp_name not in MODDED_CONFIGS:
+        raise ValueError(
+            f"Unknown experiment '{exp_name}'. Choose from: {list(MODDED_CONFIGS.keys())}"
+        )
+    modded_cfg = MODDED_CONFIGS[exp_name]
+    num_kv_heads = modded_cfg.get("num_kv_heads", args.num_kv_heads)
+    use_value_embeds = modded_cfg.get("use_value_embeds", False)
+    ve_layers = modded_cfg.get("ve_layers_each_side", 2)
+    mlp_mult = modded_cfg.get("mlp_mult", args.mlp_mult)
+
+    print(f"[MODDED] Experiment: {exp_name}")
+    print(f"[MODDED] KV heads: {num_kv_heads}, Value Embeds: {use_value_embeds} (layers_each_side={ve_layers}), MLP mult: {mlp_mult}")
+
+    # --- Distributed + CUDA setup (same as baseline) ---
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+
+    # --- Seed ---
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    # --- Tokenizer + Validation ---
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+
+    # --- Model (ModdedGPT) ---
+    base_model = ModdedGPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=num_kv_heads,
+        mlp_mult=mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        use_value_embeds=use_value_embeds,
+        ve_layers_each_side=ve_layers,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+
+    # Log VE layer map
+    if use_value_embeds:
+        ve_map_str = ", ".join(
+            f"L{i}->VE{k}" for i, k in enumerate(base_model.ve_layer_map) if k >= 0
+        )
+        log0(f"[MODDED] Value embedding map: {ve_map_str}")
+
+    # --- Compile + DDP ---
+    # torch.compile hangs on some GPU architectures (e.g. Blackwell).
+    # Respect TORCH_COMPILE_DISABLE / TORCHDYNAMO_DISABLE env vars.
+    use_compile = not (
+        os.environ.get("TORCH_COMPILE_DISABLE", "0") == "1"
+        or os.environ.get("TORCHDYNAMO_DISABLE", "0") == "1"
+    )
+    # DDP must wrap the model BEFORE torch.compile (PyTorch DDP+compile guidance).
+    if distributed:
+        model: nn.Module = DDP(base_model, device_ids=[local_rank], broadcast_buffers=False)
+    else:
+        model = base_model
+
+    if use_compile:
+        log0("[MODDED] torch.compile enabled (fullgraph=False for DDP compatibility)")
+        model = torch.compile(model, dynamic=False, fullgraph=False)
+    else:
+        log0("[MODDED] torch.compile DISABLED")
+
+    # --- Optimizers (same split as baseline) ---
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+
+    # VE tables go into scalar optimizer (they're embeddings, not matrices for Muon)
+    if base_model.ve_tables is not None:
+        scalar_params.append(base_model.ve_tables)
+
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params, lr=args.matrix_lr, momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+
+    # --- WandB ---
+    wandb_run = None
+    if master_process:
+        try:
+            import wandb
+            wandb_run = wandb.init(
+                project="jepa-ntp-parameter-golf",
+                entity=os.environ.get("WANDB_ENTITY", None),  # auto-detect if not set
+                group=exp_name,
+                tags=[exp_name, f"kv{num_kv_heads}", f"mlp{mlp_mult}x"]
+                      + (["value-embeds"] if use_value_embeds else []),
+                name=f"{exp_name}_{args.run_id}",
+                config={
+                    "experiment": exp_name,
+                    "model_dim": args.model_dim,
+                    "num_layers": args.num_layers,
+                    "vocab_size": args.vocab_size,
+                    "num_kv_heads": num_kv_heads,
+                    "mlp_mult": mlp_mult,
+                    "use_value_embeds": use_value_embeds,
+                    "ve_layers_each_side": ve_layers,
+                    "total_params": n_params,
+                },
+            )
+            log0(f"[MODDED] WandB run: {wandb_run.url}")
+        except ImportError:
+            log0("[MODDED] wandb not installed, logging to stdout only")
+        except Exception as e:
+            log0(f"[MODDED] WandB init failed: {e}, continuing without WandB")
+
+    # --- Data loader ---
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all():
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # --- Warmup (same as baseline, resets state after) ---
+    if args.warmup_steps > 0:
+        initial_model_state = {n: t.detach().cpu().clone() for n, t in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    loss = model(x, y)
+                (loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+        # Reset everything
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+        log0(f"[MODDED] Warmup complete ({args.warmup_steps} steps)")
+
+    # --- Main training loop ---
+    training_time_ms = 0.0
+    total_tokens_seen: int = 0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    model.train()
+    step = 0
+
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        # --- Validation ---
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"tokens:{total_tokens_seen:,} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            if wandb_run:
+                wandb_run.log({
+                    "val/loss": val_loss,
+                    "val/bpb": val_bpb,
+                    "throughput/tokens_seen": total_tokens_seen,
+                }, step=step)
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms step:{step}/{args.iterations}")
+            break
+
+        # --- Training step ---
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+
+        train_loss /= grad_accum_steps
+        total_tokens_seen += args.train_batch_tokens
+
+        # Muon momentum warmup
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        # LR schedule
+        for opt in optimizers:
+            for group in opt.param_groups:
+                if "base_lr" in group:
+                    group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+
+        # --- Logging ---
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            tokens_per_sec = total_tokens_seen / (approx_training_time_ms / 1000.0) if approx_training_time_ms > 0 else 0.0
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"tokens:{total_tokens_seen:,} tok/s:{tokens_per_sec:,.0f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+            if wandb_run:
+                wandb_run.log({
+                    "loss/train": train_loss.item(),
+                    "throughput/tokens_seen": total_tokens_seen,
+                    "throughput/tokens_per_sec": tokens_per_sec,
+                }, step=step)
+
+        # --- Wallclock cap ---
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # --- Serialization (same as baseline) ---
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_size = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes (code: {code_size})")
+        log0(f"Total submission size: {model_bytes + code_size} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_size = len(code.encode("utf-8"))
+        log0(f"Int8+zlib model: {quant_file_bytes} bytes, total: {quant_file_bytes + code_size} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args, model, rank, world_size, device, grad_accum_steps,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+
+    if wandb_run:
+        wandb_run.log({
+            "final/val_loss": q_val_loss,
+            "final/val_bpb": q_val_bpb,
+            "final/model_size_bytes": os.path.getsize("final_model.int8.ptz") if master_process else 0,
+        })
+        wandb_run.finish()
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a non-record submission under:

`records/track_non_record_16mb/2026-04-11_JEPA_NTP_Auxiliary_Losses_Negative_Result`

**Negative result**: JEPA-style auxiliary losses (spectral variance floor + cosine-MSE latent prediction from LeWM/LeWorldModel) do not improve next-token prediction in the parameter golf regime.

## Results (1 epoch, 2xRTX PRO 6000 Blackwell, torch.compile enabled)

| Experiment | val_bpb (post-quant) | Throughput | Int8+zlib |
|-----------|:--------------------:|----------:|----------:|
| **Baseline** | **1.4326** | 2,119K tok/s | 9.90 MB |
| JEPA exp4 (spectral + cosine-MSE, layers 2-5) | 1.4352 (+0.003) | 1,703K tok/s | 9.90 MB |
| MQA + Value Embeds | 1.4439 (+0.011) | 2,201K tok/s | 9.68 MB |
| MQA + VE + 3x MLP | 1.4364 (+0.004) | 1,936K tok/s | 12.12 MB |

## Key findings

- Spectral floor loss mechanically prevents dimensional collapse (effective rank 424->445/512) but this doesn't translate to better language modeling at 17M params
- Cosine-MSE predictor was essentially inert (loss values 0.001-0.003, negligible gradient contribution)
- An initial apparent improvement was traced to a **torch.compile confound** (comparing compiled JEPA vs uncompiled baseline)
- MQA at this scale is harmful -- 4 KV heads are too few to spare one
- Includes full experimental framework with WandB diagnostics for reproducibility

## Submission contents

- `README.md` -- detailed results, methodology, and analysis
- `submission.json` -- leaderboard metadata
- `train_jepa_ntp.py` -- JEPA training script with spectral + cosine-MSE losses
- `train_modded.py` -- MQA + Value Embeddings training script
- `config.py` -- experiment configurations
- `losses/` -- spectral variance floor, cosine-MSE loss implementations
- `metrics/` -- effective rank, singular spectrum, latent curvature diagnostics