### PR TITLE
Non-record: Mamba-3 Hybrid SSM + SP8192 + Legal TTT — 1.1473 bpb

### DIFF
--- a/records/track_non_record_16mb/2026-04-15_Mamba3Hybrid_SP8192_GPTQ_TTT/README.md
+++ b/records/track_non_record_16mb/2026-04-15_Mamba3Hybrid_SP8192_GPTQ_TTT/README.md
@@ -1,0 +1,22 @@
+# Mamba-3 Hybrid SSM + SP8192 + Legal TTT — 1.1473 bpb
+
+Non-record submission. See PR description for full details.
+
+## Run
+
+```bash
+# Install Mamba-3
+bash setup_mamba3.sh
+
+# Generate SP8192 data (~35 min)
+cd data && python3 download_hf_docs_and_tokenize.py \
+  --output-root . --tokenizer-config tokenizer_specs_8192.json --skip-byte
+
+# Train + eval
+VOCAB_SIZE=8192 NUM_LAYERS=7 NUM_ATTN_LAYERS=2 USE_BIGRAM_HASH=0 TRAIN_SEQ_LEN=4096 \
+WARMDOWN_ITERS=2600 WARMDOWN_SHAPE=linear MUON_EQ_R=1 \
+LATE_QAT_THRESHOLD=0.15 USE_GPTQ=1 QUANT_BITS=6 QUANT_BITS_EMBED=8 GPTQ_NUM_SEQS=32 \
+EVAL_OVERLAP=1024 USE_LZMA=1 EVAL_TEMP=0.9 \
+WEIGHT_DECAY=0.04 MUON_MOMENTUM=0.99 MATRIX_LR=0.025 \
+torchrun --nproc_per_node=8 train_mamba3_hybrid.py
+```

--- a/records/track_non_record_16mb/2026-04-15_Mamba3Hybrid_SP8192_GPTQ_TTT/requirements.txt
+++ b/records/track_non_record_16mb/2026-04-15_Mamba3Hybrid_SP8192_GPTQ_TTT/requirements.txt
@@ -1,0 +1,6 @@
+torch>=2.9.1
+triton>=3.5.0
+mamba-ssm>=2.3.1
+sentencepiece
+einops
+numpy

--- a/records/track_non_record_16mb/2026-04-15_Mamba3Hybrid_SP8192_GPTQ_TTT/submission.json
+++ b/records/track_non_record_16mb/2026-04-15_Mamba3Hybrid_SP8192_GPTQ_TTT/submission.json
@@ -1,0 +1,11 @@
+{
+  "author": "mradassaad",
+  "github_id": "mradassaad",
+  "name": "Mamba-3 Hybrid SSM + SP8192 + Legal TTT",
+  "blurb": "7L Mamba-3 SISO hybrid (5 SSM + 2 attn), SP8192, 25.2M params. AR GPTQ with INT8 embed + embed Hessian. Chunk score-first TTT (SGD lr=0.010). Stateful-overlap eval.",
+  "date": "2026-04-15",
+  "val_loss": 2.96361204,
+  "val_bpb": 1.14730259,
+  "bytes_total": 15930354,
+  "bytes_code": 104754
+}

--- a/records/track_non_record_16mb/2026-04-15_Mamba3Hybrid_SP8192_GPTQ_TTT/train_mamba3_hybrid.py
+++ b/records/track_non_record_16mb/2026-04-15_Mamba3Hybrid_SP8192_GPTQ_TTT/train_mamba3_hybrid.py
@@ -1,0 +1,2232 @@
+"""Mamba-3 Hybrid for Parameter Golf.
+
+Mostly Mamba-3 SSD blocks with a few standalone attention layers (Mamba-2 paper
+Section 9.2.3: ~10% attention optimal at scale; higher ratio may help at our
+small model size). Env-var-driven hyperparameter sweep.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import lzma
+import zlib
+from pathlib import Path
+
+try:
+    import zstandard as zstd
+    HAS_ZSTD = True
+except ImportError:
+    HAS_ZSTD = False
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    # Defaults auto-select based on VOCAB_SIZE (e.g. 4096 → fineweb10B_sp4096).
+    _vs = os.environ.get("VOCAB_SIZE", "1024")
+    data_path = os.environ.get("DATA_PATH", f"./data/datasets/fineweb10B_sp{_vs}")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", f"./data/tokenizers/fineweb_{_vs}_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 3000))
+    warmdown_shape = os.environ.get("WARMDOWN_SHAPE", "cosine")  # "linear" or "cosine"
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 1_048_576))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 4096))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    sweep_mode = bool(int(os.environ.get("SWEEP_MODE", "0")))  # skip post-training (quant, serialize, TTT)
+
+    # Evaluation.
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 16))  # sliding window stride (0 = disabled)
+    eval_overlap = int(os.environ.get("EVAL_OVERLAP", 0))  # stateful-overlap eval (0 = disabled, e.g. 1024)
+    eval_state_reset = int(os.environ.get("EVAL_STATE_RESET", 0))  # reset SSM state every N windows during eval (0 = never)
+    eval_batch_seqs = int(os.environ.get("EVAL_BATCH_SEQS", 32))  # batch size for sliding eval
+    # Test-Time Training (TTT): chunk-based score-first adaptation on val data.
+    # Score each chunk (32×4096) under no_grad, then SGD adapt on the same chunk.
+    # Sweep result: lr=0.010 const (SGD, momentum=0.9) → −6.7 mBPB, 184s.
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.010))
+    ttt_freeze_blocks = int(os.environ.get("TTT_FREEZE_BLOCKS", 0))
+    ttt_optimizer = os.environ.get("TTT_OPTIMIZER", "sgd")  # "sgd" or "adamw"
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 1))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+
+    # Quantization.
+    quant_bits = int(os.environ.get("QUANT_BITS", 6))  # quantization bit width for attention (6 or 8)
+    quant_bits_mlp = int(os.environ.get("QUANT_BITS_MLP", 0))  # MLP bit width (0 = same as quant_bits)
+    quant_bits_embed = int(os.environ.get("QUANT_BITS_EMBED", 0))  # embedding bit width (0 = same as quant_bits, SOTA: 8)
+    gptq_clip_sigmas = float(os.environ.get("GPTQ_CLIP_SIGMAS", 0))  # SDClip for matrices (0 = percentile search, SOTA: 12.85)
+    gptq_embed_clip_sigmas = float(os.environ.get("GPTQ_EMBED_CLIP_SIGMAS", 0))  # SDClip for embeddings (0 = same as matrices, SOTA: 20)
+    qat_start_frac = float(os.environ.get("QAT_START_FRAC", 0.0))  # QAT: start at this fraction of training (0 = disabled)
+    gptq_lite = bool(int(os.environ.get("GPTQ_LITE", "1")))  # search for optimal clip percentile per tensor
+    use_zstd = bool(int(os.environ.get("USE_ZSTD", "1")))  # use zstd instead of zlib
+    use_lzma = bool(int(os.environ.get("USE_LZMA", "0")))  # use lzma instead of zlib (better ratio, slower)
+    use_brotli = bool(int(os.environ.get("USE_BROTLI", "0")))  # use brotli (SOTA uses quality=11)
+    eval_temp = float(os.environ.get("EVAL_TEMP", "1.0"))  # temperature scaling at eval (T<1 sharpens, improves bpb)
+    use_gptq = bool(int(os.environ.get("USE_GPTQ", "0")))  # Full Hessian GPTQ instead of per-row min-max
+    gptq_num_seqs = int(os.environ.get("GPTQ_NUM_SEQS", "32"))    # AR self-gen sequences for Hessian collection
+    gptq_gen_len = int(os.environ.get("GPTQ_GEN_LEN", "4096"))   # tokens per generated sequence (match train_seq_len)
+    gptq_gen_temp = float(os.environ.get("GPTQ_GEN_TEMP", "0.8"))  # sampling temperature during generation
+    gptq_damp = float(os.environ.get("GPTQ_DAMP", "0.01"))  # Hessian damping factor (λI added for stability)
+    late_qat_threshold = float(os.environ.get("LATE_QAT_THRESHOLD", "0.0"))  # enable QAT when lr_mul drops below this (SOTA uses 0.15)
+    target_mb = float(os.environ.get("TARGET_MB", "15.25"))  # target compressed submission size in MiB (16,000,000 bytes = 15.25 MiB)
+    muon_eq_r = bool(int(os.environ.get("MUON_EQ_R", "0")))  # MuonEq-R: row-normalize before Newton-Schulz
+
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 8))  # unique (physical) layers
+
+    # Layer loop (depth recurrence): repeat a block of layers for free effective depth.
+    num_loops = int(os.environ.get("NUM_LOOPS", 0))  # 0 = disabled, 2 = repeat loop segment twice
+    loop_start = int(os.environ.get("LOOP_START", 3))  # first layer in loop segment
+    loop_end = int(os.environ.get("LOOP_END", 4))  # last layer in loop segment (inclusive)
+    enable_looping_at = float(os.environ.get("ENABLE_LOOPING_AT", 0.35))  # fraction of training before activating loop
+
+    # BigramHash.
+    use_bigram_hash = bool(int(os.environ.get("USE_BIGRAM_HASH", "1")))
+    bigram_buckets = int(os.environ.get("BIGRAM_BUCKETS", 4096))
+    bigram_hash_dim = int(os.environ.get("BIGRAM_HASH_DIM", 128))
+
+    # OrthoInit + SWA.
+    use_ortho_init = bool(int(os.environ.get("USE_ORTHO_INIT", "1")))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    swa_start_frac = float(os.environ.get("SWA_START_FRAC", 0.4))
+    swa_every = int(os.environ.get("SWA_EVERY", 50))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    mlp_mult = float(os.environ.get("MLP_MULT", 3))
+    mamba3_d_state = int(os.environ.get("MAMBA3_D_STATE", 64))
+    mamba3_expand = float(os.environ.get("MAMBA3_EXPAND", 2))
+    mamba3_headdim = int(os.environ.get("MAMBA3_HEADDIM", 64))
+    mamba3_chunk_size = int(os.environ.get("MAMBA3_CHUNK_SIZE", 64))
+    mamba3_ngroups = int(os.environ.get("MAMBA3_NGROUPS", 1))
+    mamba3_rope_fraction = float(os.environ.get("MAMBA3_ROPE_FRACTION", 0.5))
+    mamba3_outproj_norm = bool(int(os.environ.get("MAMBA3_OUTPROJ_NORM", "0")))
+    # Attention layers (evenly spaced among SSD layers).
+    num_attn_layers = int(os.environ.get("NUM_ATTN_LAYERS", 1))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    ve_enabled = bool(int(os.environ.get("VE_ENABLED", "0")))
+    ve_dim = int(os.environ.get("VE_DIM", 64))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    weight_decay = float(os.environ.get("WEIGHT_DECAY", 0.02))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.0))  # embedding weight decay (SOTA: 0.085)
+    ema_enabled = bool(int(os.environ.get("EMA_ENABLED", "1")))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.997))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.02))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+
+# MUON OPTIMIZER
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7, eq_r: bool = False) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    if eq_r:
+        row_norms = X.norm(dim=-1, keepdim=True).clamp(min=eps)
+        X = X / row_norms
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True, weight_decay: float = 0.0, eq_r: bool = False):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov, weight_decay=weight_decay, eq_r=eq_r),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            weight_decay = group.get("weight_decay", 0.0)
+            eq_r = group.get("eq_r", False)
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps, eq_r=eq_r)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                if weight_decay > 0:
+                    p.data.mul_(1.0 - lr * weight_decay)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# TOKENIZER + EVALUATION
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters, model: nn.Module, rank: int, world_size: int,
+    device: torch.device, grad_accum_steps: int, val_tokens: Tensor,
+    base_bytes_lut: Tensor, has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+def eval_val_sliding(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    """Sliding window evaluation: score each token with maximal left-context."""
+    seq_len = args.train_seq_len
+    stride = args.eval_stride
+    batch_size = args.eval_batch_seqs
+    total_tokens = val_tokens.numel() - 1
+
+    window_starts = [ws for ws in range(0, total_tokens - seq_len + 1, stride)]
+    if window_starts[-1] + seq_len < total_tokens:
+        window_starts.append(total_tokens - seq_len)
+
+    my_starts = window_starts[rank::world_size]
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    with torch.inference_mode():
+        for batch_start in range(0, len(my_starts), batch_size):
+            batch_ws = my_starts[batch_start:batch_start + batch_size]
+            bsz = len(batch_ws)
+
+            x_list, y_list = [], []
+            for ws in batch_ws:
+                chunk = val_tokens[ws:ws + seq_len + 1].to(dtype=torch.int64)
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            x_batch = torch.stack(x_list).to(device=device, non_blocking=True)
+            y_batch = torch.stack(y_list).to(device=device, non_blocking=True)
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = base_model.forward_logits(x_batch)
+            scaled_logits = logits.float()
+            if args.eval_temp != 1.0:
+                scaled_logits = scaled_logits / args.eval_temp
+            nll = F.cross_entropy(
+                scaled_logits.reshape(-1, scaled_logits.size(-1)),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+
+            for i, ws in enumerate(batch_ws):
+                wlen = min(seq_len, total_tokens - ws)
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+
+                prev_ids = x_batch[i, s:wlen]
+                tgt_ids = y_batch[i, s:wlen]
+                tbytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                tbytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+                byte_count += tbytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return float(val_loss), float(bits_per_token * tokens_per_byte)
+
+
+def eval_val_stateful_overlap(
+    args: Hyperparameters, base_model: nn.Module, rank: int, world_size: int,
+    device: torch.device, val_tokens: Tensor, base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor, is_boundary_token_lut: Tensor,
+    initial_states: list | None = None,
+) -> tuple[float, float]:
+    """Stateful eval with overlapping windows: SSM state carries forward,
+    attention gets `overlap` tokens of prior context per window."""
+    seq_len = args.train_seq_len
+    overlap = args.eval_overlap
+    score_len = seq_len - overlap
+    total_tokens = val_tokens.numel() - 1
+
+    segment_tokens = (total_tokens // world_size // score_len) * score_len
+    seg_start = rank * segment_tokens
+    num_windows = segment_tokens // score_len
+
+    log0 = (lambda msg: print(msg)) if rank == 0 else (lambda msg: None)
+    state_reset = args.eval_state_reset
+    log0(f"stateful_overlap_eval: {num_windows} windows, overlap={overlap}, "
+         f"score_len={score_len}, segment={segment_tokens} tokens, state_reset={state_reset}")
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    layer_states = initial_states
+
+    with torch.inference_mode():
+        # Pre-warm SSM state for non-first segments so only rank 0 pays cold-start
+        if layer_states is None and seg_start > 0:
+            warmup_len = min(seq_len, seg_start)
+            warmup_chunk = val_tokens[seg_start - warmup_len : seg_start + 1].to(dtype=torch.int64)
+            wx = warmup_chunk[:-1].unsqueeze(0).to(device=device, non_blocking=True)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                _, layer_states = base_model.forward_logits_stateful(wx, None)
+            layer_states = [tuple(s.detach() for s in st) for st in layer_states]
+        log0(f"stateful_overlap_eval: pre-warmed={seg_start > 0} warmup_len={min(seq_len, seg_start) if seg_start > 0 else 0} initial_states={'provided' if initial_states is not None else 'None'}")
+
+        for wi in range(num_windows):
+            if state_reset > 0 and wi % state_reset == 0:
+                layer_states = None
+
+            score_start = seg_start + wi * score_len
+            tok_start = max(score_start - overlap, seg_start)
+            tok_end = score_start + score_len
+            actual_overlap = score_start - tok_start
+
+            chunk = val_tokens[tok_start:tok_end + 1].to(dtype=torch.int64)
+            x = chunk[:-1].unsqueeze(0).to(device=device, non_blocking=True)
+            y = chunk[1:].unsqueeze(0).to(device=device, non_blocking=True)
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits, layer_states = base_model.forward_logits_stateful(x, layer_states)
+
+            layer_states = [tuple(s.detach() for s in st) for st in layer_states]
+
+            scored_logits = logits[:, actual_overlap:, :].float()
+            scored_y = y[:, actual_overlap:]
+
+            if args.eval_temp != 1.0:
+                scored_logits = scored_logits / args.eval_temp
+
+            nll = F.cross_entropy(
+                scored_logits.reshape(-1, scored_logits.size(-1)),
+                scored_y.reshape(-1),
+                reduction="none",
+            )
+
+            loss_sum += nll.to(torch.float64).sum()
+            token_count += score_len
+
+            prev_ids = x.squeeze(0)[actual_overlap:]
+            tgt_ids = y.squeeze(0)[actual_overlap:]
+            tbytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            tbytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            byte_count += tbytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return float(val_loss), float(bits_per_token * tokens_per_byte)
+
+
+# eval_val_stateful_overlap_slot (residual-stream SLOT) — archived to profiling/eval_ttt.py
+# null result: consistently +2–8 mBPB; no consistent gradient direction in FineWeb bpb.
+
+# eval_val_stateful_overlap_ttt (window-level TTT) — archived to profiling/eval_ttt.py
+# null result: −0.1 mBPB in 573s; gradient signal from 1×1024 tokens is too weak vs chunk TTT.
+# Chunk TTT (32×4096 chunks, lr=0.010, SGD) gives −6.7 mBPB in 184s.
+
+# QUANTIZATION
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "m3_scale,mlp_scale,mlp_scales,attn_scale,resid_mix,resid_mixes,skip_weight,skip_weights,dt_bias,B_bias,C_bias,.D,A_log,q_gain,ve_layer_scales,ve_shared.scale",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def _quantize_with_clip(t32: Tensor, clip_abs: Tensor | float, qmax: int) -> tuple[Tensor, Tensor, Tensor]:
+    if t32.ndim == 2 and isinstance(clip_abs, Tensor):
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / qmax).clamp_min(1.0 / qmax)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -qmax, qmax).to(torch.int8)
+        recon = q.float() * scale[:, None]
+        return q.contiguous(), scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous(), recon
+    clip_abs_f = float(clip_abs) if isinstance(clip_abs, Tensor) else clip_abs
+    scale_f = clip_abs_f / qmax if clip_abs_f > 0 else 1.0
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs_f, clip_abs_f) / scale_f), -qmax, qmax).to(torch.int8)
+    recon = q.float() * scale_f
+    return q.contiguous(), torch.tensor(scale_f, dtype=torch.float32), recon
+
+def quantize_float_tensor(t: Tensor, bits: int = 8, search_clip: bool = False) -> tuple[Tensor, Tensor]:
+    qmax = (1 << (bits - 1)) - 1
+    t32 = t.float()
+
+    if not search_clip:
+        if t32.ndim == 2:
+            clip_abs = (
+                torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+                if t32.numel()
+                else torch.empty((t32.shape[0],), dtype=torch.float32)
+            )
+            q, scale, _ = _quantize_with_clip(t32, clip_abs, qmax)
+            return q, scale
+        clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+        q, scale, _ = _quantize_with_clip(t32, clip_abs, qmax)
+        return q, scale
+
+    candidates = [0.999, 0.9995, 0.9999, 0.99995, 0.99999, 0.999999, 1.0]
+    best_q, best_scale, best_mse = None, None, float("inf")
+
+    for pct in candidates:
+        if t32.ndim == 2:
+            if pct >= 1.0:
+                clip_abs = t32.abs().amax(dim=1)
+            else:
+                clip_abs = torch.quantile(t32.abs(), pct, dim=1)
+            q, scale, recon = _quantize_with_clip(t32, clip_abs, qmax)
+        else:
+            if pct >= 1.0:
+                clip_abs = float(t32.abs().max().item())
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), pct).item()) if t32.numel() else 0.0
+            q, scale, recon = _quantize_with_clip(t32, clip_abs, qmax)
+        mse = (t32 - recon).pow(2).mean().item()
+        if mse < best_mse:
+            best_mse = mse
+            best_q, best_scale = q, scale
+
+    return best_q, best_scale
+
+def generate_autoregressive_calib(
+    model: nn.Module, device: torch.device, num_seqs: int = 64, seq_len: int = 2048,
+    vocab_size: int = 1024, temperature: float = 0.8, batch_size: int = 8, seed: int = 42,
+) -> list[Tensor]:
+    """Generate sequences autoregressively from the model for GPTQ calibration.
+    No external data accessed — fully self-contained and legal."""
+    model.eval()
+    rng = torch.Generator(device=device)
+    rng.manual_seed(seed)
+    all_tokens = []
+    with torch.inference_mode(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        for batch_start in range(0, num_seqs, batch_size):
+            bs = min(batch_size, num_seqs - batch_start)
+            tokens = torch.randint(0, vocab_size, (bs, 1), device=device, generator=rng)
+            for _ in range(seq_len - 1):
+                logits = model.forward_logits(tokens)
+                next_logit = logits[:, -1, :]
+                probs = torch.softmax(next_logit / temperature, dim=-1)
+                next_tok = torch.multinomial(probs, 1, generator=rng)
+                tokens = torch.cat([tokens, next_tok], dim=1)
+            for i in range(bs):
+                all_tokens.append(tokens[i:i+1])
+    return all_tokens
+
+
+def collect_hessians_from_tokens(
+    model: nn.Module, token_seqs: list[Tensor], device: torch.device,
+    gptq_embed: bool = False,
+) -> dict[str, Tensor]:
+    """Collect H = X^T X from pre-generated token sequences via forward hooks on CastedLinear layers."""
+    hessians: dict[str, Tensor] = {}
+    hooks = []
+    for name, module in model.named_modules():
+        if isinstance(module, CastedLinear):
+            param_name = name + ".weight"
+            cols = module.weight.shape[1]
+            hessians[param_name] = torch.zeros(cols, cols, dtype=torch.float32, device=device)
+            def make_hook(pname: str):
+                def hook_fn(mod: nn.Module, inp: tuple, out: Tensor) -> None:
+                    x = inp[0].detach().float()
+                    if x.ndim == 3:
+                        x = x.reshape(-1, x.shape[-1])
+                    hessians[pname].addmm_(x.T, x)
+                return hook_fn
+            hooks.append(module.register_forward_hook(make_hook(param_name)))
+
+    if gptq_embed and model.tie_embeddings:
+        def make_output_hook(pname: str):
+            def hook_fn(mod: nn.Module, inp: tuple, out: Tensor) -> None:
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if pname not in hessians:
+                    hessians[pname] = torch.zeros(x.shape[1], x.shape[1], dtype=torch.float32, device=device)
+                hessians[pname].addmm_(x.T, x)
+            return hook_fn
+        hooks.append(model.final_norm.register_forward_hook(make_output_hook("tok_emb.weight")))
+
+    model.eval()
+    with torch.no_grad(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        for seq in token_seqs:
+            x = seq[:, :-1].to(device)
+            y = seq[:, 1:].to(device)
+            model(x, y)
+    for h in hooks:
+        h.remove()
+    num_batches = len(token_seqs)
+    for name in hessians:
+        H = hessians[name]
+        H /= num_batches
+        damp = 0.01 * torch.diag(H).mean().clamp_min(1e-6)
+        H += damp * torch.eye(H.shape[0], device=device)
+        hessians[name] = H.cpu()
+    return hessians
+
+
+def collect_hessians_from_train_data(
+    model: nn.Module, train_loader, device: torch.device,
+    train_batch_tokens: int, seq_len: int, grad_accum_steps: int,
+    n_batches: int = 64, gptq_embed: bool = True,
+) -> dict[str, Tensor]:
+    """Collect GPTQ Hessians from training data (like SOTA). Much faster than AR self-gen.
+    Also collects Hessian for tied embeddings via output hook on final_norm."""
+    hessians: dict[str, Tensor] = {}
+    hooks = []
+
+    def make_hook(pname: str):
+        def hook_fn(mod: nn.Module, inp: tuple, out: Tensor) -> None:
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            if pname not in hessians:
+                hessians[pname] = torch.zeros(x.shape[1], x.shape[1], dtype=torch.float32, device=device)
+            hessians[pname].addmm_(x.T, x)
+        return hook_fn
+
+    for name, module in model.named_modules():
+        if isinstance(module, CastedLinear) and module.weight.numel() > INT8_KEEP_FLOAT_MAX_NUMEL:
+            hooks.append(module.register_forward_hook(make_hook(name + ".weight")))
+
+    # Embedding Hessian: hook the output of final_norm (input to logit projection = tok_emb.weight^T)
+    if gptq_embed and model.tie_embeddings:
+        def make_output_hook(pname: str):
+            def hook_fn(mod: nn.Module, inp: tuple, out: Tensor) -> None:
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if pname not in hessians:
+                    hessians[pname] = torch.zeros(x.shape[1], x.shape[1], dtype=torch.float32, device=device)
+                hessians[pname].addmm_(x.T, x)
+            return hook_fn
+        hooks.append(model.final_norm.register_forward_hook(make_output_hook("tok_emb.weight")))
+
+    model.eval()
+    with torch.no_grad(), torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+        for _ in range(n_batches):
+            x, _ = train_loader.next_batch(train_batch_tokens, seq_len, grad_accum_steps)
+            model.forward_logits(x)
+
+    for h in hooks:
+        h.remove()
+    for name in hessians:
+        H = hessians[name]
+        H /= n_batches
+        damp = 0.01 * torch.diag(H).mean().clamp_min(1e-6)
+        H += damp * torch.eye(H.shape[0], device=device)
+        hessians[name] = H.cpu()
+    return hessians
+
+
+def quantize_int6_gptq(
+    weight: Tensor, hessian: Tensor | None = None, clip_range: int = 31, block_size: int = 128,
+    clip_sigmas: float = 0.0,
+) -> tuple[Tensor, Tensor]:
+    """Full GPTQ: Hessian-aware int6 quantization with Cholesky error compensation and column reordering.
+    If clip_sigmas > 0, uses SDClip (std-deviation-based clipping like SOTA) instead of percentile search.
+    Falls back to percentile search if hessian is None (same as existing gptq_lite path)."""
+    t32 = weight.float()
+    if t32.ndim != 2 or hessian is None:
+        return _quantize_int6_percentile(t32, clip_range)
+    rows, cols = t32.shape
+    H = hessian.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * torch.mean(torch.diag(H))
+    H[torch.arange(cols), torch.arange(cols)] += damp
+    # Column reordering: quantize most-activated (sensitive) columns first
+    perm = torch.argsort(torch.diag(H), descending=True)
+    inv_perm = torch.argsort(perm)
+    W = t32[:, perm].clone()
+    W[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    # Compute upper Cholesky of H_inv for the error propagation sweep
+    try:
+        Hinv = torch.linalg.cholesky(H)
+        Hinv = torch.cholesky_inverse(Hinv)
+        Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    except torch.linalg.LinAlgError:
+        print(f"gptq:cholesky_fallback shape={tuple(weight.shape)} dead={int(dead.sum())}/{cols}", flush=True)
+        return _quantize_int6_percentile(weight, clip_range=clip_range)
+
+    def _gptq_sweep(s: Tensor) -> tuple[Tensor, float]:
+        """Run GPTQ block-wise quantization with given per-row scale s."""
+        sf = s.float()
+        Q = torch.zeros_like(W, dtype=torch.int8)
+        W_work = W.clone()
+        for i1 in range(0, cols, block_size):
+            i2 = min(i1 + block_size, cols)
+            count = i2 - i1
+            W1 = W_work[:, i1:i2].clone()
+            Q1 = torch.zeros(rows, count, dtype=torch.int8)
+            Err1 = torch.zeros(rows, count)
+            Hinv1 = Hinv[i1:i2, i1:i2]
+            for i in range(count):
+                w = W1[:, i]
+                d = Hinv1[i, i]
+                q = torch.clamp(torch.round(w / sf), -clip_range, clip_range).to(torch.int8)
+                Q1[:, i] = q
+                err = (w - q.float() * sf) / d
+                W1[:, i:] -= err.unsqueeze(1) * Hinv1[i, i:].unsqueeze(0)
+                Err1[:, i] = err
+            Q[:, i1:i2] = Q1
+            if i2 < cols:
+                W_work[:, i2:] -= Err1 @ Hinv[i1:i2, i2:]
+        recon = Q.float() * sf[:, None]
+        mse = (W - recon).pow(2).mean().item()
+        return Q, mse
+
+    if clip_sigmas > 0:
+        # SDClip: scale = clip_sigmas * row_std / clip_range (SOTA approach)
+        row_std = t32.std(dim=1)
+        s = (clip_sigmas * row_std / clip_range).clamp_min(1e-10).to(torch.float16)
+        Q, _ = _gptq_sweep(s)
+        Q = Q[:, inv_perm]
+        return Q, s
+    else:
+        # Percentile search (original approach)
+        best_q, best_scale, best_err = None, None, float("inf")
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            row_clip = torch.quantile(t32.abs(), pct, dim=1) if pct < 1.0 else t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            Q, mse = _gptq_sweep(s)
+            if mse < best_err:
+                best_q, best_scale, best_err = Q, s, mse
+        best_q = best_q[:, inv_perm]
+        return best_q, best_scale
+
+
+def _quantize_int6_percentile(t32: Tensor, clip_range: int = 31) -> tuple[Tensor, Tensor]:
+    """Fallback percentile-search quantization (no Hessian)."""
+    if t32.ndim == 2:
+        best_q, best_s, best_err = None, None, float("inf")
+        for pct in [0.9990, 0.9995, 0.9999, 0.99999, 1.0]:
+            row_clip = torch.quantile(t32.abs(), pct, dim=1) if pct < 1.0 else t32.abs().amax(dim=1)
+            s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+            q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+            err = (t32 - q.float() * s.float()[:, None]).pow(2).mean().item()
+            if err < best_err:
+                best_q, best_s, best_err = q, s, err
+        return best_q, best_s
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor], quant_bits: int = 8, quant_bits_mlp: int = 0, quant_bits_embed: int = 0, search_clip: bool = False):
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        bits = quant_bits
+        if quant_bits_embed > 0 and "tok_emb" in name:
+            bits = quant_bits_embed
+        elif quant_bits_mlp > 0 and "mlp" in name:
+            bits = quant_bits_mlp
+        q, s = quantize_float_tensor(t, bits=bits, search_clip=search_clip)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    passthrough_data = obj["passthrough"]
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            deq = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            deq = (q.float() * scale).to(dtype=dtype).contiguous()
+        out[name] = deq
+    for name, t in passthrough_data.items():
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class FakeQuantizeSTE(torch.autograd.Function):
+    """Simulated quantization with Straight-Through Estimator for QAT."""
+    @staticmethod
+    def forward(ctx, w: Tensor, bits: int) -> Tensor:
+        qmax = (1 << (bits - 1)) - 1
+        if w.ndim == 2:
+            scale = w.detach().abs().amax(dim=1, keepdim=True) / qmax
+            scale = scale.clamp_min(1.0 / qmax)
+            return (torch.clamp(torch.round(w / scale), -qmax, qmax) * scale).to(w.dtype)
+        scale = w.detach().abs().amax() / qmax
+        scale = scale.clamp_min(1.0 / qmax)
+        return (torch.clamp(torch.round(w / scale), -qmax, qmax) * scale).to(w.dtype)
+
+    @staticmethod
+    def backward(ctx, grad: Tensor) -> tuple[Tensor, None]:
+        return grad, None
+
+
+class CastedLinear(nn.Linear):
+    _qat_bits: int = 0
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        if self._qat_bits > 0 and self.weight.numel() > 65536:
+            w = FakeQuantizeSTE.apply(w, self._qat_bits)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+class BigramHash(nn.Module):
+    def __init__(self, num_buckets: int, hash_dim: int, model_dim: int):
+        super().__init__()
+        self.num_buckets = num_buckets
+        self.table = nn.Embedding(num_buckets, hash_dim)
+        self.proj = CastedLinear(hash_dim, model_dim, bias=False)
+        self.proj._zero_init = True
+        nn.init.normal_(self.table.weight, std=0.01)
+
+    def forward(self, input_ids: Tensor) -> Tensor:
+        bsz, seqlen = input_ids.shape
+        prev_ids = torch.cat([torch.zeros(bsz, 1, dtype=input_ids.dtype, device=input_ids.device),
+                              input_ids[:, :-1]], dim=1)
+        h = ((prev_ids.long() * 92821 + input_ids.long()) % self.num_buckets).long()
+        return self.proj(self.table(h))
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+@torch._dynamo.disable
+def _mamba3_ssd_kernel(Q, K, V, ADT, DT, Trap, Q_bias, K_bias, Angles, D, Z,
+                       chunk_size, Input_States=None, return_final_states=False):
+    from mamba_ssm.ops.triton.mamba3.mamba3_siso_combined import mamba3_siso_combined
+    return mamba3_siso_combined(
+        Q=Q, K=K, V=V, ADT=ADT, DT=DT, Trap=Trap,
+        Q_bias=Q_bias, K_bias=K_bias, Angles=Angles, D=D, Z=Z,
+        chunk_size=chunk_size, Input_States=Input_States,
+        return_final_states=return_final_states,
+    )
+
+
+class Mamba3Layer(nn.Module):
+    """Pure Mamba-3 SISO layer. Uses the Mamba3 module directly."""
+    def __init__(self, dim: int, d_state: int = 64, expand: float = 2,
+                 headdim: int = 64, chunk_size: int = 64,
+                 ngroups: int = 1, rope_fraction: float = 0.5,
+                 is_outproj_norm: bool = False):
+        super().__init__()
+        from mamba_ssm.modules.mamba3 import Mamba3
+        self.mamba3 = Mamba3(
+            d_model=dim, d_state=d_state, expand=expand,
+            headdim=headdim, is_mimo=False, chunk_size=chunk_size,
+            ngroups=ngroups, rope_fraction=rope_fraction,
+            is_outproj_norm=is_outproj_norm,
+        )
+        # Replace nn.Linear with CastedLinear so QAT fake-quant and float32 master
+        # weights apply to Mamba-3's projections (which have the worst outlier problem).
+        for attr in ("in_proj", "out_proj"):
+            src = getattr(self.mamba3, attr)
+            dst = CastedLinear(src.in_features, src.out_features, bias=src.bias is not None)
+            dst.weight = src.weight
+            if src.bias is not None:
+                dst.bias = src.bias
+            setattr(self.mamba3, attr, dst)
+
+    def _pre_ssd(self, x):
+        """Pre-SSD ops: in_proj, split, reshape, compute ADT/DT, norms."""
+        from einops import rearrange
+        m = self.mamba3
+        zxBCdtAtrap = m.in_proj(x)
+        z, xv, B, C, dd_dt, dd_A, trap, angles = torch.split(
+            zxBCdtAtrap,
+            [m.d_inner, m.d_inner,
+             m.d_state * m.num_bc_heads * m.mimo_rank,
+             m.d_state * m.num_bc_heads * m.mimo_rank,
+             m.nheads, m.nheads, m.nheads, m.num_rope_angles],
+            dim=-1)
+        z = rearrange(z, "b l (h p) -> b l h p", p=m.headdim)
+        xv = rearrange(xv, "b l (h p) -> b l h p", p=m.headdim)
+        B = rearrange(B, "b l (r g n) -> b l r g n", r=m.mimo_rank, g=m.num_bc_heads)
+        C = rearrange(C, "b l (r g n) -> b l r g n", r=m.mimo_rank, g=m.num_bc_heads)
+        trap = rearrange(trap, "b l h -> b h l")
+        _A = -F.softplus(dd_A.to(torch.float32))
+        _A = torch.clamp(_A, max=-m.A_floor)
+        DT = F.softplus(dd_dt + m.dt_bias)
+        ADT = _A * DT
+        DT = rearrange(DT, "b l n -> b n l")
+        ADT = rearrange(ADT, "b l n -> b n l")
+        angles = angles.unsqueeze(-2).expand(-1, -1, m.nheads, -1)
+        B = m.B_norm(B).squeeze(2)
+        C = m.C_norm(C).squeeze(2)
+        return z, xv, B, C, ADT, DT, trap, angles
+
+    def _post_ssd(self, y, z):
+        """Post-SSD ops: reshape, optional norm, out_proj."""
+        from einops import rearrange
+        m = self.mamba3
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if m.is_outproj_norm:
+            z_flat = rearrange(z, "b l h p -> b l (h p)")
+            y = m.outproj_rmsnorm(y) * (z_flat * F.silu(z_flat))
+        y = m.out_proj(y)
+        return y
+
+    def forward(self, x: Tensor) -> Tensor:
+        m = self.mamba3
+        z, xv, B, C, ADT, DT, trap, angles = self._pre_ssd(x)
+        y = _mamba3_ssd_kernel(
+            Q=C, K=B, V=xv,
+            ADT=ADT, DT=DT, Trap=trap,
+            Q_bias=m.C_bias.squeeze(1), K_bias=m.B_bias.squeeze(1),
+            Angles=angles, D=m.D,
+            Z=z if not m.is_outproj_norm else None,
+            chunk_size=m.chunk_size,
+        )
+        return self._post_ssd(y, z)
+
+    def forward_stateful(self, x: Tensor, input_states=None):
+        """Forward with SSM state carry. Returns (output, final_states)."""
+        m = self.mamba3
+        z, xv, B, C, ADT, DT, trap, angles = self._pre_ssd(x)
+        result = _mamba3_ssd_kernel(
+            Q=C, K=B, V=xv,
+            ADT=ADT, DT=DT, Trap=trap,
+            Q_bias=m.C_bias.squeeze(1), K_bias=m.B_bias.squeeze(1),
+            Angles=angles, D=m.D,
+            Z=z if not m.is_outproj_norm else None,
+            chunk_size=m.chunk_size,
+            Input_States=input_states,
+            return_final_states=True,
+        )
+        y, last_angle, last_state, last_k, last_v, *rest = result
+        final_states = (last_angle, last_state, last_k, last_v)
+        return self._post_ssd(y, z), final_states
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class AttentionLayer(nn.Module):
+    """Standalone causal self-attention with GQA and RoPE."""
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int,
+                 rope_base: float, qk_gain_init: float):
+        super().__init__()
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        kv_dim = num_kv_heads * self.head_dim
+
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor, v_embed: Tensor | None = None) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        if v_embed is not None:
+            v = v + v_embed.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = v.transpose(1, 2)
+        v = v * v.sigmoid()
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q, k, v, attn_mask=None, is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        return self.proj(y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim))
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: float):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = F.leaky_relu(self.fc(x), negative_slope=0.5)
+        return self.proj(x.square())
+
+
+class ValueEmbedding(nn.Module):
+    """Reinject token identity into attention values. Shared table across all attn layers."""
+    def __init__(self, vocab_size: int, ve_dim: int, kv_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, ve_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(ve_dim, kv_dim, bias=False) if ve_dim != kv_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(token_ids)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+class Block(nn.Module):
+    def __init__(
+        self, dim: int, mlp_mult: int,
+        mamba3_d_state: int = 64, mamba3_expand: float = 2,
+        mamba3_headdim: int = 64, mamba3_chunk_size: int = 64,
+        mamba3_ngroups: int = 1, mamba3_rope_fraction: float = 0.5,
+        mamba3_outproj_norm: bool = False,
+        layer_idx: int = 0,
+    ):
+        super().__init__()
+        self.m3_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.mamba3 = Mamba3Layer(
+            dim, d_state=mamba3_d_state, expand=mamba3_expand,
+            headdim=mamba3_headdim, chunk_size=mamba3_chunk_size,
+            ngroups=mamba3_ngroups, rope_fraction=mamba3_rope_fraction,
+            is_outproj_norm=mamba3_outproj_norm,
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.m3_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor, v_embed: Tensor | None = None) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        m3_out = self.mamba3(self.m3_norm(x))
+        x = x + self.m3_scale.to(dtype=x.dtype)[None, None, :] * m3_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+    def forward_stateful(self, x: Tensor, x0: Tensor, v_embed: Tensor | None = None, ssm_states=None):
+        """Forward with SSM state carry. Returns (output, final_states)."""
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        m3_out, fstate = self.mamba3.forward_stateful(self.m3_norm(x), input_states=ssm_states)
+        x = x + self.m3_scale.to(dtype=x.dtype)[None, None, :] * m3_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x, fstate
+
+
+class AttnBlock(nn.Module):
+    """Block with standalone attention (no SSM)."""
+    def __init__(
+        self, dim: int, mlp_mult: int,
+        num_heads: int = 8, num_kv_heads: int = 4,
+        rope_base: float = 10000.0, qk_gain_init: float = 1.0,
+        layer_idx: int = 0,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = AttentionLayer(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor, v_embed: Tensor | None = None) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x), v_embed=v_embed)
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self, vocab_size: int, num_layers: int, model_dim: int,
+        mlp_mult: int, tie_embeddings: bool, tied_embed_init_std: float,
+        logit_softcap: float,
+        use_bigram_hash: bool = False,
+        bigram_buckets: int = 4096, bigram_hash_dim: int = 128,
+        use_ortho_init: bool = False,
+        mamba3_d_state: int = 64, mamba3_expand: float = 2,
+        mamba3_headdim: int = 64, mamba3_chunk_size: int = 64,
+        mamba3_ngroups: int = 1, mamba3_rope_fraction: float = 0.5,
+        mamba3_outproj_norm: bool = False,
+        num_attn_layers: int = 1, num_heads: int = 8, num_kv_heads: int = 4,
+        rope_base: float = 10000.0, qk_gain_init: float = 1.0,
+        ve_enabled: bool = False, ve_dim: int = 64,
+        num_loops: int = 0, loop_start: int = 3, loop_end: int = 4,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.use_ortho_init = use_ortho_init
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+
+        self.bigram_hash = BigramHash(bigram_buckets, bigram_hash_dim, model_dim) if use_bigram_hash else None
+
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+
+        self.skip_weights = nn.Parameter(
+            torch.ones(1, self.num_skip_weights, model_dim, dtype=torch.float32)
+        )
+
+        # Layer loop (depth recurrence): build flat index sequences for encoder/decoder.
+        # When looping_active=True, _run_blocks uses the expanded indices.
+        # Physical blocks are reused — no extra params.
+        self.num_loops = num_loops
+        self.looping_active = False
+        if num_loops > 0:
+            loop_seg = list(range(loop_start, loop_end + 1))
+            all_indices = list(range(loop_start))  # layers before loop
+            for _ in range(num_loops + 1):  # original + repeats
+                all_indices.extend(loop_seg)
+            all_indices.extend(range(loop_end + 1, num_layers))  # layers after loop
+            num_enc = len(all_indices) // 2
+            self.encoder_indices = all_indices[:num_enc]
+            self.decoder_indices = all_indices[num_enc:]
+            # Size skip_weights for the larger (looped) case so all params are always used
+            self.num_skip_weights = max(
+                self.num_skip_weights,
+                min(len(self.encoder_indices), len(self.decoder_indices)),
+            )
+            self.skip_weights = nn.Parameter(
+                torch.ones(1, self.num_skip_weights, model_dim, dtype=torch.float32)
+            )
+        else:
+            self.encoder_indices = list(range(self.num_encoder_layers))
+            self.decoder_indices = list(range(self.num_encoder_layers, num_layers))
+
+        # Compute evenly spaced attention layer indices
+        attn_indices = set()
+        if num_attn_layers > 0:
+            for i in range(1, num_attn_layers + 1):
+                attn_indices.add(round(i * num_layers / (num_attn_layers + 1)))
+        self.attn_indices = sorted(attn_indices)
+
+        self.blocks = nn.ModuleList()
+        for i in range(num_layers):
+            if i in attn_indices:
+                self.blocks.append(AttnBlock(
+                    model_dim, mlp_mult,
+                    num_heads=num_heads, num_kv_heads=num_kv_heads,
+                    rope_base=rope_base, qk_gain_init=qk_gain_init,
+                    layer_idx=i,
+                ))
+            else:
+                self.blocks.append(Block(
+                    model_dim, mlp_mult,
+                    mamba3_d_state=mamba3_d_state, mamba3_expand=mamba3_expand,
+                    mamba3_headdim=mamba3_headdim, mamba3_chunk_size=mamba3_chunk_size,
+                    mamba3_ngroups=mamba3_ngroups, mamba3_rope_fraction=mamba3_rope_fraction,
+                    mamba3_outproj_norm=mamba3_outproj_norm,
+                    layer_idx=i,
+                ))
+
+        kv_dim = num_kv_heads * (model_dim // num_heads)
+        if ve_enabled and self.attn_indices:
+            self.ve_shared = ValueEmbedding(vocab_size, ve_dim, kv_dim)
+            self.ve_layer_scales = nn.ParameterList(
+                [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.attn_indices]
+            )
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        num_layers = len(self.blocks)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif self.use_ortho_init and module.weight.ndim == 2 and min(module.weight.shape) >= 16:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj" in name and name.split(".")[-1] in ("proj", "proj_D"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * num_layers))
+
+    def _compute_logits_and_loss(self, x: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+    def _get_ve(self, block_idx: int, ve_cache: Tensor | None) -> Tensor | None:
+        if ve_cache is None or block_idx not in self.attn_indices:
+            return None
+        ve_idx = self.attn_indices.index(block_idx)
+        return ve_cache * self.ve_layer_scales[ve_idx].to(dtype=ve_cache.dtype)
+
+    _embed_qat_bits: int = 0
+
+    def _embed(self, input_ids: Tensor) -> Tensor:
+        if self._embed_qat_bits > 0:
+            w = FakeQuantizeSTE.apply(self.tok_emb.weight.to(torch.bfloat16), self._embed_qat_bits)
+            x = F.embedding(input_ids, w)
+        else:
+            x = self.tok_emb(input_ids)
+        if self.bigram_hash is not None:
+            x = x + self.bigram_hash(input_ids)
+        return F.rms_norm(x, (x.size(-1),))
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor,
+                layer_states: list | None = None, stateful: bool = False):
+        x = self._embed(input_ids)
+        if stateful:
+            x, new_states = self._run_blocks_stateful(x, x, input_ids, layer_states)
+            loss = self._compute_logits_and_loss(x, target_ids)
+            return loss, new_states
+        x = self._run_blocks(x, x, input_ids)
+        return self._compute_logits_and_loss(x, target_ids)
+
+    def _run_blocks(self, x: Tensor, x0: Tensor, input_ids: Tensor | None = None) -> Tensor:
+        ve_cache = self.ve_shared(input_ids) if (self.ve_shared is not None and input_ids is not None) else None
+        if self.looping_active:
+            enc_idx, dec_idx = self.encoder_indices, self.decoder_indices
+        else:
+            enc_idx = list(range(self.num_encoder_layers))
+            dec_idx = list(range(self.num_encoder_layers, len(self.blocks)))
+        skips: list[Tensor] = []
+        for bi in enc_idx:
+            x = self.blocks[bi](x, x0, v_embed=self._get_ve(bi, ve_cache))
+            skips.append(x)
+        for i, bi in enumerate(dec_idx):
+            if i < len(skips) and i < self.skip_weights.shape[1]:
+                x = x + self.skip_weights[0, i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            elif skips:
+                skips.pop()  # discard if more skips than weights
+            x = self.blocks[bi](x, x0, v_embed=self._get_ve(bi, ve_cache))
+        return x
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        bsz, seqlen = input_ids.shape
+        x = self._embed(input_ids)
+        x = self._run_blocks(x, x, input_ids)
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        w = self.tok_emb.weight if self.tie_embeddings else self.lm_head.weight
+        logits = self.logit_softcap * torch.tanh(F.linear(x, w) / self.logit_softcap)
+        return logits.reshape(bsz, seqlen, -1)
+
+    def _run_blocks_stateful(self, x: Tensor, x0: Tensor, input_ids: Tensor | None = None,
+                             layer_states: list | None = None):
+        """Like _run_blocks but carries SSM state per layer. Returns (output, new_layer_states).
+        Note: when looping, the same physical block may appear multiple times in the index list.
+        Each *appearance* gets its own state slot — the state from pass 1 feeds into pass 2."""
+        ve_cache = self.ve_shared(input_ids) if (self.ve_shared is not None and input_ids is not None) else None
+        new_states: list = []
+        si = 0
+        if self.looping_active:
+            enc_idx, dec_idx = self.encoder_indices, self.decoder_indices
+        else:
+            enc_idx = list(range(self.num_encoder_layers))
+            dec_idx = list(range(self.num_encoder_layers, len(self.blocks)))
+        skips: list[Tensor] = []
+        for bi in enc_idx:
+            block = self.blocks[bi]
+            if isinstance(block, Block):
+                prev = layer_states[si] if layer_states is not None else None
+                x, fstate = block.forward_stateful(x, x0, v_embed=self._get_ve(bi, ve_cache), ssm_states=prev)
+                new_states.append(fstate)
+                si += 1
+            else:
+                x = block(x, x0, v_embed=self._get_ve(bi, ve_cache))
+            skips.append(x)
+        for i, bi in enumerate(dec_idx):
+            if i < len(skips) and i < self.skip_weights.shape[1]:
+                x = x + self.skip_weights[0, i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            elif skips:
+                skips.pop()
+            block = self.blocks[bi]
+            if isinstance(block, Block):
+                prev = layer_states[si] if layer_states is not None else None
+                x, fstate = block.forward_stateful(x, x0, v_embed=self._get_ve(bi, ve_cache), ssm_states=prev)
+                new_states.append(fstate)
+                si += 1
+            else:
+                x = block(x, x0, v_embed=self._get_ve(bi, ve_cache))
+        return x, new_states
+
+    def forward_logits_stateful(self, input_ids: Tensor, layer_states: list | None = None):
+        """Forward returning (logits, new_layer_states) for stateful eval."""
+        bsz, seqlen = input_ids.shape
+        x = self._embed(input_ids)
+        x, new_states = self._run_blocks_stateful(x, x, input_ids, layer_states)
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        w = self.tok_emb.weight if self.tie_embeddings else self.lm_head.weight
+        logits = self.logit_softcap * torch.tanh(F.linear(x, w) / self.logit_softcap)
+        return logits.reshape(bsz, seqlen, -1), new_states
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = int(os.environ.get("GRAD_ACCUM_STEPS", 8 // world_size))
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.backends.cuda.enable_flash_sdp(True)
+    torch.backends.cuda.enable_mem_efficient_sdp(False)
+    torch.backends.cuda.enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    base_model = GPT(
+        vocab_size=args.vocab_size, num_layers=args.num_layers, model_dim=args.model_dim,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings, tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        use_bigram_hash=args.use_bigram_hash,
+        bigram_buckets=args.bigram_buckets, bigram_hash_dim=args.bigram_hash_dim,
+        use_ortho_init=args.use_ortho_init,
+        mamba3_d_state=args.mamba3_d_state, mamba3_expand=args.mamba3_expand,
+        mamba3_headdim=args.mamba3_headdim, mamba3_chunk_size=args.mamba3_chunk_size,
+        mamba3_ngroups=args.mamba3_ngroups, mamba3_rope_fraction=args.mamba3_rope_fraction,
+        mamba3_outproj_norm=args.mamba3_outproj_norm,
+        num_attn_layers=args.num_attn_layers, num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads, rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        ve_enabled=args.ve_enabled, ve_dim=args.ve_dim,
+        num_loops=args.num_loops, loop_start=args.loop_start, loop_end=args.loop_end,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=False)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False,
+                           find_unused_parameters=(args.num_loops > 0)) if distributed else compiled_model
+
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if hasattr(base_model, 'skip_weights') and base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    if base_model.bigram_hash is not None:
+        scalar_params.append(base_model.bigram_hash.table.weight)
+        matrix_params.append(base_model.bigram_hash.proj.weight)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+    if base_model.ve_shared is not None:
+        tok_params.append({"params": [base_model.ve_shared.embed.weight], "lr": token_lr, "base_lr": token_lr})
+        scalar_params.append(base_model.ve_shared.scale)
+        for p in base_model.ve_layer_scales:
+            scalar_params.append(p)
+        if base_model.ve_shared.proj is not None:
+            matrix_params.append(base_model.ve_shared.proj.weight)
+    optimizer_tok = torch.optim.Adam(
+        tok_params, weight_decay=args.embed_wd,
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params, lr=args.matrix_lr, momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps, weight_decay=args.weight_decay,
+        eq_r=args.muon_eq_r,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2), eps=args.adam_eps, fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"mode:mamba3_hybrid num_attn_layers:{args.num_attn_layers} attn_indices:{base_model.attn_indices}")
+    log0(f"ssd: d_state:{args.mamba3_d_state} expand:{args.mamba3_expand} headdim:{args.mamba3_headdim} ngroups:{args.mamba3_ngroups} rope_frac:{args.mamba3_rope_fraction} outproj_norm:{args.mamba3_outproj_norm}")
+    log0(f"attn: num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads} rope_base:{args.rope_base}")
+    log0(f"num_layers:{args.num_layers} mlp_mult:{args.mlp_mult}")
+    if args.muon_eq_r:
+        log0(f"muon_eq_r:enabled")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            frac = max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        else:
+            step_ms = elapsed_ms / max(step, 1)
+            warmdown_ms = args.warmdown_iters * step_ms
+            remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+            frac = remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+        if args.warmdown_shape == "cosine" and frac < 1.0:
+            return 0.5 * (1.0 + math.cos(math.pi * (1.0 - frac)))
+        return frac
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        # Pre-warm the looped graph too so torch.compile caches both variants
+        if args.num_loops > 0:
+            base_model.looping_active = True
+            log0(f"loop_warmup:enabled encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}")
+            for warmup_step in range(args.warmup_steps):
+                zero_grad_all()
+                for micro_step in range(grad_accum_steps):
+                    if distributed:
+                        model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                    x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                        warmup_loss = model(x, y)
+                    (warmup_loss * grad_scale).backward()
+                for opt in optimizers:
+                    opt.step()
+                zero_grad_all()
+                if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                    log0(f"loop_warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+            base_model.looping_active = False
+
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+
+    ema_state: dict[str, Tensor] | None = None
+    if args.ema_enabled:
+        ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+
+        if args.qat_start_frac > 0 and max_wallclock_ms:
+            elapsed_frac_qat = elapsed_ms / max_wallclock_ms
+            qat_active = elapsed_frac_qat >= args.qat_start_frac
+            qat_bits = args.quant_bits if qat_active else 0
+            if qat_active and any(m._qat_bits == 0 for m in base_model.modules() if isinstance(m, CastedLinear)):
+                log0(f"qat:enabled bits={qat_bits} at step {step} frac={elapsed_frac_qat:.2f}")
+                for m in base_model.modules():
+                    if isinstance(m, CastedLinear):
+                        m._qat_bits = qat_bits
+
+        # Late QAT: trigger when lr_mul drops below threshold (SOTA approach)
+        if args.late_qat_threshold > 0 and scale < args.late_qat_threshold:
+            if any(m._qat_bits == 0 for m in base_model.modules() if isinstance(m, CastedLinear)):
+                qat_bits = args.quant_bits
+                embed_qat_bits = args.quant_bits_embed if args.quant_bits_embed > 0 else args.quant_bits
+                log0(f"late_qat:enabled bits={qat_bits} embed_bits={embed_qat_bits} at step {step} scale={scale:.4f}")
+                for m in base_model.modules():
+                    if isinstance(m, CastedLinear):
+                        m._qat_bits = qat_bits
+                base_model._embed_qat_bits = embed_qat_bits
+
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        cur_seq_len = args.train_seq_len
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, cur_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+
+        if ema_state is not None:
+            d = args.ema_decay
+            with torch.no_grad():
+                for name, t in base_model.state_dict().items():
+                    ema_state[name].mul_(d).add_(t.detach().float(), alpha=1.0 - d)
+
+        if args.swa_enabled and scale < args.swa_start_frac and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {name: t.detach().cpu().clone().float() for name, t in base_model.state_dict().items()}
+                swa_count = 1
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu().float()
+                swa_count += 1
+
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+
+        # Delayed layer loop activation
+        if args.num_loops > 0 and not base_model.looping_active:
+            frac = approx_training_time_ms / (max_wallclock_ms or 600_000)
+            if frac >= args.enable_looping_at:
+                base_model.looping_active = True
+                log0(f"layer_loop:enabled step:{step} frac:{frac:.3f} "
+                     f"encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}")
+
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            tok_per_sec = step * args.train_batch_tokens / (approx_training_time_ms / 1000.0)
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms "
+                f"tok/s:{tok_per_sec:.0f}"
+            )
+
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    if args.sweep_mode:
+        log0("sweep_mode:exiting after training loop (skipping quantization/serialization)")
+        if distributed:
+            dist.destroy_process_group()
+        return
+
+    for m in base_model.modules():
+        if isinstance(m, CastedLinear):
+            m._qat_bits = 0
+    base_model._embed_qat_bits = 0
+
+    if ema_state is not None:
+        log0("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+        del ema_state
+        base_model.load_state_dict(avg_state, strict=True)
+    elif args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"swa:applying averaged {swa_count} checkpoints")
+        current_state = base_model.state_dict()
+        avg_state = {
+            name: (tensor / swa_count).to(dtype=current_state[name].dtype)
+            for name, tensor in swa_state.items()
+        }
+        del swa_state
+        base_model.load_state_dict(avg_state, strict=True)
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    # Tear down DDP before GPTQ and eval: GPTQ hooks + TTT backward are incompatible
+    # with live NCCL context (CUDA illegal memory access in hook_fn on DDP teardown).
+    # TTT also doesn't parallelize across GPUs. Non-master ranks exit here.
+    if distributed:
+        dist.barrier()
+        dist.destroy_process_group()
+        distributed = False
+    torch.cuda.synchronize()  # drain async NCCL event destruction before GPTQ touches memory
+    torch.cuda.empty_cache()
+    if not master_process:
+        return
+
+    if args.use_gptq:
+        t_gptq = time.perf_counter()
+        # AR GPTQ: torch.compile + triton.set_allocator(ContextVar.set) in _Mamba3Function
+        # corrupts the CUDA driver state, making train-data GPTQ crash (even in subprocesses
+        # on different GPUs). AR generation uses the compiled model (kernels cached), then
+        # Hessian collection with hooks also uses cached kernels — no autotuning needed.
+        # Cost: +5.5 mBPB vs train-data GPTQ (9.8 vs 4.3 gap), +220s eval time.
+        base_model.eval()
+        log0("gptq:generating autoregressive calibration data...")
+        ar_tokens = generate_autoregressive_calib(
+            base_model, device, num_seqs=args.gptq_num_seqs,
+            seq_len=args.train_seq_len, vocab_size=args.vocab_size,
+        )
+        log0(f"gptq:generated {len(ar_tokens)} seqs in {time.perf_counter()-t_gptq:.1f}s")
+        log0("gptq:collecting hessians...")
+        hessians = collect_hessians_from_tokens(base_model, ar_tokens, device, gptq_embed=args.tie_embeddings)
+        del ar_tokens
+        log0(f"gptq:collected hessians for {len(hessians)} layers in {time.perf_counter()-t_gptq:.1f}s")
+        torch.cuda.empty_cache()
+        # Apply GPTQ to each quantizable layer in the state dict.
+        sd = base_model.state_dict()
+        gptq_sd = {}
+        for name, t in sd.items():
+            t_cpu = t.detach().cpu()
+            H = hessians.get(name)
+            if H is not None and t_cpu.is_floating_point() and t_cpu.ndim == 2 and t_cpu.numel() > INT8_KEEP_FLOAT_MAX_NUMEL:
+                is_embed = "tok_emb" in name
+                bits = args.quant_bits_embed if (is_embed and args.quant_bits_embed > 0) else args.quant_bits
+                cr = (1 << (bits - 1)) - 1
+                cs = args.gptq_embed_clip_sigmas if (is_embed and args.gptq_embed_clip_sigmas > 0) else args.gptq_clip_sigmas
+                q, s = quantize_int6_gptq(t_cpu, hessian=H, clip_range=cr, clip_sigmas=cs)
+                gptq_sd[name] = (q.float() * s.float()[:, None]).to(t_cpu.dtype)
+            else:
+                gptq_sd[name] = t_cpu
+        base_model.load_state_dict(gptq_sd, strict=True)
+        del hessians, gptq_sd
+        torch.cuda.empty_cache()
+        log0(f"gptq:quantization complete in {time.perf_counter()-t_gptq:.1f}s total")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(
+        base_model.state_dict(), quant_bits=args.quant_bits,
+        quant_bits_mlp=args.quant_bits_mlp, quant_bits_embed=args.quant_bits_embed,
+        search_clip=args.gptq_lite,
+    )
+    # Selective ±1 pruning: zero out least-impactful ±1 quantized values to fit target size
+    if (args.use_lzma or args.use_brotli) and args.target_mb > 0 and master_process:
+        target_bytes = int(args.target_mb * 1024 * 1024)
+        code_bytes_est = len(code.encode("utf-8"))
+        ones_info = []
+        for name, q in quant_obj["quantized"].items():
+            s = quant_obj["scales"].get(name)
+            if s is None or s.ndim == 0:
+                continue
+            ones_mask = (q.abs() == 1)
+            if ones_mask.any():
+                row_idx = torch.arange(q.shape[0]).unsqueeze(1).expand_as(q)[ones_mask]
+                flat_idx = torch.arange(q.numel()).reshape(q.shape)[ones_mask]
+                errors = s.float()[row_idx].pow(2)
+                for fi, err in zip(flat_idx.tolist(), errors.tolist()):
+                    ones_info.append((name, fi, err))
+        if ones_info:
+            ones_info.sort(key=lambda x: x[2])
+            def _compress_for_prune(raw):
+                if args.use_brotli:
+                    import brotli
+                    return brotli.compress(raw, quality=11)
+                return lzma.compress(raw, preset=9)
+            def _try_prune(n):
+                tmp_q = {k: v.clone() for k, v in quant_obj["quantized"].items()}
+                for i in range(min(n, len(ones_info))):
+                    tmp_q[ones_info[i][0]].view(-1)[ones_info[i][1]] = 0
+                tmp_obj = {**quant_obj, "quantized": tmp_q}
+                buf = io.BytesIO()
+                torch.save(tmp_obj, buf)
+                return len(_compress_for_prune(buf.getvalue())) + code_bytes_est, tmp_q
+            no_sz, _ = _try_prune(0)
+            log0(f"selective_prune: {len(ones_info)} ±1 candidates, unpruned={no_sz/(1024*1024):.2f}MB target={args.target_mb}MB")
+            if no_sz <= target_bytes:
+                log0("selective_prune: already fits, no pruning needed")
+            else:
+                full_sz, _ = _try_prune(len(ones_info))
+                log0(f"selective_prune: full ±1 prune={full_sz/(1024*1024):.2f}MB")
+                if full_sz > target_bytes:
+                    log0("selective_prune: even full prune not enough, applying all")
+                    _, quant_obj["quantized"] = _try_prune(len(ones_info))
+                else:
+                    # Linear interpolation instead of binary search (LZMA-9 is too slow for 22 iterations)
+                    frac = (no_sz - target_bytes) / max(no_sz - full_sz, 1)
+                    est = int(frac * len(ones_info) * 1.1) + 1  # 10% margin
+                    est = min(est, len(ones_info))
+                    log0(f"selective_prune: pruning {est}/{len(ones_info)} ±1 values ({100*est/len(ones_info):.1f}%) to fit {args.target_mb}MB")
+                    _, quant_obj["quantized"] = _try_prune(est)
+
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    if args.use_brotli:
+        import brotli
+        quant_blob = brotli.compress(quant_raw, quality=11)
+        compress_fmt = "brotli-11"
+    elif args.use_lzma:
+        quant_blob = lzma.compress(quant_raw, preset=9)
+        compress_fmt = "lzma-9"
+    elif args.use_zstd and HAS_ZSTD:
+        cctx = zstd.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+        compress_fmt = "zstd-22"
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+        compress_fmt = "zlib-9"
+    quant_raw_bytes = len(quant_raw)
+    quant_filename = f"final_model.int{args.quant_bits}.ptz"
+    if master_process:
+        with open(quant_filename, "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize(quant_filename)
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int{args.quant_bits}+{compress_fmt}: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int{args.quant_bits}+{compress_fmt}: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open(quant_filename, "rb") as f:
+        quant_blob_disk = f.read()
+    if args.use_brotli:
+        import brotli
+        quant_decompressed = brotli.decompress(quant_blob_disk)
+    elif args.use_lzma:
+        quant_decompressed = lzma.decompress(quant_blob_disk)
+    elif args.use_zstd and HAS_ZSTD:
+        dctx = zstd.ZstdDecompressor()
+        quant_decompressed = dctx.decompress(quant_blob_disk)
+    else:
+        quant_decompressed = zlib.decompress(quant_blob_disk)
+    quant_state = torch.load(io.BytesIO(quant_decompressed), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+
+    if args.ttt_enabled:
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+
+        num_frozen = min(args.ttt_freeze_blocks, len(base_model.blocks))
+        for i in range(num_frozen):
+            for p in base_model.blocks[i].parameters():
+                p.requires_grad_(False)
+        ttt_params = [p for p in base_model.parameters() if p.requires_grad]
+        if args.ttt_optimizer == "adamw":
+            ttt_opt = torch.optim.AdamW(ttt_params, lr=args.ttt_lr, weight_decay=0.01)
+        else:
+            ttt_opt = torch.optim.SGD(ttt_params, lr=args.ttt_lr, momentum=args.ttt_momentum)
+        ttt_seq_len = args.train_seq_len
+
+        total_tokens_val = val_tokens.numel() - 1
+        total_seqs = total_tokens_val // ttt_seq_len
+        total_chunks = (total_seqs + args.eval_batch_seqs - 1) // args.eval_batch_seqs
+
+        ttt_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+        ttt_token_count = torch.zeros((), device=device, dtype=torch.float64)
+        ttt_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+        ttt_step = 0
+
+        log0(f"ttt:starting optimizer={args.ttt_optimizer} lr={args.ttt_lr} freeze_blocks={num_frozen} epochs={args.ttt_epochs} chunks={total_chunks}")
+
+        for seq_idx in range(0, total_seqs, args.eval_batch_seqs):
+            batch_end = min(seq_idx + args.eval_batch_seqs, total_seqs)
+            bsz = batch_end - seq_idx
+            raw_start = seq_idx * ttt_seq_len
+            raw_end = batch_end * ttt_seq_len + 1
+            chunk = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64)
+            x = chunk[:-1].reshape(bsz, ttt_seq_len)
+            y = chunk[1:].reshape(bsz, ttt_seq_len)
+
+            base_model.eval()
+            with torch.no_grad():
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model.forward_logits(x)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(), y.reshape(-1), reduction="none",
+                )
+                ttt_loss_sum += nll.to(torch.float64).sum()
+                n_tokens = float(y.numel())
+                ttt_token_count += n_tokens
+                prev_ids = x.reshape(-1)
+                tgt_ids = y.reshape(-1)
+                tbytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                tbytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+                ttt_byte_count += tbytes.to(torch.float64).sum()
+
+            base_model.train()
+            for _epoch in range(args.ttt_epochs):
+                ttt_opt.zero_grad()
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    loss = base_model(x, y)
+                loss.backward()
+                ttt_opt.step()
+                ttt_step += 1
+
+        for p in base_model.parameters():
+            p.requires_grad_(True)
+        base_model.eval()
+
+        if dist.is_available() and dist.is_initialized():
+            dist.all_reduce(ttt_loss_sum, op=dist.ReduceOp.SUM)
+            dist.all_reduce(ttt_token_count, op=dist.ReduceOp.SUM)
+            dist.all_reduce(ttt_byte_count, op=dist.ReduceOp.SUM)
+
+        q_val_loss = (ttt_loss_sum / ttt_token_count).item()
+        bits_per_token = q_val_loss / math.log(2.0)
+        tokens_per_byte = ttt_token_count.item() / ttt_byte_count.item()
+        q_val_bpb = float(bits_per_token * tokens_per_byte)
+        eval_mode = "online_ttt"
+        log0(f"ttt:completed steps:{ttt_step} time:{time.perf_counter() - t_ttt:.1f}s")
+
+    else:
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+
+    if not args.ttt_enabled:
+        if args.eval_overlap > 0:
+            q_val_loss, q_val_bpb = eval_val_stateful_overlap(
+                args, base_model, rank, world_size, device,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            eval_mode = "stateful_overlap"
+        elif args.eval_stride > 0 and args.eval_stride < args.train_seq_len:
+            q_val_loss, q_val_bpb = eval_val_sliding(
+                args, base_model, rank, world_size, device,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            eval_mode = "sliding"
+        else:
+            q_val_loss, q_val_bpb = eval_val(
+                args, model, rank, world_size, device, grad_accum_steps,
+                val_tokens, base_bytes_lut, has_leading_space_lut, is_boundary_token_lut,
+            )
+            eval_mode = "standard"
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_mode:{eval_mode} eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-04-15_Mamba3Hybrid_SP8192_GPTQ_TTT/train_seed1337.log
+++ b/records/track_non_record_16mb/2026-04-15_Mamba3Hybrid_SP8192_GPTQ_TTT/train_seed1337.log
@@ -1,0 +1,102 @@
+W0415 16:41:45.786000 2237 torch/distributed/run.py:803] 
+W0415 16:41:45.786000 2237 torch/distributed/run.py:803] *****************************************
+W0415 16:41:45.786000 2237 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0415 16:41:45.786000 2237 torch/distributed/run.py:803] *****************************************
+logs/3aee07a9-0356-4db2-90d9-123b074dbc3c.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_8192_bpe.model
+train_loader:dataset:fineweb10B_sp8192 train_shards:128
+val_loader:shards pattern=./data/datasets/fineweb10B_sp8192/fineweb_val_*.bin tokens:40538112
+model_params:25159984
+world_size:8 grad_accum_steps:1
+mode:mamba3_hybrid num_attn_layers:2 attn_indices:[2, 5]
+ssd: d_state:64 expand:2.0 headdim:64 ngroups:1 rope_frac:0.5 outproj_norm:False
+attn: num_heads:8 num_kv_heads:4 rope_base:10000.0
+num_layers:7 mlp_mult:3.0
+muon_eq_r:enabled
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.025 scalar_lr:0.02
+train_batch_tokens:1048576 train_seq_len:4096 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:9.0136 val_bpb:3.4894 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:9.0133 train_time:75ms step_avg:75.04ms tok/s:13972862
+step:2/20000 train_loss:8.5278 train_time:167ms step_avg:83.47ms tok/s:12562054
+step:3/20000 train_loss:9.1235 train_time:278ms step_avg:92.74ms tok/s:11306544
+step:4/20000 train_loss:10.0868 train_time:390ms step_avg:97.39ms tok/s:10767096
+step:5/20000 train_loss:9.2926 train_time:501ms step_avg:100.24ms tok/s:10460168
+step:6/20000 train_loss:8.2806 train_time:612ms step_avg:102.07ms tok/s:10273544
+step:7/20000 train_loss:7.9833 train_time:724ms step_avg:103.42ms tok/s:10138730
+step:8/20000 train_loss:7.5762 train_time:835ms step_avg:104.38ms tok/s:10045991
+step:9/20000 train_loss:7.3195 train_time:946ms step_avg:105.15ms tok/s:9972650
+step:10/20000 train_loss:7.0939 train_time:1057ms step_avg:105.75ms tok/s:9915929
+step:200/20000 train_loss:3.7190 train_time:22531ms step_avg:112.65ms tok/s:9307882
+step:400/20000 train_loss:3.4429 train_time:45131ms step_avg:112.83ms tok/s:9293566
+step:600/20000 train_loss:3.4300 train_time:67842ms step_avg:113.07ms tok/s:9273740
+step:800/20000 train_loss:3.2515 train_time:90607ms step_avg:113.26ms tok/s:9258282
+step:1000/20000 train_loss:3.2830 train_time:113354ms step_avg:113.35ms tok/s:9250444
+step:1000/20000 val_loss:3.1968 val_bpb:1.2376 train_time:113414ms step_avg:113.41ms
+step:1200/20000 train_loss:3.0950 train_time:136068ms step_avg:113.39ms tok/s:9247516
+step:1400/20000 train_loss:3.2334 train_time:158773ms step_avg:113.41ms tok/s:9245956
+step:1600/20000 train_loss:3.0370 train_time:181459ms step_avg:113.41ms tok/s:9245716
+step:1800/20000 train_loss:3.1314 train_time:204132ms step_avg:113.41ms tok/s:9246181
+step:2000/20000 train_loss:3.2353 train_time:226793ms step_avg:113.40ms tok/s:9246993
+step:2000/20000 val_loss:3.1047 val_bpb:1.2019 train_time:226852ms step_avg:113.43ms
+step:2200/20000 train_loss:3.1123 train_time:249491ms step_avg:113.41ms tok/s:9246284
+step:2400/20000 train_loss:3.0928 train_time:272150ms step_avg:113.40ms tok/s:9247027
+step:2600/20000 train_loss:3.0686 train_time:294890ms step_avg:113.42ms tok/s:9245119
+step:2800/20000 train_loss:3.0380 train_time:317517ms step_avg:113.40ms tok/s:9246803
+step:3000/20000 train_loss:3.1455 train_time:340150ms step_avg:113.38ms tok/s:9248060
+step:3000/20000 val_loss:3.0606 val_bpb:1.1849 train_time:340210ms step_avg:113.40ms
+step:3200/20000 train_loss:3.1334 train_time:362776ms step_avg:113.37ms tok/s:9249349
+step:3400/20000 train_loss:3.1016 train_time:385404ms step_avg:113.35ms tok/s:9250453
+step:3600/20000 train_loss:2.9900 train_time:408035ms step_avg:113.34ms tok/s:9251344
+step:3800/20000 train_loss:3.1399 train_time:430661ms step_avg:113.33ms tok/s:9252256
+step:4000/20000 train_loss:2.7410 train_time:453271ms step_avg:113.32ms tok/s:9253412
+step:4000/20000 val_loss:2.9991 val_bpb:1.1610 train_time:453330ms step_avg:113.33ms
+step:4200/20000 train_loss:2.9595 train_time:475945ms step_avg:113.32ms tok/s:9253220
+step:4400/20000 train_loss:3.0971 train_time:498750ms step_avg:113.35ms tok/s:9250593
+step:4600/20000 train_loss:3.0484 train_time:521499ms step_avg:113.37ms tok/s:9249205
+step:4800/20000 train_loss:2.9405 train_time:544227ms step_avg:113.38ms tok/s:9248279
+late_qat:enabled bits=6 embed_bits=8 at step 4902 scale=0.1499
+step:5000/20000 train_loss:2.9817 train_time:574394ms step_avg:114.88ms tok/s:9127669
+step:5000/20000 val_loss:2.9593 val_bpb:1.1456 train_time:574412ms step_avg:114.88ms
+step:5200/20000 train_loss:3.0211 train_time:597456ms step_avg:114.90ms tok/s:9126356
+step:5224/20000 val_loss:2.9422 val_bpb:1.1390 train_time:600164ms step_avg:114.89ms
+stopping_early: wallclock_cap train_time:600164ms step:5224/20000
+peak memory allocated: 26118 MiB reserved: 28778 MiB
+ema:applying EMA weights
+Serialized model: 92283538 bytes
+Code size: 104754 bytes
+Total submission size: 92388292 bytes
+gptq:generating autoregressive calibration data...
+gptq:generated 32 seqs in 199.1s
+gptq:collecting hessians...
+gptq:collected hessians for 33 layers in 199.6s
+gptq:quantization complete in 223.4s total
+selective_prune: 3321622 ±1 candidates, unpruned=15.58MB target=15.25MB
+selective_prune: full ±1 prune=14.59MB
+selective_prune: pruning 1227367/3321622 ±1 values (37.0%) to fit 15.25MB
+Serialized model int6+lzma-9: 15825600 bytes (payload:25318208 raw_torch:25355471 payload_ratio:3.64x)
+Total submission size int6+lzma-9: 15930354 bytes
+ttt:starting optimizer=sgd lr=0.01 freeze_blocks=0 epochs=1 chunks=310
+ttt:completed steps:310 time:76.2s
+final_int8_zlib_roundtrip val_loss:2.9636 val_bpb:1.1473 eval_mode:online_ttt eval_time:0ms
+final_int8_zlib_roundtrip_exact val_loss:2.96361204 val_bpb:1.14730259


### PR DESCRIPTION
# Non-record: Mamba-3 Hybrid SSM + SP8192 + Legal TTT — 1.1473 bpb

**val_bpb: 1.1473** | 15.93MB | 5,224 steps | 113ms/step | 8×H100

A Mamba-3 state-space model submission. Improves on our prior SSM entry (PR #1355, 1.1526 bpb) by 5.3 mBPB via SP8192 tokenizer, INT8 embed GPTQ, and chunk score-first TTT.

| Stage | val_bpb | Delta | Size |
|-------|---------|-------|------|
| BF16 (5,224 steps) | 1.1390 | — | 88MB |
| + AR GPTQ (INT8 embed / INT6 matrix) | ~1.1490 | +10.0 mBPB | 15.93MB |
| + Chunk TTT (SGD lr=0.010, 310 chunks) | **1.1473** | −1.7 mBPB | 15.93MB |

## Architecture

7-layer Mamba-3 SISO hybrid: 5 SSM blocks + 2 FlashAttention layers at positions 2 and 5, dim=512, d_state=64, expand=2, headdim=64, chunk_size=64, mlp_mult=3, 25.2M params. SP8192 BPE tokenizer (trained from scratch on FineWeb — see data section below).

Mamba-3's SSD (Structured State-Space Duality) kernels are **pure Triton** — no CUDA C++ dependencies, no custom extensions to install. SSD crosses over FlashAttention-2 in throughput at seq_len≈2K and is ~2× faster at our training length of 4096. The SSM state carries forward across eval windows (unlike attention KV), enabling stateful evaluation.

The hybrid design places attention at layers 2 and 5 (U-net encoder/decoder positions) because pure SSM at our 25M scale loses ~15 mBPB vs hybrid — attention is essential for short-range precision at this model size.

### Mamba3Block refactoring: `_pre_ssd` / `_post_ssd`

We factored the Mamba-3 forward pass into `_pre_ssd` (in_proj, split, reshape, compute ADT/DT, norms) and `_post_ssd` (reshape, optional outproj_norm, out_proj). This separates the Python-level tensor manipulation from the core SSD kernel call, making the code more readable and enabling targeted profiling of each phase. The split also makes it easier to experiment with alternative SSD kernel implementations without touching the pre/post logic.

## Triton kernel analysis

Significant time went into understanding and profiling the Mamba-3 Triton kernels to find fusion opportunities or tuning headroom.

**Per-kernel microbenchmark** (1×H100, bsz=32, seq=4096, isolated Mamba3Layer):

| Kernel | Time | regs/thread | SMEM | Notes |
|--------|------|-------------|------|-------|
| mamba3_siso_fwd_kernel | 1322 µs | 255 | 82,496 B | stages=3 |
| mamba3_siso_bwd_kernel_dqkv | 1190 µs | 255 | 107,280 B | stages=2 |
| mamba3_siso_bwd_kernel_rotary_bias_angles | 588 µs | 255 | 4,096 B | atomic-add |
| mamba3_siso_bwd_kernel_dzdo | 455 µs | 32 | 0 B | produces dO_scaled + dZ |
| mamba3_siso_bwd_kernel_ddt_dtrap_dinput_states | 18 µs | 30 | 0 B | negligible |

Total fwd+bwd = 9.59 ms/iter. Triton kernels ≈ 3.57 ms; the remaining ~6 ms is in_proj/out_proj GEMMs, RMSNorm, SiLU, residuals.

**Key insight: the bottleneck is SMEM-per-pipeline-stage, not register pressure.** The dqkv backward kernel uses 107 KB × 2 stages = 214 KB, nearly saturating H100's 228 KB L1/SMEM budget. `regs/thread=255` is the ptxas ceiling but not the binding constraint — spill lands in L1 (cheap). Any kernel fusion at these SMEM levels must be **SMEM-neutral**.

**dzdo→dqkv prologue fusion attempt:** Implemented a fused variant that moves the dzdo epilogue (dO_scaled, dZ computation) into the dqkv kernel's prologue, eliminating one kernel launch and the HBM round-trip. The fusion was **mathematically correct** (rel_l2=0 on all 9 output gradients) but **+1.56 ms slower** (9.59 → 11.15 ms, −16%). Root cause: +8 KB SMEM for the extra z tile at stage=2 pipelining broke the autotuner's optimal schedule. Left env-gated (`MAMBA3_FUSED_BWD=1`), off by default.

**Extended autotune grid:** Expanded from 9 to 36 configs (adding maxnreg ∈ {None, 128, 192, 255} × num_warps ∈ {4, 8, 16}). Both fwd and dqkv picked **identical winners** to the stock 9-config grid. The upstream kernels are already at the Pareto front for our shape.

<details><summary><b>Mamba-3 tuning parameters (all tested, all negative)</b></summary>

| Parameter | Result | Why |
|-----------|--------|-----|
| rope_fraction=1.0 | No improvement, 1.6% slower | |
| headdim=128 | 145ms/step (vs 115ms baseline) | Worse tensor core utilization at our config |
| headdim=32 | 135ms/step | Too many kernel launches |
| chunk_size=128 | Slower than default 64 | |
| ngroups=2 at expand=2 | +25.2 mBPB post-quant | Adds ~500KB, forces destructive pruning |
| d_state=128 | 25%+ slower at any seq_len | |
| Pure Mamba 8K seq | −10.7 mBPB vs hybrid 4K | But no attention = worse overall |
| Pure Mamba 16K seq | Only +2.5 mBPB over 8K | Sub-linear scaling, not free |
| MIMO at our scale | Negligible per Mamba-3 paper Table 3 | Only meaningful at 1.5B+ |

</details>

## Quantization: GPTQ with Embed Hessian

We ran 13 quantization configurations on a fixed BF16 checkpoint to isolate each component's contribution:

| Config | Gap (mBPB) | Size |
|--------|-----------|------|
| INT6 all (no GPTQ) | +90.8 | 14.17MB |
| INT8 embed (no GPTQ) | +10.1 | 15.18MB |
| AR GPTQ + INT8 embed | +8.9 | 15.15MB |
| AR GPTQ + INT8 embed + embed Hessian | +9.8 | 15.21MB |
| Train-data GPTQ + INT8 embed + embed Hessian | +4.3 | 15.18MB |
| SDClip k=12.85 | +153.4 | 13.10MB |

**Findings:**
1. **INT8 embeddings = 90% of the fix** (90.8 → 10.1 mBPB). The 8192×512 embedding is 16% of the model but extremely sensitive to INT6.
2. **GPTQ on matrices is negligible** (0.3 mBPB difference).
3. **Embed Hessian via final_norm output hook** closes the remaining gap for train-data GPTQ. The logit projection activation Hessian guides embedding quantization.
4. **SDClip is catastrophic for our architecture** at any k value. SOTA's SDClip sigmas are tuned for different weight distributions.

### The torch.compile + Triton allocator bug

We discovered that `torch.compile` + `triton.set_allocator(ContextVar.set)` in Mamba-3's `_Mamba3Function` corrupts the CUDA driver state. After compiled training, any Triton kernel not cached by torch._inductor crashes with "illegal memory access" in `load_binary`.

This forced us to use **AR self-generated GPTQ** instead of the optimal train-data approach — AR generation uses the compiled model (kernels cached), avoiding fresh autotuning. Cost: +5.5 mBPB quant gap (9.8 vs 4.3).

We confirmed the corruption persists across `torch._dynamo.reset()`, `triton.set_allocator(None)`, Triton cache deletion, different GPUs, and fresh Python subprocesses. It does NOT occur without prior `torch.compile`.

## Test-Time Training

**Chunk score-first TTT:** Score 310 chunks of 32×4096 tokens under `no_grad`, then SGD adapt (lr=0.010, momentum=0.9, 1 epoch) on the same chunk. 76s eval time.

TTT sweep (15 configs on a fixed checkpoint):
- lr=0.010 const = optimal (−6.7 mBPB on prior checkpoint)
- Warmup-cosine: +0.07-0.12 mBPB gain only — not worth complexity
- Window TTT (per-window on overlap tokens): −0.1 mBPB in 573s — **dead**. Gradient signal from 1×1024 tokens per window too weak vs chunk TTT's 32×4096.

**RoPE cache bug (fixed):** Scoring under `torch.inference_mode()` caches RoPE cos/sin as inference tensors. TTT adaptation forward hits the cache → crash. Fix: use `torch.no_grad()` instead.

## Stateful-Overlap Evaluation

Instead of sliding-window eval (~500s), we use **stateful-overlap** with 1024-token overlap (~32s). SSM state carries forward across windows; attention gets 1024 tokens of prior context to re-establish KV cache. Matches sliding-window within 0.3 mBPB and frees 468s of eval budget for GPTQ + TTT.

An earlier diagnosis that stateful eval accumulates INT6 quant error in the SSM state was **wrong** — measurement showed quant delta is flat ~8.2 mBPB across 100-1892 windows. The real cause of pure-stateful BF16 regression was attention context loss at window boundaries, which the overlap fixes.

## What didn't work

### TBPTT (Truncated BPTT with Persistent SSM State)

The longest exploration dead-end: 10+ runs over several days. Maintain SSM state across training segments so the model learns to use long-range recurrent memory.

**Why it failed:** The model learns content-specific state from training document streams that can't be recovered at eval on unseen documents. Training loss (1.8895) vs eval loss (1.9667) gap = 77 mNats of unrecoverable state advantage. AR self-gen warmup (0-131K tokens) didn't help — the model's self-generated text doesn't produce the content-specific state. BF16 stateful-overlap: 1.1648 (+17.4 mBPB vs baseline). Quant gap 5× worse (13.1 vs 2.7 mBPB).

### Residual-Stream SLOT

Optimize initial SSM state per eval window using gradients from already-scored overlap tokens. Result: **+2–8 mBPB consistently**. No consistent gradient direction in general-domain FineWeb.

### Other negative results

| Tried | Effect | Why |
|-------|--------|-----|
| WD=0.085 (matching SOTA) | Plateaus at train_loss=6.5 | Our 26M/7L can't absorb that much regularization |
| 10 layers at expand=1.5 | 135-150ms/step | Too slow |
| Depth recurrence (loop layers) | BF16 works (+21 mBPB) | Post-quant +60 mBPB, no pruning headroom |
| FP16 in_proj rows | Only 3 mBPB, costs 400KB | Removed |
| INT8 embed + Brotli-11 | +1MB vs INT6 + LZMA | Net larger |

## SP8192 Data

The SP8192 tokenizer from `kevclark/parameter-golf` HF repo uses a **different tokenizer** than what SOTA submissions use (tok/byte 0.2835 vs 0.2683), causing ~64 mBPB inflation. All top entrants regenerate locally. We train the SentencePiece BPE tokenizer from scratch on `docs_selected.jsonl`. Our tokenizer: tok/byte = 0.2634.

## Eval Time Budget (1×H100, after DDP teardown)

| Phase | Time |
|-------|------|
| AR GPTQ (32 seqs × 4096 tokens + Hessians) | 223s |
| Chunk TTT (310 chunks, SGD) | 76s |
| Stateful-overlap eval | 32s |
| **Total** | **331s of 600s** |

## Training

- **Optimizer:** Muon with MuonEq-R. WD=0.04, momentum=0.99, matrix_lr=0.025.
- **Schedule:** Linear warmdown starting at iter 2600 (50% of training at full LR). Late QAT activates at lr_mul < 0.15.
- **Batch:** 1M tokens per step, seq_len=4096.
- **EMA:** decay=0.997, applied before GPTQ.

## Setup & Run

```bash
# Install Mamba-3 (pure Triton, no CUDA build)
bash setup_mamba3.sh

# Generate SP8192 data from scratch (~35 min)
cd data && python3 download_hf_docs_and_tokenize.py \
  --output-root . --tokenizer-config tokenizer_specs_8192.json --skip-byte

# Run
VOCAB_SIZE=8192 NUM_LAYERS=7 NUM_ATTN_LAYERS=2 USE_BIGRAM_HASH=0 TRAIN_SEQ_LEN=4096 \
WARMDOWN_ITERS=2600 WARMDOWN_SHAPE=linear MUON_EQ_R=1 \
LATE_QAT_THRESHOLD=0.15 USE_GPTQ=1 QUANT_BITS=6 QUANT_BITS_EMBED=8 GPTQ_NUM_SEQS=32 \
EVAL_OVERLAP=1024 USE_LZMA=1 EVAL_TEMP=0.9 \
WEIGHT_DECAY=0.04 MUON_MOMENTUM=0.99 MATRIX_LR=0.025 \
torchrun --nproc_per_node=8 train_mamba3_hybrid.py
```

## Requirements

- PyTorch 2.9.1+cu128
- Triton 3.5.1
- `mamba-ssm` 2.3.1 (installed via `setup_mamba3.sh`)
- SentencePiece, NumPy, LZMA (stdlib)
- 8×H100 80GB SXM

## Credits

| Component | Origin | Author |
|-----------|--------|--------|
| Mamba-3 SISO kernels | [state-spaces/mamba](https://github.com/state-spaces/mamba) | @tridao, @albertgu |
| SP8192 vocabulary + GPTQ on embeddings | PR #1394 | @clarkkev |
| MuonEq-R | PR #1217 | @bigbig |
| U-Net skip connections | PR #289, PR #1089 | @integrate-your-mind, @mikeapedia |
| Muon optimizer | PR #399 | @abaybektursun |
| Full Hessian GPTQ | PR #535, PR #1060 | @raahilshah, @dexhunter |
| Sliding window eval | PR #122 | @mtybadger |
| Warmdown schedule | PR #364 | @shikhar1729 |
| EMA | PR #315, PR #401 | @jfprincz, @newjordan |
| LeakyReLU² activation | PR #185 | @dttdrv |
| Logit softcap | PR #315 | @jfprincz |
| Late QAT | Competition folk knowledge | Multiple contributors |
| Score-first TTT | PR #549, PR #756 | @abaybektursun |