### PR TITLE
Non-record: MDLM Masked Diffusion + Depth Recurrence — val_bpb 1.3428 (8×H100, seed=1337)

### DIFF
--- a/records/track_non_record_16mb/2026-04-12_MDLM_DepthRecurrence/README.md
+++ b/records/track_non_record_16mb/2026-04-12_MDLM_DepthRecurrence/README.md
@@ -1,0 +1,59 @@
+# MDLM Masked Diffusion + Depth Recurrence
+
+**val_bpb: 1.3428** (int8+zlib roundtrip) | **14.73 MB** | 8×H100 SXM, 600s | Beats #1403 by 0.0057 BPB
+
+Extends the MDLM baseline (PR #1403) with depth recurrence and quantization improvements.
+
+## Stack
+
+- **Depth recurrence**: physical layers L1–L3 looped 1× extra → 12 effective layers / 9 physical layers
+- **QAT (STE)**: straight-through quantization at lr_scale < 0.40 (~last 480 steps of 8,049 total)
+- **EMA** (decay=0.997) applied to weights before serialization
+- **GPTQ-lite**: 5-candidate percentile clip search (99.9%→100%) per row, min-MSE selection
+- **Linear LR → 0** (Muon warmdown), **relu² MLP** (hidden=1024), **Muon WD=0.01**
+- **Antithetic sampling** for variance reduction during training
+- **U-Net skip connections** (encoder → decoder learned weights)
+
+## Results (8×H100 SXM, seed=1337, 600s wallclock)
+
+| Metric | This | #1403 |
+|--------|------|-------|
+| Pre-quant val_bpb | 1.3379 | 1.3409 |
+| **Post-roundtrip val_bpb** | **1.3428** | 1.3485 |
+| Quant penalty | **0.0049** | 0.0076 |
+| Artifact | 14.73 MB | 15.63 MB |
+| Steps | 8,049 | 11,808 |
+| ms/step | 74.6 ms | 50.8 ms |
+| Wallclock | 600,028 ms | 600s |
+
+EMA + GPTQ-lite cuts quant penalty from 0.0076 → 0.0049. Depth recurrence gives better pre-quant quality (1.3379 vs 1.3409) even with fewer total steps, due to ~12 effective layers of compute per forward pass.
+
+## Architecture
+
+- 9 physical layers, 512d, 8 heads, GQA kv_groups=4
+- Depth recurrence: encoder layers L1–L3 (idx 1, 2, 3) looped 1× extra
+- Hidden dim: 1024 (mlp_mult=2, relu²)
+- SP1024 vocabulary, seq_len=1024
+- int8 per-row quantization + zlib-9 compression
+
+## Run script
+
+```bash
+export NUM_LAYERS=9
+export MLP_MULT=2
+export NUM_KV_GROUPS=4
+export RECURRENCE_EXTRA=1
+export RECURRENCE_START=1
+export RECURRENCE_END=4
+export MAX_WALLCLOCK_SECONDS=600
+export MIN_LR_RATIO=0.0
+export MUON_WEIGHT_DECAY=0.01
+export ADAM_WEIGHT_DECAY=0.0
+export EMA_DECAY=0.997
+export NOISE_EPS=0.05
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+## Hardware
+
+8×H100 SXM 80GB HBM3 (RunPod), 600,028 ms wallclock, seed=1337

--- a/records/track_non_record_16mb/2026-04-12_MDLM_DepthRecurrence/submission.json
+++ b/records/track_non_record_16mb/2026-04-12_MDLM_DepthRecurrence/submission.json
@@ -1,0 +1,9 @@
+{
+  "author": "Wenhao He",
+  "github_id": "He-Wenhao",
+  "name": "Non-record: MDLM Masked Diffusion + Depth Recurrence",
+  "blurb": "Extends PR #1403 MDLM baseline with depth recurrence (L1-L3 looped 1x extra = 12 effective layers), QAT/STE at lr_scale<0.40, EMA decay=0.997, GPTQ-lite 5-candidate clip search, linear LR->0, relu^2 MLP, Muon WD=0.01. Beats #1403 by 0.0057 BPB with 0.0049 quant penalty.",
+  "date": "2026-04-12T00:00:00Z",
+  "val_bpb": 1.34275319,
+  "bytes_total": 14726814
+}

--- a/records/track_non_record_16mb/2026-04-12_MDLM_DepthRecurrence/train_gpt.py
+++ b/records/track_non_record_16mb/2026-04-12_MDLM_DepthRecurrence/train_gpt.py
@@ -1,0 +1,1020 @@
+"""
+MDLM for Parameter Golf. No AdaLN — implicit sigma via masked tokens.
+resid_mix + q_gain per block (from #1403), relu^2 MLP, 9L, fullgraph compile.
+Antithetic mask-fraction sampling for variance reduction.
+Run20: depth recurrence L1-L3 x1 extra (12/9 virtual layers, ~8000 steps) — tune depth vs steps tradeoff vs Run19's x2.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+
+class Hyperparameters:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))   # prime torch.compile
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    batch_size_per_gpu = int(os.environ.get("BATCH_SIZE_PER_GPU", 64))
+    grad_accum_steps = int(os.environ.get("GRAD_ACCUM_STEPS", 1))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    mask_id = vocab_size        # 1024
+    total_vocab = vocab_size + 1  # 1025
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    num_kv_groups = int(os.environ.get("NUM_KV_GROUPS", 4))
+    mlp_mult = int(os.environ.get("MLP_MULT", 2))            # relu^2 hidden = dim * mlp_mult
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    num_unet_layers = int(os.environ.get("NUM_UNET_LAYERS", 3))
+    # Depth recurrence: loop encoder layers [recurrence_start, recurrence_end) extra times
+    recurrence_extra = int(os.environ.get("RECURRENCE_EXTRA", 1))   # extra passes (1 = 2 total)
+    recurrence_start = int(os.environ.get("RECURRENCE_START", 1))   # first layer to loop
+    recurrence_end = int(os.environ.get("RECURRENCE_END", 4))       # exclusive end (L1,L2,L3)
+
+    # Optimizer hyperparameters.
+    muon_lr = float(os.environ.get("MUON_LR", 0.04))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.05))        # Adam for tok_emb
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))      # Adam for scalars/norms
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    muon_ns_steps = int(os.environ.get("MUON_NS_STEPS", 5))
+    muon_weight_decay = float(os.environ.get("MUON_WEIGHT_DECAY", 0.01))
+    adam_weight_decay = float(os.environ.get("ADAM_WEIGHT_DECAY", 0.0))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+    min_lr_ratio = float(os.environ.get("MIN_LR_RATIO", 0.0))  # Linear warmdown to 0 (matches #1403)
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))      # EMA weight averaging
+
+    # Diffusion hyperparameters.
+    noise_eps = float(os.environ.get("NOISE_EPS", 0.1))
+
+    # Eval hyperparameters.
+    max_eval_seqs = int(os.environ.get("MAX_EVAL_SEQS", 512))
+    final_eval_seqs = int(os.environ.get("FINAL_EVAL_SEQS", 100000))  # use all val seqs
+
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+
+# Control tensors: stored as float32 (small scalars that strongly affect quality)
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    p for p in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,mlp_scale,resid_mix,q_gain,skip_weights",
+    ).split(",") if p
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = CONTROL_TENSOR_NAME_PATTERNS
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(p in name for p in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    """Per-row int8 quantization with GPTQ-lite: try 5 clip percentiles, keep min MSE."""
+    t32 = t.float()
+    if t32.ndim == 2:
+        if not t32.numel():
+            return (torch.empty_like(t32, dtype=torch.int8),
+                    torch.empty((t32.shape[0],), dtype=INT8_PER_ROW_SCALE_DTYPE))
+        best_q: Tensor | None = None
+        best_scale: Tensor | None = None
+        best_err = float("inf")
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            clip_abs = torch.quantile(t32.abs(), pct, dim=1) if pct < 1.0 else t32.abs().amax(dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            q = torch.clamp(torch.round(t32 / scale[:, None]), -127, 127).to(torch.int8)
+            err = (t32 - q.float() * scale[:, None]).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_scale, best_err = q, scale, err
+        return best_q.contiguous(), best_scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()  # type: ignore[union-attr]
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors",
+         "baseline_tensor_bytes", "int8_payload_bytes"), 0,
+    )
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized, "scales": scales, "dtypes": dtypes, "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            out[name] = (q.float() * float(s.item())).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedSeqLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, batch_size: int, seq_len: int) -> Tensor:
+        total_tokens = batch_size * seq_len * self.world_size
+        chunk = self.stream.take(total_tokens)
+        rank_tokens = batch_size * seq_len
+        start = self.rank * rank_tokens
+        local = chunk[start : start + rank_tokens].to(dtype=torch.int64)
+        return local.reshape(batch_size, seq_len).to(self.device, non_blocking=True)
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP
+# -----------------------------
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = (tokens.numel() // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[:usable]
+
+
+def count_bytes_for_tokens(
+    token_ids: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> float:
+    flat = token_ids.reshape(-1)
+    byte_counts = base_bytes_lut[flat].to(torch.float64)
+    if flat.numel() > 1:
+        prev = flat[:-1]
+        curr = flat[1:]
+        extra = (has_leading_space_lut[curr] & ~is_boundary_token_lut[prev]).to(torch.float64)
+        byte_counts[1:] += extra
+    return byte_counts.sum().item()
+
+
+# -----------------------------
+# DISCRETE ELBO EVALUATION
+# -----------------------------
+
+def eval_elbo_bpb(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    """8-point trapezoidal ELBO evaluation. No terminal KL needed for absorbing diffusion."""
+    _t = [0.05, 0.1, 0.2, 0.35, 0.5, 0.65, 0.8, 0.95]
+    _w = [(_t[1]-_t[0])/2, (_t[2]-_t[0])/2, (_t[3]-_t[1])/2, (_t[4]-_t[2])/2,
+          (_t[5]-_t[3])/2, (_t[6]-_t[4])/2, (_t[7]-_t[5])/2, (_t[7]-_t[6])/2]
+    T_EVAL = torch.tensor(_t, device=device, dtype=torch.float32)
+    W_EVAL = torch.tensor(_w, device=device, dtype=torch.float64)
+
+    seq_len = args.train_seq_len
+    total_seqs = min(val_tokens.numel() // seq_len, args.max_eval_seqs)
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+
+    total_elbo_nats = torch.zeros((), device=device, dtype=torch.float64)
+    total_tokens = torch.zeros((), device=device, dtype=torch.float64)
+    total_bytes = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    batch_size = 4
+    unwrapped = model.module if hasattr(model, "module") else model
+    # Unwrap compiled model to access forward_logits
+    if hasattr(unwrapped, "_orig_mod"):
+        unwrapped = unwrapped._orig_mod
+
+    with torch.inference_mode():
+        for batch_start in range(seq_start, seq_end, batch_size):
+            batch_end = min(batch_start + batch_size, seq_end)
+            bsz = batch_end - batch_start
+            x0 = torch.stack([
+                val_tokens[s * seq_len : (s + 1) * seq_len]
+                for s in range(batch_start, batch_end)
+            ]).to(device=device, dtype=torch.int64)
+
+            for s in range(bsz):
+                total_bytes += count_bytes_for_tokens(
+                    x0[s], base_bytes_lut, has_leading_space_lut, is_boundary_token_lut
+                )
+
+            seq_elbo_nats = torch.zeros(bsz, device=device, dtype=torch.float64)
+            for t_val, w_val in zip(T_EVAL, W_EVAL):
+                t_f = float(t_val)
+                mask_k = torch.rand(bsz, seq_len, device=device) < t_f
+                xt = torch.where(mask_k, args.mask_id, x0)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = unwrapped.forward_logits(xt)  # (B, L, V) float32
+                log_probs = F.log_softmax(logits, dim=-1)
+                log_p_x0 = torch.gather(log_probs, -1, x0[..., None]).squeeze(-1)
+                ce_masked = (-log_p_x0) * mask_k.float()
+                step_nats = (float(w_val) / t_f) * ce_masked.sum(dim=-1)
+                seq_elbo_nats += step_nats.to(torch.float64)
+
+            total_elbo_nats += seq_elbo_nats.sum()
+            total_tokens += bsz * seq_len
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(total_elbo_nats, op=dist.ReduceOp.SUM)
+        dist.all_reduce(total_tokens, op=dist.ReduceOp.SUM)
+        dist.all_reduce(total_bytes, op=dist.ReduceOp.SUM)
+
+    val_loss = total_elbo_nats / total_tokens
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = total_tokens.item() / total_bytes.item()
+    val_bpb = bits_per_token * tokens_per_byte
+
+    model.train()
+    return float(val_loss.item()), float(val_bpb)
+
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class CastedLinear(nn.Linear):
+    """Weight stays fp32; cast to activation dtype at matmul time. Late-stage QAT via STE."""
+    _qat_enabled: bool = False
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            # STE: forward uses int8-quantized weights; gradient passes through identity
+            w32 = self.weight.detach().float()
+            scale = (w32.abs().amax(dim=1) / 127.0).clamp_min(1.0 / 127.0)
+            w_q = (torch.clamp(torch.round(w32 / scale[:, None]), -127, 127) * scale[:, None]).to(x.dtype)
+            w = w + (w_q - w).detach()  # STE: forward=w_q, backward=identity
+        return F.linear(x, w)
+
+
+def rms_norm(x: Tensor) -> Tensor:
+    return F.rms_norm(x, (x.size(-1),))
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class BidirectionalAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_groups: int, qk_gain_init: float):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.num_kv_heads = num_kv_groups if num_kv_groups > 0 else num_heads
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.c_proj = CastedLinear(dim, dim, bias=False)
+        self.c_proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+
+    def forward(self, x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+        B, T, _ = x.shape
+        q = self.c_q(x).reshape(B, T, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(B, T, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(B, T, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = rms_norm(q)
+        k = rms_norm(k)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(q, k, v, is_causal=False,
+                                           enable_gqa=(self.num_kv_heads != self.num_heads))
+        return self.c_proj(y.transpose(1, 2).contiguous().reshape(B, T, -1))
+
+
+class Block(nn.Module):
+    """Transformer block with resid_mix, attn/mlp scale, relu^2 MLP. No AdaLN."""
+    def __init__(self, dim: int, num_heads: int, mlp_mult: int, num_kv_groups: int, qk_gain_init: float):
+        super().__init__()
+        self.attn = BidirectionalAttention(dim, num_heads, num_kv_groups, qk_gain_init)
+        hidden = mlp_mult * dim
+        self.mlp_fc = CastedLinear(dim, hidden, bias=False)
+        self.mlp_proj = CastedLinear(hidden, dim, bias=False)
+        self.mlp_proj._zero_init = True
+        # Learnable per-channel scales (stored as float32, small → passthrough)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        # Learnable blend of current state and initial embedding x0
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(dim), torch.zeros(dim)]).float())
+
+    def forward(self, x: Tensor, x0: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * self.attn(rms_norm(x), cos, sin)
+        mlp_out = self.mlp_proj(torch.relu(self.mlp_fc(rms_norm(x))).square())
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * mlp_out
+        return x
+
+
+class DiffusionLM(nn.Module):
+    def __init__(self, args: Hyperparameters):
+        super().__init__()
+        self.args = args
+        dim = args.model_dim
+        self.tok_emb = nn.Embedding(args.total_vocab, dim)
+        self.blocks = nn.ModuleList([
+            Block(dim, args.num_heads, args.mlp_mult, args.num_kv_groups, args.qk_gain_init)
+            for _ in range(args.num_layers)
+        ])
+        # U-Net: encoder stores skips, decoder adds them in reverse
+        self.num_encoder_layers = args.num_layers // 2
+        self.num_decoder_layers = args.num_layers - self.num_encoder_layers
+        self.num_skip = min(
+            min(args.num_unet_layers, self.num_encoder_layers),
+            self.num_decoder_layers,
+        )
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip, dim, dtype=torch.float32))
+
+        # Precompute RoPE tables
+        hd = dim // args.num_heads
+        inv_freq = 1.0 / (args.rope_base ** (torch.arange(0, hd, 2, dtype=torch.float32) / hd))
+        freqs = torch.outer(torch.arange(args.train_seq_len * 2, dtype=torch.float32), inv_freq)
+        self.register_buffer("rope_cos", freqs.cos()[None, None, :, :])
+        self.register_buffer("rope_sin", freqs.sin()[None, None, :, :])
+
+        # Precompute logit bias: suppress mask token without in-place scatter (graph-break-free)
+        logit_bias = torch.zeros(args.total_vocab)
+        logit_bias[args.mask_id] = -1e6
+        self.register_buffer("logit_bias", logit_bias)
+
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        nn.init.normal_(self.tok_emb.weight, mean=0.0, std=0.005)
+        for module in self.modules():
+            if isinstance(module, CastedLinear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                else:
+                    nn.init.orthogonal_(module.weight)  # orthogonal: better early convergence than Kaiming
+
+    def _forward_blocks(self, xt: Tensor) -> Tensor:
+        """Shared encoder/decoder pass with depth recurrence. Returns (B, L, dim) hidden states."""
+        B, L = xt.shape
+        x = rms_norm(self.tok_emb(xt))
+        x0 = x
+        cos = self.rope_cos[:, :, :L].to(dtype=x.dtype)
+        sin = self.rope_sin[:, :, :L].to(dtype=x.dtype)
+
+        # Encoder: collect skips (pre-allocated to avoid dynamic list growth)
+        skips: list[Tensor] = [x] * self.num_encoder_layers
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0, cos, sin)
+            skips[i] = x
+
+        # Depth recurrence: loop encoder layers [recurrence_start, recurrence_end) extra times
+        # Gives more effective depth without adding parameters (same artifact size)
+        args = self.args
+        for _ in range(args.recurrence_extra):
+            for i in range(args.recurrence_start, args.recurrence_end):
+                x = self.blocks[i](x, x0, cos, sin)
+
+        # Decoder: add reversed encoder skips (last encoder → first decoder)
+        for i in range(self.num_decoder_layers):
+            if i < self.num_skip:
+                skip_idx = self.num_skip - 1 - i
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips[self.num_encoder_layers - self.num_skip + skip_idx]
+            x = self.blocks[self.num_encoder_layers + i](x, x0, cos, sin)
+
+        return x
+
+    def _logits(self, h: Tensor) -> Tensor:
+        """Project hidden states to vocab logits with softcap."""
+        cap = self.args.logit_softcap
+        logits = F.linear(rms_norm(h), self.tok_emb.weight).float()[..., :self.args.total_vocab]
+        logits = logits + self.logit_bias  # suppress mask token without in-place scatter
+        return cap * torch.tanh(logits / cap)
+
+    def forward(self, masked_ids: Tensor, original_ids: Tensor, mask_float: Tensor, t: Tensor) -> Tensor:
+        """Training forward: returns (1/t)-weighted CE loss scalar."""
+        h = self._forward_blocks(masked_ids)
+        logits = self._logits(h)
+        B, L = masked_ids.shape
+        ce = F.cross_entropy(logits.reshape(-1, self.args.total_vocab), original_ids.reshape(-1), reduction="none")
+        flat_mask = mask_float.reshape(-1)
+        inv_t = (1.0 / t).unsqueeze(1).expand(B, L).reshape(-1)
+        w = flat_mask * inv_t
+        return (ce * w).sum() / w.sum()
+
+    def forward_logits(self, xt: Tensor) -> Tensor:
+        """Eval forward: returns (B, L, V) logits."""
+        return self._logits(self._forward_blocks(xt))
+
+
+# -----------------------------
+# MDLM TRAINING LOSS
+# -----------------------------
+
+def create_mdlm_mask(
+    x0: Tensor, mask_id: int, noise_eps: float
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Create masked inputs with antithetic mask-fraction sampling."""
+    B, L = x0.shape
+    eps = noise_eps
+    # Antithetic: pair t and (1+eps-t), both in [eps, 1]
+    t_half = torch.rand(B // 2 + 1, device=x0.device) * (1 - eps) + eps
+    t = torch.cat([t_half, (1 + eps) - t_half])[:B]
+    mask_float = (torch.rand(B, L, device=x0.device) < t[:, None]).float()
+    masked_ids = torch.where(mask_float.bool(), mask_id, x0)
+    return masked_ids, mask_float, t
+
+
+# -----------------------------
+# MUON OPTIMIZER (distributed shard)
+# -----------------------------
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 5, eps: float = 1e-7) -> Tensor:
+    a, b, c = 3.4445, -4.7750, 2.0315
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        X = a * X + (b * A + c * A @ A) @ X
+    return X.T if transposed else X
+
+
+zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """Muon with distributed Newton-Schulz sharding across GPUs."""
+    def __init__(self, params, lr: float = 0.02, momentum: float = 0.95,
+                 nesterov: bool = True, ns_steps: int = 5, weight_decay: float = 0.0):
+        super().__init__(params, dict(lr=lr, momentum=momentum, nesterov=nesterov, ns_steps=ns_steps,
+                                     weight_decay=weight_decay))
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            nesterov = group["nesterov"]
+            ns_steps = group["ns_steps"]
+            params = [p for p in group["params"] if p.grad is not None]
+            if not params:
+                continue
+
+            total = sum(p.numel() for p in params)
+            updates_flat = torch.zeros(total, device=params[0].device, dtype=torch.bfloat16)
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "buf" not in state:
+                        state["buf"] = torch.zeros_like(g)
+                    buf = state["buf"]
+                    buf.mul_(momentum).add_(g)
+                    update = g.add(buf, alpha=momentum) if nesterov else buf.clone()
+                    update = zeropower_via_newtonschulz5(update, steps=ns_steps)
+                    update *= max(1, update.size(0) / update.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = update.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                if wd > 0.0:
+                    p.data.mul_(1.0 - lr * wd)  # Decoupled L2 weight decay before update
+                p.add_(updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype), alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    grad_accum_steps = max(args.grad_accum_steps, 8 // world_size)
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_flash_sdp, enable_cudnn_sdp, enable_mem_efficient_sdp, enable_math_sdp
+    enable_flash_sdp(True)
+    enable_cudnn_sdp(False)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_tokens:{val_tokens.numel()}")
+
+    # Model: fp32 weights via CastedLinear; control/small tensors also fp32
+    base_model = DiffusionLM(args).to(device).bfloat16()
+    # Restore CastedLinear weights and small/control params to fp32
+    with torch.no_grad():
+        for name, param in base_model.named_parameters():
+            if (param.ndim < 2 or
+                    any(pat in name for pat in CONTROL_TENSOR_NAME_PATTERNS) or
+                    "tok_emb" in name):
+                param.data = param.data.float()
+            elif isinstance(base_model.blocks[0].attn.c_q if base_model.blocks else None, CastedLinear):
+                pass  # CastedLinear weights restored below
+        for module in base_model.modules():
+            if isinstance(module, CastedLinear):
+                module.weight.data = module.weight.data.float()
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model:DiffusionLM(MDLM) params:{n_params}")
+    log0(f"arch: {args.num_layers}L {args.model_dim}d {args.num_heads}h relu^2-hidden={args.mlp_mult * args.model_dim} kv_groups={args.num_kv_groups}")
+    log0(f"training: muon_lr={args.muon_lr} embed_lr={args.embed_lr} scalar_lr={args.scalar_lr}")
+    log0(f"diffusion: noise_eps={args.noise_eps}")
+    log0(f"batch: {args.batch_size_per_gpu}x{world_size}x{grad_accum_steps} seq_len={args.train_seq_len}")
+
+    # Compile for speed — fullgraph=True requires static control flow (fixed num_layers)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    # Optimizer groups: matrix weights (Muon), tok_emb (Adam), scalars (Adam)
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p for name, p in block_named_params
+        if p.ndim == 2 and not any(pat in name for pat in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p for name, p in block_named_params
+        if p.ndim < 2 or any(pat in name for pat in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params.append(base_model.skip_weights)
+
+    optimizer_muon = Muon(matrix_params, lr=args.muon_lr, momentum=args.muon_momentum,
+                          ns_steps=args.muon_ns_steps, weight_decay=args.muon_weight_decay)
+    for g in optimizer_muon.param_groups:
+        g["base_lr"] = args.muon_lr
+
+    optimizer_emb = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": args.embed_lr, "base_lr": args.embed_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,  # no WD on embedding
+    )
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizers = [optimizer_muon, optimizer_emb, optimizer_scalar]
+    log0(f"optimizer: Muon({len(matrix_params)} matrices, wd={args.muon_weight_decay}) + Adam(emb+scalars, wd={args.adam_weight_decay})")
+
+    train_loader = DistributedSeqLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_scale(step: int, elapsed_ms: float) -> float:
+        """Returns LR multiplier. Linear warmdown to min_lr_ratio (0 by default, matches #1403)."""
+        if max_wallclock_ms is None:
+            return 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        if remaining_ms <= warmdown_ms:
+            progress = remaining_ms / max(warmdown_ms, 1e-9)  # 1.0 at start, 0.0 at end
+            return args.min_lr_ratio + (1.0 - args.min_lr_ratio) * progress  # Linear
+        return 1.0
+
+    # Warmup: prime torch.compile then reset state
+    if args.warmup_steps > 0:
+        saved_model = {n: t.detach().cpu().clone() for n, t in base_model.state_dict().items()}
+        saved_opts = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for wu_step in range(args.warmup_steps):
+            zero_grad_all()
+            x0 = train_loader.next_batch(args.batch_size_per_gpu, args.train_seq_len)
+            masked_ids, mask_float, t = create_mdlm_mask(x0, args.mask_id, args.noise_eps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                loss = model(masked_ids, x0, mask_float, t) / grad_accum_steps
+            loss.backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            log0(f"warmup_step:{wu_step+1}/{args.warmup_steps}")
+        base_model.load_state_dict(saved_model, strict=True)
+        for opt, state in zip(optimizers, saved_opts):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        train_loader = DistributedSeqLoader(args.train_files, rank, world_size, device)
+
+    # EMA state: maintain running average of float32 model weights
+    ema_state: dict[str, Tensor] = {}
+    if args.ema_decay > 0:
+        ema_state = {n: p.detach().float().clone() for n, p in base_model.named_parameters()}
+
+    # Main training loop
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    ema_loss = 0.0
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_elbo_bpb(
+                args, model, rank, world_size, device,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms step:{step}/{args.iterations}")
+            break
+
+        # LR schedule
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_scale(step, elapsed_ms)
+        for opt in optimizers:
+            for g in opt.param_groups:
+                g["lr"] = g["base_lr"] * scale
+
+        # Muon momentum warmup
+        frac = min(step / max(args.muon_momentum_warmup_steps, 1), 1.0)
+        mom = (1 - frac) * 0.85 + frac * args.muon_momentum
+        for g in optimizer_muon.param_groups:
+            g["momentum"] = mom
+
+        # Training step
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x0 = train_loader.next_batch(args.batch_size_per_gpu, args.train_seq_len)
+            masked_ids, mask_float, t = create_mdlm_mask(x0, args.mask_id, args.noise_eps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                loss = model(masked_ids, x0, mask_float, t) / grad_accum_steps
+            train_loss += loss.detach() * grad_accum_steps
+            loss.backward()
+        train_loss /= grad_accum_steps
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+
+        # EMA update
+        if ema_state:
+            with torch.no_grad():
+                for n, p in base_model.named_parameters():
+                    ema_state[n].mul_(args.ema_decay).add_(p.float(), alpha=1.0 - args.ema_decay)
+
+        # Late-stage QAT trigger: enable STE int8 simulation when LR drops below 40% (~last 480 steps)
+        if not CastedLinear._qat_enabled:
+            should_enable = scale < 0.40
+            if distributed:
+                enable_tensor = torch.tensor(int(should_enable), device=device)
+                dist.all_reduce(enable_tensor, op=dist.ReduceOp.MAX)
+                should_enable = bool(enable_tensor.item())
+            if should_enable:
+                CastedLinear._qat_enabled = True
+                log0(f"QAT enabled: step={step} lr_scale={scale:.3f}")
+
+        step += 1
+        tl = train_loss.item()
+        ema_loss = tl if step == 1 else 0.95 * ema_loss + 0.05 * tl
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log = args.train_log_every > 0 and (step <= 10 or step % args.train_log_every == 0)
+        if should_log:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{tl:.4f} ema_loss:{ema_loss:.4f} lr_scale:{scale:.3f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # Load EMA weights before serialization (if EMA is active, use averaged weights)
+    if ema_state:
+        sd = base_model.state_dict()
+        ema_sd = {n: ema_state[n].to(sd[n].dtype) for n in ema_state}
+        base_model.load_state_dict(ema_sd, strict=False)
+        log0("EMA weights loaded for serialization")
+
+    # Serialization + roundtrip validation
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+
+    saved_max_eval = args.max_eval_seqs
+    args.max_eval_seqs = args.final_eval_seqs
+    log0(f"final_eval: {args.max_eval_seqs} sequences (training used {saved_max_eval})")
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_elbo_bpb(
+        args, base_model, rank, world_size, device,
+        val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

**val_bpb: 1.3428** (int8+zlib roundtrip) | **14.73 MB** | 8×H100 SXM, 600s | Beats #1403 by 0.0057 BPB

Extends the MDLM baseline (#1403) with depth recurrence and quantization improvements.

## Stack

- **Depth recurrence**: physical layers L1–L3 looped 1× extra → 12 effective layers / 9 physical layers
- **QAT (STE)**: straight-through quantization at lr_scale < 0.40 (~last 480 steps of 8,049 total)
- **EMA** (decay=0.997) applied before serialization
- **GPTQ-lite**: 5-candidate percentile clip search (99.9%→100%) per row, min-MSE selection
- **Linear LR → 0** (Muon warmdown), **relu² MLP**, **Muon WD=0.01**

## Results (8×H100 SXM, seed=1337, 600s)

| Metric | This | #1403 |
|--------|------|-------|
| Pre-quant val_bpb | 1.3379 | 1.3409 |
| **Post-roundtrip val_bpb** | **1.3428** | 1.3485 |
| Quant penalty | **0.0049** | 0.0076 |
| Artifact | 14.73 MB | 15.63 MB |
| Steps | 8,049 | 11,808 |
| ms/step | 74.6 ms | 50.8 ms |

EMA + GPTQ-lite cuts quant penalty from 0.0076 → 0.0049. Depth recurrence improves pre-quant quality (1.3379 vs 1.3409) even with fewer steps, because ~12 effective layers of compute per forward pass.