### PR TITLE
Notable Non-Record: Switched Deep Supervision (first DS submission)

### DIFF
--- a/records/track_non_record_16mb/2026-04-14_SwitchedDeepSupervision/README.md
+++ b/records/track_non_record_16mb/2026-04-14_SwitchedDeepSupervision/README.md
@@ -1,0 +1,159 @@
+# Notable Non-Record: Switched Deep Supervision
+
+**val_bpb: 1.08288** (TTT, single-seed) | **val_bpb: 1.08449** (sliding window, single-seed) | **15.997 MB artifact** | 8×H100 SXM, 588s
+
+The first Deep Supervision (DS) submission in the Parameter Golf competition. Introduces **Switched Deep Supervision** — a training-time technique that adds intermediate cross-entropy supervision through the shared LM head at randomly-selected layers each step.
+
+This submission does NOT beat SOTA (PR #1493 at 1.0810 BPB). It is presented as scientifically interesting research on auxiliary loss techniques in compute-constrained LM training, with detailed negative results and ongoing work.
+
+## Results (Single Seed 42)
+
+| Metric | Value |
+|--------|-------|
+| Pre-quantization post-EMA BPB | 1.08933 |
+| Quantized BPB | 1.10110 |
+| **Quantized sliding window BPB** | **1.08449** |
+| **Quantized + TTT BPB** | **1.08288** |
+| Total artifact size | 15,997,104 bytes |
+| Training steps | 4316 |
+| Training time | 588 seconds (8×H100) |
+
+For comparison: merged SOTA (PR #1493) achieves 1.0810 TTT (3-seed mean). Our gap: +0.0019 BPB.
+
+## Novel Contributions
+
+### 1. Deep Supervision via Shared LM Head
+At selected intermediate transformer layers (default 6, 7, 9), compute auxiliary cross-entropy loss using the shared LM head:
+
+```
+total_loss = main_CE + alpha * mean(layer_CE_for_each_DS_layer)
+```
+
+No new parameters — reuses the existing tied embedding / LM head. Zero artifact cost. The supervision provides direct gradient signals to intermediate layers, accelerating per-step convergence.
+
+**Inspired by:** LayerSkip (Meta ACL 2024), Deeply Supervised Nets (Lee et al. 2015).
+
+### 2. Switched DS — Random Single-Layer Supervision
+Standard DS supervises ALL selected layers every step (3 auxiliary losses per step in our config). We introduce **Switched DS**: randomly pick ONE layer per step instead. Reduces compute overhead by ~3x while preserving most of the per-step benefit.
+
+**Per-step supervision rotation:** Over thousands of steps, each DS layer receives ~1/N of the supervision events but with diverse training contexts. Our experiments show Switched DS produces better final BPB than non-switched DS at the same wallclock budget.
+
+**Inspired by:** "Switched Auxiliary Loss" literature in multi-task learning.
+
+### 3. Fraction-Based DS Decay
+DS auxiliary loss alpha is ramped up over `DS_WARMUP_STEPS`, then linearly decayed to 0 between `DS_DECAY_START_FRAC=0.70` and `DS_DECAY_END_FRAC=0.85` of total training. This decouples DS-induced weight oscillation from the final EMA averaging window, allowing EMA to capture clean post-DS weights.
+
+### 4. Per-Layer Adaptive GPTQ + int7 Embeddings
+For artifact size compliance, we adopt per-layer adaptive GPTQ clipping (PR #1586 lineage):
+- MLP weights: int6 with `MLP_CLIP_SIGMAS=12.0` (tighter)
+- Attention weights: int6 with `ATTN_CLIP_SIGMAS=13.0`
+- Embeddings: int7 with `EMBED_CLIP_SIGMAS=15.0` (saves ~530 KB vs int8)
+
+This brings total artifact to 15.997 MB (within 16 MB limit).
+
+## Architecture
+
+Built on the April 2026 SOTA stack (PR #1493 by bigbag):
+
+| Component | Setting |
+|-----------|---------|
+| Tokenizer | SP8192 |
+| Layers | 11 physical, 512d, 8 heads, 4 KV heads |
+| Depth Recurrence | Loop layers 3-5 three times, activate at 35% |
+| Parallel Residuals | Layers 7-10 (GPT-J style) |
+| MLP | 4x expansion (2048 hidden), LeakyReLU(0.5)^2 |
+| Optimizer | MuonEq-R (row-normalized Muon), WD=0.095 |
+| QK-Gain | 5.25 |
+| Attention | XSA on all 11 layers, FlashAttention 3 |
+| EMA decay | 0.9965 |
+| Warmdown | Wallclock-fraction 0.72 |
+| TTT | Score-first SGD, 3 epochs per chunk, cosine decay |
+| **DS layers** | **6, 7, 9 (switched, alpha=0.01)** |
+| **DS schedule** | **warmup 200 steps, decay 70%-85% of training** |
+
+## Negative Results (What We Tried That Didn't Work)
+
+These findings may be valuable to others exploring auxiliary loss approaches:
+
+### Predictive Coding (PC) with Cosine Similarity
+Tried cosine-similarity loss between intermediate layer outputs and (detached) next layer outputs. **Net negative across all alpha values tested (0.005, 0.01, 0.1).** Cosine similarity gradients shrink inversely with hidden state norms — pathological at scale.
+
+### Multi-Token Prediction (MTP)
+Combined DS with MTP heads predicting tokens t+2, t+3 via small transformer blocks sharing the LM head:
+
+| MTP Variant | Sliding BPB | Verdict |
+|-------------|-------------|---------|
+| Block heads, horizons=2 | 1.09332 | -0.010 worse than pure DS |
+| Block heads, horizons=1 | 1.08931 | -0.006 worse |
+| Medusa heads (linear), horizons=2 | ~1.088 | -0.005 worse |
+| Medusa heads (linear), horizons=1 | 1.08526 | -0.0016 worse |
+
+**Verdict:** MTP provides genuine per-step convergence benefit (~0.005 BPB) but adds throughput overhead and EMA oscillation that consistently outweigh the gain. Even the lightest configuration (Medusa linear heads, 1 horizon) underperforms pure Switched DS at our compute budget.
+
+This corroborates SPThole's broader finding (PR #1602): "Auxiliary losses are fatal in compute-starved regimes." However, our switched DS specifically is *not* fatal — it's slightly net-positive vs no-DS baseline at the per-step level, with throughput cost slightly exceeding the per-step gain.
+
+## Ongoing / Future Work
+
+### Top-K Sampled Softmax for DS Auxiliary Losses (in progress)
+The dominant cost of DS is the LM head matmul (512 × 8192). We are exploring **sampled softmax with K random negatives** to reduce auxiliary loss compute by ~16x:
+
+```
+DS_aux_loss = CE([target, K random negatives], target_at_index_0)
+```
+
+This is mathematically a biased approximation of full CE but should preserve the gradient direction sufficiently for auxiliary supervision. Implementation is on a separate branch and pending H100 validation.
+
+If successful, this would unlock **non-switched DS** (supervising all 3 layers every step at affordable compute), potentially providing strong enough per-step benefit to overcome the throughput penalty and beat SOTA.
+
+This direction has zero precedent in the competition (verified across ~1600 PRs) — sparse/top-K LM head techniques are completely unexplored territory here.
+
+## Reproduction
+
+```bash
+# Install dependencies
+pip install brotli sentencepiece flash_attn_3
+
+# Download SP8192 dataset (Kevin Clark's HF mirror)
+MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf python3 data/cached_challenge_fineweb.py --variant sp8192
+
+# Run training (8×H100)
+SEED=42 \
+DS_ENABLED=1 DS_SWITCHED=1 DS_ALPHA=0.01 DS_WARMUP_STEPS=200 \
+DS_LAYERS=6,7,9 DS_DECAY_START_FRAC=0.70 DS_DECAY_END_FRAC=0.85 \
+QK_GAIN_INIT=5.25 \
+TTT_ENABLED=1 TTT_LR=0.005 TTT_EPOCHS=3 \
+WARMDOWN_FRAC=0.72 \
+MLP_CLIP_SIGMAS=12.0 ATTN_CLIP_SIGMAS=13.0 \
+EMBED_BITS=7 EMBED_CLIP_SIGMAS=15.0 \
+COMPRESSOR=brotli \
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+## Compliance (Track B)
+
+- **Condition 1 (Causality):** Sliding-window eval, prefix only ✓
+- **Condition 2 (Normalized):** Standard softmax, no n-gram/logit bias ✓
+- **Condition 3 (Score before update):** Each TTT chunk scored under `torch.no_grad()` BEFORE SGD ✓
+- **Condition 4 (Single pass):** Each token scored once, no rescoring ✓
+
+DS heads are training-only (not in artifact). All artifacts < 16,000,000 bytes. Training < 600s on 8×H100.
+
+## Credits
+
+Built on the SOTA stack from:
+- PR #1493 (bigbag): SP8192 + 3-Layer Recurrence + Parallel Residuals + Legal TTT
+- PR #1394 (Kevin Clark): SP8192 tokenizer + GPTQ Embeddings + Depth Recurrence + SDClip
+- PR #1412 (Robby Sneiderman): Parallel Residuals
+- PR #1586 (dexhunter): Per-Layer Adaptive GPTQ Clip + int7 Embeddings
+- PR #1019 (abaybektursun): XSA-all + AR Self-Gen GPTQ + BigramHash
+- PR #549 (abaybektursun): Score-First TTT framework
+
+## Status
+
+This is a **non-record submission** (does not beat current SOTA). Posted as documentation of:
+1. The first Deep Supervision attempt in the competition
+2. Switched DS as a novel auxiliary loss scheduling strategy
+3. Negative results on PC and MTP variants
+4. Roadmap for top-K sampled softmax (in progress)
+
+3-seed validation pending. Single-seed (seed 42) result reported above.

--- a/records/track_non_record_16mb/2026-04-14_SwitchedDeepSupervision/requirements.txt
+++ b/records/track_non_record_16mb/2026-04-14_SwitchedDeepSupervision/requirements.txt
@@ -1,0 +1,5 @@
+torch>=2.9.0
+numpy>=1.24
+sentencepiece>=0.2.0
+brotli>=1.1.0
+flash_attn_3

--- a/records/track_non_record_16mb/2026-04-14_SwitchedDeepSupervision/submission.json
+++ b/records/track_non_record_16mb/2026-04-14_SwitchedDeepSupervision/submission.json
@@ -1,0 +1,51 @@
+{
+  "track": "non_record_16mb",
+  "date": "2026-04-14",
+  "name": "Switched Deep Supervision (first DS submission)",
+  "author": "channyzf6",
+  "github_id": "channyzf6",
+  "blurb": "First Deep Supervision (DS) submission in the competition. Introduces Switched DS — random single-layer auxiliary CE supervision through the shared LM head — combined with per-layer adaptive GPTQ + int7 embeddings. Single-seed result: TTT BPB 1.08288, sliding BPB 1.08449, artifact 15.997 MB. Includes documented negative results on PC (cosine similarity inter-layer prediction) and MTP variants (block, Medusa-style, multiple horizons).",
+  "val_bpb": 1.08288,
+  "val_loss": 2.79718,
+  "val_bpb_sliding": 1.08449,
+  "val_bpb_quantized": 1.10110,
+  "val_bpb_pre_quant_post_ema": 1.08933,
+  "seeds": [42],
+  "seed_results": {
+    "42": {
+      "val_bpb_pre_quant_post_ema": 1.08933,
+      "val_bpb_quantized": 1.10110,
+      "val_bpb_sliding": 1.08449,
+      "val_bpb_ttt": 1.08288,
+      "artifact_bytes": 15997104,
+      "steps": 4316,
+      "training_time_seconds": 588
+    }
+  },
+  "bytes_total": 15997104,
+  "hardware": "8xH100 80GB SXM",
+  "pytorch_version": "2.9.1+cu128",
+  "techniques": [
+    "Switched Deep Supervision (random single layer per step, alpha=0.01)",
+    "Fraction-based DS alpha decay (active 0-70%, decay 70-85%, off 85-100%)",
+    "Per-layer adaptive GPTQ (MLP sigma=12.0, attn sigma=13.0)",
+    "int7 embeddings (sigma=15.0) — saves ~530KB",
+    "SP8192 tokenizer",
+    "Depth recurrence (loop layers 3-5, 3x, activate at 35%)",
+    "Parallel residuals (layers 7-10, GPT-J style)",
+    "MuonEq-R optimizer with WD=0.095",
+    "QK-Gain 5.25",
+    "XSA on all 11 layers",
+    "Legal score-first TTT (SGD lr=0.005, mom=0.9, 3 epochs)",
+    "EMA decay 0.9965, warmdown fraction 0.72"
+  ],
+  "novel_contributions": [
+    "First Deep Supervision submission in the competition",
+    "Switched DS — random single-layer aux supervision (novel scheduling)",
+    "Documented negative results on PC and MTP variants"
+  ],
+  "comparison_baseline_pr": 1493,
+  "delta_vs_sota_bpb": 0.0019,
+  "is_record": false,
+  "notes": "Single-seed result; 3-seed validation pending. Top-K sampled softmax for DS auxiliary losses is in progress on a separate branch — would unlock non-switched DS at affordable compute and potentially beat SOTA."
+}

--- a/records/track_non_record_16mb/2026-04-14_SwitchedDeepSupervision/train_gpt.py
+++ b/records/track_non_record_16mb/2026-04-14_SwitchedDeepSupervision/train_gpt.py
@@ -1,0 +1,2021 @@
+"""
+train_gpt_pc.py — Parameter Golf GPT Training with Predictive Coding
+
+Clean, readable version of the SOTA (1.0810 BPB) from PR #1493, with the
+addition of Predictive Coding auxiliary losses.
+
+Architecture:
+  - SP8192 tokenizer (vocab_size=8192)
+  - 11 layers, 512d, 8 heads, 4 KV heads, MLP 4x (2048 hidden)
+  - Depth recurrence: loop layers 3-5 three times (17 virtual layers),
+    activated at 35% training progress
+  - Parallel residuals: layers 7-10 (GPT-J style)
+  - MuonEq-R: row-normalized Muon with WD=0.095
+  - QK-Gain 5.0, XSA on all 11 layers
+  - SDClip GPTQ: int6 matrices (k=12.85), int8 embeddings (k=20)
+  - Brotli compression with byte-shuffle
+  - EMA decay=0.9965
+  - Warmdown fraction 0.72 (wallclock-based)
+  - Score-first TTT: SGD(lr=0.005, mom=0.9), 3 epochs, cosine decay
+  - ShuffledSequenceLoader (shard-based, per-rank shuffled sequences)
+  - Skip gates (sigmoid-gated skip connections)
+
+Novel addition — Predictive Coding (PC):
+  Each intermediate layer predicts the next layer's hidden state via a
+  small linear projection.  The cosine-similarity loss is weighted by a
+  ramping alpha that warms up over pc_warmup_steps and decays with the
+  learning-rate warmdown.  PC heads are stripped before quantization
+  and excluded from the final artifact.
+"""
+
+import collections
+import copy
+import glob
+import io
+import lzma
+import math
+import os
+from pathlib import Path
+import random
+import re
+import subprocess
+import sys
+import time
+import uuid
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+from flash_attn_interface import flash_attn_func as flash_attn_3_func
+
+
+# ---------------------------------------------------------------------------
+# Hyperparameters
+# ---------------------------------------------------------------------------
+
+class Hyperparameters:
+    # Directories / seeds
+    data_dir        = os.environ.get('DATA_DIR', './data/')
+    seed            = int(os.environ.get('SEED', 1337))
+    run_id          = os.environ.get('RUN_ID', str(uuid.uuid4()))
+
+    # Training schedule
+    iterations      = int(os.environ.get('ITERATIONS', 20000))
+    warmdown_frac   = float(os.environ.get('WARMDOWN_FRAC', 0.72))
+    warmup_steps    = int(os.environ.get('WARMUP_STEPS', 20))
+    train_batch_tokens = int(os.environ.get('TRAIN_BATCH_TOKENS', 786432))
+    train_seq_len   = int(os.environ.get('TRAIN_SEQ_LEN', 2048))
+    train_log_every = int(os.environ.get('TRAIN_LOG_EVERY', 500))
+    max_wallclock_seconds = float(os.environ.get('MAX_WALLCLOCK_SECONDS', 600))
+
+    # Validation / eval
+    val_batch_tokens = int(os.environ.get('VAL_BATCH_TOKENS', 524288))
+    eval_seq_len    = int(os.environ.get('EVAL_SEQ_LEN', 2048))
+    val_loss_every  = int(os.environ.get('VAL_LOSS_EVERY', 4000))
+    sliding_window_enabled = bool(int(os.environ.get('SLIDING_WINDOW_ENABLED', '1')))
+
+    # Model architecture
+    vocab_size      = int(os.environ.get('VOCAB_SIZE', 8192))
+    num_layers      = int(os.environ.get('NUM_LAYERS', 11))
+    xsa_last_n      = int(os.environ.get('XSA_LAST_N', 11))
+    model_dim       = int(os.environ.get('MODEL_DIM', 512))
+    embedding_dim   = int(os.environ.get('EMBEDDING_DIM', 512))
+    num_kv_heads    = int(os.environ.get('NUM_KV_HEADS', 4))
+    num_heads       = int(os.environ.get('NUM_HEADS', 8))
+    mlp_mult        = float(os.environ.get('MLP_MULT', 4.0))
+
+    # Skip gates
+    skip_gates_enabled = bool(int(os.environ.get('SKIP_GATES_ENABLED', '1')))
+
+    # Tied embeddings
+    tie_embeddings  = bool(int(os.environ.get('TIE_EMBEDDINGS', '1')))
+    logit_softcap   = float(os.environ.get('LOGIT_SOFTCAP', 30.0))
+
+    # RoPE
+    rope_base       = float(os.environ.get('ROPE_BASE', 10000.0))
+    rope_dims       = int(os.environ.get('ROPE_DIMS', 16))
+    rope_train_seq_len = int(os.environ.get('ROPE_TRAIN_SEQ_LEN', 2048))
+
+    # Layer norm scaling
+    ln_scale        = bool(int(os.environ.get('LN_SCALE', '1')))
+    qk_gain_init    = float(os.environ.get('QK_GAIN_INIT', 5.0))
+
+    # Depth recurrence (layer looping)
+    num_loops       = int(os.environ.get('NUM_LOOPS', 2))
+    loop_start      = int(os.environ.get('LOOP_START', 3))
+    loop_end        = int(os.environ.get('LOOP_END', 5))
+    enable_looping_at = float(os.environ.get('ENABLE_LOOPING_AT', 0.35))
+
+    # Parallel residuals (GPT-J style)
+    parallel_residual_start = int(os.environ.get('PARALLEL_RESIDUAL_START', 7))
+
+    # Learning rates
+    min_lr          = float(os.environ.get('MIN_LR', 0.0))
+    embed_lr        = float(os.environ.get('EMBED_LR', 0.6))
+    head_lr         = float(os.environ.get('HEAD_LR', 0.008))
+    tied_embed_lr   = float(os.environ.get('TIED_EMBED_LR', 0.03))
+    tied_embed_init_std = float(os.environ.get('TIED_EMBED_INIT_STD', 0.005))
+    matrix_lr       = float(os.environ.get('MATRIX_LR', 0.022))
+    scalar_lr       = float(os.environ.get('SCALAR_LR', 0.02))
+
+    # Muon optimizer
+    muon_momentum   = float(os.environ.get('MUON_MOMENTUM', 0.99))
+    muon_backend_steps = int(os.environ.get('MUON_BACKEND_STEPS', 5))
+    muon_momentum_warmup_start = float(os.environ.get('MUON_MOMENTUM_WARMUP_START', 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get('MUON_MOMENTUM_WARMUP_STEPS', 1500))
+    muon_row_normalize = bool(int(os.environ.get('MUON_ROW_NORMALIZE', '1')))
+
+    # Adam
+    beta1           = float(os.environ.get('BETA1', 0.9))
+    beta2           = float(os.environ.get('BETA2', 0.95))
+    adam_eps         = float(os.environ.get('ADAM_EPS', 1e-8))
+    grad_clip_norm  = float(os.environ.get('GRAD_CLIP_NORM', 0.3))
+    eval_stride     = int(os.environ.get('EVAL_STRIDE', 64))
+    muon_beta2      = float(os.environ.get('MUON_BETA2', 0.95))
+    adam_wd         = float(os.environ.get('ADAM_WD', 0.02))
+    muon_wd         = float(os.environ.get('MUON_WD', 0.095))
+    embed_wd        = float(os.environ.get('EMBED_WD', 0.085))
+
+    # EMA
+    ema_decay       = float(os.environ.get('EMA_DECAY', 0.9965))
+
+    # Test-time training (TTT)
+    ttt_enabled     = bool(int(os.environ.get('TTT_ENABLED', '0')))
+    ttt_lr          = float(os.environ.get('TTT_LR', 0.005))
+    ttt_epochs      = int(os.environ.get('TTT_EPOCHS', 3))
+    ttt_momentum    = float(os.environ.get('TTT_MOMENTUM', 0.9))
+    ttt_chunk_tokens = int(os.environ.get('TTT_CHUNK_TOKENS', 32768))
+
+    # Entropy-based token-level boosting (ETLB) — stub
+    etlb_enabled    = bool(int(os.environ.get('ETLB_ENABLED', '0')))
+    etlb_lr         = float(os.environ.get('ETLB_LR', 0.05))
+    etlb_steps      = int(os.environ.get('ETLB_STEPS', 5))
+    etlb_clip       = float(os.environ.get('ETLB_CLIP', 3.0))
+
+    # Compression / quantization
+    compressor      = os.environ.get('COMPRESSOR', 'brotli')
+    gptq_calibration_batches = int(os.environ.get('GPTQ_CALIBRATION_BATCHES', 64))
+    gptq_reserve_seconds = float(os.environ.get('GPTQ_RESERVE_SECONDS', 12.0))
+    matrix_bits     = int(os.environ.get('MATRIX_BITS', 6))
+    embed_bits      = int(os.environ.get('EMBED_BITS', 8))
+    matrix_clip_sigmas = float(os.environ.get('MATRIX_CLIP_SIGMAS', 12.85))
+    embed_clip_sigmas  = float(os.environ.get('EMBED_CLIP_SIGMAS', 20.0))
+    # Per-layer adaptive GPTQ clipping: MLP and attention get different sigmas.
+    # MLP tighter (more precision where weights are well-conditioned).
+    # Attn looser (preserve outliers in K/Q/V which have larger variance).
+    # Defaults match MATRIX_CLIP_SIGMAS for backward compat (single-sigma mode).
+    mlp_clip_sigmas  = float(os.environ.get('MLP_CLIP_SIGMAS', matrix_clip_sigmas))
+    attn_clip_sigmas = float(os.environ.get('ATTN_CLIP_SIGMAS', matrix_clip_sigmas))
+
+    # ---- Deep Supervision (novel addition) ----
+    # Intermediate CE loss at selected layers through the shared LM head.
+    # Each selected layer predicts the next token directly — a much more direct
+    # training signal than inter-layer hidden state prediction (PC).
+    ds_enabled            = bool(int(os.environ.get('DS_ENABLED', '1')))
+    ds_alpha              = float(os.environ.get('DS_ALPHA', 0.01))
+    ds_warmup_steps       = int(os.environ.get('DS_WARMUP_STEPS', 200))
+    ds_decay_with_warmdown = bool(int(os.environ.get('DS_DECAY_WITH_WARMDOWN', '1')))
+    # Fraction-based DS decay — decouples DS from final EMA averaging.
+    # Alpha = full from 0 to ds_decay_start_frac, linearly decays to 0 by ds_decay_end_frac,
+    # then 0 for the rest. Scales to any training duration.
+    # Default: decay 70%-85% of training → last 15% is clean baseline for EMA.
+    ds_decay_start_frac   = float(os.environ.get('DS_DECAY_START_FRAC', 0.70))
+    ds_decay_end_frac     = float(os.environ.get('DS_DECAY_END_FRAC', 0.85))
+    # Which physical layers get auxiliary CE loss (comma-separated).
+    # Default: layers 3, 5, 8 — spread across encoder/decoder, skip looped layers.
+    ds_layers             = os.environ.get('DS_LAYERS', '3,5,8')
+    # Switched DS: pick ONE random layer from ds_layers each step instead of
+    # computing all auxiliary losses. Reduces compute overhead ~3x, enabling
+    # more training steps. Based on "switched auxiliary loss" literature.
+    ds_switched           = bool(int(os.environ.get('DS_SWITCHED', '0')))
+
+    # Distributed
+    distributed     = 'RANK' in os.environ and 'WORLD_SIZE' in os.environ
+    rank            = int(os.environ.get('RANK', '0'))
+    world_size      = int(os.environ.get('WORLD_SIZE', '1'))
+    local_rank      = int(os.environ.get('LOCAL_RANK', '0'))
+    is_main_process = rank == 0
+    grad_accum_steps = 8 // world_size
+
+    # Derived paths
+    datasets_dir    = os.path.join(data_dir, 'datasets', f"fineweb10B_sp{vocab_size}")
+    train_files     = os.path.join(datasets_dir, 'fineweb_train_*.bin')
+    val_files       = os.path.join(datasets_dir, 'fineweb_val_*.bin')
+    tokenizer_path  = os.path.join(data_dir, 'tokenizers', f"fineweb_{vocab_size}_bpe.model")
+    logfile         = f"logs/{run_id}.txt"
+    model_path      = 'final_model.pt'
+    quantized_model_path = 'final_model.int6.ptz'
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+_logger_hparams = None
+
+
+def set_logging_hparams(h):
+    global _logger_hparams
+    _logger_hparams = h
+
+
+def log(msg, console=True):
+    if _logger_hparams is None:
+        print(msg)
+        return
+    if _logger_hparams.is_main_process:
+        if console:
+            print(msg)
+        if _logger_hparams.logfile is not None:
+            with open(_logger_hparams.logfile, 'a', encoding='utf-8') as f:
+                print(msg, file=f)
+
+
+# ---------------------------------------------------------------------------
+# Data loading utilities
+# ---------------------------------------------------------------------------
+
+def load_data_shard(file):
+    """Load a single binary shard of tokenized data."""
+    header_bytes = 256 * np.dtype('<i4').itemsize
+    token_bytes = np.dtype('<u2').itemsize
+    header = np.fromfile(file, dtype='<i4', count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype='<u2', count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+def load_validation_tokens(pattern, seq_len):
+    """Load and concatenate all validation shards."""
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = (tokens.numel() - 1) // seq_len * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[:usable + 1]
+
+
+# Shard memmap cache for fast random-access loading
+_SHARD_HEADER_BYTES = 256 * np.dtype('<i4').itemsize
+_SHARD_NTOKENS_CACHE = {}
+_MMAP_CACHE = {}
+
+
+def _read_num_tokens(file):
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype='<i4', count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+
+def _get_shard_memmap(file):
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode='r', dtype='<u2', offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+# ---------------------------------------------------------------------------
+# SentencePiece look-up tables for BPB computation
+# ---------------------------------------------------------------------------
+
+def build_sentencepiece_luts(sp, vocab_size, device):
+    """Build byte-count, leading-space, and boundary-token LUTs for BPB eval."""
+    sp_vocab_size = int(sp.vocab_size())
+    assert sp.piece_to_id('\u2581') != sp.unk_id(), \
+        "Tokenizer must have '\u2581' (space) as its own token for correct BPB byte counting"
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith('\u2581'):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode('utf-8'))
+
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+class ValidationData:
+    def __init__(self, h, device):
+        self.sp = spm.SentencePieceProcessor(model_file=h.tokenizer_path)
+        if int(self.sp.vocab_size()) != h.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={h.vocab_size} does not match "
+                f"tokenizer vocab_size={int(self.sp.vocab_size())}"
+            )
+        self.val_tokens = load_validation_tokens(h.val_files, h.eval_seq_len)
+        self.base_bytes_lut, self.has_leading_space_lut, self.is_boundary_token_lut = \
+            build_sentencepiece_luts(self.sp, h.vocab_size, device)
+
+
+# ---------------------------------------------------------------------------
+# ShuffledSequenceLoader — shard-based, per-rank shuffled sequences
+# ---------------------------------------------------------------------------
+
+class ShuffledSequenceLoader:
+    def __init__(self, h, device):
+        self.world_size = h.world_size
+        self.seq_len = h.train_seq_len
+        self.device = device
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files[h.rank::h.world_size]
+        self.rng = np.random.Generator(np.random.PCG64(h.rank))
+        self.num_tokens = [_read_num_tokens(f) for f in self.files]
+        self.start_inds = [[] for _ in self.files]
+        for si in range(len(self.files)):
+            self._reset_shard(si)
+
+    def _reset_shard(self, si):
+        max_phase = min(self.seq_len - 1, max(0, self.num_tokens[si] - self.seq_len - 1))
+        phase = int(self.rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        num_sequences = (self.num_tokens[si] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[si] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+
+        for bi in range(device_batch_size):
+            total = remaining.sum()
+            if total <= 0:
+                for si in range(len(self.files)):
+                    self._reset_shard(si)
+                remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+                total = remaining.sum()
+            probs = remaining / total
+            si = int(self.rng.choice(len(self.files), p=probs))
+            start_ind = self.start_inds[si].pop()
+            remaining[si] -= 1
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(
+                np.array(mm[start_ind:start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[bi] = window[:-1]
+            y[bi] = window[1:]
+
+        return (
+            x.to(self.device, non_blocking=True),
+            y.to(self.device, non_blocking=True),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Core modules
+# ---------------------------------------------------------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    """Linear that casts weights to input dtype (bf16) on the fly."""
+    def forward(self, x):
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+class Rotary(nn.Module):
+    """Rotary positional embeddings with NTK-aware dynamic scaling."""
+    def __init__(self, dim, base=1e4, train_seq_len=1024, rope_dims=0):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / base ** (
+            torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims
+        )
+        self.register_buffer('inv_freq', inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+
+    def forward(self, seq_len, device, dtype):
+        if (self._cos_cached is None or self._sin_cached is None
+                or self._seq_len_cached != seq_len
+                or self._cos_cached.device != device):
+            rd = self.rope_dims
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * scale ** (rd / (rd - 2))
+                inv_freq = 1.0 / new_base ** (
+                    torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd
+                )
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x, cos, sin, rope_dims=0):
+    """Apply rotary embeddings, optionally only to the first rope_dims dimensions."""
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+
+
+# ---------------------------------------------------------------------------
+# Attention (GQA + QK-RMSNorm + RoPE + FlashAttention3 + XSA)
+# ---------------------------------------------------------------------------
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError('model_dim must be divisible by num_heads')
+        if num_heads % num_kv_heads != 0:
+            raise ValueError('num_heads must be divisible by num_kv_heads')
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError('head_dim must be even for RoPE')
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y, v):
+        """XSA: subtract the value-direction component from attention output."""
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x):
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        # QK-RMSNorm
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        # RoPE
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        # QK gain
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        # FlashAttention-3
+        y = flash_attn_3_func(q, k, v, causal=True)
+        # XSA: subtract value-direction component
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+# ---------------------------------------------------------------------------
+# MLP with squared leaky-ReLU activation
+# ---------------------------------------------------------------------------
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x):
+        return self.proj(F.leaky_relu(self.fc(x), negative_slope=0.5).square())
+
+
+# ---------------------------------------------------------------------------
+# Transformer block (supports parallel residuals a la GPT-J)
+# ---------------------------------------------------------------------------
+
+class Block(nn.Module):
+    def __init__(self, dim, num_heads, num_kv_heads, mlp_mult, rope_base,
+                 qk_gain_init, train_seq_len, layer_idx=0, ln_scale=False):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len,
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(
+            torch.stack((torch.ones(dim), torch.zeros(dim))).float()
+        )
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+        self.parallel = False  # set True for GPT-J style parallel residuals
+
+    def forward(self, x, x0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x_in) * self.ln_scale_factor)
+        if self.parallel:
+            # GPT-J style: attn and MLP read the same (normed) input
+            mlp_out = self.mlp(self.mlp_norm(x_in) * self.ln_scale_factor)
+            x_out = (x_in
+                     + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+                     + self.mlp_scale.to(dtype=x_in.dtype)[None, None, :] * mlp_out)
+        else:
+            x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+            x_out = (x_out
+                     + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] *
+                     self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor))
+        return x_out
+
+
+# ---------------------------------------------------------------------------
+# Predictive Coding Head (novel addition)
+# ---------------------------------------------------------------------------
+
+def _compute_ds_loss(x, final_norm, tok_emb_weight, head_proj, lm_head,
+                     tie_embeddings, logit_softcap, targets, layer_frac):
+    """Compute auxiliary CE loss at an intermediate layer.
+
+    Uses the shared LM head (or tied embeddings) to predict next token
+    from the intermediate hidden state.  Weighted by layer_frac so that
+    deeper layers contribute more to the auxiliary signal.
+
+    No new parameters — reuses the existing LM head.  Zero artifact cost.
+    """
+    h = final_norm(x)
+    if head_proj is not None:
+        h = head_proj(h)
+    if tie_embeddings:
+        logits = F.linear(h, tok_emb_weight)
+    else:
+        logits = lm_head(h)
+    logits = logit_softcap * torch.tanh(logits / logit_softcap)
+    loss = F.cross_entropy(
+        logits.reshape(-1, logits.size(-1)).float(),
+        targets.reshape(-1),
+        reduction='mean',
+    )
+    return loss * layer_frac
+
+
+# ---------------------------------------------------------------------------
+# GPT model
+# ---------------------------------------------------------------------------
+
+class GPT(nn.Module):
+    def __init__(self, h):
+        super().__init__()
+        if h.logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {h.logit_softcap}")
+
+        self.tie_embeddings = h.tie_embeddings
+        self.tied_embed_init_std = h.tied_embed_init_std
+        self.logit_softcap = h.logit_softcap
+        self.tok_emb = nn.Embedding(h.vocab_size, h.embedding_dim)
+
+        # Optional projection when embedding_dim != model_dim
+        if h.embedding_dim != h.model_dim:
+            self.embed_proj = CastedLinear(h.embedding_dim, h.model_dim, bias=False)
+            self.head_proj = CastedLinear(h.model_dim, h.embedding_dim, bias=False)
+        else:
+            self.embed_proj = None
+            self.head_proj = None
+
+        # Encoder/decoder split for skip connections
+        self.num_encoder_layers = h.num_layers // 2
+        self.num_decoder_layers = h.num_layers - self.num_encoder_layers
+
+        # Transformer blocks
+        self.blocks = nn.ModuleList([
+            Block(
+                h.model_dim, h.num_heads, h.num_kv_heads, h.mlp_mult,
+                h.rope_base, h.qk_gain_init, h.train_seq_len,
+                layer_idx=i, ln_scale=h.ln_scale,
+            )
+            for i in range(h.num_layers)
+        ])
+
+        # Override RoPE dims if specified
+        if h.rope_dims > 0:
+            head_dim = h.model_dim // h.num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = h.rope_dims
+                block.attn.rotary = Rotary(
+                    head_dim, base=h.rope_base,
+                    train_seq_len=h.train_seq_len, rope_dims=h.rope_dims,
+                )
+
+        # Output head
+        self.final_norm = RMSNorm()
+        self.lm_head = None if h.tie_embeddings else CastedLinear(
+            h.embedding_dim, h.vocab_size, bias=False,
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+
+        # XSA: enable on last N layers
+        if h.xsa_last_n > 0:
+            for i in range(max(0, h.num_layers - h.xsa_last_n), h.num_layers):
+                self.blocks[i].attn.use_xsa = True
+
+        # Parallel residuals (GPT-J style) for specified layers
+        if h.parallel_residual_start >= 0:
+            for i in range(h.parallel_residual_start, h.num_layers):
+                self.blocks[i].parallel = True
+
+        # Depth recurrence (layer looping)
+        self.looping_active = False
+        if h.num_loops > 0:
+            loop_seg = list(range(h.loop_start, h.loop_end + 1))
+            all_indices = list(range(h.loop_start))
+            for _ in range(h.num_loops + 1):
+                all_indices.extend(loop_seg)
+            all_indices.extend(range(h.loop_end + 1, h.num_layers))
+            num_enc = len(all_indices) // 2
+            self.encoder_indices = all_indices[:num_enc]
+            self.decoder_indices = all_indices[num_enc:]
+        else:
+            self.encoder_indices = list(range(self.num_encoder_layers))
+            self.decoder_indices = list(range(self.num_encoder_layers, h.num_layers))
+
+        # Skip connections (with optional sigmoid gating)
+        self.num_skip_weights = min(len(self.encoder_indices), len(self.decoder_indices))
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+        )
+        self.skip_gates = nn.Parameter(
+            torch.zeros(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+        ) if h.skip_gates_enabled else None
+
+        # ---- Deep Supervision (novel addition) ----
+        # No new parameters — reuses the shared LM head at intermediate layers.
+        # Zero artifact cost.  Alpha buffer avoids dynamo recompilation.
+        self.ds_enabled = h.ds_enabled
+        self.ds_switched = h.ds_switched
+        self.register_buffer('_ds_alpha_buf', torch.zeros(()), persistent=False)
+        self.ds_layer_set = set(
+            int(x) for x in h.ds_layers.split(',') if x.strip()
+        ) if h.ds_enabled else set()
+        self.ds_layer_list = sorted(self.ds_layer_set)  # for random selection
+        # -1 means "use all DS layers" (non-switched mode).
+        # Set to a specific layer index from training loop for switched mode.
+        self._ds_current_layer = -1
+
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, '_zero_init', False):
+                    nn.init.zeros_(module.weight)
+                elif (module.weight.ndim == 2
+                      and module.weight.shape[0] >= 64
+                      and module.weight.shape[1] >= 64):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _run_blocks(self, x, x0):
+        """Run the encoder and decoder blocks with skip connections."""
+        skips = []
+
+        enc_iter = (self.encoder_indices if self.looping_active
+                    else range(self.num_encoder_layers))
+        dec_iter = (self.decoder_indices if self.looping_active
+                    else range(self.num_encoder_layers,
+                               self.num_encoder_layers + self.num_decoder_layers))
+
+        # Encoder pass
+        for i in enc_iter:
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+
+        # Decoder pass with skip connections
+        for skip_idx, i in enumerate(dec_iter):
+            if skip_idx < self.num_skip_weights and skips:
+                scaled_skip = (
+                    self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                    * skips.pop()
+                )
+                if self.skip_gates is not None:
+                    g = torch.sigmoid(
+                        self.skip_gates[skip_idx].to(dtype=x.dtype)
+                    )[None, None, :]
+                    x = torch.lerp(scaled_skip, x, g)
+                else:
+                    x = x + scaled_skip
+            x = self.blocks[i](x, x0)
+
+        return x
+
+    def _compute_logits(self, x):
+        """Shared logit computation for both forward and forward_logits."""
+        x = self.final_norm(x)
+        if self.head_proj is not None:
+            x = self.head_proj(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward_logits(self, input_ids):
+        """Compute logits only (used for eval)."""
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+        x = self._run_blocks(x, x0)
+        return self._compute_logits(x)
+
+    def forward(self, input_ids, target_ids):
+        """
+        Training forward pass.  Returns CE loss (+ Deep Supervision aux loss).
+
+        When ds_enabled=True, selected intermediate layers predict the next
+        token through the shared LM head.  The auxiliary CE loss is weighted
+        by self._ds_alpha_buf (a registered buffer set each step to avoid
+        dynamo recompilation) and by layer_frac (deeper layers count more).
+
+        No new parameters — no artifact cost.  No dynamic lists — compatible
+        with torch.compile(fullgraph=True).
+        """
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+
+        # ---- Forward through blocks with optional Deep Supervision ----
+        ds_loss = torch.zeros((), device=x.device, dtype=torch.float32)
+        ds_count = 0
+        skips = []
+
+        enc_iter = (self.encoder_indices if self.looping_active
+                    else range(self.num_encoder_layers))
+        dec_iter = (self.decoder_indices if self.looping_active
+                    else range(self.num_encoder_layers,
+                               self.num_encoder_layers + self.num_decoder_layers))
+
+        total_virtual = (len(self.encoder_indices) + len(self.decoder_indices)
+                         if self.looping_active
+                         else self.num_encoder_layers + self.num_decoder_layers)
+        virtual_idx = 0
+
+        # Helper: should we apply DS at this physical layer index?
+        # In non-switched mode: apply at all ds_layer_set layers.
+        # In switched mode: apply ONLY at the current selected layer.
+        def _ds_active_at(layer_idx):
+            if not self.ds_enabled or layer_idx not in self.ds_layer_set:
+                return False
+            if self.ds_switched:
+                return layer_idx == self._ds_current_layer
+            return True
+
+        # Encoder pass
+        for i in enc_iter:
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+            if _ds_active_at(i):
+                layer_frac = (virtual_idx + 1) / total_virtual
+                ds_loss = ds_loss + _compute_ds_loss(
+                    x, self.final_norm, self.tok_emb.weight,
+                    self.head_proj, self.lm_head,
+                    self.tie_embeddings, self.logit_softcap,
+                    target_ids, layer_frac,
+                )
+                ds_count += 1
+            virtual_idx += 1
+
+        # Decoder pass with skip connections
+        for skip_idx, i in enumerate(dec_iter):
+            if skip_idx < self.num_skip_weights and skips:
+                scaled_skip = (
+                    self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                    * skips.pop()
+                )
+                if self.skip_gates is not None:
+                    g = torch.sigmoid(
+                        self.skip_gates[skip_idx].to(dtype=x.dtype)
+                    )[None, None, :]
+                    x = torch.lerp(scaled_skip, x, g)
+                else:
+                    x = x + scaled_skip
+            x = self.blocks[i](x, x0)
+            if _ds_active_at(i):
+                layer_frac = (virtual_idx + 1) / total_virtual
+                ds_loss = ds_loss + _compute_ds_loss(
+                    x, self.final_norm, self.tok_emb.weight,
+                    self.head_proj, self.lm_head,
+                    self.tie_embeddings, self.logit_softcap,
+                    target_ids, layer_frac,
+                )
+                ds_count += 1
+            virtual_idx += 1
+
+        # Main CE loss from final layer
+        logits = self._compute_logits(x)
+        ce_loss = F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            target_ids.reshape(-1),
+            reduction='mean',
+        )
+
+        # Add weighted Deep Supervision loss
+        if self.ds_enabled and ds_count > 0:
+            return ce_loss + self._ds_alpha_buf * (ds_loss / ds_count)
+
+        return ce_loss
+
+
+# ---------------------------------------------------------------------------
+# Parameter classification for optimizer dispatch
+# ---------------------------------------------------------------------------
+
+def classify_param(name):
+    if 'tok_emb' in name or 'lm_head' in name:
+        return 'embed'
+    if '.mlp.' in name:
+        return 'mlp'
+    if '.attn.' in name or '.proj.' in name and '.mlp.' not in name:
+        return 'attn'
+    return 'other'
+
+
+# ---------------------------------------------------------------------------
+# Muon optimizer (Newton-Schulz zero-power preconditioning, row-normalized)
+# ---------------------------------------------------------------------------
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps=10, eps=1e-7):
+    """Compute the zero-power (sign) of a matrix via Newton-Schulz iteration."""
+    a, b, c = 3.4445, -4.7750, 2.0315
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer: Muon = Momentum + Newton-Schulz orthogonalization.
+    Supports row normalization (MuonEq-R) and distributed all-reduce.
+    """
+    def __init__(self, params, lr, momentum, backend_steps, nesterov=True,
+                 weight_decay=0.0, row_normalize=False):
+        super().__init__(params, dict(
+            lr=lr, momentum=momentum, backend_steps=backend_steps,
+            nesterov=nesterov, weight_decay=weight_decay,
+            row_normalize=row_normalize,
+        ))
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group['params']
+            if not params:
+                continue
+            lr = group['lr']
+            momentum = group['momentum']
+            backend_steps = group['backend_steps']
+            nesterov = group['nesterov']
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(
+                total_params, device=params[0].device, dtype=torch.bfloat16,
+            )
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if 'momentum_buffer' not in state:
+                        state['momentum_buffer'] = torch.zeros_like(g)
+                    buf = state['momentum_buffer']
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    # Row normalization (MuonEq-R)
+                    if group.get('row_normalize', False):
+                        row_norms = g.float().norm(dim=-1, keepdim=True).clamp_min(1e-7)
+                        g = g / row_norms.to(g.dtype)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr:curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            wd = group.get('weight_decay', 0.0)
+            curr = 0
+            for p in params:
+                if wd > 0.0:
+                    p.data.mul_(1.0 - lr * wd)
+                g = updates_flat[curr:curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+        return loss
+
+
+# Patterns for control tensors (scalars/gains) that go to Adam, not Muon
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern for pattern in os.environ.get(
+        'CONTROL_TENSOR_NAME_PATTERNS',
+        'attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,'
+        'q_gain,skip_weight,skip_weights,skip_gates',
+    ).split(',') if pattern
+)
+
+
+# ---------------------------------------------------------------------------
+# Optimizer ensemble
+# ---------------------------------------------------------------------------
+
+class Optimizers:
+    """
+    Manages separate optimizers for different parameter groups:
+      - tok_emb: AdamW with embed_lr
+      - lm_head (if not tied): Adam with head_lr
+      - block matrices: Muon with matrix_lr
+      - scalars/controls: AdamW with scalar_lr
+    """
+    def __init__(self, h, base_model):
+        block_named_params = list(base_model.blocks.named_parameters())
+        matrix_params = [
+            p for (name, p) in block_named_params
+            if p.ndim == 2 and not any(
+                pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS
+            )
+        ]
+        scalar_params = [
+            p for (name, p) in block_named_params
+            if p.ndim < 2 or any(
+                pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS
+            )
+        ]
+
+        if base_model.skip_weights.numel() > 0:
+            scalar_params.append(base_model.skip_weights)
+        if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
+            scalar_params.append(base_model.skip_gates)
+
+        # Token embedding optimizer
+        token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
+        tok_params = [{'params': [base_model.tok_emb.weight], 'lr': token_lr, 'base_lr': token_lr}]
+        self.optimizer_tok = torch.optim.AdamW(
+            tok_params, betas=(h.beta1, h.beta2), eps=h.adam_eps,
+            weight_decay=h.embed_wd, fused=True,
+        )
+
+        # Muon for block matrices
+        self.optimizer_muon = Muon(
+            matrix_params, lr=h.matrix_lr, momentum=h.muon_momentum,
+            backend_steps=h.muon_backend_steps, weight_decay=h.muon_wd,
+            row_normalize=h.muon_row_normalize,
+        )
+        for group in self.optimizer_muon.param_groups:
+            group['base_lr'] = h.matrix_lr
+
+        # AdamW for scalar / control parameters
+        self.optimizer_scalar = torch.optim.AdamW(
+            [{'params': scalar_params, 'lr': h.scalar_lr, 'base_lr': h.scalar_lr}],
+            betas=(h.beta1, h.beta2), eps=h.adam_eps,
+            weight_decay=h.adam_wd, fused=True,
+        )
+
+        self.optimizers = [self.optimizer_tok, self.optimizer_muon, self.optimizer_scalar]
+
+        # Optional separate head optimizer
+        if base_model.lm_head is not None:
+            self.optimizer_head = torch.optim.Adam(
+                [{'params': [base_model.lm_head.weight], 'lr': h.head_lr, 'base_lr': h.head_lr}],
+                betas=(h.beta1, h.beta2), eps=h.adam_eps, fused=True,
+            )
+            self.optimizers.insert(1, self.optimizer_head)
+        else:
+            self.optimizer_head = None
+
+        # Deep Supervision has no new parameters (reuses shared LM head)
+
+    def __iter__(self):
+        return iter(self.optimizers)
+
+    def zero_grad_all(self):
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    def step(self):
+        for opt in self.optimizers:
+            opt.step()
+        self.zero_grad_all()
+
+
+# ---------------------------------------------------------------------------
+# FP32 restore
+# ---------------------------------------------------------------------------
+
+def restore_fp32_params(model):
+    """Ensure all CastedLinear and scalar/control params are stored in fp32."""
+    for module in model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    for name, param in model.named_parameters():
+        if ((param.ndim < 2
+             or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS))
+                and param.dtype != torch.float32):
+            param.data = param.data.float()
+
+
+# ---------------------------------------------------------------------------
+# GPTQ quantization
+# ---------------------------------------------------------------------------
+
+def collect_hessians(model, train_loader, h, device, n_calibration_batches=64):
+    """Collect Hessian approximations for GPTQ calibration."""
+    hessians = {}
+    hooks = []
+
+    def make_hook(name):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            if name not in hessians:
+                hessians[name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device,
+                )
+            hessians[name].addmm_(x.T, x)
+        return hook_fn
+
+    for name, module in model.named_modules():
+        if isinstance(module, CastedLinear) and module.weight.numel() > 65536:
+            cat = classify_param(name + '.weight')
+            if cat in ('mlp', 'attn'):
+                hooks.append(module.register_forward_hook(make_hook(name + '.weight')))
+
+    # For tied embeddings, hook on the output of head_proj or final_norm
+    if model.tie_embeddings:
+        hook_module = model.head_proj if model.head_proj is not None else model.final_norm
+
+        def make_output_hook(name):
+            def hook_fn(module, inp, out):
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device,
+                    )
+                hessians[name].addmm_(x.T, x)
+            return hook_fn
+        hooks.append(hook_module.register_forward_hook(make_output_hook('tok_emb.weight')))
+
+    model.eval()
+    with torch.no_grad():
+        for _ in range(n_calibration_batches):
+            x, _ = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+            model.forward_logits(x)
+    for hook in hooks:
+        hook.remove()
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / n_calibration_batches
+    return hessians
+
+
+def gptq_quantize_weight(w, H, clip_sigmas=3.0, clip_range=63, block_size=128):
+    """GPTQ quantization of a single weight matrix."""
+    W_orig = w.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * H.diag().mean()
+    H.diagonal().add_(damp)
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+    Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    row_std = W_orig.std(dim=1)
+    s = (clip_sigmas * row_std / clip_range).clamp_min(1e-10).to(torch.float16)
+    sf = s.float()
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    W_work = W_perm.clone()
+
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W_work[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros(rows, i2 - i1)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            d = Hinv_block[j, j]
+            q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - q_col.float() * sf) / d
+            Err[:, j] = err
+            W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+        if i2 < cols:
+            W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+
+    return Q[:, invperm], s
+
+
+def gptq_mixed_quantize(state_dict, hessians, h):
+    """Quantize all large matrices via GPTQ with per-layer adaptive clipping.
+
+    Per-layer sigmas (PR #1586 approach):
+      - Embeddings: h.embed_clip_sigmas at int h.embed_bits (default int8, σ=20)
+      - MLP weights: h.mlp_clip_sigmas at int h.matrix_bits (default int6, σ=12.85)
+      - Attention weights: h.attn_clip_sigmas at int h.matrix_bits
+      - Other large matrices: h.matrix_clip_sigmas (backward-compat fallback)
+    """
+    result = {}
+    meta = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = 'passthrough (float16)'
+            continue
+        # Per-layer adaptive sigma + bit-width dispatch
+        if 'tok_emb' in name:
+            cs = h.embed_clip_sigmas
+            bits = h.embed_bits
+        elif '.mlp.' in name:
+            cs = h.mlp_clip_sigmas
+            bits = h.matrix_bits
+        elif '.attn.' in name:
+            cs = h.attn_clip_sigmas
+            bits = h.matrix_bits
+        else:
+            cs = h.matrix_clip_sigmas
+            bits = h.matrix_bits
+        q, s = gptq_quantize_weight(t, hessians[name], clip_sigmas=cs,
+                                     clip_range=2 ** (bits - 1) - 1)
+        result[name + '.q'] = q
+        result[name + '.scale'] = s
+        meta[name] = f"gptq (int{bits}, sigma={cs})"
+
+    categories = collections.defaultdict(set)
+    for name, cat in meta.items():
+        short = re.sub(r'\.\d+$', '', re.sub(r'blocks\.\d+', 'blocks', name))
+        categories[cat].add(short)
+    log('Quantized weights:')
+    for cat in sorted(categories):
+        log(f"  {cat}: {', '.join(sorted(categories[cat]))}")
+    return result, meta
+
+
+def dequantize_mixed(result, meta, template_sd):
+    """Dequantize a mixed-precision state dict back to floating point."""
+    out = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if 'passthrough' in info:
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + '.q'], result[name + '.scale']
+        if s.ndim > 0:
+            out[name] = (
+                q.float() * s.float().view(q.shape[0], *[1] * (q.ndim - 1))
+            ).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Compression (byte-shuffle + brotli/lzma)
+# ---------------------------------------------------------------------------
+
+_BSHF_MAGIC = b'BSHF'
+
+
+def _byte_shuffle(data, stride=2):
+    if stride <= 1 or len(data) < stride:
+        return data
+    src = np.frombuffer(data, dtype=np.uint8)
+    n = len(src)
+    out = np.empty(n, dtype=np.uint8)
+    dest_off = 0
+    for pos in range(stride):
+        chunk = src[pos::stride]
+        out[dest_off:dest_off + len(chunk)] = chunk
+        dest_off += len(chunk)
+    return _BSHF_MAGIC + bytes([stride]) + out.tobytes()
+
+
+def _byte_unshuffle(data):
+    if len(data) < 5 or data[:4] != _BSHF_MAGIC:
+        return data
+    stride = data[4]
+    if stride < 2:
+        return data[5:]
+    payload = np.frombuffer(data, dtype=np.uint8, offset=5)
+    n = len(payload)
+    out = np.empty(n, dtype=np.uint8)
+    src_off = 0
+    for pos in range(stride):
+        chunk_len = n // stride + (1 if pos < n % stride else 0)
+        out[pos::stride][:chunk_len] = payload[src_off:src_off + chunk_len]
+        src_off += chunk_len
+    return out.tobytes()
+
+
+def _compress(data, compressor):
+    data = _byte_shuffle(data)
+    if compressor == 'lzma':
+        return lzma.compress(data, preset=6)
+    elif compressor == 'brotli':
+        import brotli
+        return brotli.compress(data, quality=11)
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def _decompress(data, compressor):
+    if compressor == 'lzma':
+        raw = lzma.decompress(data)
+    elif compressor == 'brotli':
+        import brotli
+        raw = brotli.decompress(data)
+    else:
+        raise ValueError(f"Unknown compressor: {compressor!r}")
+    raw = _byte_unshuffle(raw)
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Serialization / deserialization
+# ---------------------------------------------------------------------------
+
+    # (Deep Supervision has no extra parameters to strip)
+
+
+def serialize(h, base_model, code):
+    """Quantize (GPTQ), compress, and save the final artifact."""
+    code_bytes = len(code.encode('utf-8'))
+
+    if h.is_main_process:
+        torch.save(base_model.state_dict(), h.model_path)
+        model_bytes = os.path.getsize(h.model_path)
+        log(f"Serialized model: {model_bytes} bytes")
+        log(f"Code size: {code_bytes} bytes")
+
+    # Strip PC heads before quantization — they are training-only
+    sd_cpu = {k: v.detach().cpu() for k, v in base_model.state_dict().items()}
+    device = torch.device('cuda', h.local_rank)
+
+    log('GPTQ:collecting Hessians from calibration data...')
+    t0 = time.perf_counter()
+    calib_loader = ShuffledSequenceLoader(h, device)
+    hessians = collect_hessians(
+        base_model, calib_loader, h, device,
+        n_calibration_batches=h.gptq_calibration_batches,
+    )
+    log(f"GPTQ:collected {len(hessians)} Hessians in {time.perf_counter() - t0:.1f}s")
+
+    quant_result, quant_meta = gptq_mixed_quantize(sd_cpu, hessians, h)
+    quant_buf = io.BytesIO()
+    torch.save({'w': quant_result, 'm': quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = _compress(quant_raw, h.compressor)
+    quant_file_bytes = len(quant_blob)
+    bytes_total = quant_file_bytes + code_bytes
+
+    if h.is_main_process:
+        with open(h.quantized_model_path, 'wb') as f:
+            f.write(quant_blob)
+        log(f"Serialized model quantized+{h.compressor}: {quant_file_bytes} bytes")
+        log(f"Total submission size quantized+{h.compressor}: {bytes_total} bytes")
+
+    return bytes_total, quant_file_bytes
+
+
+def deserialize(h, device):
+    """Load a quantized model artifact and dequantize."""
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    sd_cpu = {k: v.detach().cpu() for k, v in eval_model.state_dict().items()}
+    with open(h.quantized_model_path, 'rb') as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(_decompress(quant_blob_disk, h.compressor)), map_location='cpu',
+    )
+    deq_state = dequantize_mixed(quant_state['w'], quant_state['m'], sd_cpu)
+    eval_model.load_state_dict(deq_state, strict=True)
+    return eval_model
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+def _loss_bpb(loss_sum, token_count, byte_count):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    return val_loss, val_bpb
+
+
+def eval_val(h, device, val_data, model):
+    """Standard (non-sliding) validation evaluation."""
+    seq_len = h.eval_seq_len
+    local_batch_tokens = h.val_batch_tokens // (h.world_size * h.grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            f"VAL_BATCH_SIZE must provide at least one sequence per rank; got "
+            f"VAL_BATCH_SIZE={h.val_batch_tokens}, WORLD_SIZE={h.world_size}, "
+            f"GRAD_ACCUM_STEPS={h.grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = total_seqs * h.rank // h.world_size
+    seq_end = total_seqs * (h.rank + 1) // h.world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    model.eval()
+
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_data.val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True,
+            )
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type='cuda', dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = val_data.base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (
+                val_data.has_leading_space_lut[tgt_ids]
+                & ~val_data.is_boundary_token_lut[prev_ids]
+            ).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    model.train()
+    return _loss_bpb(val_loss_sum, val_token_count, val_byte_count)
+
+
+def eval_val_sliding(h, device, val_data, base_model, batch_seqs=32):
+    """Sliding-window validation evaluation."""
+    base_model.eval()
+    logits_fn = torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+    seq_len = h.eval_seq_len
+    context_size = seq_len - h.eval_stride
+    total_tokens = val_data.val_tokens.numel() - 1
+    window_starts = [
+        ws for ws in range(0, total_tokens, h.eval_stride)
+        if ws + context_size < total_tokens
+    ]
+    total_windows = len(window_starts)
+    my_s = total_windows * h.rank // h.world_size
+    my_e = total_windows * (h.rank + 1) // h.world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens = []
+            for i, ws in enumerate(batch_ws):
+                we = min(ws + seq_len, total_tokens)
+                wlen = we - ws
+                wlens.append(wlen)
+                chunk = val_data.val_tokens[ws:we + 1].to(
+                    dtype=torch.int64, device=device,
+                )
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type='cuda', dtype=torch.bfloat16):
+                logits = logits_fn(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1), reduction='none',
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else context_size
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = val_data.base_bytes_lut[tgt].to(torch.float64)
+                tb += (
+                    val_data.has_leading_space_lut[tgt]
+                    & ~val_data.is_boundary_token_lut[prev]
+                ).to(torch.float64)
+                byte_count += tb.sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    base_model.train()
+    return _loss_bpb(loss_sum, token_count, byte_count)
+
+
+def eval_val_ttt(h, device, val_data, base_model, batch_seqs=32):
+    """Test-time training evaluation (score-first TTT with SGD)."""
+    rank = h.rank
+    world_size = h.world_size
+    seq_len = h.eval_seq_len
+    stride = h.eval_stride
+    total_tokens = val_data.val_tokens.numel() - 1
+    ttt_chunk = h.ttt_chunk_tokens
+    context_size = seq_len - stride
+
+    window_starts = [
+        ws for ws in range(0, total_tokens, stride)
+        if ws + context_size < total_tokens
+    ]
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    chunk_windows = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        wlen = min(ws + seq_len, total_tokens) - ws
+        s = 0 if ws == 0 else context_size
+        scored_start = ws + s
+        ci = min(scored_start // ttt_chunk, num_chunks - 1)
+        chunk_windows[ci].append(ws)
+
+    log(f"ttt:start chunks={num_chunks} ttt_lr={h.ttt_lr} ttt_epochs={h.ttt_epochs}")
+    compiled_logits = torch.compile(
+        base_model.forward_logits, dynamic=False, fullgraph=True,
+    )
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    ttt_params = [p for p in base_model.parameters()]
+    for p in ttt_params:
+        p.requires_grad_(True)
+    optimizer = torch.optim.SGD(ttt_params, lr=h.ttt_lr, momentum=h.ttt_momentum)
+
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows:
+            continue
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+        my_s = len(windows) * rank // world_size
+        my_e = len(windows) * (rank + 1) // world_size
+        my_windows = windows[my_s:my_e]
+        base_model.eval()
+
+        # Score windows in this chunk
+        with torch.no_grad():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi:bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens = []
+                for i, ws in enumerate(batch_ws):
+                    we = min(ws + seq_len, total_tokens)
+                    wlen = we - ws
+                    wlens.append(wlen)
+                    chunk_tok = val_data.val_tokens[ws:we + 1].to(
+                        dtype=torch.int64, device=device,
+                    )
+                    x_batch[i, :wlen] = chunk_tok[:-1]
+                    y_batch[i, :wlen] = chunk_tok[1:]
+                with torch.autocast(device_type='cuda', dtype=torch.bfloat16):
+                    logits = compiled_logits(x_batch)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y_batch.reshape(-1), reduction='none',
+                ).reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]
+                    s = 0 if ws == 0 else context_size
+                    scored_nll = nll[i, s:wlen].to(torch.float64)
+                    loss_sum += scored_nll.sum()
+                    token_count += float(wlen - s)
+                    tgt = y_batch[i, s:wlen]
+                    prev = x_batch[i, s:wlen]
+                    tb = val_data.base_bytes_lut[tgt].to(torch.float64)
+                    tb += (
+                        val_data.has_leading_space_lut[tgt]
+                        & ~val_data.is_boundary_token_lut[prev]
+                    ).to(torch.float64)
+                    byte_count += tb.sum()
+
+        # TTT: fine-tune on this chunk (skip last chunk)
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and h.ttt_epochs > 0:
+            base_model.train()
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if chunk_seqs > 0:
+                cos_lr = h.ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                for pg in optimizer.param_groups:
+                    pg['lr'] = cos_lr
+                my_seq_s = chunk_seqs * rank // world_size
+                my_seq_e = chunk_seqs * (rank + 1) // world_size
+                my_chunk_seqs = my_seq_e - my_seq_s
+                for _ep in range(h.ttt_epochs):
+                    for bs in range(0, my_chunk_seqs, batch_seqs):
+                        be = min(bs + batch_seqs, my_chunk_seqs)
+                        actual_bs = my_seq_s + bs
+                        start_tok = chunk_start + actual_bs * seq_len
+                        end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                        if end_tok > val_data.val_tokens.numel():
+                            continue
+                        local = val_data.val_tokens[start_tok:end_tok].to(
+                            device=device, dtype=torch.int64,
+                        )
+                        x = local[:-1].reshape(-1, seq_len)
+                        y = local[1:].reshape(-1, seq_len)
+                        optimizer.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type='cuda', dtype=torch.bfloat16):
+                            loss = base_model(x, y)
+                        loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        torch.nn.utils.clip_grad_norm_(ttt_params, 1.0)
+                        optimizer.step()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+    return _loss_bpb(loss_sum, token_count, byte_count)
+
+
+def timed_eval(label, fn, *args, **kwargs):
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    val_loss, val_bpb = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    elapsed_ms = 1e3 * (time.perf_counter() - t0)
+    log(f"{label} val_loss:{val_loss:.8f} val_bpb:{val_bpb:.8f} eval_time:{elapsed_ms:.0f}ms")
+    return val_loss, val_bpb
+
+
+# ---------------------------------------------------------------------------
+# Training loop
+# ---------------------------------------------------------------------------
+
+def train_model(h, device, val_data):
+    base_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(base_model)
+
+    # Deep Supervision: fullgraph=True when non-switched (static control flow).
+    # Switched DS changes _ds_current_layer each step, so use fullgraph=False
+    # to avoid recompilation penalty (dynamo would recompile per unique value).
+    compiled_model = torch.compile(
+        base_model, dynamic=False,
+        fullgraph=(not h.ds_switched),
+    )
+
+    if h.distributed:
+        # DS adds no new parameters — all params always participate in the graph.
+        model = DDP(compiled_model, device_ids=[h.local_rank],
+                    broadcast_buffers=False)
+    else:
+        model = compiled_model
+
+    log(f"model_params:{sum(p.numel() for p in base_model.parameters())}")
+    optimizers = Optimizers(h, base_model)
+    train_loader = ShuffledSequenceLoader(h, device)
+
+    # Wallclock budget (minus GPTQ reserve)
+    max_wallclock_ms = (1e3 * h.max_wallclock_seconds
+                        if h.max_wallclock_seconds > 0 else None)
+    if max_wallclock_ms is not None:
+        max_wallclock_ms -= h.gptq_reserve_seconds * 1e3
+        log(f"gptq:reserving {h.gptq_reserve_seconds:.0f}s, "
+            f"effective={max_wallclock_ms:.0f}ms")
+
+    def training_frac(step, elapsed_ms):
+        if max_wallclock_ms is None:
+            return step / max(h.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-9)
+
+    def lr_mul(frac):
+        if h.warmdown_frac <= 0:
+            return 1.0
+        if frac >= 1.0 - h.warmdown_frac:
+            return max((1.0 - frac) / h.warmdown_frac, h.min_lr)
+        return 1.0
+
+    def step_fn(step, lr_scale, ds_alpha_effective=0.0):
+        # Set DS alpha buffer BEFORE forward (outside compiled graph)
+        base_model._ds_alpha_buf.fill_(ds_alpha_effective)
+        # Switched DS: pick one random layer to supervise this step
+        if h.ds_switched and base_model.ds_layer_list:
+            base_model._ds_current_layer = random.choice(base_model.ds_layer_list)
+        optimizers.zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(h.grad_accum_steps):
+            if h.distributed:
+                model.require_backward_grad_sync = (
+                    micro_step == h.grad_accum_steps - 1
+                )
+            x, y = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+            with torch.autocast(device_type='cuda', dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss / h.grad_accum_steps).backward()
+
+        train_loss /= h.grad_accum_steps
+
+        # Muon momentum warmup
+        frac = (min(step / h.muon_momentum_warmup_steps, 1.0)
+                if h.muon_momentum_warmup_steps > 0 else 1.0)
+        muon_momentum = ((1 - frac) * h.muon_momentum_warmup_start
+                         + frac * h.muon_momentum)
+        for group in optimizers.optimizer_muon.param_groups:
+            group['momentum'] = muon_momentum
+
+        # Scale all learning rates
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group['lr'] = group['base_lr'] * lr_scale
+
+        if h.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), h.grad_clip_norm)
+        optimizers.step()
+        return train_loss
+
+    # ---- Warmup phase ----
+    if h.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for name, tensor in base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in optimizers
+        ]
+        model.train()
+        for warmup_step in range(h.warmup_steps):
+            step_fn(warmup_step, 1.0)
+            if warmup_step <= 5 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == h.warmup_steps:
+                log(f"warmup_step: {warmup_step + 1}/{h.warmup_steps}")
+
+        # Extra warmup with looping enabled (if applicable)
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            log(f"loop_warmup:enabled encoder:{base_model.encoder_indices} "
+                f"decoder:{base_model.decoder_indices}")
+            for warmup_step in range(h.warmup_steps):
+                step_fn(warmup_step, 1.0)
+                if (warmup_step <= 5 or (warmup_step + 1) % 10 == 0
+                        or warmup_step + 1 == h.warmup_steps):
+                    log(f"loop_warmup_step: {warmup_step + 1}/{h.warmup_steps}")
+            base_model.looping_active = False
+
+        # Reset model and optimizer state after warmup
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        optimizers.zero_grad_all()
+        if h.distributed:
+            model.require_backward_grad_sync = True
+        train_loader = ShuffledSequenceLoader(h, device)
+
+    # ---- Main training loop ----
+    ema_state = {
+        name: t.detach().float().clone()
+        for name, t in base_model.state_dict().items()
+    }
+    ema_decay = h.ema_decay
+    training_time_ms = 0.0
+    stop_after_step = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+
+    while True:
+        last_step = (step == h.iterations
+                     or (stop_after_step is not None and step >= stop_after_step))
+        should_validate = (
+            last_step
+            or (h.val_loss_every > 0 and step % h.val_loss_every == 0)
+        )
+
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1e3 * (time.perf_counter() - t0)
+            # Zero DS alpha so validation loss is pure CE (comparable to baseline)
+            base_model._ds_alpha_buf.fill_(0.0)
+            val_loss, val_bpb = eval_val(h, device, val_data, model)
+            log(f"{step}/{h.iterations} val_loss: {val_loss:.4f} val_bpb: {val_bpb:.4f}")
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < h.iterations:
+                log(f"stopping_early: wallclock_cap train_time: "
+                    f"{training_time_ms:.0f}ms step: {step}/{h.iterations}")
+            break
+
+        # Compute training fraction and LR multiplier
+        elapsed_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        frac = training_frac(step, elapsed_ms)
+        scale = lr_mul(frac)
+
+        # Enable depth recurrence at the scheduled point
+        if (h.num_loops > 0 and not base_model.looping_active
+                and frac >= h.enable_looping_at):
+            base_model.looping_active = True
+            log(f"layer_loop:enabled step:{step} frac:{frac:.3f} "
+                f"encoder:{base_model.encoder_indices} "
+                f"decoder:{base_model.decoder_indices}")
+
+        # ---- Compute effective DS alpha ----
+        # Step-based warmup + fraction-based decay (+ optional LR warmdown coupling).
+        # The fraction-based decay ensures EMA captures clean post-DS weights.
+        if h.ds_enabled:
+            ds_warmup_factor = min(step / max(h.ds_warmup_steps, 1), 1.0)
+            # Fraction-based decay: 1.0 before ds_decay_start_frac,
+            # linearly decays to 0 by ds_decay_end_frac, then 0
+            if frac < h.ds_decay_start_frac:
+                ds_frac_factor = 1.0
+            elif frac < h.ds_decay_end_frac:
+                span = max(h.ds_decay_end_frac - h.ds_decay_start_frac, 1e-9)
+                ds_frac_factor = 1.0 - (frac - h.ds_decay_start_frac) / span
+            else:
+                ds_frac_factor = 0.0
+            ds_warmdown_factor = scale if h.ds_decay_with_warmdown else 1.0
+            ds_alpha_effective = (h.ds_alpha * ds_warmup_factor
+                                  * ds_frac_factor * ds_warmdown_factor)
+        else:
+            ds_alpha_effective = 0.0
+
+        train_loss = step_fn(step, scale, ds_alpha_effective=ds_alpha_effective)
+
+        # EMA update
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(
+                    t.detach().float(), alpha=1.0 - ema_decay,
+                )
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        should_log_train = (
+            h.train_log_every > 0
+            and (step <= 5 or step % h.train_log_every == 0
+                 or stop_after_step is not None)
+        )
+        if should_log_train:
+            tok_per_sec = step * h.train_batch_tokens / (approx_training_time_ms / 1e3)
+            log(f"{step}/{h.iterations} train_loss: {train_loss.item():.4f} "
+                f"train_time: {approx_training_time_ms / 60000:.1f}m "
+                f"tok/s: {tok_per_sec:.0f}")
+
+        # Check wallclock cap
+        reached_cap = (max_wallclock_ms is not None
+                       and approx_training_time_ms >= max_wallclock_ms)
+        if h.distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log(f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB")
+
+    # Apply EMA weights (strip PC keys from EMA before loading)
+    log('ema:applying EMA weights')
+    current_state = base_model.state_dict()
+    avg_state = {
+        name: t.to(dtype=current_state[name].dtype)
+        for name, t in ema_state.items()
+    }
+    base_model.load_state_dict(avg_state, strict=True)
+
+    return base_model, compiled_model
+
+
+# ---------------------------------------------------------------------------
+# Top-level train + eval orchestration
+# ---------------------------------------------------------------------------
+
+def train_and_eval(h, device):
+    random.seed(h.seed)
+    np.random.seed(h.seed)
+    torch.manual_seed(h.seed)
+    torch.cuda.manual_seed_all(h.seed)
+    val_data = ValidationData(h, device)
+    log(f"train_shards: {len(list(Path(h.datasets_dir).resolve().glob('fineweb_train_*.bin')))}")
+    log(f"val_tokens: {val_data.val_tokens.numel() - 1}")
+
+    base_model, compiled_model = train_model(h, device, val_data)
+    torch._dynamo.reset()
+
+    base_model._ds_alpha_buf.fill_(0.0)  # pure CE for eval
+    timed_eval('pre-quantization post-ema', eval_val, h, device, val_data, compiled_model)
+    serialize(h, base_model, Path(__file__).read_text(encoding='utf-8'))
+
+    if h.distributed:
+        dist.barrier()
+
+    eval_model = deserialize(h, device)
+    if h.num_loops > 0:
+        eval_model.looping_active = True
+    compiled_model = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    timed_eval('quantized', eval_val, h, device, val_data, compiled_model)
+
+    if h.sliding_window_enabled:
+        timed_eval('quantized_sliding_window', eval_val_sliding,
+                    h, device, val_data, eval_model)
+
+    if h.ttt_enabled and h.sliding_window_enabled:
+        del eval_model, compiled_model
+        torch._dynamo.reset()
+        torch.cuda.empty_cache()
+        ttt_model = deserialize(h, device)
+        if h.num_loops > 0:
+            ttt_model.looping_active = True
+        timed_eval('quantized_ttt', eval_val_ttt, h, device, val_data, ttt_model)
+        del ttt_model
+
+    # ETLB stub — enabled via env var but not yet implemented in SOTA
+    if h.etlb_enabled and h.sliding_window_enabled:
+        if 'eval_model' not in dir():
+            eval_model = deserialize(h, device)
+            if h.num_loops > 0:
+                eval_model.looping_active = True
+        # eval_val_sliding_etlb is referenced in SOTA but not defined
+        # (etlb_enabled defaults to False)
+        log('WARNING: ETLB evaluation requested but not implemented')
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    world_size = int(os.environ.get('WORLD_SIZE', '1'))
+    local_rank = int(os.environ.get('LOCAL_RANK', '0'))
+    distributed = 'RANK' in os.environ and 'WORLD_SIZE' in os.environ
+
+    if not torch.cuda.is_available():
+        raise RuntimeError('CUDA is required')
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+
+    device = torch.device('cuda', local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend='nccl', device_id=device)
+        dist.barrier()
+
+    # CUDA / precision settings
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision('high')
+    from torch.backends.cuda import (
+        enable_cudnn_sdp, enable_flash_sdp,
+        enable_math_sdp, enable_mem_efficient_sdp,
+    )
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    torch._dynamo.config.optimize_ddp = False
+
+    h = Hyperparameters()
+    set_logging_hparams(h)
+
+    if h.is_main_process:
+        os.makedirs('logs', exist_ok=True)
+        log(100 * '=', console=False)
+        log('Hyperparameters:', console=True)
+        for k, v in sorted(vars(type(h)).items()):
+            if not k.startswith('_'):
+                log(f"  {k}: {v}", console=True)
+        log('=' * 100, console=False)
+        log(f"Running Python {sys.version}", console=False)
+        log(f"Running PyTorch {torch.__version__}", console=False)
+        log(
+            subprocess.run(
+                ['nvidia-smi'], stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, text=True, check=False,
+            ).stdout,
+            console=False,
+        )
+        log('=' * 100, console=False)
+
+    train_and_eval(h, device)
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

First Deep Supervision (DS) submission in the competition. Introduces **Switched Deep Supervision** — a novel auxiliary loss scheduling strategy where a single randomly-chosen intermediate layer receives auxiliary CE supervision through the shared LM head each step.

**Single-seed result (seed 42, 8×H100, 588s):**
- Quantized + TTT BPB: **1.08288**
- Quantized + sliding window BPB: **1.08449**
- Pre-quant post-EMA BPB: 1.08933
- Total artifact: 15,997,104 bytes (under 16 MB) ✓

**Status: Non-record.** Does not beat current SOTA (PR #1493 at 1.0810). Submitted as scientifically interesting research with documented negative results.

## Novel Contributions

1. **Deep Supervision via shared LM head** — auxiliary CE loss at intermediate layers (default 6, 7, 9), reusing the existing tied embedding. Zero new parameters, zero artifact cost.

2. **Switched DS** — randomly pick ONE DS layer per step instead of supervising all selected layers. Reduces per-step compute by ~3× while preserving most of the per-step convergence benefit.

3. **Fraction-based DS alpha decay** — alpha decays linearly from 70% → 85% of training, then off, decoupling DS-induced weight oscillation from final EMA averaging.

4. **Per-layer adaptive GPTQ + int7 embeddings** — adopted from PR #1586 lineage to fit valid 16 MB artifact.

## Documented Negative Results

Included for community benefit:
- **Predictive Coding** (cosine similarity inter-layer prediction): net negative across all alpha values tested (0.005, 0.01, 0.1)
- **Multi-Token Prediction** with full transformer block heads: -0.005 to -0.010 BPB worse than pure DS
- **Medusa-style MTP** (RMSNorm + Linear heads): -0.0016 BPB worse than pure DS even with init fix
- See README for full ablation table

## Architecture

Built on the April 2026 SOTA stack (PR #1493 by bigbag): SP8192, depth recurrence (loop layers 3-5 three times, activate at 35%), parallel residuals (layers 7-10), MuonEq-R optimizer, QK-Gain 5.25, XSA on all 11 layers, FlashAttention 3, EMA decay 0.9965, warmdown fraction 0.72, legal score-first TTT.

Plus our novel additions: Switched DS at layers 6,7,9 with alpha=0.01.

## Compliance (Track B)

All four conditions per Issue #1017 satisfied:
- Causality (sliding window with prefix-only)
- Normalized softmax (no n-gram/logit bias)
- Score-before-update (TTT chunks scored under `torch.no_grad()` before SGD)
- Single pass (each token scored once)

DS heads are training-only (not in artifact). All artifacts < 16,000,000 bytes. Training < 600s on 8×H100.

## Reproduction

See [README.md](https://github.com/channyzf6/parameter-golf/blob/ds-submission/records/track_non_record_16mb/2026-04-14_SwitchedDeepSupervision/README.md) for full reproduction commands.

## Test plan
- [x] Single-seed (42) validated on 8×H100, fits in 16 MB
- [x] All four compliance conditions (Issue #1017) verified
- [x] Documented architecture, hyperparameters, ablation
- [ ] 3-seed validation (in progress, pending compute credits)
- [ ] Top-K sampled softmax for DS auxiliary losses (separate branch, pending H100 validation)