### PR TITLE
Record: SP8192 + 3-layer recurrence + hard onset — val_bpb 1.0862 (3-seed mean)

### DIFF
--- a/records/track_10min_16mb/2026-04-16_SP8192_3LayerRecur_HardOnset_NoTTT/README.md
+++ b/records/track_10min_16mb/2026-04-16_SP8192_3LayerRecur_HardOnset_NoTTT/README.md
@@ -1,0 +1,29 @@
+## SP8192 + 3-layer recurrence + hard onset
+
+val_bpb 1.0862 (3-seed mean, std 0.0023) at ~15.94 MB on 8x H100 in 600s.
+
+The main change here is recurrence activation: using a hard onset at step 3000
+for the 3-layer recurrence stack gave the best final artifact metric in this line.
+
+Recipe:
+- SP8192
+- 3-layer recurrence on layers 3-5
+- hard onset at step 3000
+- GPTQ int6 + brotli
+- EMA 0.9965
+- SDClip 12.85
+
+Results:
+
+| Seed | Steps | Post-EMA fp32 val_bpb | Sliding val_bpb | Artifact bytes |
+|------|------:|----------------------:|----------------:|---------------:|
+| 314  |  5258 |               1.08438 |       1.08424   |   15,998,501   |
+| 1337 |  5247 |               1.08536 |       1.08582   |   15,857,563   |
+| 42   |  5033 |               1.08683 |       1.08868   |   15,974,578   |
+| Mean |       |               1.08552 |       1.08625   |                |
+
+Notes:
+- VAL_LOSS_EVERY=99999 removes mid-training validation passes and increases
+  realized training steps within the same 600s wallclock budget.
+- Hard onset outperformed the smooth-onset variants on the final artifact
+  metric in this recurrence line.

--- a/records/track_10min_16mb/2026-04-16_SP8192_3LayerRecur_HardOnset_NoTTT/eval_seed1337.log
+++ b/records/track_10min_16mb/2026-04-16_SP8192_3LayerRecur_HardOnset_NoTTT/eval_seed1337.log
@@ -1,0 +1,166 @@
+=== EVAL-ONLY START 2026-04-16T03:50:43Z ===
+  ckpt: stage_recur_homotopy/outputs/hard_onset_seed1337/final_model.pt
+  gpus: 8
+  output: stage_recur_homotopy/outputs/hard_onset_seed1337/eval
+W0416 03:50:44.984000 137479 torch/distributed/run.py:803] 
+W0416 03:50:44.984000 137479 torch/distributed/run.py:803] *****************************************
+W0416 03:50:44.984000 137479 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0416 03:50:44.984000 137479 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  beta1: 0.9
+  beta2: 0.95
+  bigram_dim: 112
+  bigram_enabled: False
+  bigram_vocab_size: 3072
+  clip_reg_lambda: 0.0
+  compressor: brotli
+  contractive_rho_enabled: False
+  contractive_rho_init: 5.0
+  data_dir: ./data/
+  datasets_dir: /dev/shm/fineweb10B_sp8192
+  distributed: True
+  ema_decay: 0.9965
+  embed_lr: 0.6
+  embed_wd: 0.095
+  embedding_dim: 512
+  eval_seq_len: 2048
+  eval_stride: 64
+  gptq_calibration_batches: 64
+  gptq_enabled: True
+  gptq_reserve_seconds: 0.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  haqr_lambda: 0.0
+  haqr_onset: 0.7
+  head_lr: 0.008
+  is_main_process: True
+  iterations: 20000
+  late_ste_enabled: False
+  late_ste_onset: 0.85
+  late_ste_ramp: 0.0
+  ln_scale: True
+  load_checkpoint_path: stage_recur_homotopy/outputs/hard_onset_seed1337/final_model.pt
+  local_attn_start_layer: 8
+  local_attn_window: -1
+  local_rank: 0
+  logfile: logs/ec7a9933-dda7-428f-854c-66d765b186f5.txt
+  logit_softcap: 30.0
+  matrix_lr: 0.022
+  max_wallclock_seconds: 600.0
+  min_lr: 0.1
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: final_model.pt
+  muon_backend_steps: 5
+  muon_beta2: 0.95
+  muon_momentum: 0.99
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_wd: 0.095
+  normuon_enabled: False
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  parallel_start_layer: 7
+  prequant_ttt_batch_seqs: 32
+  prequant_ttt_cosine_decay: True
+  prequant_ttt_enabled: False
+  prequant_ttt_epochs: 6
+  prequant_ttt_freeze_blocks: 2
+  prequant_ttt_grad_clip: 1.0
+  prequant_ttt_lr: 0.0005
+  qk_gain_init: 5.25
+  quantized_model_path: final_model.int6.ptz
+  rank: 0
+  recur_homotopy: True
+  recur_homotopy_beta: 20.0
+  recur_homotopy_tau: 400.0
+  recur_homotopy_tmid: 3000
+  recur_layers: 3,4,5
+  recur_start_step: 3000
+  ridge_chunk_tokens: 65536
+  ridge_enabled: False
+  ridge_lambda: 1.0
+  ridge_rank: 32
+  ridge_resolve_every: 1
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  run_id: ec7a9933-dda7-428f-854c-66d765b186f5
+  scalar_lr: 0.02
+  sdclip_k: 12.85
+  sdclip_k_attn: 12.85
+  sdclip_k_early: 12.85
+  sdclip_k_embed: 20.0
+  sdclip_k_late: 12.85
+  sdclip_k_mlp: 12.85
+  sdclip_k_other: 12.85
+  sdclip_k_recur: 12.85
+  seed: 42
+  skip_gates_enabled: True
+  sliding_window_enabled: True
+  swc_lambda: 0.0
+  swc_window: 512
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  titans_enabled: False
+  titans_eta: 0.05
+  titans_gate_init: -5.0
+  titans_layers: 5,8
+  titans_mem_dim: 256
+  titans_momentum: 0.9
+  tokenizer_path: /workspace/parameter-golf/data/tokenizers/fineweb_8192_bpe.model
+  train_batch_tokens: 786432
+  train_files: /dev/shm/fineweb10B_sp8192/fineweb_train_*.bin
+  train_log_every: 500
+  train_seq_len: 2048
+  ttt_batch_seqs: 32
+  ttt_chunk_tokens: 32768
+  ttt_enabled: False
+  ttt_epochs: 3
+  ttt_freeze_blocks: 0
+  ttt_grad_clip: 1.0
+  ttt_lr: 0.002
+  ttt_momentum: 0.9
+  val_batch_tokens: 524288
+  val_files: /dev/shm/fineweb10B_sp8192/fineweb_val_*.bin
+  val_loss_every: 99999
+  ve_dim: 128
+  ve_enabled: True
+  ve_layers: 9,10
+  vocab_size: 8192
+  vpd_enabled: False
+  vpd_init: 0.01
+  warmdown_frac: 0.72
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+  zloss_alpha: 0.0
+train_shards: 30
+val_tokens: 40546304
+load_checkpoint: loading from stage_recur_homotopy/outputs/hard_onset_seed1337/final_model.pt
+load_checkpoint: model loaded, recurrence_active=True
+pre-quantization post-ema val_loss:2.80310854 val_bpb:1.08536091 eval_time:11422ms
+Serialized model: 137649029 bytes
+Code size: 132539 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 66 Hessians in 10.8s
+GPTQ quantization: 66 layers with full GPTQ, 0 fallback to clip-search
+selective_prune: unpruned=16.01MB target=16.0MB
+selective_prune: pruning 46112/10778148 lowest-error ±1 values (excess=5764B)
+Serialized model int6+brotli: 15860737 bytes
+Total submission size int6+brotli: 15993276 bytes
+final_int6_roundtrip val_loss:2.84792313 val_bpb:1.10271307 eval_time:2125ms
+final_int6_sliding_window val_loss:2.80430163 val_bpb:1.08582287 eval_time:78509ms
+stage_b_timers total_wallclock_s:234.966 effective_training_wallclock_s:0.000
+relocated final_model.pt → stage_recur_homotopy/outputs/hard_onset_seed1337/eval/
+relocated final_model.int6.ptz → stage_recur_homotopy/outputs/hard_onset_seed1337/eval/
+=== EVAL-ONLY COMPLETE rc=0 2026-04-16T03:54:51Z ===
+  gate lines:
+pre-quantization post-ema val_loss:2.80310854 val_bpb:1.08536091 eval_time:11422ms
+Total submission size int6+brotli: 15993276 bytes
+final_int6_roundtrip val_loss:2.84792313 val_bpb:1.10271307 eval_time:2125ms
+final_int6_sliding_window val_loss:2.80430163 val_bpb:1.08582287 eval_time:78509ms

--- a/records/track_10min_16mb/2026-04-16_SP8192_3LayerRecur_HardOnset_NoTTT/eval_seeds42_314.log
+++ b/records/track_10min_16mb/2026-04-16_SP8192_3LayerRecur_HardOnset_NoTTT/eval_seeds42_314.log
@@ -1,0 +1,334 @@
+=== EVAL SEED 42 ===
+=== EVAL-ONLY START 2026-04-16T07:07:57Z ===
+  ckpt: stage_recur_homotopy/outputs/hard_onset_seed42/final_model.pt
+  gpus: 8
+  output: stage_recur_homotopy/outputs/hard_onset_seed42/eval
+W0416 07:07:59.488000 74624 torch/distributed/run.py:803] 
+W0416 07:07:59.488000 74624 torch/distributed/run.py:803] *****************************************
+W0416 07:07:59.488000 74624 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0416 07:07:59.488000 74624 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  beta1: 0.9
+  beta2: 0.95
+  bigram_dim: 112
+  bigram_enabled: False
+  bigram_vocab_size: 3072
+  clip_reg_lambda: 0.0
+  compressor: brotli
+  contractive_rho_enabled: False
+  contractive_rho_init: 5.0
+  data_dir: ./data/
+  datasets_dir: /dev/shm/fineweb10B_sp8192
+  distributed: True
+  ema_decay: 0.9965
+  embed_lr: 0.6
+  embed_wd: 0.095
+  embedding_dim: 512
+  eval_seq_len: 2048
+  eval_stride: 64
+  gptq_calibration_batches: 64
+  gptq_enabled: True
+  gptq_reserve_seconds: 0.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  haqr_lambda: 0.0
+  haqr_onset: 0.7
+  head_lr: 0.008
+  is_main_process: True
+  iterations: 20000
+  late_ste_enabled: False
+  late_ste_onset: 0.85
+  late_ste_ramp: 0.0
+  ln_scale: True
+  load_checkpoint_path: stage_recur_homotopy/outputs/hard_onset_seed42/final_model.pt
+  local_attn_start_layer: 8
+  local_attn_window: -1
+  local_rank: 0
+  logfile: logs/3199e492-bc3d-46b2-93ce-1f4e8ba7bd51.txt
+  logit_softcap: 30.0
+  matrix_lr: 0.022
+  max_wallclock_seconds: 600.0
+  min_lr: 0.1
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: final_model.pt
+  muon_backend_steps: 5
+  muon_beta2: 0.95
+  muon_momentum: 0.99
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_wd: 0.095
+  normuon_enabled: False
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  parallel_start_layer: 7
+  prequant_ttt_batch_seqs: 32
+  prequant_ttt_cosine_decay: True
+  prequant_ttt_enabled: False
+  prequant_ttt_epochs: 6
+  prequant_ttt_freeze_blocks: 2
+  prequant_ttt_grad_clip: 1.0
+  prequant_ttt_lr: 0.0005
+  qk_gain_init: 5.25
+  quantized_model_path: final_model.int6.ptz
+  rank: 0
+  recur_homotopy: True
+  recur_homotopy_beta: 20.0
+  recur_homotopy_tau: 400.0
+  recur_homotopy_tmid: 3000
+  recur_layers: 3,4,5
+  recur_start_step: 3000
+  ridge_chunk_tokens: 65536
+  ridge_enabled: False
+  ridge_lambda: 1.0
+  ridge_rank: 32
+  ridge_resolve_every: 1
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  run_id: 3199e492-bc3d-46b2-93ce-1f4e8ba7bd51
+  scalar_lr: 0.02
+  sdclip_k: 12.85
+  sdclip_k_attn: 12.85
+  sdclip_k_early: 12.85
+  sdclip_k_embed: 20.0
+  sdclip_k_late: 12.85
+  sdclip_k_mlp: 12.85
+  sdclip_k_other: 12.85
+  sdclip_k_recur: 12.85
+  seed: 42
+  skip_gates_enabled: True
+  sliding_window_enabled: True
+  swc_lambda: 0.0
+  swc_window: 512
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  titans_enabled: False
+  titans_eta: 0.05
+  titans_gate_init: -5.0
+  titans_layers: 5,8
+  titans_mem_dim: 256
+  titans_momentum: 0.9
+  tokenizer_path: /workspace/parameter-golf/data/tokenizers/fineweb_8192_bpe.model
+  train_batch_tokens: 786432
+  train_files: /dev/shm/fineweb10B_sp8192/fineweb_train_*.bin
+  train_log_every: 500
+  train_seq_len: 2048
+  ttt_batch_seqs: 32
+  ttt_chunk_tokens: 32768
+  ttt_enabled: False
+  ttt_epochs: 3
+  ttt_freeze_blocks: 0
+  ttt_grad_clip: 1.0
+  ttt_lr: 0.002
+  ttt_momentum: 0.9
+  val_batch_tokens: 524288
+  val_files: /dev/shm/fineweb10B_sp8192/fineweb_val_*.bin
+  val_loss_every: 99999
+  ve_dim: 128
+  ve_enabled: True
+  ve_layers: 9,10
+  vocab_size: 8192
+  vpd_enabled: False
+  vpd_init: 0.01
+  warmdown_frac: 0.72
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+  zloss_alpha: 0.0
+train_shards: 30
+val_tokens: 40546304
+load_checkpoint: loading from stage_recur_homotopy/outputs/hard_onset_seed42/final_model.pt
+load_checkpoint: model loaded, recurrence_active=True
+pre-quantization post-ema val_loss:2.80690313 val_bpb:1.08683017 eval_time:31023ms
+Serialized model: 137649093 bytes
+Code size: 136256 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 66 Hessians in 10.8s
+GPTQ quantization: 66 layers with full GPTQ, 0 fallback to clip-search
+selective_prune: unpruned=16.02MB target=16.0MB
+selective_prune: pruning 152016/10765570 lowest-error ±1 values (excess=19002B)
+Serialized model int6+brotli: 15838322 bytes
+Total submission size int6+brotli: 15974578 bytes
+final_int6_roundtrip val_loss:2.85535081 val_bpb:1.10558906 eval_time:1967ms
+final_int6_sliding_window val_loss:2.81168312 val_bpb:1.08868098 eval_time:104577ms
+stage_b_timers total_wallclock_s:281.951 effective_training_wallclock_s:0.000
+relocated final_model.pt → stage_recur_homotopy/outputs/hard_onset_seed42/eval/
+relocated final_model.int6.ptz → stage_recur_homotopy/outputs/hard_onset_seed42/eval/
+=== EVAL-ONLY COMPLETE rc=0 2026-04-16T07:12:52Z ===
+  gate lines:
+pre-quantization post-ema val_loss:2.80690313 val_bpb:1.08683017 eval_time:31023ms
+Total submission size int6+brotli: 15974578 bytes
+final_int6_roundtrip val_loss:2.85535081 val_bpb:1.10558906 eval_time:1967ms
+final_int6_sliding_window val_loss:2.81168312 val_bpb:1.08868098 eval_time:104577ms
+=== EVAL SEED 314 ===
+=== EVAL-ONLY START 2026-04-16T07:12:52Z ===
+  ckpt: stage_recur_homotopy/outputs/hard_onset_seed314/final_model.pt
+  gpus: 8
+  output: stage_recur_homotopy/outputs/hard_onset_seed314/eval
+W0416 07:12:54.252000 83914 torch/distributed/run.py:803] 
+W0416 07:12:54.252000 83914 torch/distributed/run.py:803] *****************************************
+W0416 07:12:54.252000 83914 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0416 07:12:54.252000 83914 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  beta1: 0.9
+  beta2: 0.95
+  bigram_dim: 112
+  bigram_enabled: False
+  bigram_vocab_size: 3072
+  clip_reg_lambda: 0.0
+  compressor: brotli
+  contractive_rho_enabled: False
+  contractive_rho_init: 5.0
+  data_dir: ./data/
+  datasets_dir: /dev/shm/fineweb10B_sp8192
+  distributed: True
+  ema_decay: 0.9965
+  embed_lr: 0.6
+  embed_wd: 0.095
+  embedding_dim: 512
+  eval_seq_len: 2048
+  eval_stride: 64
+  gptq_calibration_batches: 64
+  gptq_enabled: True
+  gptq_reserve_seconds: 0.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  haqr_lambda: 0.0
+  haqr_onset: 0.7
+  head_lr: 0.008
+  is_main_process: True
+  iterations: 20000
+  late_ste_enabled: False
+  late_ste_onset: 0.85
+  late_ste_ramp: 0.0
+  ln_scale: True
+  load_checkpoint_path: stage_recur_homotopy/outputs/hard_onset_seed314/final_model.pt
+  local_attn_start_layer: 8
+  local_attn_window: -1
+  local_rank: 0
+  logfile: logs/e36e4f10-2558-4e40-b65e-2484dfce49b6.txt
+  logit_softcap: 30.0
+  matrix_lr: 0.022
+  max_wallclock_seconds: 600.0
+  min_lr: 0.1
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: final_model.pt
+  muon_backend_steps: 5
+  muon_beta2: 0.95
+  muon_momentum: 0.99
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_wd: 0.095
+  normuon_enabled: False
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  parallel_start_layer: 7
+  prequant_ttt_batch_seqs: 32
+  prequant_ttt_cosine_decay: True
+  prequant_ttt_enabled: False
+  prequant_ttt_epochs: 6
+  prequant_ttt_freeze_blocks: 2
+  prequant_ttt_grad_clip: 1.0
+  prequant_ttt_lr: 0.0005
+  qk_gain_init: 5.25
+  quantized_model_path: final_model.int6.ptz
+  rank: 0
+  recur_homotopy: True
+  recur_homotopy_beta: 20.0
+  recur_homotopy_tau: 400.0
+  recur_homotopy_tmid: 3000
+  recur_layers: 3,4,5
+  recur_start_step: 3000
+  ridge_chunk_tokens: 65536
+  ridge_enabled: False
+  ridge_lambda: 1.0
+  ridge_rank: 32
+  ridge_resolve_every: 1
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  run_id: e36e4f10-2558-4e40-b65e-2484dfce49b6
+  scalar_lr: 0.02
+  sdclip_k: 12.85
+  sdclip_k_attn: 12.85
+  sdclip_k_early: 12.85
+  sdclip_k_embed: 20.0
+  sdclip_k_late: 12.85
+  sdclip_k_mlp: 12.85
+  sdclip_k_other: 12.85
+  sdclip_k_recur: 12.85
+  seed: 42
+  skip_gates_enabled: True
+  sliding_window_enabled: True
+  swc_lambda: 0.0
+  swc_window: 512
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  titans_enabled: False
+  titans_eta: 0.05
+  titans_gate_init: -5.0
+  titans_layers: 5,8
+  titans_mem_dim: 256
+  titans_momentum: 0.9
+  tokenizer_path: /workspace/parameter-golf/data/tokenizers/fineweb_8192_bpe.model
+  train_batch_tokens: 786432
+  train_files: /dev/shm/fineweb10B_sp8192/fineweb_train_*.bin
+  train_log_every: 500
+  train_seq_len: 2048
+  ttt_batch_seqs: 32
+  ttt_chunk_tokens: 32768
+  ttt_enabled: False
+  ttt_epochs: 3
+  ttt_freeze_blocks: 0
+  ttt_grad_clip: 1.0
+  ttt_lr: 0.002
+  ttt_momentum: 0.9
+  val_batch_tokens: 524288
+  val_files: /dev/shm/fineweb10B_sp8192/fineweb_val_*.bin
+  val_loss_every: 99999
+  ve_dim: 128
+  ve_enabled: True
+  ve_layers: 9,10
+  vocab_size: 8192
+  vpd_enabled: False
+  vpd_init: 0.01
+  warmdown_frac: 0.72
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+  zloss_alpha: 0.0
+train_shards: 30
+val_tokens: 40546304
+load_checkpoint: loading from stage_recur_homotopy/outputs/hard_onset_seed314/final_model.pt
+load_checkpoint: model loaded, recurrence_active=True
+pre-quantization post-ema val_loss:2.80058791 val_bpb:1.08438492 eval_time:11290ms
+Serialized model: 137649093 bytes
+Code size: 136256 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 66 Hessians in 10.8s
+GPTQ quantization: 66 layers with full GPTQ, 0 fallback to clip-search
+selective_prune: unpruned=16.00MB target=16.0MB
+selective_prune: already fits, no pruning needed
+Serialized model int6+brotli: 15862245 bytes
+Total submission size int6+brotli: 15998501 bytes
+final_int6_roundtrip val_loss:2.84412915 val_bpb:1.10124405 eval_time:1980ms
+final_int6_sliding_window val_loss:2.80020987 val_bpb:1.08423854 eval_time:78487ms
+stage_b_timers total_wallclock_s:227.486 effective_training_wallclock_s:0.000
+relocated final_model.pt → stage_recur_homotopy/outputs/hard_onset_seed314/eval/
+relocated final_model.int6.ptz → stage_recur_homotopy/outputs/hard_onset_seed314/eval/
+=== EVAL-ONLY COMPLETE rc=0 2026-04-16T07:16:55Z ===
+  gate lines:
+pre-quantization post-ema val_loss:2.80058791 val_bpb:1.08438492 eval_time:11290ms
+Total submission size int6+brotli: 15998501 bytes
+final_int6_roundtrip val_loss:2.84412915 val_bpb:1.10124405 eval_time:1980ms
+final_int6_sliding_window val_loss:2.80020987 val_bpb:1.08423854 eval_time:78487ms

--- a/records/track_10min_16mb/2026-04-16_SP8192_3LayerRecur_HardOnset_NoTTT/submission.json
+++ b/records/track_10min_16mb/2026-04-16_SP8192_3LayerRecur_HardOnset_NoTTT/submission.json
@@ -1,0 +1,58 @@
+{
+  "author": "pablinga19",
+  "github_id": "pablinga19",
+  "name": "SP8192 + 3-Layer Recurrence + Hard Onset",
+  "blurb": "3-layer depth recurrence on layers 3-5 with hard onset at step 3000. GPTQ int6+brotli, EMA 0.9965, SDClip 12.85. 3-seed mean 1.0862 sliding val_bpb.",
+  "date": "2026-04-16",
+  "track": "10min_16mb",
+  "val_loss": 2.80540487,
+  "val_bpb": 1.08624746,
+  "val_bpb_std": 0.00225,
+  "seeds": [314, 1337, 42],
+  "seed_results": {
+    "314": {
+      "val_loss": 2.80020987,
+      "val_bpb": 1.08423854,
+      "val_bpb_prequant": 1.08438492,
+      "val_bpb_roundtrip": 1.10124405,
+      "artifact_bytes": 15998501,
+      "steps": 5258,
+      "wallclock_seconds": 600,
+      "eval_method": "int6_sliding_stride64"
+    },
+    "1337": {
+      "val_loss": 2.80430163,
+      "val_bpb": 1.08582287,
+      "val_bpb_prequant": 1.08536091,
+      "val_bpb_roundtrip": 1.10271307,
+      "artifact_bytes": 15857563,
+      "steps": 5247,
+      "wallclock_seconds": 600,
+      "eval_method": "int6_sliding_stride64"
+    },
+    "42": {
+      "val_loss": 2.81168312,
+      "val_bpb": 1.08868098,
+      "val_bpb_prequant": 1.08683017,
+      "val_bpb_roundtrip": 1.10558906,
+      "artifact_bytes": 15974578,
+      "steps": 5033,
+      "wallclock_seconds": 600,
+      "eval_method": "int6_sliding_stride64"
+    }
+  },
+  "config": {
+    "vocab_size": 8192,
+    "num_layers": 11,
+    "model_dim": 512,
+    "num_heads": 8,
+    "num_kv_heads": 4,
+    "mlp_mult": 4,
+    "recur_layers": "3,4,5",
+    "recur_start_step": 3000,
+    "ema_decay": 0.9965,
+    "sdclip_k": 12.85,
+    "gptq_calibration_batches": 64,
+    "compressor": "brotli"
+  }
+}

--- a/records/track_10min_16mb/2026-04-16_SP8192_3LayerRecur_HardOnset_NoTTT/train_gpt.py
+++ b/records/track_10min_16mb/2026-04-16_SP8192_3LayerRecur_HardOnset_NoTTT/train_gpt.py
@@ -1,0 +1,2807 @@
+import copy
+import glob
+import io
+import lzma
+import math
+import os
+from pathlib import Path
+import random
+import subprocess
+import sys
+import time
+import uuid
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch import Tensor, nn
+
+from flash_attn_interface import flash_attn_func as flash_attn_3_func
+
+try:
+    import brotli
+    _HAS_BROTLI = True
+except ImportError:
+    _HAS_BROTLI = False
+
+# ----------------------------------------
+# Hyperparameters
+# ----------------------------------------
+
+class Hyperparameters():
+    # Experiment settings
+    data_dir = os.environ.get('DATA_DIR', './data/')
+    seed = int(os.environ.get('SEED', 1337))
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+
+    # Checkpoint loading: skip training, go straight to GPTQ + eval
+    load_checkpoint_path = os.environ.get('LOAD_CHECKPOINT_PATH', '')
+
+    # Training length
+    iterations = int(os.environ.get('ITERATIONS', 20000))
+    warmdown_frac = float(os.environ.get('WARMDOWN_FRAC', 0.40))  # Research: 30-40% beats 66.7%
+    warmup_steps = int(os.environ.get('WARMUP_STEPS', 20))
+    train_batch_tokens = int(os.environ.get('TRAIN_BATCH_TOKENS', 2048 * 48 * 8))
+    train_seq_len = int(os.environ.get('TRAIN_SEQ_LEN', 2048))
+    eval_seq_len = int(os.environ.get('EVAL_SEQ_LEN', 2048))
+    max_wallclock_seconds = float(os.environ.get('MAX_WALLCLOCK_SECONDS', 600.0))
+    train_log_every = int(os.environ.get('TRAIN_LOG_EVERY', 500))
+
+    # Validation/Evals
+    val_batch_tokens = int(os.environ.get('VAL_BATCH_TOKENS', 2048 * 32 * 8))
+    val_loss_every = int(os.environ.get('VAL_LOSS_EVERY', 4000))
+    sliding_window_enabled = bool(int(os.environ.get('SLIDING_WINDOW_ENABLED', '1')))
+
+    # Model architecture
+    vocab_size = int(os.environ.get('VOCAB_SIZE', 4096))
+    num_layers = int(os.environ.get('NUM_LAYERS', 11))
+    xsa_last_n = int(os.environ.get('XSA_LAST_N', 11))
+    num_kv_heads = int(os.environ.get('NUM_KV_HEADS', 4))
+    model_dim = int(os.environ.get('MODEL_DIM', 512))
+    embedding_dim = int(os.environ.get('EMBEDDING_DIM', 512))
+    num_heads = int(os.environ.get('NUM_HEADS', 8))
+    mlp_mult = float(os.environ.get('MLP_MULT', 4.0))
+    skip_gates_enabled = bool(int(os.environ.get('SKIP_GATES_ENABLED', '1')))
+    tie_embeddings = bool(int(os.environ.get('TIE_EMBEDDINGS', '1')))
+    logit_softcap = float(os.environ.get('LOGIT_SOFTCAP', 30.0))
+    rope_base = float(os.environ.get('ROPE_BASE', 10000.0))
+    rope_dims = int(os.environ.get('ROPE_DIMS', 16))
+    rope_train_seq_len = int(os.environ.get('ROPE_TRAIN_SEQ_LEN', 2048))
+    ln_scale = bool(int(os.environ.get('LN_SCALE', '1')))
+    ve_enabled = bool(int(os.environ.get('VE_ENABLED', '1')))
+    ve_dim = int(os.environ.get('VE_DIM', 128))
+    ve_layers = os.environ.get('VE_LAYERS', '9,10')
+    qk_gain_init = float(os.environ.get('QK_GAIN_INIT', 5.0))
+
+    # --- OUR INNOVATIONS (feature-flagged) ---
+    # Learned Local Attention: late layers use windowed attention via FA3 window_size
+    local_attn_window = int(os.environ.get('LOCAL_ATTN_WINDOW', '-1'))  # -1=full, >0=window size
+    local_attn_start_layer = int(os.environ.get('LOCAL_ATTN_START_LAYER', '8'))  # layers >= this get local attn
+    # Value Position Decay: learned per-head exponential decay on V before attention
+    vpd_enabled = bool(int(os.environ.get('VPD_ENABLED', '1')))
+    vpd_init = float(os.environ.get('VPD_INIT', 0.01))  # initial decay rate (small = almost no decay)
+    # BigramHash: hash-based bigram embedding table
+    bigram_enabled = bool(int(os.environ.get('BIGRAM_ENABLED', '0')))
+    bigram_vocab_size = int(os.environ.get('BIGRAM_VOCAB_SIZE', 3072))
+    bigram_dim = int(os.environ.get('BIGRAM_DIM', 112))
+    # NorMuon: per-row second-moment normalization after NS (11% efficiency gain)
+    normuon_enabled = bool(int(os.environ.get('NORMUON_ENABLED', '0')))  # Quarantined: promising but unproven in pgolf
+    # Late STE: quantization-aware training in warmdown
+    late_ste_enabled = bool(int(os.environ.get('LATE_STE_ENABLED', '0')))
+    late_ste_onset = float(os.environ.get('LATE_STE_ONSET', 0.85))  # fraction of training
+    late_ste_ramp = float(os.environ.get('LATE_STE_RAMP', 0.0))  # ramp width in frac units; 0 = hard switch
+    # Score-first ridge eval adapter (legal: score chunk K with state from chunks <K, update after)
+    ridge_enabled = bool(int(os.environ.get('RIDGE_ENABLED', '0')))
+    ridge_rank = int(os.environ.get('RIDGE_RANK', 32))  # low-rank correction
+    ridge_lambda = float(os.environ.get('RIDGE_LAMBDA', 1.0))  # ridge regularizer
+    ridge_chunk_tokens = int(os.environ.get('RIDGE_CHUNK_TOKENS', 65536))  # chunk size for score-first updates
+    ridge_resolve_every = int(os.environ.get('RIDGE_RESOLVE_EVERY', 1))  # recompute SVD every N chunks
+    # Z-loss: logit norm regularization (PaLM)
+    zloss_alpha = float(os.environ.get('ZLOSS_ALPHA', 0.0))  # 0 = disabled, 1e-4 = standard
+    # Clip-aware weight regularization
+    clip_reg_lambda = float(os.environ.get('CLIP_REG_LAMBDA', 0.0))  # 0 = disabled
+    # Hessian-Aware Quantization Regularization: minimize deployed GPTQ loss during training
+    haqr_lambda = float(os.environ.get('HAQR_LAMBDA', 0.0))  # 0 = disabled, try 1e-4 to 1e-2
+    haqr_onset = float(os.environ.get('HAQR_ONSET', 0.70))  # fraction of training to start
+    # Recurrence Homotopy: smooth sigmoid onset instead of hard step.
+    #   r(step) = sigmoid((step - t_mid) / tau)
+    # Recurrence is "available" (set_recurrence_active=True) from step t_mid - 5*tau
+    # so r ramps continuously from ~0.0067 through 0.5 at t_mid to ~0.9933 at t_mid + 5*tau.
+    # When RECUR_HOMOTOPY=0, the hard-gate activation at recur_start_step is preserved
+    # byte-for-byte. TMID/_TAU sentinels: -1 / -1.0 fall back to recur_start_step /
+    # recur_homotopy_beta for back-compat with prior implementations.
+    recur_homotopy = bool(int(os.environ.get('RECUR_HOMOTOPY', '0')))
+    recur_homotopy_beta = float(os.environ.get('RECUR_HOMOTOPY_BETA', 20.0))  # legacy; superseded by _TAU
+    recur_homotopy_tmid = int(os.environ.get('RECUR_HOMOTOPY_TMID', -1))
+    recur_homotopy_tau = float(os.environ.get('RECUR_HOMOTOPY_TAU', -1.0))
+    # Sliding-Window Consistency Training: KL(full || slide) during training
+    swc_lambda = float(os.environ.get('SWC_LAMBDA', 0.0))  # 0 = disabled, try 0.1 to 1.0
+    swc_window = int(os.environ.get('SWC_WINDOW', 512))  # sliding window size for consistency
+    # Titans Neural Memory: architecture-native online adaptation
+    titans_enabled = bool(int(os.environ.get('TITANS_ENABLED', '0')))
+    titans_mem_dim = int(os.environ.get('TITANS_MEM_DIM', 256))
+    titans_layers = os.environ.get('TITANS_LAYERS', '5,8')  # which layers get memory modules
+    titans_gate_init = float(os.environ.get('TITANS_GATE_INIT', -5.0))  # sigmoid(-5)=0.007, starts near-zero
+    titans_eta = float(os.environ.get('TITANS_ETA', 0.05))
+    titans_momentum = float(os.environ.get('TITANS_MOMENTUM', 0.9))
+
+    # Optimizer (Modification 3: weight decay 0.090)
+    min_lr = float(os.environ.get('MIN_LR', 0.10))  # Research: floor at 0.10-0.15, not decay to 0
+    embed_lr = float(os.environ.get('EMBED_LR', 0.6))
+    head_lr = float(os.environ.get('HEAD_LR', 0.008))
+    tied_embed_lr = float(os.environ.get('TIED_EMBED_LR', 0.03))
+    tied_embed_init_std = float(os.environ.get('TIED_EMBED_INIT_STD', 0.005))
+    matrix_lr = float(os.environ.get('MATRIX_LR', 0.022))
+    scalar_lr = float(os.environ.get('SCALAR_LR', 0.02))
+    muon_momentum = float(os.environ.get('MUON_MOMENTUM', 0.99))
+    muon_backend_steps = int(os.environ.get('MUON_BACKEND_STEPS', 5))
+    muon_momentum_warmup_start = float(os.environ.get('MUON_MOMENTUM_WARMUP_START', 0.92))
+    muon_momentum_warmup_steps = int(os.environ.get('MUON_MOMENTUM_WARMUP_STEPS', 1500))
+    beta1 = float(os.environ.get('BETA1', 0.9))
+    beta2 = float(os.environ.get('BETA2', 0.95))
+    adam_eps = float(os.environ.get('ADAM_EPS', 1e-8))
+    grad_clip_norm = float(os.environ.get('GRAD_CLIP_NORM', 0.3))
+    eval_stride = int(os.environ.get('EVAL_STRIDE', 64))
+    muon_beta2 = float(os.environ.get('MUON_BETA2', 0.95))
+    adam_wd = float(os.environ.get('ADAM_WD', 0.02))
+    muon_wd = float(os.environ.get('MUON_WD', 0.095))
+    embed_wd = float(os.environ.get('EMBED_WD', 0.095))
+    ema_decay = float(os.environ.get('EMA_DECAY', 0.9965))
+
+    # Depth Recurrence (Modification 2)
+    recur_layers = os.environ.get("RECUR_LAYERS", "3,4,5")
+    recur_start_step = int(os.environ.get("RECUR_START_STEP", 3000))
+    # Contractive recurrence (Lever 2): learnable per-pass Δ_r ∈ (0,1).
+    # When enabled, adds one scalar param per recur layer; initial sigmoid(5)≈0.9933 ≈ rho=1 baseline.
+    contractive_rho_enabled = bool(int(os.environ.get('CONTRACTIVE_RHO_ENABLED', '0')))
+    contractive_rho_init = float(os.environ.get('CONTRACTIVE_RHO_INIT', 5.0))  # raw logit; sigmoid(5)=0.9933
+
+    # Parallel Residuals (Modification 5)
+    parallel_start_layer = int(os.environ.get("PARALLEL_START_LAYER", "7"))
+
+    # TTT (Modification 4)
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))  # Score-first TTT ON by default
+    ttt_lr = float(os.environ.get("TTT_LR", 0.002))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 3))
+    ttt_chunk_tokens = int(os.environ.get("TTT_CHUNK_TOKENS", 32768))
+    ttt_freeze_blocks = int(os.environ.get("TTT_FREEZE_BLOCKS", 0))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+    ttt_batch_seqs = int(os.environ.get("TTT_BATCH_SEQS", 32))
+    ttt_grad_clip = float(os.environ.get("TTT_GRAD_CLIP", 1.0))
+
+    # Pre-quant AdamW TTT (ported from #1423) — runs BEFORE GPTQ, baked into artifact
+    prequant_ttt_enabled = bool(int(os.environ.get("PREQUANT_TTT_ENABLED", "0")))  # QUARANTINED: legality unresolved
+    prequant_ttt_lr = float(os.environ.get("PREQUANT_TTT_LR", 0.0005))
+    prequant_ttt_epochs = int(os.environ.get("PREQUANT_TTT_EPOCHS", 6))
+    prequant_ttt_freeze_blocks = int(os.environ.get("PREQUANT_TTT_FREEZE_BLOCKS", 2))
+    prequant_ttt_batch_seqs = int(os.environ.get("PREQUANT_TTT_BATCH_SEQS", 32))
+    prequant_ttt_grad_clip = float(os.environ.get("PREQUANT_TTT_GRAD_CLIP", 1.0))
+    prequant_ttt_cosine_decay = bool(int(os.environ.get("PREQUANT_TTT_COSINE_DECAY", "1")))
+
+    # Compression
+    compressor = os.environ.get('COMPRESSOR', 'brotli')  #(lzma or brotli)
+    gptq_enabled = bool(int(os.environ.get('GPTQ_ENABLED', '1')))
+    gptq_calibration_batches = int(os.environ.get('GPTQ_CALIBRATION_BATCHES', 64))
+    gptq_reserve_seconds = float(os.environ.get('GPTQ_RESERVE_SECONDS', 10.0))
+    sdclip_k = float(os.environ.get('SDCLIP_K', 12.85))
+    sdclip_k_embed = float(os.environ.get('SDCLIP_K_EMBED', 20.0))
+    # Per-group sdclip overrides — fall back to global SDCLIP_K when unset.
+    sdclip_k_mlp = float(os.environ.get('SDCLIP_K_MLP', sdclip_k))
+    sdclip_k_attn = float(os.environ.get('SDCLIP_K_ATTN', sdclip_k))
+    sdclip_k_other = float(os.environ.get('SDCLIP_K_OTHER', sdclip_k))
+    # Per-layer-position sdclip overrides (early/recur/late). Recur layers from RECUR_LAYERS.
+    sdclip_k_early = float(os.environ.get('SDCLIP_K_EARLY', sdclip_k))
+    sdclip_k_recur = float(os.environ.get('SDCLIP_K_RECUR', sdclip_k))
+    sdclip_k_late = float(os.environ.get('SDCLIP_K_LATE', sdclip_k))
+
+    # Distributed setup
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_main_process = rank == 0
+    grad_accum_steps = 8 // world_size
+
+    # Data paths (env overrides allow custom tokenizer/dataset experiments)
+    datasets_dir = os.environ.get('DATASETS_DIR_OVERRIDE',
+                                  os.path.join(data_dir, 'datasets', f'fineweb10B_sp{vocab_size}'))
+    train_files = os.environ.get('TRAIN_FILES_OVERRIDE',
+                                 os.path.join(datasets_dir, 'fineweb_train_*.bin'))
+    val_files = os.environ.get('VAL_FILES_OVERRIDE',
+                               os.path.join(datasets_dir, 'fineweb_val_*.bin'))
+    tokenizer_path = os.environ.get('TOKENIZER_PATH_OVERRIDE',
+                                    os.path.join(data_dir, 'tokenizers', f'fineweb_{vocab_size}_bpe.model'))
+
+    # Experiment files
+    logfile = f"logs/{run_id}.txt"
+    model_path = "final_model.pt"
+    quantized_model_path = "final_model.int6.ptz"
+
+# ----------------------------------------
+# Global Logging Function
+# ----------------------------------------
+
+_logger_hparams = None
+
+
+def set_logging_hparams(h: Hyperparameters) -> None:
+    global _logger_hparams
+    _logger_hparams = h
+
+
+def log(msg, console: bool = True) -> None:
+    if _logger_hparams is None:
+        print(msg)
+        return
+    if _logger_hparams.is_main_process:
+        if console:
+            print(msg)
+        if _logger_hparams.logfile is not None:
+            with open(_logger_hparams.logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+# ----------------------------------------
+# Data Loading
+# ----------------------------------------
+
+class ValidationData:
+    def __init__(self, h: Hyperparameters, device: torch.device):
+        if not h.tokenizer_path.endswith(".model"):
+            raise ValueError(f"Script only setup for SentencePiece .model file: {h.tokenizer_path}")
+        self.sp = spm.SentencePieceProcessor(model_file=h.tokenizer_path)
+        if int(self.sp.vocab_size()) != h.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={h.vocab_size} does not match tokenizer vocab_size={int(self.sp.vocab_size())}"
+            )
+
+        self.val_tokens = load_validation_tokens(h.val_files, h.eval_seq_len)
+        self.base_bytes_lut, self.has_leading_space_lut, self.is_boundary_token_lut = (
+            build_sentencepiece_luts(self.sp, h.vocab_size, device))
+
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    # The BPB calculation assumes "▁" is its own token so that leading-space bytes
+    # are counted correctly. See https://github.com/openai/parameter-golf/issues/897
+    assert sp.piece_to_id("\u2581") != sp.unk_id(), \
+        "Tokenizer must have '▁' (space) as its own token for correct BPB byte counting"
+    # R11 byte-accounting sanity check: verify LUT sums match raw UTF-8 byte count
+    _test_str = "The quick brown fox jumps over the lazy dog. 123 !@# αβγ"
+    _test_ids = sp.encode(_test_str)
+    _expected_bytes = len(_test_str.encode("utf-8"))
+    _lut_bytes = 0
+    for _i, _tid in enumerate(_test_ids):
+        if _tid < sp_vocab_size and not (sp.is_control(_tid) or sp.is_unknown(_tid) or sp.is_unused(_tid)):
+            _piece = sp.id_to_piece(_tid)
+            if _piece.startswith("\u2581"):
+                _b = len(_piece[1:].encode("utf-8"))
+                if _i > 0:
+                    _b += 1  # leading space byte
+            elif sp.is_byte(_tid):
+                _b = 1
+            else:
+                _b = len(_piece.encode("utf-8"))
+            _lut_bytes += _b
+    assert abs(_lut_bytes - _expected_bytes) <= 1, \
+        f"R11 BYTE ACCOUNTING FAILED: LUT says {_lut_bytes} bytes, raw UTF-8 says {_expected_bytes}"
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("\u2581"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE: dict[str, int] = {}
+_MMAP_CACHE: dict[str, np.memmap] = {}
+
+
+def _read_num_tokens(file: Path) -> int:
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+
+def _get_shard_memmap(file: Path) -> np.memmap:
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode="r", dtype="<u2", offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+class DistributedTokenLoader:
+    """Coprime-stride multi-shard loader. Samples windows across shards with
+    increasing diversity over training, using coprime strides for coverage."""
+
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self._num_tokens = np.array([_read_num_tokens(f) for f in self.files], dtype=np.int64)
+        seed = 0
+        for f in self.files:
+            for b in str(f).encode():
+                seed = ((seed ^ b) * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+        self._rng = np.random.Generator(np.random.PCG64(seed))
+        self._cfg: tuple[int, int, int, int] | None = None
+        self._eligible_shards: np.ndarray | None = None
+        self._base_block_counts: np.ndarray | None = None
+        n = len(self.files)
+        self._cursor_phase = np.zeros(n, dtype=np.int64)
+        self._cursor_block_count = np.zeros(n, dtype=np.int64)
+        self._cursor_next = np.zeros(n, dtype=np.int64)
+        self._cursor_start = np.zeros(n, dtype=np.int64)
+        self._cursor_stride = np.ones(n, dtype=np.int64)
+        self._cursor_init = np.zeros(n, dtype=np.bool_)
+        self._batches_built = 0
+
+    def _pick_coprime_stride(self, n: int) -> int:
+        if n <= 1:
+            return 1
+        while True:
+            s = int(self._rng.integers(1, n))
+            if math.gcd(s, n) == 1:
+                return s
+
+    def _reset_cursor(self, si: int, seq_len: int) -> None:
+        nt = int(self._num_tokens[si])
+        max_phase = min(seq_len - 1, max(0, nt - seq_len - 1))
+        phase = int(self._rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        bc = (nt - 1 - phase) // seq_len
+        self._cursor_phase[si] = phase
+        self._cursor_block_count[si] = bc
+        self._cursor_next[si] = 0
+        self._cursor_start[si] = int(self._rng.integers(bc)) if bc > 1 else 0
+        self._cursor_stride[si] = self._pick_coprime_stride(bc)
+        self._cursor_init[si] = True
+
+    def _ensure_cursor(self, si: int, seq_len: int) -> None:
+        if not self._cursor_init[si] or self._cursor_next[si] >= self._cursor_block_count[si]:
+            self._reset_cursor(si, seq_len)
+
+    def _take_from_shard(self, si: int, seq_len: int, count: int, out: list[tuple[int, int]]) -> None:
+        rem = count
+        while rem > 0:
+            self._ensure_cursor(si, seq_len)
+            bc = int(self._cursor_block_count[si])
+            ni = int(self._cursor_next[si])
+            take = min(rem, bc - ni)
+            phase = int(self._cursor_phase[si])
+            start = int(self._cursor_start[si])
+            stride = int(self._cursor_stride[si])
+            for j in range(take):
+                bi = (start + (ni + j) * stride) % bc
+                out.append((si, phase + bi * seq_len))
+            self._cursor_next[si] = ni + take
+            rem -= take
+
+    def _init_pipeline(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> None:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        num_seqs = local_tokens // seq_len
+        global_num_seqs = num_seqs * self.world_size
+        self._cfg = (local_tokens, seq_len, num_seqs, global_num_seqs)
+        bbc = (self._num_tokens - 1) // seq_len
+        eligible = bbc > 0
+        self._eligible_shards = np.nonzero(eligible)[0].astype(np.int64)
+        self._base_block_counts = bbc[self._eligible_shards].astype(np.int64)
+
+    def _sample_global_windows(self) -> list[tuple[int, int]]:
+        assert self._cfg is not None and self._eligible_shards is not None
+        _, seq_len, _, gns = self._cfg
+        ec = int(self._eligible_shards.size)
+        progress = min(self._batches_built / 1800.0, 1.0)
+        remaining = np.empty(ec, dtype=np.float64)
+        for i, si in enumerate(self._eligible_shards.tolist()):
+            if self._cursor_init[si]:
+                r = int(self._cursor_block_count[si]) - int(self._cursor_next[si])
+                remaining[i] = float(max(r, 1))
+            else:
+                remaining[i] = float(self._base_block_counts[i])
+        alpha = 0.90 - 0.40 * progress
+        weights = np.power(remaining, alpha)
+        ws = float(weights.sum())
+        if not np.isfinite(ws) or ws <= 0.0:
+            weights = np.ones(ec, dtype=np.float64)
+            ws = float(weights.sum())
+        probs = weights / ws
+        low = min(max(8, self.world_size), ec, gns)
+        high = min(max(32, self.world_size * 8), ec, gns)
+        mix = max(1, min(int(round(low + progress * (high - low))), ec, gns))
+        cp = self._rng.choice(ec, size=mix, replace=False, p=probs)
+        cs = self._eligible_shards[cp]
+        cpr = probs[cp].copy()
+        cpr /= cpr.sum()
+        counts = np.ones(mix, dtype=np.int64)
+        extra = gns - mix
+        if extra > 0:
+            counts += self._rng.multinomial(extra, cpr).astype(np.int64)
+        perm = self._rng.permutation(mix)
+        cs, counts = cs[perm], counts[perm]
+        buckets: list[list[tuple[int, int]]] = []
+        for si, cnt in zip(cs.tolist(), counts.tolist()):
+            b: list[tuple[int, int]] = []
+            self._take_from_shard(int(si), seq_len, int(cnt), b)
+            if b:
+                if len(b) > 1:
+                    bp = self._rng.permutation(len(b))
+                    b = [b[int(k)] for k in bp.tolist()]
+                buckets.append(b)
+        windows: list[tuple[int, int]] = []
+        active = [i for i, bk in enumerate(buckets) if bk]
+        while active:
+            order = self._rng.permutation(len(active))
+            new_active: list[int] = []
+            for oi in order.tolist():
+                bi = active[oi]
+                if buckets[bi]:
+                    windows.append(buckets[bi].pop())
+                if buckets[bi]:
+                    new_active.append(bi)
+            active = new_active
+        return windows
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        if self._cfg is None:
+            self._init_pipeline(global_tokens, seq_len, grad_accum_steps)
+        _, _, num_seqs, _ = self._cfg
+        gw = self._sample_global_windows()
+        local_w = gw[self.rank::self.world_size]
+        x = torch.empty((num_seqs, seq_len), dtype=torch.int64)
+        y = torch.empty((num_seqs, seq_len), dtype=torch.int64)
+        for slot, (si, pos) in enumerate(local_w):
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(np.array(mm[pos:pos + seq_len + 1], dtype=np.int64))
+            x[slot] = window[:-1]
+            y[slot] = window[1:]
+        self._batches_built += 1
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# ----------------------------------------
+# Model Architecture
+# ----------------------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+# Late-stage STE — module-level state.
+# Compiled-in flag is read at import time so torch.compile constant-folds the
+# branch when STE is disabled (zero overhead). When enabled, the strength
+# tensor is mutated in-place from the training loop, so toggling does NOT
+# trigger a torch.compile recompile.
+_LATE_STE_COMPILED_IN: bool = bool(int(os.environ.get('LATE_STE_ENABLED', '0')))
+_LATE_STE_STRENGTH: Tensor | None = None  # scalar tensor; init in init_late_ste()
+_LATE_STE_CLIP_K: float = 12.85
+_LATE_STE_CLIP_RANGE: int = 31
+
+
+def init_late_ste(device: torch.device, clip_k: float = 12.85, clip_range: int = 31) -> None:
+    """Initialize the late-STE strength tensor on the target device.
+    Must be called after the device is known but before model compile."""
+    global _LATE_STE_STRENGTH, _LATE_STE_CLIP_K, _LATE_STE_CLIP_RANGE
+    _LATE_STE_STRENGTH = torch.zeros((), device=device, dtype=torch.float32)
+    _LATE_STE_CLIP_K = clip_k
+    _LATE_STE_CLIP_RANGE = clip_range
+
+
+def set_late_ste_strength(value: float) -> None:
+    """Mutate the strength tensor in-place. Safe to call mid-training."""
+    if _LATE_STE_STRENGTH is not None:
+        _LATE_STE_STRENGTH.fill_(float(value))
+
+
+def _ste_quantize_per_row_int6(w: Tensor, clip_k: float, clip_range: int) -> Tensor:
+    """Per-row int6 fake-quant matching the post-train GPTQ pipeline
+    (sdclip per-row scale, clip_range=31 = int6). Returns w quantized to the
+    int6 grid; caller is responsible for blending with original w via STE."""
+    w_f = w.float()
+    row_std = w_f.detach().std(dim=1)
+    row_clip = (clip_k * row_std).clamp_min(1e-6)
+    s = (row_clip / clip_range).clamp_min(1.0 / clip_range)
+    w_q = torch.clamp(torch.round(w_f.detach() / s[:, None]), -clip_range, clip_range) * s[:, None]
+    return w_q.to(w.dtype)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight
+        # Late STE: applied only to large 2-D matrix layers (mlp, attn).
+        # Constant `_LATE_STE_COMPILED_IN` makes this branch a no-op when
+        # disabled (torch.compile folds it out at trace time).
+        if _LATE_STE_COMPILED_IN and w.ndim == 2 and w.numel() > 65536:
+            w_q = _ste_quantize_per_row_int6(w, _LATE_STE_CLIP_K, _LATE_STE_CLIP_RANGE)
+            # STE blend: forward = (1-s)*w + s*w_q, backward = identity gradient
+            # through `w` regardless of strength (the blend term is detached).
+            w = w + _LATE_STE_STRENGTH * (w_q - w).detach()
+        w = w.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024, rope_dims: int = 0):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / (base ** (torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (rd / (rd - 2)))
+                inv_freq = 1.0 / (new_base ** (torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd))
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor, rope_dims: int = 0) -> Tensor:
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int,
+                 rope_base: float, qk_gain_init: float, train_seq_len: int,
+                 vpd_enabled: bool = False, vpd_init: float = 0.01,
+                 local_attn_window: int = -1):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len)
+        self.use_xsa = False
+        # Value Position Decay: learned per-head exponential decay applied to V before FA3
+        self.vpd_enabled = vpd_enabled
+        if vpd_enabled:
+            # log_alpha: softplus(log_alpha) gives the decay rate per position per head
+            self.vpd_log_alpha = nn.Parameter(
+                torch.full((num_kv_heads,), math.log(math.expm1(vpd_init)), dtype=torch.float32))
+        # Local attention window (FA3-compatible)
+        self.local_attn_window = local_attn_window
+
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x: Tensor, v_embed: Tensor | None = None) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = self.c_v(x)
+        if v_embed is not None:
+            v = v + v_embed
+        v = v.reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        # Value Position Decay: scale V by learned exponential decay before FA3
+        # Effect: attention output naturally emphasizes recent tokens' values
+        if self.vpd_enabled:
+            alpha = F.softplus(self.vpd_log_alpha)  # (num_kv_heads,), positive
+            # Position indices from end of sequence (0 = most recent)
+            dist_from_end = torch.arange(seqlen - 1, -1, -1, device=x.device, dtype=torch.float32)
+            decay = torch.exp(-alpha[None, None, :, None] * dist_from_end[None, :, None, None])
+            v = v * decay.to(dtype=v.dtype)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        ws = (self.local_attn_window, 0) if self.local_attn_window > 0 else (-1, -1)
+        # FA3 (flash_attn_interface >=3.0.0) strictly rejects fp32 q/k/v
+        # (only fp16/bf16/fp8_e4m3 allowed). F.rms_norm applied to q,k above
+        # promotes to fp32 internally for numerical stability even under
+        # torch.autocast, so we must cast back explicitly before the FA3 call.
+        _fa_dt = torch.bfloat16
+        y = flash_attn_3_func(q.to(_fa_dt), k.to(_fa_dt), v.to(_fa_dt),
+                              causal=True, window_size=ws)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class ValueEmbedding(nn.Module):
+    def __init__(self, vocab_size: int, ve_dim: int, model_dim: int):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, ve_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(ve_dim, model_dim, bias=False) if ve_dim != model_dim else None
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.1, dtype=torch.float32))
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(token_ids)
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+class BigramHash(nn.Module):
+    """Hash-based bigram embedding: maps (prev_token, curr_token) pairs to learned vectors."""
+    def __init__(self, hash_size: int, embed_dim: int, model_dim: int):
+        super().__init__()
+        self.hash_size = hash_size
+        self.embed = nn.Embedding(hash_size, embed_dim)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        self.proj = CastedLinear(embed_dim, model_dim, bias=False)
+        nn.init.zeros_(self.proj.weight)
+
+    def forward(self, input_ids: Tensor) -> Tensor:
+        prev = F.pad(input_ids[:, :-1], (1, 0), value=0)
+        # Hash: (prev * large_prime + curr) mod hash_size
+        h = ((prev.long() * 104729 + input_ids.long()) % self.hash_size).clamp(0, self.hash_size - 1)
+        return self.proj(self.embed(h))
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.proj(F.leaky_relu(self.fc(x), negative_slope=0.5).square())
+
+
+class DeltaMemory(nn.Module):
+    """Delta-rule fast-weight memory: architecture-native online adaptation.
+    M_t = λ M_{t-1} + η (v_t - M_{t-1} k_t) k_t^T
+    Read: r_t = M_{t-1} q_t
+    No autograd, no MLP, no sequential per-token loop. Pure linear algebra.
+    Legal: memory state is transient (like KV cache), artifact is fixed."""
+
+    def __init__(self, dim: int, mem_dim: int = 64, gate_init: float = -5.0):
+        super().__init__()
+        self.dim = dim
+        self.mem_dim = mem_dim
+        # Projections: input → key, value, query (all learned, frozen at eval)
+        self.proj_k = CastedLinear(dim, mem_dim, bias=False)
+        self.proj_v = CastedLinear(dim, mem_dim, bias=False)
+        self.proj_q = CastedLinear(dim, mem_dim, bias=False)
+        self.proj_out = CastedLinear(mem_dim, dim, bias=False)
+        self.proj_out._zero_init = True
+        # Learnable decay and write strength
+        self.log_lambda = nn.Parameter(torch.tensor(math.log(0.95 / 0.05), dtype=torch.float32))  # sigmoid → 0.95
+        self.log_eta = nn.Parameter(torch.tensor(math.log(0.1 / 0.9), dtype=torch.float32))  # sigmoid → 0.1
+        # Gate: controls memory contribution to residual
+        self.gate_logit = nn.Parameter(torch.tensor(gate_init, dtype=torch.float32))
+
+    def forward(self, x: Tensor, chunk_size: int = 256) -> Tensor:
+        """x: (batch, seq_len, dim). Processes in chunks for efficiency."""
+        bsz, seq_len, dim = x.shape
+        lam = torch.sigmoid(self.log_lambda)  # decay ∈ (0,1)
+        eta = torch.sigmoid(self.log_eta)  # write strength ∈ (0,1)
+        gate = torch.sigmoid(self.gate_logit)
+
+        # Project inputs (parallel, standard backprop trains these)
+        k = self.proj_k(x)  # (bsz, seq, mem_dim)
+        v = self.proj_v(x)  # (bsz, seq, mem_dim)
+        q = self.proj_q(x)  # (bsz, seq, mem_dim)
+
+        # Normalize keys for stable memory updates
+        k = F.normalize(k, dim=-1)
+        q = F.normalize(q, dim=-1)
+
+        # Memory: M is (bsz, mem_dim, mem_dim), starts at zero
+        M = torch.zeros(bsz, self.mem_dim, self.mem_dim, device=x.device, dtype=x.dtype)
+
+        reads = []
+        for chunk_start in range(0, seq_len, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, seq_len)
+            k_c = k[:, chunk_start:chunk_end]  # (bsz, chunk, mem_dim)
+            v_c = v[:, chunk_start:chunk_end]
+            q_c = q[:, chunk_start:chunk_end]
+
+            # Read from memory: r = M @ q  (parallel over chunk)
+            r_c = torch.bmm(q_c, M.transpose(1, 2))  # (bsz, chunk, mem_dim)
+            reads.append(r_c)
+
+            # Write to memory: delta rule (chunk-averaged for efficiency)
+            # M_new = λ M + η Σ_t (v_t - M k_t) k_t^T / chunk_size
+            with torch.no_grad():
+                Mk = torch.bmm(k_c, M.transpose(1, 2))  # (bsz, chunk, mem_dim)
+                delta = v_c.detach() - Mk  # surprise: what memory predicted vs actual
+                # Outer product update: Σ delta_t ⊗ k_t
+                update = torch.bmm(delta.transpose(1, 2), k_c.detach()) / max(chunk_end - chunk_start, 1)
+                M = lam * M + eta * update
+
+        # Concatenate reads and project to model dim
+        read_out = torch.cat(reads, dim=1)  # (bsz, seq, mem_dim)
+        out = self.proj_out(read_out)  # (bsz, seq, dim)
+        return gate * out
+
+
+class Block(nn.Module):
+    def __init__(self, dim: int, num_heads: int, num_kv_heads: int, mlp_mult: int,
+                 rope_base: float, qk_gain_init: float, train_seq_len: int,
+                 layer_idx: int = 0, ln_scale: bool = False,
+                 vpd_enabled: bool = False, vpd_init: float = 0.01,
+                 local_attn_window: int = -1):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init,
+                                        train_seq_len, vpd_enabled=vpd_enabled, vpd_init=vpd_init,
+                                        local_attn_window=local_attn_window)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+
+    def forward(self, x: Tensor, x0: Tensor, v_embed: Tensor | None = None) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x_in) * self.ln_scale_factor, v_embed=v_embed)
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor)
+        return x_out
+
+
+class GPT(nn.Module):
+    def __init__(self, h: Hyperparameters):
+        super().__init__()
+        self._ve_target_dim = h.num_kv_heads * (h.model_dim // h.num_heads)
+        if h.logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {h.logit_softcap}")
+        self.tie_embeddings = h.tie_embeddings
+        self.tied_embed_init_std = h.tied_embed_init_std
+        self.logit_softcap = h.logit_softcap
+        self.tok_emb = nn.Embedding(h.vocab_size, h.embedding_dim)
+        if h.embedding_dim != h.model_dim:
+            self.embed_proj = CastedLinear(h.embedding_dim, h.model_dim, bias=False)
+            self.head_proj = CastedLinear(h.model_dim, h.embedding_dim, bias=False)
+        else:
+            self.embed_proj = None
+            self.head_proj = None
+        self.num_encoder_layers = h.num_layers // 2
+        self.num_decoder_layers = h.num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, h.model_dim, dtype=torch.float32))
+        self.skip_gates = nn.Parameter(torch.zeros(self.num_skip_weights, h.model_dim, dtype=torch.float32)) if h.skip_gates_enabled else None
+        self.blocks = nn.ModuleList([
+            Block(h.model_dim, h.num_heads, h.num_kv_heads, h.mlp_mult, h.rope_base,
+                  h.qk_gain_init, h.train_seq_len, layer_idx=i, ln_scale=h.ln_scale,
+                  vpd_enabled=h.vpd_enabled,
+                  vpd_init=h.vpd_init,
+                  local_attn_window=h.local_attn_window if i >= h.local_attn_start_layer else -1)
+            for i in range(h.num_layers)
+        ])
+        if h.rope_dims > 0:
+            head_dim = h.model_dim // h.num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = h.rope_dims
+                block.attn.rotary = Rotary(head_dim, base=h.rope_base, train_seq_len=h.train_seq_len, rope_dims=h.rope_dims)
+        # BigramHash: hash-based bigram embedding added to input
+        self.bigram = BigramHash(h.bigram_vocab_size, h.bigram_dim, h.model_dim) if h.bigram_enabled else None
+
+        # Titans Neural Memory: architecture-native online adaptation
+        self.titans_layer_indices = [int(x) for x in h.titans_layers.split(",") if x.strip()] if h.titans_enabled else []
+        if self.titans_layer_indices:
+            self.titans_memories = nn.ModuleDict({
+                str(li): DeltaMemory(h.model_dim, mem_dim=h.titans_mem_dim,
+                                      gate_init=h.titans_gate_init)
+                for li in self.titans_layer_indices
+            })
+        else:
+            self.titans_memories = nn.ModuleDict()
+
+        self.ve_layer_indices = [int(x) for x in h.ve_layers.split(",") if x.strip()] if h.ve_enabled else []
+        kv_dim = self._ve_target_dim
+        if self.ve_layer_indices:
+            self.ve_shared = ValueEmbedding(h.vocab_size, h.ve_dim, kv_dim)
+            self.ve_layer_scales = nn.ParameterList(
+                [nn.Parameter(torch.ones(1, dtype=torch.float32)) for _ in self.ve_layer_indices]
+            )
+        else:
+            self.ve_shared = None
+            self.ve_layer_scales = nn.ParameterList()
+        self.value_embeds = nn.ModuleList()
+        self.final_norm = RMSNorm()
+        self.lm_head = None if h.tie_embeddings else CastedLinear(h.embedding_dim, h.vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if h.xsa_last_n > 0:
+            for i in range(max(0, h.num_layers - h.xsa_last_n), h.num_layers):
+                self.blocks[i].attn.use_xsa = True
+
+        # Modification 2: Depth Recurrence with optional homotopy
+        self.recur_layers = [int(x) for x in h.recur_layers.split(",") if x.strip()]
+        # Stage B port — fail fast on malformed RECUR_LAYERS (matches root port).
+        # Silent misconfiguration on 8× is expensive; catch here at init.
+        if self.recur_layers:
+            if not all(0 <= idx < h.num_layers for idx in self.recur_layers):
+                raise ValueError(
+                    f"RECUR_LAYERS out-of-range: {self.recur_layers} (num_layers={h.num_layers})"
+                )
+            if len(set(self.recur_layers)) != len(self.recur_layers):
+                raise ValueError(f"RECUR_LAYERS has duplicates: {self.recur_layers}")
+            if self.recur_layers != sorted(self.recur_layers):
+                raise ValueError(
+                    f"RECUR_LAYERS must be sorted ascending: got {self.recur_layers}, "
+                    f"expected {sorted(self.recur_layers)}"
+                )
+        self._recurrence_active = False
+        # homotopy weight: 0=no recurrence, 1=full recurrence.
+        # Stored as a 0-d buffer (not a Python float) so in-place updates via
+        # .fill_() don't trigger torch.compile retrace. Python-float assignment
+        # on every training step thrashes dynamo (~30s/step observed in proxy_v2
+        # τ=100 leg 3 before this fix).
+        self.register_buffer("_recur_rho", torch.tensor(1.0, dtype=torch.float32), persistent=False)
+        # Lever 2: learnable per-pass contractive rho. One scalar param per recur layer.
+        # Δ_r = sigmoid(raw). Init raw=5 → Δ≈0.9933 so initial behavior ≈ rho=1.
+        self.contractive_rho_enabled = h.contractive_rho_enabled
+        if self.contractive_rho_enabled and self.recur_layers:
+            self.contractive_rho_raw = nn.ParameterDict({
+                str(li): nn.Parameter(torch.tensor(float(h.contractive_rho_init), dtype=torch.float32))
+                for li in self.recur_layers
+            })
+        else:
+            self.contractive_rho_raw = None
+
+        # Modification 5: Parallel Residuals
+        self.parallel_start_layer = h.parallel_start_layer
+        if self.parallel_start_layer > 0 and self.parallel_start_layer < h.num_layers:
+            self.lane_merge = nn.Parameter(torch.tensor(0.5, dtype=torch.float32))
+        else:
+            self.lane_merge = None
+
+        self._init_weights()
+
+    def set_recurrence_active(self, active: bool) -> None:
+        self._recurrence_active = active
+
+    def _get_virtual_layers(self) -> list[int]:
+        """Return virtual->physical block mapping.
+        When recurrence is active, the recur_layers are repeated once,
+        e.g. with num_layers=11 and recur_layers=[4,5]:
+            [0,1,2,3, 4,5, 4,5, 6,7,8,9,10]
+        When inactive: [0,1,2,...,num_layers-1]
+        """
+        n = len(self.blocks)
+        if not self._recurrence_active or not self.recur_layers:
+            return list(range(n))
+        virtual = []
+        inserted = False
+        for i in range(n):
+            virtual.append(i)
+            if not inserted and i == self.recur_layers[-1]:
+                # repeat the recur_layers
+                for rl in self.recur_layers:
+                    virtual.append(rl)
+                inserted = True
+        return virtual
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif module.weight.ndim == 2 and module.weight.shape[0] >= 64 and module.weight.shape[1] >= 64:
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _get_ve(self, layer_idx: int, input_ids: Tensor, ve_cache: dict | None = None) -> Tensor | None:
+        if self.ve_shared is None or layer_idx not in self.ve_layer_indices:
+            return None
+        if ve_cache is not None and 've' not in ve_cache:
+            ve_cache['ve'] = self.ve_shared(input_ids)
+        ve_base = ve_cache['ve'] if ve_cache is not None else self.ve_shared(input_ids)
+        ve_idx = self.ve_layer_indices.index(layer_idx)
+        return ve_base * self.ve_layer_scales[ve_idx].to(dtype=ve_base.dtype)
+
+    def forward_logits(self, input_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+
+        virtual_layers = self._get_virtual_layers()
+        num_virtual = len(virtual_layers)
+        num_enc = num_virtual // 2
+        num_dec = num_virtual - num_enc
+
+        skips: list[Tensor] = []
+        ve_cache: dict = {}
+
+        # Determine the physical layer threshold for parallel residuals
+        parallel_start_physical = self.parallel_start_layer if self.lane_merge is not None else num_virtual + 1
+        is_parallel_mode = False
+        lane0 = None  # attention lane
+        lane1 = None  # MLP lane
+
+        # Pre-compute recurrence pass mask (torch.compile friendly — no Python set)
+        rho = self._recur_rho
+        _block_count = [0] * len(self.blocks)  # count executions per physical block
+
+        # Encoder phase
+        for vi in range(num_enc):
+            phys_idx = virtual_layers[vi]
+            is_recur_pass = _block_count[phys_idx] > 0
+            _block_count[phys_idx] += 1
+            ve = self._get_ve(phys_idx, input_ids, ve_cache)
+            if is_recur_pass and self.contractive_rho_raw is not None and str(phys_idx) in self.contractive_rho_raw:
+                # Learnable contractive recurrence (Lever 2)
+                delta_r = torch.sigmoid(self.contractive_rho_raw[str(phys_idx)]).to(dtype=x.dtype)
+                x_before = x
+                x = self.blocks[phys_idx](x, x0, v_embed=ve)
+                x = x_before + delta_r * (x - x_before)
+            elif is_recur_pass:
+                # Always apply rho scaling on recur passes. When rho=1.0 (the default,
+                # non-homotopy case) the formula reduces to x_before + (x - x_before) = x,
+                # so the math is identical. The branch was previously gated on `rho < 1.0`
+                # as a Python-level comparison; with rho now a 0-d buffer (see __init__
+                # comment re: compile retrace), that comparison triggers graph breaks.
+                x_before = x
+                x = self.blocks[phys_idx](x, x0, v_embed=ve)
+                x = x_before + rho.to(dtype=x.dtype) * (x - x_before)
+            else:
+                x = self.blocks[phys_idx](x, x0, v_embed=ve)
+            # Delta-rule memory: always active (both train and eval)
+            # Projections trained via backprop; memory state is transient (like KV cache)
+            if str(phys_idx) in self.titans_memories:
+                x = x + self.titans_memories[str(phys_idx)](x)
+            skips.append(x)
+
+        # Decoder phase with U-Net skip connections
+        for vi in range(num_dec):
+            phys_idx = virtual_layers[num_enc + vi]
+            if skips and vi < self.num_skip_weights:
+                scaled_skip = self.skip_weights[vi].to(dtype=x.dtype)[None, None, :] * skips.pop()
+                if self.skip_gates is not None:
+                    g = torch.sigmoid(self.skip_gates[vi].to(dtype=x.dtype))[None, None, :]
+                    x = torch.lerp(scaled_skip, x, g)
+                else:
+                    x = x + scaled_skip
+
+            # Check if we should enter parallel mode
+            if phys_idx >= parallel_start_physical and not is_parallel_mode:
+                lane0 = x  # attention lane
+                lane1 = x  # MLP lane
+                is_parallel_mode = True
+
+            if is_parallel_mode:
+                block = self.blocks[phys_idx]
+                ve = self._get_ve(phys_idx, input_ids, ve_cache)
+
+                # Attention operates on lane0
+                mix = block.resid_mix.to(dtype=lane0.dtype)
+                attn_in = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+                attn_out = block.attn(block.attn_norm(attn_in) * block.ln_scale_factor, v_embed=ve)
+                lane0 = attn_in + block.attn_scale.to(dtype=attn_in.dtype)[None, None, :] * attn_out
+
+                # MLP operates on lane1
+                mlp_in = block.mlp_norm(lane1) * block.ln_scale_factor
+                mlp_out = block.mlp(mlp_in)
+                lane1 = lane1 + block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * mlp_out
+            else:
+                is_recur_pass = _block_count[phys_idx] > 0
+                _block_count[phys_idx] += 1
+                ve = self._get_ve(phys_idx, input_ids, ve_cache)
+                if is_recur_pass and self.contractive_rho_raw is not None and str(phys_idx) in self.contractive_rho_raw:
+                    # Learnable contractive recurrence (Lever 2)
+                    delta_r = torch.sigmoid(self.contractive_rho_raw[str(phys_idx)]).to(dtype=x.dtype)
+                    x_before = x
+                    x = self.blocks[phys_idx](x, x0, v_embed=ve)
+                    x = x_before + delta_r * (x - x_before)
+                elif is_recur_pass:
+                    # Always apply rho scaling; identity when rho=1.0. See encoder-phase
+                    # comment above (line ~1049) for why the rho<1.0 guard was removed.
+                    x_before = x
+                    x = self.blocks[phys_idx](x, x0, v_embed=ve)
+                    x = x_before + rho.to(dtype=x.dtype) * (x - x_before)
+                else:
+                    x = self.blocks[phys_idx](x, x0, v_embed=ve)
+                # Delta-rule memory: always active
+                if str(phys_idx) in self.titans_memories:
+                    x = x + self.titans_memories[str(phys_idx)](x)
+
+        # Merge parallel lanes if active
+        if is_parallel_mode:
+            m = self.lane_merge.to(dtype=lane0.dtype)
+            x = m * lane0 + (1 - m) * lane1
+
+        x = self.final_norm(x)
+        if self.head_proj is not None:
+            x = self.head_proj(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor,
+                zloss_alpha: float = 0.0, swc_lambda: float = 0.0,
+                swc_window: int = 512) -> Tensor:
+        logits = self.forward_logits(input_ids)
+        logits_flat = logits.reshape(-1, logits.size(-1)).float()
+        loss = F.cross_entropy(logits_flat, target_ids.reshape(-1), reduction="mean")
+        # Z-loss: penalize large logit norms (PaLM, stabilizes training)
+        if zloss_alpha > 0:
+            log_z = torch.logsumexp(logits_flat, dim=-1)
+            loss = loss + zloss_alpha * (log_z ** 2).mean()
+        # Sliding-Window Consistency: KL(full_context || windowed_context)
+        # Train the model to agree between full and sliding-window attention views
+        # Uses FA3 window_size to actually mask attention, not input zeroing
+        if swc_lambda > 0 and input_ids.size(1) > swc_window:
+            with torch.no_grad():
+                p_full = F.softmax(logits_flat.detach(), dim=-1)
+            # Temporarily set local attention window on all layers
+            old_windows = []
+            for block in self.blocks:
+                old_windows.append(block.attn.local_attn_window)
+                block.attn.local_attn_window = swc_window
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits_w = self.forward_logits(input_ids)
+            # Restore original windows
+            for block, ow in zip(self.blocks, old_windows):
+                block.attn.local_attn_window = ow
+            log_p_w = F.log_softmax(logits_w.reshape(-1, logits_w.size(-1)).float(), dim=-1)
+            kl = F.kl_div(log_p_w, p_full, reduction="batchmean")
+            loss = loss + swc_lambda * kl
+        return loss
+
+
+def haqr_loss(model: nn.Module, sdclip_k: float = 12.85, clip_range: int = 31) -> Tensor:
+    """Hessian-Aware Quantization Regularization: penalize int6 quantization error
+    using STE (Straight-Through Estimator). Gradients flow through w, not w_q.
+    Minimizes: Σ_layers mean((w - Q(w))²) weighted by per-row scale²."""
+    total = torch.tensor(0.0, device=next(model.parameters()).device)
+    for name, p in model.named_parameters():
+        if p.ndim == 2 and p.numel() > 65536:
+            cat = classify_param(name)
+            if cat in ("mlp", "attn"):
+                w = p.float()
+                row_std = w.detach().std(dim=1)
+                row_clip = (sdclip_k * row_std).clamp_min(1e-6)
+                s = (row_clip / clip_range).clamp_min(1.0 / clip_range)
+                # STE fake quantize: gradient flows through w, not the round()
+                w_q = torch.clamp(torch.round(w.detach() / s[:, None]), -clip_range, clip_range) * s[:, None]
+                w_ste = w + (w_q - w).detach()  # STE: forward uses w_q, backward uses w
+                # Penalize quant error weighted by scale² (proxy for Hessian sensitivity)
+                delta_sq = (w - w_ste).pow(2)
+                h_proxy = s.detach().pow(2)  # rows with large scale = large quant error impact
+                total = total + (h_proxy[:, None] * delta_sq).mean()
+    return total
+
+
+def classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name or "bigram" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+
+# ----------------------------------------
+# Optimization
+# ----------------------------------------
+
+@torch.compile
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0,
+                 normuon_enabled: bool = False, normuon_beta2: float = 0.95):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay,
+                 normuon_enabled=normuon_enabled, normuon_beta2=normuon_beta2),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    # Modification 1: MuonEq-R row normalization before NS5
+                    update = g
+                    row_norms = update.float().norm(dim=-1, keepdim=True).clamp_min(1e-7)
+                    update = update / row_norms.to(update.dtype)
+                    g = zeropower_via_newtonschulz5(update, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    # NorMuon: per-row second-moment normalization AFTER NS (arxiv 2510.05491)
+                    if group.get("normuon_enabled", False):
+                        row_sq = g.float().pow(2).mean(dim=-1)
+                        if "normuon_v" not in state:
+                            state["normuon_v"] = row_sq.clone()
+                        else:
+                            nb2 = group.get("normuon_beta2", 0.95)
+                            state["normuon_v"].mul_(nb2).add_(row_sq, alpha=1 - nb2)
+                        g = g / (state["normuon_v"].sqrt().unsqueeze(-1).clamp_min(1e-7)).to(g.dtype)
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                if wd > 0.0:
+                    p.data.mul_(1.0 - lr * wd)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+        return loss
+
+
+class Optimizers():
+    def __init__(self, h: Hyperparameters, base_model: GPT):
+        block_named_params = list(base_model.blocks.named_parameters())
+        matrix_params = [
+            p
+            for name, p in block_named_params
+            if p.ndim == 2 and not any(pattern in name for pattern in
+                                       CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        scalar_params = [
+            p
+            for name, p in block_named_params
+            if p.ndim < 2 or any(pattern in name for pattern in
+                                 CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        if base_model.skip_weights.numel() > 0:
+            scalar_params.append(base_model.skip_weights)
+        if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
+            scalar_params.append(base_model.skip_gates)
+        if base_model.lane_merge is not None:
+            scalar_params.append(base_model.lane_merge)
+        # Lever 2: learnable contractive rho params (top-level on GPT, not inside blocks)
+        if getattr(base_model, "contractive_rho_raw", None) is not None:
+            for _p in base_model.contractive_rho_raw.values():
+                scalar_params.append(_p)
+
+        token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
+        tok_params = [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}]
+        if base_model.ve_shared is not None:
+            tok_params.append({"params": [base_model.ve_shared.embed.weight], "lr": token_lr, "base_lr": token_lr})
+            if base_model.ve_shared.proj is not None:
+                matrix_params.append(base_model.ve_shared.proj.weight)
+            scalar_params.append(base_model.ve_shared.scale)
+            for s in base_model.ve_layer_scales:
+                scalar_params.append(s)
+
+        self.optimizer_tok = torch.optim.AdamW(
+            tok_params,
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.embed_wd,
+            fused=True,
+        )
+        self.optimizer_muon = Muon(
+            matrix_params,
+            lr=h.matrix_lr,
+            momentum=h.muon_momentum,
+            backend_steps=h.muon_backend_steps,
+            weight_decay=h.muon_wd,
+            normuon_enabled=h.normuon_enabled,
+            normuon_beta2=h.muon_beta2,
+        )
+        for group in self.optimizer_muon.param_groups:
+            group["base_lr"] = h.matrix_lr
+        self.optimizer_scalar = torch.optim.AdamW(
+            [{"params": scalar_params, "lr": h.scalar_lr, "base_lr": h.scalar_lr}],
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.adam_wd,
+            fused=True,
+        )
+        self.optimizers: list[torch.optim.Optimizer] = [self.optimizer_tok, self.optimizer_muon, self.optimizer_scalar]
+        if base_model.lm_head is not None:
+            self.optimizer_head = torch.optim.Adam(
+                [{"params": [base_model.lm_head.weight], "lr": h.head_lr, "base_lr": h.head_lr}],
+                betas=(h.beta1, h.beta2),
+                eps=h.adam_eps,
+                fused=True,
+            )
+            self.optimizers.insert(1, self.optimizer_head)
+        else:
+            self.optimizer_head = None
+
+    def __iter__(self):
+        return iter(self.optimizers)
+
+    def zero_grad_all(self) -> None:
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    def step(self):
+        for opt in self.optimizers:
+            opt.step()
+        self.zero_grad_all()
+
+# ----------------------------------------
+# Quantization
+# ----------------------------------------
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,ve_layer_scales,ve_shared.scale,lane_merge,vpd_log_alpha,gate_logit,log_eta",
+    ).split(",")
+    if pattern
+)
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+
+def quantize_float_tensor(t: Tensor, sdclip_k_embed: float = 20.0) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # SDClip for embeddings: c = k * std(row)
+        row_std = t32.std(dim=1)
+        clip_abs = (sdclip_k_embed * row_std).clamp_min(1e-6)
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+
+def restore_fp32_params(model: nn.Module) -> None:
+    """After .bfloat16(), restore CastedLinear weights and control params to FP32."""
+    for module in model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    for name, param in model.named_parameters():
+        if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+            param.data = param.data.float()
+
+
+def quantize_int6_per_row(t: Tensor, clip_range: int = 31, sdclip_k: float = 12.85) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # SDClip: c = k * std(row)
+        row_std = t32.std(dim=1)
+        row_clip = (sdclip_k * row_std).clamp_min(1e-6)
+        s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+        q = torch.clamp(torch.round(t32 / s.float()[:, None]), -clip_range, clip_range).to(torch.int8)
+        return q, s
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / clip_range if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -clip_range, clip_range).to(torch.int8)
+    return q, scale
+
+
+def collect_hessians(
+    model: nn.Module,
+    train_loader: DistributedTokenLoader,
+    h: Hyperparameters,
+    device: torch.device,
+    n_calibration_batches: int = 64,
+) -> dict[str, Tensor]:
+    """Run calibration batches and collect H = X^T X for each CastedLinear layer."""
+    hessians: dict[str, Tensor] = {}
+    hooks = []
+
+    def make_hook(name: str):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            if name not in hessians:
+                hessians[name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[name].addmm_(x.T, x)
+        return hook_fn
+
+    for name, module in model.named_modules():
+        if isinstance(module, CastedLinear) and module.weight.numel() > 65536:
+            cat = classify_param(name + ".weight")
+            if cat in ("mlp", "attn"):
+                hooks.append(module.register_forward_hook(make_hook(name + ".weight")))
+
+    model.eval()
+    with torch.no_grad():
+        for _i in range(n_calibration_batches):
+            x, y = train_loader.next_batch(
+                h.train_batch_tokens,
+                h.train_seq_len, h.grad_accum_steps,
+            )
+            model.forward_logits(x)
+
+    for hk in hooks:
+        hk.remove()
+
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / n_calibration_batches
+
+    return hessians
+
+
+def gptq_quantize_weight(
+    w: Tensor,
+    H: Tensor,
+    clip_range: int = 31,
+    block_size: int = 128,
+    sdclip_k: float = 12.85,
+) -> tuple[Tensor, Tensor]:
+    """GPTQ with Cholesky error compensation and actorder (Frantar et al., ICLR 2023)."""
+    W_orig = w.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+
+    # Zero out dead columns and add damping
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * H.diag().mean()
+    H.diagonal().add_(damp)
+
+    # Column reordering by descending Hessian diagonal (actorder)
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+
+    # Upper Cholesky of the inverse
+    try:
+        Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+        Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    except torch.linalg.LinAlgError:
+        return quantize_int6_per_row(W_orig, clip_range)
+
+    # SDClip: c = k * std(row)
+    row_std = W_orig.std(dim=1)
+    row_clip = (sdclip_k * row_std).clamp_min(1e-6)
+    s = (row_clip / clip_range).clamp_min(1.0 / clip_range).to(torch.float16)
+    sf = s.float()
+
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    W_work = W_perm.clone()
+
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W_work[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros(rows, i2 - i1)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            d = Hinv_block[j, j]
+            q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - q_col.float() * sf) / d
+            Err[:, j] = err
+            W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+        if i2 < cols:
+            W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+
+    return Q[:, invperm], s
+
+
+def gptq_mixed_quantize_int6(
+    state_dict: dict[str, Tensor],
+    int6_cats: set[str],
+    hessians: dict[str, Tensor],
+    sdclip_k: float = 12.85,
+    sdclip_k_embed: float = 20.0,
+    sdclip_k_mlp: float | None = None,
+    sdclip_k_attn: float | None = None,
+    sdclip_k_other: float | None = None,
+    sdclip_k_early: float | None = None,
+    sdclip_k_recur: float | None = None,
+    sdclip_k_late: float | None = None,
+    recur_layer_indices: set[int] | None = None,
+    early_layer_max: int = 2,
+) -> tuple[dict[str, Tensor], dict[str, object]]:
+    """Mixed quantization using full GPTQ for layers with Hessians, fallback to clip-search.
+    Supports per-group sdclip via sdclip_k_{mlp,attn,other} (TYPE grouping)
+    AND sdclip_k_{early,recur,late} (POSITION grouping). Type wins if both apply.
+    Position grouping uses the layer index parsed from 'blocks.N.' name segments."""
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    gptq_count = 0
+    fallback_count = 0
+    if recur_layer_indices is None:
+        recur_layer_indices = set()
+
+    def _layer_idx_from_name(name: str) -> int | None:
+        # Names look like 'blocks.7.attn.qkv.weight'
+        parts = name.split(".")
+        for i, p in enumerate(parts):
+            if p == "blocks" and i + 1 < len(parts):
+                try:
+                    return int(parts[i + 1])
+                except ValueError:
+                    return None
+        return None
+
+    # Per-group lookup with fallback to global. Type takes precedence over position.
+    def _sdclip_for(cat_str: str, name: str) -> tuple[float, str]:
+        # Type override (mlp/attn/other)
+        type_override = None
+        if cat_str == "mlp" and sdclip_k_mlp is not None and sdclip_k_mlp != sdclip_k:
+            type_override = sdclip_k_mlp
+        elif cat_str == "attn" and sdclip_k_attn is not None and sdclip_k_attn != sdclip_k:
+            type_override = sdclip_k_attn
+        elif cat_str not in ("mlp", "attn", "embed") and sdclip_k_other is not None and sdclip_k_other != sdclip_k:
+            type_override = sdclip_k_other
+        if type_override is not None:
+            return type_override, f"type:{cat_str}"
+        # Position override (early/recur/late)
+        layer_idx = _layer_idx_from_name(name)
+        if layer_idx is not None:
+            if layer_idx in recur_layer_indices and sdclip_k_recur is not None and sdclip_k_recur != sdclip_k:
+                return sdclip_k_recur, f"recur:{layer_idx}"
+            if layer_idx <= early_layer_max and sdclip_k_early is not None and sdclip_k_early != sdclip_k:
+                return sdclip_k_early, f"early:{layer_idx}"
+            if layer_idx > early_layer_max and layer_idx not in recur_layer_indices and sdclip_k_late is not None and sdclip_k_late != sdclip_k:
+                return sdclip_k_late, f"late:{layer_idx}"
+        return sdclip_k, "global"
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = classify_param(name)
+        cur_sdclip, cur_group = _sdclip_for(cat, name)
+
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+
+        if cat in int6_cats and t.ndim == 2:
+            if name in hessians:
+                q, s = gptq_quantize_weight(t, hessians[name], sdclip_k=cur_sdclip)
+                gptq_count += 1
+                meta[name] = {"type": "int6", "method": "gptq_sdclip", "sdclip_k": cur_sdclip, "group": cur_group}
+            else:
+                q, s = quantize_int6_per_row(t, sdclip_k=cur_sdclip)
+                fallback_count += 1
+                meta[name] = {"type": "int6", "method": "sdclip", "sdclip_k": cur_sdclip, "group": cur_group}
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+        elif cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t, sdclip_k=cur_sdclip)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6", "sdclip_k": cur_sdclip, "group": cur_group}
+        else:
+            q, s = quantize_float_tensor(t, sdclip_k_embed=sdclip_k_embed)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8_sdclip"}
+
+    log(f"GPTQ quantization: {gptq_count} layers with full GPTQ, {fallback_count} fallback to clip-search")
+    return result, meta
+
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        if cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+
+
+def dequantize_mixed_int6(result: dict[str, Tensor], meta: dict[str, object],
+                          template_sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (torch.float32, torch.bfloat16):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+_BSHF_MAGIC = b"BSHF"
+
+
+def _byte_shuffle(data: bytes, stride: int = 2) -> bytes:
+    """Transpose byte stream by stride position for better compression."""
+    if stride <= 1 or len(data) < stride:
+        return data
+    src = np.frombuffer(data, dtype=np.uint8)
+    n = len(src)
+    out = np.empty(n, dtype=np.uint8)
+    dest_off = 0
+    for pos in range(stride):
+        chunk = src[pos::stride]
+        out[dest_off:dest_off + len(chunk)] = chunk
+        dest_off += len(chunk)
+    return _BSHF_MAGIC + bytes([stride]) + out.tobytes()
+
+
+def _byte_unshuffle(data: bytes) -> bytes:
+    """Inverse of _byte_shuffle. Auto-detects BSHF magic header."""
+    if len(data) < 5 or data[:4] != _BSHF_MAGIC:
+        return data
+    stride = data[4]
+    if stride < 2:
+        return data[5:]
+    payload = np.frombuffer(data, dtype=np.uint8, offset=5)
+    n = len(payload)
+    out = np.empty(n, dtype=np.uint8)
+    src_off = 0
+    for pos in range(stride):
+        chunk_len = n // stride + (1 if pos < n % stride else 0)
+        out[pos::stride][:chunk_len] = payload[src_off:src_off + chunk_len]
+        src_off += chunk_len
+    return out.tobytes()
+
+
+def _compress(data: bytes, compressor: str, byte_shuffle: bool = True) -> bytes:
+    if byte_shuffle:
+        data = _byte_shuffle(data)
+    if compressor == "lzma":
+        return lzma.compress(data, preset=6)
+    elif compressor == "brotli":
+        import brotli as _brotli
+        return _brotli.compress(data, quality=11)
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def _decompress(data: bytes, compressor: str, byte_shuffle: bool = True) -> bytes:
+    if compressor == "lzma":
+        raw = lzma.decompress(data)
+    elif compressor == "brotli":
+        import brotli as _brotli
+        raw = _brotli.decompress(data)
+    else:
+        raise ValueError(f"Unknown compressor: {compressor!r}")
+    if byte_shuffle:
+        raw = _byte_unshuffle(raw)
+    return raw
+
+
+def prequant_ttt_adapt_adamw(
+    h: Hyperparameters, base_model: nn.Module, device: torch.device,
+    val_tokens: Tensor, rank: int = 0, world_size: int = 1,
+) -> None:
+    """AdamW TTT: fine-tune on val data BEFORE quantization (ported from PR #1423)."""
+    seq_len = h.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    batch_seqs = h.prequant_ttt_batch_seqs
+    if h.prequant_ttt_freeze_blocks > 0:
+        for i, block in enumerate(base_model.blocks):
+            if i < h.prequant_ttt_freeze_blocks:
+                for p in block.parameters():
+                    p.requires_grad_(False)
+    ttt_params = [p for p in base_model.parameters() if p.requires_grad]
+    log(f"prequant_ttt:params trainable={sum(p.numel() for p in ttt_params)} "
+        f"frozen={sum(p.numel() for p in base_model.parameters() if not p.requires_grad)}")
+    optimizer = torch.optim.AdamW(ttt_params, lr=h.prequant_ttt_lr, weight_decay=0.0)
+    scheduler = None
+    if h.prequant_ttt_cosine_decay:
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer, T_max=h.prequant_ttt_epochs, eta_min=h.prequant_ttt_lr * 0.1)
+    my_start = (total_seqs * rank) // world_size
+    my_end = (total_seqs * (rank + 1)) // world_size
+    base_model.train()
+    t0 = time.perf_counter()
+    for epoch in range(h.prequant_ttt_epochs):
+        epoch_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+        epoch_tokens = torch.zeros((), device=device, dtype=torch.float64)
+        for bs in range(my_start, my_end, batch_seqs):
+            be = min(bs + batch_seqs, my_end)
+            raw_start = bs * seq_len
+            raw_end = be * seq_len + 1
+            if raw_end > val_tokens.numel():
+                continue
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64)
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            optimizer.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                loss = base_model(x, y)
+            loss.backward()
+            if world_size > 1:
+                for p in ttt_params:
+                    if p.grad is not None:
+                        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+            torch.nn.utils.clip_grad_norm_(ttt_params, h.prequant_ttt_grad_clip)
+            optimizer.step()
+            epoch_loss_sum += loss.detach().to(torch.float64) * float(y.numel())
+            epoch_tokens += float(y.numel())
+        if world_size > 1:
+            dist.all_reduce(epoch_loss_sum, op=dist.ReduceOp.SUM)
+            dist.all_reduce(epoch_tokens, op=dist.ReduceOp.SUM)
+        epoch_avg = epoch_loss_sum.item() / max(epoch_tokens.item(), 1)
+        if scheduler is not None:
+            scheduler.step()
+        log(f"prequant_ttt:epoch {epoch+1}/{h.prequant_ttt_epochs} loss:{epoch_avg:.4f} "
+            f"time:{time.perf_counter() - t0:.1f}s")
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+    log(f"prequant_ttt:done elapsed={time.perf_counter() - t0:.1f}s")
+
+
+def serialize(h: Hyperparameters, base_model: torch.nn.Module, code: str) -> int:
+    model_bytes = None
+    code_bytes = len(code.encode("utf-8"))
+    if h.is_main_process:
+        torch.save(base_model.state_dict(), h.model_path)
+        model_bytes = os.path.getsize(h.model_path)
+        log(f"Serialized model: {model_bytes} bytes")
+        log(f"Code size: {code_bytes} bytes")
+
+    sd_cpu = {k: v.detach().cpu() for k, v in base_model.state_dict().items()}
+    if h.gptq_enabled:
+        log("GPTQ:collecting Hessians from calibration data...")
+        t0 = time.perf_counter()
+        calib_loader = DistributedTokenLoader(h.train_files, h.rank, h.world_size,
+                                              torch.device("cuda", h.local_rank))
+        hessians = collect_hessians(
+            base_model, calib_loader, h,
+            torch.device("cuda", h.local_rank),
+            n_calibration_batches=h.gptq_calibration_batches,
+        )
+        log(f"GPTQ:collected {len(hessians)} Hessians in {time.perf_counter() - t0:.1f}s")
+        _recur_set = set(int(x) for x in h.recur_layers.split(",") if x.strip())
+        quant_result, quant_meta = gptq_mixed_quantize_int6(
+            sd_cpu, {"mlp", "attn"}, hessians,
+            sdclip_k=h.sdclip_k, sdclip_k_embed=h.sdclip_k_embed,
+            sdclip_k_mlp=h.sdclip_k_mlp, sdclip_k_attn=h.sdclip_k_attn, sdclip_k_other=h.sdclip_k_other,
+            sdclip_k_early=h.sdclip_k_early, sdclip_k_recur=h.sdclip_k_recur, sdclip_k_late=h.sdclip_k_late,
+            recur_layer_indices=_recur_set,
+        )
+    else:
+        quant_result, quant_meta = mixed_quantize_int6(sd_cpu, {"mlp", "attn"})
+
+    # Fast selective +-1 pruning to fit under target size
+    target_bytes = 16_000_000
+    quant_buf_check = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf_check)
+    check_blob = _compress(quant_buf_check.getvalue(), h.compressor)
+    unpruned_sz = len(check_blob) + code_bytes
+    log(f"selective_prune: unpruned={unpruned_sz/1e6:.2f}MB target={target_bytes/1e6:.1f}MB")
+    if unpruned_sz > target_bytes:
+        excess = unpruned_sz - target_bytes
+        safety_margin = int(excess * 8)  # prune 8x the excess for safety
+        ones_info = []
+        for name, info in quant_meta.items():
+            if not (isinstance(info, dict) and info.get("type") == "int6"):
+                continue
+            qk, sk = name + ".q", name + ".scale"
+            if qk not in quant_result or sk not in quant_result:
+                continue
+            q, s = quant_result[qk], quant_result[sk]
+            if s.ndim > 0:
+                ones_mask = (q.abs() == 1)
+                if ones_mask.any():
+                    row_idx = torch.arange(q.shape[0]).unsqueeze(1).expand_as(q)[ones_mask]
+                    flat_idx = torch.arange(q.numel()).reshape(q.shape)[ones_mask]
+                    errors = s.float()[row_idx].pow(2)
+                    for fi, err in zip(flat_idx.tolist(), errors.tolist()):
+                        ones_info.append((qk, fi, err))
+        ones_info.sort(key=lambda x: x[2])
+        n_prune = min(safety_margin, len(ones_info))
+        log(f"selective_prune: pruning {n_prune}/{len(ones_info)} lowest-error ±1 values (excess={excess}B)")
+        for i in range(n_prune):
+            quant_result[ones_info[i][0]].view(-1)[ones_info[i][1]] = 0
+    else:
+        log("selective_prune: already fits, no pruning needed")
+
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = _compress(quant_raw, h.compressor)
+    quant_file_bytes = len(quant_blob)
+    bytes_total = quant_file_bytes + code_bytes
+    if h.is_main_process:
+        with open(h.quantized_model_path, "wb") as f:
+            f.write(quant_blob)
+        log(f"Serialized model int6+{h.compressor}: {quant_file_bytes} bytes")
+        log(f"Total submission size int6+{h.compressor}: {bytes_total} bytes")
+
+
+def deserialize(h: Hyperparameters, device: torch.device) -> GPT:
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+
+    sd_cpu = {k: v.detach().cpu() for k, v in eval_model.state_dict().items()}
+
+    with open(h.quantized_model_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(_decompress(quant_blob_disk, h.compressor)),
+        map_location="cpu",
+    )
+    deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], sd_cpu)
+    eval_model.load_state_dict(deq_state, strict=True)
+
+    return eval_model
+
+# ----------------------------------------
+# Evaluation
+# ----------------------------------------
+
+def _loss_bpb(loss_sum, token_count, byte_count) -> tuple[float, float]:
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    return val_loss, val_bpb
+
+
+def eval_val(
+    h: Hyperparameters,
+    device: torch.device,
+    val_data: ValidationData,
+    model: nn.Module
+) -> tuple[float, float]:
+    seq_len = h.eval_seq_len
+    local_batch_tokens = h.val_batch_tokens // (h.world_size * h.grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={h.val_batch_tokens}, WORLD_SIZE={h.world_size}, "
+            f"GRAD_ACCUM_STEPS={h.grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * h.rank) // h.world_size
+    seq_end = (total_seqs * (h.rank + 1)) // h.world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_data.val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = val_data.base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (val_data.has_leading_space_lut[tgt_ids] & ~val_data.is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    model.train()
+    return _loss_bpb(val_loss_sum, val_token_count, val_byte_count)
+
+
+def eval_val_sliding(
+    h: Hyperparameters,
+    device: torch.device,
+    val_data: ValidationData,
+    base_model: nn.Module,
+    batch_seqs: int = 32
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context."""
+    base_model.eval()
+    logits_fn = torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+
+    seq_len = h.eval_seq_len
+    context_size = seq_len - h.eval_stride
+    total_tokens = val_data.val_tokens.numel() - 1
+
+    window_starts = [ws for ws in range(0, total_tokens, h.eval_stride)
+                     if ws + context_size < total_tokens]
+
+    total_windows = len(window_starts)
+    my_s = (total_windows * h.rank) // h.world_size
+    my_e = (total_windows * (h.rank + 1)) // h.world_size
+    my_windows = window_starts[my_s:my_e]
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            bsz = len(batch_ws)
+
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+
+            for i, ws in enumerate(batch_ws):
+                we = min(ws + seq_len, total_tokens)
+                wlen = we - ws
+                wlens.append(wlen)
+                chunk = val_data.val_tokens[ws:we + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = logits_fn(x_batch)
+
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else context_size
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = val_data.base_bytes_lut[tgt].to(torch.float64)
+                tb += (val_data.has_leading_space_lut[tgt] & ~val_data.is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    base_model.train()
+    return _loss_bpb(loss_sum, token_count, byte_count)
+
+
+# ----------------------------------------
+# TTT (Test-Time Training) - Legal Score-First
+# ----------------------------------------
+
+def eval_val_ttt(
+    h: Hyperparameters,
+    base_model: nn.Module,
+    device: torch.device,
+    val_data: ValidationData,
+    log_fn=None,
+) -> tuple[float, float]:
+    """Legal score-first TTT: score each chunk with sliding windows,
+    then train on it. Every token scored BEFORE any update that could use it."""
+    seq_len = h.eval_seq_len
+    stride = h.eval_stride
+    total_tokens = val_data.val_tokens.numel() - 1
+    ttt_chunk = h.ttt_chunk_tokens
+    rank = h.rank
+    world_size = h.world_size
+    if log_fn is None:
+        log_fn = lambda msg: None
+
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if min(ws + seq_len, total_tokens) - ws >= stride or ws == 0]
+
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    chunk_windows: list[list[int]] = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        end = min(ws + seq_len, total_tokens)
+        wlen = end - ws
+        s = 0 if ws == 0 else max(wlen - stride, 0)
+        scored_start = ws + s
+        ci = min(scored_start // ttt_chunk, num_chunks - 1)
+        chunk_windows[ci].append(ws)
+
+    log_fn(f"ttt_sliding:start chunks={num_chunks} chunk_tokens={ttt_chunk} "
+           f"total_windows={len(window_starts)} stride={stride} "
+           f"ttt_lr={h.ttt_lr} ttt_epochs={h.ttt_epochs} "
+           f"freeze_blocks={h.ttt_freeze_blocks}")
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    frozen_block_ids = set(range(min(h.ttt_freeze_blocks, len(base_model.blocks))))
+    ttt_params = []
+    for name, p in base_model.named_parameters():
+        freeze = False
+        for bi in frozen_block_ids:
+            if f"blocks.{bi}." in name:
+                freeze = True
+                break
+        if freeze:
+            p.requires_grad_(False)
+        else:
+            p.requires_grad_(True)
+            ttt_params.append(p)
+
+    log_fn(f"ttt_sliding:params unfrozen={sum(p.numel() for p in ttt_params)} "
+           f"frozen={sum(p.numel() for p in base_model.parameters() if not p.requires_grad)}")
+
+    optimizer = torch.optim.SGD(ttt_params, lr=h.ttt_lr, momentum=h.ttt_momentum)
+    batch_seqs = h.ttt_batch_seqs
+    t0 = time.perf_counter()
+
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows:
+            continue
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+
+        # --- Phase 1: SCORE this chunk's windows (no_grad for TTT compat) ---
+        my_s = (len(windows) * rank) // world_size
+        my_e = (len(windows) * (rank + 1)) // world_size
+        my_windows = windows[my_s:my_e]
+
+        base_model.eval()
+        with torch.no_grad():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi:bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens: list[int] = []
+                for i, ws in enumerate(batch_ws):
+                    end = min(ws + seq_len, total_tokens)
+                    wlen = end - ws
+                    wlens.append(wlen)
+                    chunk_tok = val_data.val_tokens[ws:end + 1].to(dtype=torch.int64, device=device)
+                    x_batch[i, :wlen] = chunk_tok[:-1]
+                    y_batch[i, :wlen] = chunk_tok[1:]
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = base_model.forward_logits(x_batch)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y_batch.reshape(-1), reduction="none",
+                ).reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]
+                    s = 0 if ws == 0 else max(wlen - stride, 0)
+                    scored_nll = nll[i, s:wlen].to(torch.float64)
+                    loss_sum += scored_nll.sum()
+                    token_count += float(wlen - s)
+                    tgt, prev = y_batch[i, s:wlen], x_batch[i, s:wlen]
+                    tb = val_data.base_bytes_lut[tgt].to(torch.float64)
+                    tb += (val_data.has_leading_space_lut[tgt] & ~val_data.is_boundary_token_lut[prev]).to(torch.float64)
+                    byte_count += tb.sum()
+
+        # --- Phase 2: TRAIN on this chunk (already scored = legal) ---
+        is_last_chunk = (ci == num_chunks - 1)
+        if not is_last_chunk and h.ttt_epochs > 0:
+            base_model.train()
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if chunk_seqs > 0:
+                cos_lr = h.ttt_lr * 0.5 * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                for pg in optimizer.param_groups:
+                    pg['lr'] = cos_lr
+                my_seq_s = (chunk_seqs * rank) // world_size
+                my_seq_e = (chunk_seqs * (rank + 1)) // world_size
+                my_chunk_seqs = my_seq_e - my_seq_s
+                for _ep in range(h.ttt_epochs):
+                    for bs in range(0, my_chunk_seqs, batch_seqs):
+                        be = min(bs + batch_seqs, my_chunk_seqs)
+                        actual_bs = my_seq_s + bs
+                        start_tok = chunk_start + actual_bs * seq_len
+                        end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                        if end_tok > val_data.val_tokens.numel():
+                            continue
+                        local = val_data.val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                        x = local[:-1].reshape(-1, seq_len)
+                        y = local[1:].reshape(-1, seq_len)
+                        optimizer.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            loss = base_model(x, y)
+                        loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        torch.nn.utils.clip_grad_norm_(ttt_params, h.ttt_grad_clip)
+                        optimizer.step()
+
+        if rank == 0 and (ci % 10 == 0 or ci == num_chunks - 1):
+            elapsed = time.perf_counter() - t0
+            rl = loss_sum.item() / max(token_count.item(), 1)
+            rbpb = rl / math.log(2.0) * (token_count.item() / max(byte_count.item(), 1)) if token_count.item() > 0 else 0.0
+            log_fn(f"  ttt_chunk [{ci+1}/{num_chunks}] bpb={rbpb:.6f} time={elapsed:.1f}s")
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+    log_fn(f"ttt_sliding:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+           f"elapsed={time.perf_counter() - t0:.1f}s")
+    return val_loss, val_bpb
+
+
+def eval_val_ridge_score_first(
+    h: Hyperparameters,
+    device: torch.device,
+    val_data: ValidationData,
+    base_model: nn.Module,
+) -> tuple[float, float]:
+    """Score-first ridge regression eval adapter — LEGAL by Parameter Golf rules.
+
+    For each chunk K of the val stream:
+      1. SCORE chunk K using the current ridge state X (built only from chunks <K).
+      2. UPDATE the ridge state with chunk K AFTER scoring.
+
+    State: HtH ∈ R^(d,d), HtG ∈ R^(d,V); correction = h @ X where
+    X = -(HtH + λI)⁻¹ HtG truncated to rank `ridge_rank` via SVD.
+
+    Hidden state captured via forward hook on `base_model.final_norm`. Uses the
+    uncompiled base_model so the hook fires reliably (compiled wrapper would
+    risk graph-break or hook bypass)."""
+    seq_len = h.eval_seq_len
+    chunk_tokens = h.ridge_chunk_tokens
+    rank = h.ridge_rank
+    lam = h.ridge_lambda
+    resolve_every = max(1, h.ridge_resolve_every)
+    d = h.embedding_dim
+    V = h.vocab_size
+
+    if chunk_tokens % seq_len != 0:
+        chunk_tokens = (chunk_tokens // seq_len) * seq_len
+        if chunk_tokens == 0:
+            raise ValueError(f"RIDGE_CHUNK_TOKENS must be at least eval_seq_len={seq_len}")
+    seqs_per_chunk = chunk_tokens // seq_len
+
+    # State accumulators (fp64 for numerical safety)
+    HtH = lam * torch.eye(d, device=device, dtype=torch.float64)
+    HtG = torch.zeros(d, V, device=device, dtype=torch.float64)
+
+    # Cached low-rank correction factors
+    U_lr = torch.zeros(d, rank, device=device, dtype=torch.float32)  # h @ U_lr @ V_lr^T = correction
+    V_lr = torch.zeros(rank, V, device=device, dtype=torch.float32)
+    have_state = False  # whether U_lr/V_lr are initialized
+    chunks_since_resolve = 0
+
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    captured = {}
+    def _hook(_module, _inp, out):
+        captured["h"] = out  # final_norm output, shape (B, T, d)
+    handle = base_model.final_norm.register_forward_hook(_hook)
+
+    base_model.eval()
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * h.rank) // h.world_size
+    seq_end = (total_seqs * (h.rank + 1)) // h.world_size
+
+    t0 = time.perf_counter()
+    log(f"ridge:start chunks=~{(seq_end - seq_start + seqs_per_chunk - 1) // seqs_per_chunk} "
+        f"chunk_tokens={chunk_tokens} rank={rank} lambda={lam} resolve_every={resolve_every}")
+
+    try:
+        with torch.inference_mode():
+            chunk_idx = 0
+            for chunk_seq_start in range(seq_start, seq_end, seqs_per_chunk):
+                chunk_seq_end = min(chunk_seq_start + seqs_per_chunk, seq_end)
+                raw_start = chunk_seq_start * seq_len
+                raw_end = chunk_seq_end * seq_len + 1
+                local = val_data.val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+                x = local[:-1].reshape(-1, seq_len)
+                y = local[1:].reshape(-1, seq_len)
+
+                # Forward pass — captures hidden state via hook
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    logits = base_model.forward_logits(x)
+                hidden = captured["h"]  # (B, T, d), bf16
+
+                logits_flat = logits.reshape(-1, V).float()
+                hidden_flat = hidden.reshape(-1, d).float()
+                y_flat = y.reshape(-1)
+                N = hidden_flat.size(0)
+                prev_ids = x.reshape(-1)
+                tgt_ids = y_flat
+
+                # ===== STEP 1: SCORE with current state =====
+                if have_state:
+                    # correction = h @ U_lr @ V_lr  → (N, V)
+                    correction = (hidden_flat @ U_lr) @ V_lr  # (N, r) @ (r, V) = (N, V)
+                    corrected_logits = logits_flat + correction
+                else:
+                    corrected_logits = logits_flat
+
+                loss_per_token = F.cross_entropy(corrected_logits, y_flat, reduction="none")  # (N,)
+                val_loss_sum += loss_per_token.double().sum()
+                val_token_count += float(N)
+
+                token_bytes = val_data.base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                token_bytes += (val_data.has_leading_space_lut[tgt_ids] & ~val_data.is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+                val_byte_count += token_bytes.to(torch.float64).sum()
+
+                # ===== STEP 2: UPDATE state with this chunk's data =====
+                # Use UNCORRECTED logits to compute the gradient signal — this is what
+                # the model originally predicted; the correction is what we're learning.
+                probs = F.softmax(logits_flat, dim=-1)  # (N, V)
+                G = probs.double()
+                G[torch.arange(N, device=device), y_flat] -= 1.0  # softmax(l) - one_hot(y)
+
+                h_d = hidden_flat.double()
+                HtH += h_d.t() @ h_d  # (d, d)
+                HtG += h_d.t() @ G    # (d, V)
+
+                chunks_since_resolve += 1
+                chunk_idx += 1
+
+                # ===== STEP 3: RECOMPUTE low-rank state every `resolve_every` chunks =====
+                if chunks_since_resolve >= resolve_every:
+                    # Solve A X_full = -HtG with A = HtH (already includes λI from init)
+                    # Then SVD-truncate X_full to rank r.
+                    try:
+                        X_full = torch.linalg.solve(HtH, -HtG)  # (d, V)
+                    except torch.linalg.LinAlgError:
+                        # Singular: skip update, keep prior state
+                        log(f"ridge:linalg-singular at chunk {chunk_idx}, keeping prior state")
+                        chunks_since_resolve = 0
+                        continue
+
+                    # Low-rank truncate via SVD
+                    try:
+                        U, S, Vh = torch.linalg.svd(X_full, full_matrices=False)  # X = U diag(S) Vh
+                    except torch.linalg.LinAlgError:
+                        log(f"ridge:svd-failed at chunk {chunk_idx}, keeping prior state")
+                        chunks_since_resolve = 0
+                        continue
+
+                    r = min(rank, S.size(0))
+                    U_lr = (U[:, :r] * S[:r].unsqueeze(0)).to(torch.float32)  # absorb S into U
+                    V_lr = Vh[:r].to(torch.float32)  # (r, V)
+                    have_state = True
+                    chunks_since_resolve = 0
+                    cur_norm = float(S[:r].sum().item())
+                    log(f"ridge:state-update chunk={chunk_idx} S_sum={cur_norm:.4f} S_max={float(S[0]):.4f}")
+
+    finally:
+        handle.remove()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    base_model.train()
+    val_loss = (val_loss_sum / val_token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (val_token_count.item() / val_byte_count.item())
+    log(f"ridge:done val_loss={val_loss:.6f} val_bpb={val_bpb:.6f} "
+        f"chunks={chunk_idx} elapsed={time.perf_counter() - t0:.1f}s")
+    return val_loss, val_bpb
+
+
+# ----------------------------------------
+# Eval orchestration
+# ----------------------------------------
+
+def timed_eval(label: str, fn, *args, **kwargs) -> tuple[float, float]:
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    val_loss, val_bpb = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    elapsed_ms = 1000.0 * (time.perf_counter() - t0)
+    log(f"{label} val_loss:{val_loss:.8f} val_bpb:{val_bpb:.8f} eval_time:{elapsed_ms:.0f}ms")
+    return val_loss, val_bpb
+
+
+def run_evals(
+    h: Hyperparameters,
+    device: torch.device,
+    val_data: ValidationData,
+    eval_model: torch.nn.Module
+):
+    # Save state dict BEFORE any inference_mode evals (for TTT later)
+    if h.ttt_enabled:
+        ttt_sd = {k: v.detach().clone() for k, v in eval_model.state_dict().items()}
+    compiled_model = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    timed_eval("final_int6_roundtrip", eval_val, h, device, val_data, compiled_model)
+    if h.sliding_window_enabled:
+        timed_eval("final_int6_sliding_window", eval_val_sliding, h, device, val_data, eval_model)
+    if h.ttt_enabled:
+        # TTT needs fresh model with clean tensors (no inference_mode)
+        ttt_model = GPT(h).to(device).bfloat16()
+        restore_fp32_params(ttt_model)
+        ttt_model.load_state_dict(ttt_sd, strict=True)
+        if hasattr(ttt_model, 'set_recurrence_active'):
+            ttt_model.set_recurrence_active(True)
+        del ttt_sd
+        timed_eval("final_int6_ttt", eval_val_ttt, h, ttt_model, device, val_data, log_fn=log)
+
+# -----------------------------
+# Training
+# -----------------------------
+
+def train_model(h: Hyperparameters, device: torch.device, val_data: ValidationData) -> None:
+    # Set up model
+    init_late_ste(device, clip_k=h.sdclip_k, clip_range=31)
+    base_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    if h.distributed:
+        # Lever 2 DDP fix: contractive_rho_raw params are only used after recur_start_step,
+        # so DDP's reducer must tolerate unused parameters in early steps.
+        _ddp_kwargs = {"device_ids": [h.local_rank], "broadcast_buffers": False}
+        if getattr(base_model, "contractive_rho_raw", None) is not None:
+            _ddp_kwargs["find_unused_parameters"] = True
+        model = DDP(compiled_model, **_ddp_kwargs)
+    else:
+        model = compiled_model
+    log(f"model_params:{sum(p.numel() for p in base_model.parameters())}")
+
+    # Set up optimizer and load train data
+    optimizers = Optimizers(h, base_model)
+    train_loader = DistributedTokenLoader( h.train_files, h.rank, h.world_size, device)
+
+    # Helper functions for training
+    max_wallclock_ms = 1000.0 * h.max_wallclock_seconds if h.max_wallclock_seconds > 0 else None
+    if h.gptq_enabled and max_wallclock_ms is not None:
+        max_wallclock_ms -= h.gptq_reserve_seconds * 1000.0
+        log(f"gptq:reserving {h.gptq_reserve_seconds:.0f}s, effective={max_wallclock_ms:.0f}ms")
+
+    def training_frac(step: int, elapsed_ms: float) -> float:
+        """Fraction of training completed (0 to 1), using step or wallclock."""
+        if max_wallclock_ms is None:
+            return step / max(h.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-9)
+
+    def lr_mul(frac: float) -> float:
+        if h.warmdown_frac <= 0:
+            return 1.0
+        if frac >= 1.0 - h.warmdown_frac:
+            return max((1.0 - frac) / h.warmdown_frac, h.min_lr)
+        return 1.0
+
+    _in_warmup = True  # flag for HAQR/late-STE to skip during warmup
+    _late_ste_last_strength = -1.0  # last strength value applied (avoid redundant fills)
+    training_time_ms = 0.0  # init early so closure can see it
+
+    def step_fn(step, lr_scale):
+        nonlocal _late_ste_last_strength
+        # Late STE strength schedule:
+        #   frac < onset                          -> strength = 0
+        #   onset <= frac < onset + ramp_window   -> strength linearly ramps 0..1
+        #   frac >= onset + ramp_window           -> strength = 1
+        # Hard switch is achieved by setting LATE_STE_RAMP=0.0.
+        if h.late_ste_enabled and not _in_warmup:
+            cur_frac = training_frac(step, training_time_ms + 1000.0 * (time.perf_counter() - t0))
+            if cur_frac >= h.late_ste_onset:
+                if h.late_ste_ramp <= 0:
+                    new_strength = 1.0
+                else:
+                    new_strength = min(1.0, (cur_frac - h.late_ste_onset) / h.late_ste_ramp)
+                # Avoid redundant fill_ calls (no perf cost, just less log noise)
+                if abs(new_strength - _late_ste_last_strength) > 1e-4:
+                    set_late_ste_strength(new_strength)
+                    if _late_ste_last_strength < 0:
+                        log(f"late_ste:enabled at step {step} frac {cur_frac:.4f} strength={new_strength:.3f}")
+                    _late_ste_last_strength = new_strength
+
+        optimizers.zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(h.grad_accum_steps):
+            if h.distributed:
+                model.require_backward_grad_sync = micro_step == h.grad_accum_steps - 1
+            x, y = train_loader.next_batch(h.train_batch_tokens, h.train_seq_len, h.grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y, zloss_alpha=h.zloss_alpha,
+                             swc_lambda=h.swc_lambda, swc_window=h.swc_window)
+            # HAQR: add Hessian-aware quant regularization after onset
+            if h.haqr_lambda > 0 and not _in_warmup and training_frac(step, training_time_ms + 1000.0 * (time.perf_counter() - t0)) >= h.haqr_onset:
+                loss = loss + h.haqr_lambda * haqr_loss(base_model, sdclip_k=h.sdclip_k)
+            train_loss += loss.detach()
+            (loss / h.grad_accum_steps).backward()
+        train_loss /= h.grad_accum_steps
+
+        frac = min(step / h.muon_momentum_warmup_steps, 1.0) if h.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * h.muon_momentum_warmup_start + frac * h.muon_momentum
+        for group in optimizers.optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * lr_scale
+
+        if h.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), h.grad_clip_norm)
+
+        optimizers.step()
+        return train_loss
+
+    # Model warmup
+    if h.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(h.warmup_steps):
+            step_fn(warmup_step, 1.0)
+            if warmup_step <= 5 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == h.warmup_steps:
+                log(f"warmup_step: {warmup_step + 1}/{h.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        optimizers.zero_grad_all()
+        if h.distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(
+            h.train_files, h.rank, h.world_size, device)
+
+    # Training loop
+    _in_warmup = False  # warmup complete, enable HAQR
+    ema_state = {name: t.detach().float().clone() for name, t in base_model.state_dict().items()}
+    ema_decay = h.ema_decay
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == h.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        # Modification 2: activate recurrence — homotopy or hard onset.
+        # Branches are disjoint: homotopy path has NO hard gate at
+        # recur_start_step (that would reintroduce a 0 → sigmoid(0)=0.5 jump
+        # at t_mid and defeat the schedule). Hard-onset path is byte-identical
+        # to pre-patch behavior when RECUR_HOMOTOPY=0.
+        if h.recur_homotopy:
+            _tmid = h.recur_homotopy_tmid if h.recur_homotopy_tmid >= 0 else h.recur_start_step
+            _tau = h.recur_homotopy_tau if h.recur_homotopy_tau > 0 else h.recur_homotopy_beta
+            _activation_step = _tmid - 5 * _tau  # sigmoid(-5) ≈ 0.0067 — effectively zero
+            if step >= _activation_step and not base_model._recurrence_active:
+                base_model.set_recurrence_active(True)
+                _r0 = 1.0 / (1.0 + math.exp(-(step - _tmid) / _tau))
+                log(f"recurrence:homotopy activated at step {step}, t_mid={_tmid} tau={_tau} "
+                    f"r={_r0:.4f} virtual_layers={base_model._get_virtual_layers()}")
+            if base_model._recurrence_active:
+                rho = 1.0 / (1.0 + math.exp(-(step - _tmid) / _tau))
+                # In-place buffer update — dynamo does NOT retrace on buffer value change,
+                # whereas a direct attribute assignment (`= rho`) DID retrace on every
+                # step and burned ~30s/step in proxy_v2 leg 3 before the fix.
+                base_model._recur_rho.fill_(rho)
+        else:
+            if step >= h.recur_start_step and not base_model._recurrence_active:
+                base_model.set_recurrence_active(True)
+                log(f"recurrence:activated at step {step}, virtual_layers={base_model._get_virtual_layers()}")
+
+        should_validate = last_step or (h.val_loss_every > 0 and step % h.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(h, device, val_data, model)
+            log(f"{step}/{h.iterations} val_loss: {val_loss:.4f} val_bpb: {val_bpb:.4f}")
+            # Log homotopy schedule state at every val tick so transient_metrics.py
+            # can extract amplitude / area / recovery from the log alone.
+            if h.recur_homotopy:
+                _tmid_log = h.recur_homotopy_tmid if h.recur_homotopy_tmid >= 0 else h.recur_start_step
+                _tau_log = h.recur_homotopy_tau if h.recur_homotopy_tau > 0 else h.recur_homotopy_beta
+                _r_log = float(base_model._recur_rho) if base_model._recurrence_active else 0.0
+                log(f"recur_homotopy:step={step} r={_r_log:.4f} t_mid={_tmid_log} tau={_tau_log} "
+                    f"active={bool(base_model._recurrence_active)}")
+            # Log learnable contractive rho state (Lever 2 sanity)
+            if base_model.contractive_rho_raw is not None:
+                _deltas = {k: float(torch.sigmoid(v).item()) for k, v in base_model.contractive_rho_raw.items()}
+                log(f"contractive_rho:{_deltas}")
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < h.iterations:
+                log(
+                    f"stopping_early: wallclock_cap train_time: {training_time_ms:.0f}ms "
+                    f"step: {step}/{h.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        frac = training_frac(step, elapsed_ms)
+        scale = lr_mul(frac)
+        train_loss = step_fn(step, scale)
+
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(t.detach().float(), alpha=1.0 - ema_decay)
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+
+        should_log_train = (
+            h.train_log_every > 0
+            and (step <= 5 or step % h.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            tok_per_sec = step * h.train_batch_tokens / (approx_training_time_ms / 1000.0)
+            log(
+                f"{step}/{h.iterations} train_loss: {train_loss.item():.4f} "
+                f"train_time: {approx_training_time_ms / 60000:.1f}m tok/s: {tok_per_sec:.0f}"
+            )
+
+        # Wallclock safety: force stop with 50s margin for GPTQ + serialization
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if h.distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # Weight averaging
+    log("ema:applying EMA weights")
+    current_state = base_model.state_dict()
+    avg_state = {name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()}
+    base_model.load_state_dict(avg_state, strict=True)
+
+    # Stage B port — hand off effective training wallclock (step-loop only)
+    # to main() via module-level. Paired with total_wallclock_s at launcher exit.
+    global _STAGE_B_EFFECTIVE_TRAINING_MS
+    _STAGE_B_EFFECTIVE_TRAINING_MS = training_time_ms
+
+    return base_model, compiled_model
+
+
+def train_and_eval(h: Hyperparameters, device: torch.device) -> None:
+    random.seed(h.seed)
+    np.random.seed(h.seed)
+    torch.manual_seed(h.seed)
+    torch.cuda.manual_seed_all(h.seed)
+
+    val_data = ValidationData(h, device)
+    log(f"train_shards: {len(list(Path(h.datasets_dir).resolve().glob('fineweb_train_*.bin')))}")
+    log(f"val_tokens: {val_data.val_tokens.numel() - 1}")
+
+    if h.load_checkpoint_path:
+        # Skip training — load pre-trained checkpoint directly
+        log(f"load_checkpoint: loading from {h.load_checkpoint_path}")
+        base_model = GPT(h).to(device).bfloat16()
+        restore_fp32_params(base_model)
+        ckpt = torch.load(h.load_checkpoint_path, map_location=device)
+        base_model.load_state_dict(ckpt, strict=True)
+        del ckpt
+        # Gate recurrence activation on load. Default 1 = activate (matches prior behavior).
+        # Set LOAD_RECUR_ACTIVE=0 for checkpoints trained with recurrence OFF throughout
+        # (e.g. short 1×H100 runs that never reach RECUR_START_STEP). Forcing recurrence
+        # active on a non-recurrent-trained checkpoint creates a train/test distribution
+        # mismatch that collapses val_bpb (+0.05+).
+        _load_recur_active = bool(int(os.environ.get('LOAD_RECUR_ACTIVE', '1')))
+        base_model.set_recurrence_active(_load_recur_active)
+        # Optional eval-time contractive override: RECUR_RHO_EVAL ∈ (0,1] sets the
+        # recurrence-step weight on the loaded model. Default empty = 1.0 (full step).
+        _rho_override = os.environ.get('RECUR_RHO_EVAL', '').strip()
+        if _rho_override:
+            # In-place buffer update (see register_buffer in GPT.__init__).
+            base_model._recur_rho.fill_(float(_rho_override))
+            log(f"load_checkpoint: RECUR_RHO_EVAL override applied, _recur_rho={float(base_model._recur_rho):.4f}")
+        compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+        log(f"load_checkpoint: model loaded, recurrence_active={_load_recur_active}")
+    else:
+        base_model, compiled_model = train_model(h, device, val_data)
+
+    timed_eval("pre-quantization post-ema", eval_val, h, device, val_data, compiled_model)
+
+    # Score-first ridge eval adapter (legal: scores chunk K with state from chunks <K only)
+    if h.ridge_enabled:
+        timed_eval("pre-quantization-ridge", eval_val_ridge_score_first, h, device, val_data, base_model)
+
+    # Pre-quant AdamW TTT: adapt EMA model on val data BEFORE GPTQ (ported from #1423)
+    if h.prequant_ttt_enabled:
+        if h.distributed:
+            dist.barrier()
+        log(f"prequant_ttt:start lr={h.prequant_ttt_lr} epochs={h.prequant_ttt_epochs} "
+            f"freeze_blocks={h.prequant_ttt_freeze_blocks} cosine={h.prequant_ttt_cosine_decay}")
+        prequant_ttt_adapt_adamw(
+            h, base_model, device, val_data.val_tokens,
+            rank=h.rank, world_size=h.world_size,
+        )
+        timed_eval("post-prequant-ttt", eval_val, h, device, val_data, compiled_model)
+        if h.distributed:
+            dist.barrier()
+
+    serialize(h, base_model, Path(__file__).read_text(encoding="utf-8"))
+    if h.distributed:
+        dist.barrier()
+
+    eval_model = deserialize(h, device)
+    # Activate recurrence on eval model for consistent evaluation
+    eval_model.set_recurrence_active(base_model._recurrence_active)
+
+    run_evals(h, device, val_data, eval_model)
+
+
+# Stage B port — module-level handoff so main() can emit dual wallclock timers.
+# Written by train_model() before return. Zero if no training happened.
+_STAGE_B_EFFECTIVE_TRAINING_MS = 0.0
+
+
+def main():
+    # Stage B port — capture total wallclock at launcher entry, before any work.
+    _launcher_start_wallclock = time.perf_counter()
+
+    # Modification 2: increase dynamo cache size for recurrence
+    torch._dynamo.config.cache_size_limit = 32
+
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    torch._dynamo.config.optimize_ddp = False
+
+    h = Hyperparameters()
+    set_logging_hparams(h)
+    # Stage B port — env-overridable protocol signature. Defaults lifted from
+    # feedback_stage_b_reopen_protocol.md.
+    _stage_b_confound_lock = os.environ.get(
+        "STAGE_B_CONFOUND_LOCK",
+        "Prior 2026-04-11 Stage B run appeared to regress on BPB but the regression "
+        "is consistent with reduced effective training steps under the 10-minute "
+        "wallclock cap, caused by DDP setup + contractive rho recompute overhead — "
+        "NOT with the recurrence mechanism itself.",
+    )
+    _stage_b_acceptance_bands = os.environ.get(
+        "STAGE_B_ACCEPTANCE_BANDS",
+        "GREEN: variant-control <= -0.006 AND effective_wc >= 95% of control; "
+        "YELLOW: variant-control <= -0.003 AND effective_wc >= 90% of control; "
+        "RED: variant-control >= 0 OR NaN OR rho collapse OR effective_wc < 90%.",
+    )
+    if h.is_main_process:
+        os.makedirs("logs", exist_ok=True)
+        log(100 * "=", console=False)
+        log("Hyperparameters:", console=True)
+        for k, v in sorted(vars(type(h)).items()):
+            if not k.startswith("_"):
+                log(f"  {k}: {v}", console=True)
+        log(Path(__file__).read_text(encoding="utf-8"), console=False)
+        log("=" * 100, console=False)
+        log(f"Running Python {sys.version}", console=False)
+        log(f"Running PyTorch {torch.__version__}", console=False)
+        log(
+            subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+            console=False,
+        )
+        log("=" * 100, console=False)
+        # Stage B protocol signature — written at every launch.
+        log(
+            f"stage_b_config recur_layers:{h.recur_layers!r} "
+            f"recur_start_step:{h.recur_start_step} "
+            f"contractive_rho_enabled:{int(h.contractive_rho_enabled)} "
+            f"contractive_rho_init:{h.contractive_rho_init}",
+            console=False,
+        )
+        log(f"stage_b_confound_lock {_stage_b_confound_lock}", console=False)
+        log(f"stage_b_acceptance_bands {_stage_b_acceptance_bands}", console=False)
+
+    train_and_eval(h, device)
+
+    # Stage B port — emit dual wallclock timers.
+    if h.is_main_process:
+        _total_wallclock_s = time.perf_counter() - _launcher_start_wallclock
+        log(
+            f"stage_b_timers total_wallclock_s:{_total_wallclock_s:.3f} "
+            f"effective_training_wallclock_s:{_STAGE_B_EFFECTIVE_TRAINING_MS / 1000.0:.3f}",
+            console=True,
+        )
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-04-16_SP8192_3LayerRecur_HardOnset_NoTTT/train_seed1337.log
+++ b/records/track_10min_16mb/2026-04-16_SP8192_3LayerRecur_HardOnset_NoTTT/train_seed1337.log
@@ -1,0 +1,234 @@
+=== PRE-LAUNCH CHECKS ===
+  shards: 30
+  output: /workspace/parameter-golf/stage_recur_homotopy/outputs/hard_onset_seed1337
+=== CONFIG ===
+  seed=1337 tag=hard_onset_seed1337
+  RECUR_HOMOTOPY=0 (hard onset at RECUR_START_STEP=3000)
+  SKIP_EVAL=1 GPTQ_ENABLED=0 VAL_LOSS_EVERY=99999
+=== RUN C START seed=1337 2026-04-16T03:37:32Z ===
+W0416 03:37:33.551000 136422 torch/distributed/run.py:803] 
+W0416 03:37:33.551000 136422 torch/distributed/run.py:803] *****************************************
+W0416 03:37:33.551000 136422 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0416 03:37:33.551000 136422 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  beta1: 0.9
+  beta2: 0.95
+  bigram_dim: 112
+  bigram_enabled: False
+  bigram_vocab_size: 3072
+  clip_reg_lambda: 0.0
+  compressor: brotli
+  contractive_rho_enabled: False
+  contractive_rho_init: 5.0
+  data_dir: ./data/
+  datasets_dir: /dev/shm/fineweb10B_sp8192
+  distributed: True
+  ema_decay: 0.9965
+  embed_lr: 0.6
+  embed_wd: 0.095
+  embedding_dim: 512
+  eval_seq_len: 2048
+  eval_stride: 64
+  gptq_calibration_batches: 64
+  gptq_enabled: False
+  gptq_reserve_seconds: 0.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  haqr_lambda: 0.0
+  haqr_onset: 0.7
+  head_lr: 0.008
+  is_main_process: True
+  iterations: 20000
+  late_ste_enabled: False
+  late_ste_onset: 0.85
+  late_ste_ramp: 0.0
+  ln_scale: True
+  load_checkpoint_path: 
+  local_attn_start_layer: 8
+  local_attn_window: -1
+  local_rank: 0
+  logfile: logs/hard_onset_seed1337_20260416T033732Z.txt
+  logit_softcap: 30.0
+  matrix_lr: 0.022
+  max_wallclock_seconds: 600.0
+  min_lr: 0.1
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: final_model.pt
+  muon_backend_steps: 5
+  muon_beta2: 0.95
+  muon_momentum: 0.99
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_wd: 0.095
+  normuon_enabled: False
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  parallel_start_layer: 7
+  prequant_ttt_batch_seqs: 32
+  prequant_ttt_cosine_decay: True
+  prequant_ttt_enabled: False
+  prequant_ttt_epochs: 6
+  prequant_ttt_freeze_blocks: 2
+  prequant_ttt_grad_clip: 1.0
+  prequant_ttt_lr: 0.0005
+  qk_gain_init: 5.25
+  quantized_model_path: final_model.int6.ptz
+  rank: 0
+  recur_homotopy: False
+  recur_homotopy_beta: 20.0
+  recur_homotopy_tau: -1.0
+  recur_homotopy_tmid: -1
+  recur_layers: 3,4,5
+  recur_start_step: 3000
+  ridge_chunk_tokens: 65536
+  ridge_enabled: False
+  ridge_lambda: 1.0
+  ridge_rank: 32
+  ridge_resolve_every: 1
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  run_id: hard_onset_seed1337_20260416T033732Z
+  scalar_lr: 0.02
+  sdclip_k: 12.85
+  sdclip_k_attn: 12.85
+  sdclip_k_early: 12.85
+  sdclip_k_embed: 20.0
+  sdclip_k_late: 12.85
+  sdclip_k_mlp: 12.85
+  sdclip_k_other: 12.85
+  sdclip_k_recur: 12.85
+  seed: 1337
+  skip_gates_enabled: True
+  sliding_window_enabled: True
+  swc_lambda: 0.0
+  swc_window: 512
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  titans_enabled: False
+  titans_eta: 0.05
+  titans_gate_init: -5.0
+  titans_layers: 5,8
+  titans_mem_dim: 256
+  titans_momentum: 0.9
+  tokenizer_path: /workspace/parameter-golf/data/tokenizers/fineweb_8192_bpe.model
+  train_batch_tokens: 786432
+  train_files: /dev/shm/fineweb10B_sp8192/fineweb_train_*.bin
+  train_log_every: 100
+  train_seq_len: 2048
+  ttt_batch_seqs: 32
+  ttt_chunk_tokens: 32768
+  ttt_enabled: False
+  ttt_epochs: 3
+  ttt_freeze_blocks: 0
+  ttt_grad_clip: 1.0
+  ttt_lr: 0.002
+  ttt_momentum: 0.9
+  val_batch_tokens: 524288
+  val_files: /dev/shm/fineweb10B_sp8192/fineweb_val_*.bin
+  val_loss_every: 99999
+  ve_dim: 128
+  ve_enabled: True
+  ve_layers: 9,10
+  vocab_size: 8192
+  vpd_enabled: False
+  vpd_init: 0.01
+  warmdown_frac: 0.72
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+  zloss_alpha: 0.0
+train_shards: 30
+val_tokens: 40546304
+model_params:37022812
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+0/20000 val_loss: 9.0083 val_bpb: 3.4880
+1/20000 train_loss: 9.0119 train_time: 0.0m tok/s: 8354203
+2/20000 train_loss: 12.1047 train_time: 0.0m tok/s: 7851345
+3/20000 train_loss: 10.8841 train_time: 0.0m tok/s: 7657449
+4/20000 train_loss: 9.2868 train_time: 0.0m tok/s: 7541932
+5/20000 train_loss: 8.1957 train_time: 0.0m tok/s: 7508261
+100/20000 train_loss: 4.3662 train_time: 0.2m tok/s: 7691732
+200/20000 train_loss: 3.6104 train_time: 0.3m tok/s: 7695754
+300/20000 train_loss: 3.4705 train_time: 0.5m tok/s: 7695879
+400/20000 train_loss: 3.4147 train_time: 0.7m tok/s: 7696603
+500/20000 train_loss: 3.3651 train_time: 0.9m tok/s: 7697970
+600/20000 train_loss: 3.2967 train_time: 1.0m tok/s: 7699882
+700/20000 train_loss: 3.2605 train_time: 1.2m tok/s: 7701303
+800/20000 train_loss: 3.2257 train_time: 1.4m tok/s: 7702241
+900/20000 train_loss: 3.2293 train_time: 1.5m tok/s: 7702818
+1000/20000 train_loss: 3.2318 train_time: 1.7m tok/s: 7699323
+1100/20000 train_loss: 3.2647 train_time: 1.9m tok/s: 7700439
+1200/20000 train_loss: 3.2116 train_time: 2.0m tok/s: 7700268
+1300/20000 train_loss: 3.1949 train_time: 2.2m tok/s: 7700969
+1400/20000 train_loss: 3.2140 train_time: 2.4m tok/s: 7701452
+1500/20000 train_loss: 3.1856 train_time: 2.6m tok/s: 7701887
+1600/20000 train_loss: 3.1621 train_time: 2.7m tok/s: 7701938
+1700/20000 train_loss: 3.2371 train_time: 2.9m tok/s: 7701575
+1800/20000 train_loss: 3.1187 train_time: 3.1m tok/s: 7701387
+1900/20000 train_loss: 3.1144 train_time: 3.2m tok/s: 7701259
+2000/20000 train_loss: 3.0520 train_time: 3.4m tok/s: 7700375
+2100/20000 train_loss: 3.1109 train_time: 3.6m tok/s: 7700605
+2200/20000 train_loss: 3.1228 train_time: 3.7m tok/s: 7699246
+2300/20000 train_loss: 3.0284 train_time: 3.9m tok/s: 7698749
+2400/20000 train_loss: 3.0975 train_time: 4.1m tok/s: 7698533
+2500/20000 train_loss: 3.0688 train_time: 4.3m tok/s: 7698563
+2600/20000 train_loss: 3.1343 train_time: 4.4m tok/s: 7698548
+2700/20000 train_loss: 3.1198 train_time: 4.6m tok/s: 7698416
+2800/20000 train_loss: 3.0232 train_time: 4.8m tok/s: 7698159
+2900/20000 train_loss: 3.0771 train_time: 4.9m tok/s: 7698208
+3000/20000 train_loss: 3.0998 train_time: 5.1m tok/s: 7698150
+recurrence:activated at step 3000, virtual_layers=[0, 1, 2, 3, 4, 5, 3, 4, 5, 6, 7, 8, 9, 10]
+3100/20000 train_loss: 3.0405 train_time: 5.5m tok/s: 7376037
+3200/20000 train_loss: 2.8708 train_time: 5.7m tok/s: 7335257
+3300/20000 train_loss: 3.0125 train_time: 5.9m tok/s: 7297532
+3400/20000 train_loss: 2.9249 train_time: 6.1m tok/s: 7261859
+3500/20000 train_loss: 2.9694 train_time: 6.3m tok/s: 7228829
+3600/20000 train_loss: 2.8960 train_time: 6.6m tok/s: 7198063
+3700/20000 train_loss: 2.9099 train_time: 6.8m tok/s: 7168980
+3800/20000 train_loss: 2.8586 train_time: 7.0m tok/s: 7141896
+3900/20000 train_loss: 2.9449 train_time: 7.2m tok/s: 7116301
+4000/20000 train_loss: 2.9380 train_time: 7.4m tok/s: 7092158
+4100/20000 train_loss: 2.8912 train_time: 7.6m tok/s: 7069451
+4200/20000 train_loss: 2.9523 train_time: 7.8m tok/s: 7047913
+4300/20000 train_loss: 2.8670 train_time: 8.0m tok/s: 7027477
+4400/20000 train_loss: 2.9824 train_time: 8.2m tok/s: 7008119
+4500/20000 train_loss: 2.9010 train_time: 8.4m tok/s: 6989531
+4600/20000 train_loss: 2.8432 train_time: 8.6m tok/s: 6971721
+4700/20000 train_loss: 2.9531 train_time: 8.9m tok/s: 6955114
+4800/20000 train_loss: 2.8690 train_time: 9.1m tok/s: 6939165
+4900/20000 train_loss: 2.9433 train_time: 9.3m tok/s: 6923774
+5000/20000 train_loss: 2.8212 train_time: 9.5m tok/s: 6909306
+5100/20000 train_loss: 2.8568 train_time: 9.7m tok/s: 6895462
+5200/20000 train_loss: 2.8980 train_time: 9.9m tok/s: 6882299
+5247/20000 val_loss: 2.8268 val_bpb: 1.0945
+stopping_early: wallclock_cap train_time: 600109ms step: 5247/20000
+peak memory allocated: 33093 MiB reserved: 33114 MiB
+ema:applying EMA weights
+pre-quantization post-ema val_loss:2.80310099 val_bpb:1.08535798 eval_time:1958ms
+Serialized model: 137649029 bytes
+Code size: 132539 bytes
+selective_prune: unpruned=15.99MB target=16.0MB
+selective_prune: already fits, no pruning needed
+Serialized model int6+brotli: 15857563 bytes
+Total submission size int6+brotli: 15990102 bytes
+SKIP_EVAL=1 — exiting after serialize, eval runs on 1× via eval_saved_artifact.py
+stage_b_timers total_wallclock_s:758.726 effective_training_wallclock_s:600.109
+real_wallclock_s=772 rc=0
+relocated final_model.pt → /workspace/parameter-golf/stage_recur_homotopy/outputs/hard_onset_seed1337/final_model.pt
+relocated final_model.int6.ptz → /workspace/parameter-golf/stage_recur_homotopy/outputs/hard_onset_seed1337/final_model.int6.ptz
+=== RUN C COMPLETE seed=1337 rc=0 2026-04-16T03:50:24Z ===
+  artifacts: /workspace/parameter-golf/stage_recur_homotopy/outputs/hard_onset_seed1337
+  NEXT: run_eval_only.sh /workspace/parameter-golf/stage_recur_homotopy/outputs/hard_onset_seed1337/final_model.pt → gate number for hard onset

--- a/records/track_10min_16mb/2026-04-16_SP8192_3LayerRecur_HardOnset_NoTTT/train_seed314.log
+++ b/records/track_10min_16mb/2026-04-16_SP8192_3LayerRecur_HardOnset_NoTTT/train_seed314.log
@@ -1,0 +1,234 @@
+=== PRE-LAUNCH CHECKS ===
+  shards: 30
+  output: /workspace/parameter-golf/stage_recur_homotopy/outputs/hard_onset_seed314
+=== CONFIG ===
+  seed=314 tag=hard_onset_seed314
+  RECUR_HOMOTOPY=0 (hard onset at RECUR_START_STEP=3000)
+  SKIP_EVAL=1 GPTQ_ENABLED=0 VAL_LOSS_EVERY=99999
+=== RUN C START seed=314 2026-04-16T06:54:14Z ===
+W0416 06:54:16.793000 73604 torch/distributed/run.py:803] 
+W0416 06:54:16.793000 73604 torch/distributed/run.py:803] *****************************************
+W0416 06:54:16.793000 73604 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0416 06:54:16.793000 73604 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  beta1: 0.9
+  beta2: 0.95
+  bigram_dim: 112
+  bigram_enabled: False
+  bigram_vocab_size: 3072
+  clip_reg_lambda: 0.0
+  compressor: brotli
+  contractive_rho_enabled: False
+  contractive_rho_init: 5.0
+  data_dir: ./data/
+  datasets_dir: /dev/shm/fineweb10B_sp8192
+  distributed: True
+  ema_decay: 0.9965
+  embed_lr: 0.6
+  embed_wd: 0.095
+  embedding_dim: 512
+  eval_seq_len: 2048
+  eval_stride: 64
+  gptq_calibration_batches: 64
+  gptq_enabled: False
+  gptq_reserve_seconds: 0.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  haqr_lambda: 0.0
+  haqr_onset: 0.7
+  head_lr: 0.008
+  is_main_process: True
+  iterations: 20000
+  late_ste_enabled: False
+  late_ste_onset: 0.85
+  late_ste_ramp: 0.0
+  ln_scale: True
+  load_checkpoint_path: 
+  local_attn_start_layer: 8
+  local_attn_window: -1
+  local_rank: 0
+  logfile: logs/hard_onset_seed314_20260416T065414Z.txt
+  logit_softcap: 30.0
+  matrix_lr: 0.022
+  max_wallclock_seconds: 600.0
+  min_lr: 0.1
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: final_model.pt
+  muon_backend_steps: 5
+  muon_beta2: 0.95
+  muon_momentum: 0.99
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_wd: 0.095
+  normuon_enabled: False
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  parallel_start_layer: 7
+  prequant_ttt_batch_seqs: 32
+  prequant_ttt_cosine_decay: True
+  prequant_ttt_enabled: False
+  prequant_ttt_epochs: 6
+  prequant_ttt_freeze_blocks: 2
+  prequant_ttt_grad_clip: 1.0
+  prequant_ttt_lr: 0.0005
+  qk_gain_init: 5.25
+  quantized_model_path: final_model.int6.ptz
+  rank: 0
+  recur_homotopy: False
+  recur_homotopy_beta: 20.0
+  recur_homotopy_tau: -1.0
+  recur_homotopy_tmid: -1
+  recur_layers: 3,4,5
+  recur_start_step: 3000
+  ridge_chunk_tokens: 65536
+  ridge_enabled: False
+  ridge_lambda: 1.0
+  ridge_rank: 32
+  ridge_resolve_every: 1
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  run_id: hard_onset_seed314_20260416T065414Z
+  scalar_lr: 0.02
+  sdclip_k: 12.85
+  sdclip_k_attn: 12.85
+  sdclip_k_early: 12.85
+  sdclip_k_embed: 20.0
+  sdclip_k_late: 12.85
+  sdclip_k_mlp: 12.85
+  sdclip_k_other: 12.85
+  sdclip_k_recur: 12.85
+  seed: 314
+  skip_gates_enabled: True
+  sliding_window_enabled: True
+  swc_lambda: 0.0
+  swc_window: 512
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  titans_enabled: False
+  titans_eta: 0.05
+  titans_gate_init: -5.0
+  titans_layers: 5,8
+  titans_mem_dim: 256
+  titans_momentum: 0.9
+  tokenizer_path: /workspace/parameter-golf/data/tokenizers/fineweb_8192_bpe.model
+  train_batch_tokens: 786432
+  train_files: /dev/shm/fineweb10B_sp8192/fineweb_train_*.bin
+  train_log_every: 100
+  train_seq_len: 2048
+  ttt_batch_seqs: 32
+  ttt_chunk_tokens: 32768
+  ttt_enabled: False
+  ttt_epochs: 3
+  ttt_freeze_blocks: 0
+  ttt_grad_clip: 1.0
+  ttt_lr: 0.002
+  ttt_momentum: 0.9
+  val_batch_tokens: 524288
+  val_files: /dev/shm/fineweb10B_sp8192/fineweb_val_*.bin
+  val_loss_every: 99999
+  ve_dim: 128
+  ve_enabled: True
+  ve_layers: 9,10
+  vocab_size: 8192
+  vpd_enabled: False
+  vpd_init: 0.01
+  warmdown_frac: 0.72
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+  zloss_alpha: 0.0
+train_shards: 30
+val_tokens: 40546304
+model_params:37022812
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+0/20000 val_loss: 9.0047 val_bpb: 3.4866
+1/20000 train_loss: 9.0082 train_time: 0.0m tok/s: 8364728
+2/20000 train_loss: 12.0604 train_time: 0.0m tok/s: 7103992
+3/20000 train_loss: 10.8195 train_time: 0.0m tok/s: 7146264
+4/20000 train_loss: 9.2611 train_time: 0.0m tok/s: 7172499
+5/20000 train_loss: 8.1884 train_time: 0.0m tok/s: 7173701
+100/20000 train_loss: 4.3744 train_time: 0.2m tok/s: 7667966
+200/20000 train_loss: 3.6242 train_time: 0.3m tok/s: 7687529
+300/20000 train_loss: 3.4693 train_time: 0.5m tok/s: 7690831
+400/20000 train_loss: 3.4133 train_time: 0.7m tok/s: 7695947
+500/20000 train_loss: 3.3670 train_time: 0.9m tok/s: 7700659
+600/20000 train_loss: 3.2993 train_time: 1.0m tok/s: 7702763
+700/20000 train_loss: 3.2555 train_time: 1.2m tok/s: 7704219
+800/20000 train_loss: 3.2149 train_time: 1.4m tok/s: 7705674
+900/20000 train_loss: 3.2284 train_time: 1.5m tok/s: 7706963
+1000/20000 train_loss: 3.2309 train_time: 1.7m tok/s: 7708021
+1100/20000 train_loss: 3.2620 train_time: 1.9m tok/s: 7708787
+1200/20000 train_loss: 3.2033 train_time: 2.0m tok/s: 7708906
+1300/20000 train_loss: 3.1903 train_time: 2.2m tok/s: 7709557
+1400/20000 train_loss: 3.2110 train_time: 2.4m tok/s: 7709453
+1500/20000 train_loss: 3.1823 train_time: 2.5m tok/s: 7710238
+1600/20000 train_loss: 3.1594 train_time: 2.7m tok/s: 7710179
+1700/20000 train_loss: 3.2306 train_time: 2.9m tok/s: 7710115
+1800/20000 train_loss: 3.1137 train_time: 3.1m tok/s: 7709711
+1900/20000 train_loss: 3.1097 train_time: 3.2m tok/s: 7709621
+2000/20000 train_loss: 3.0452 train_time: 3.4m tok/s: 7709793
+2100/20000 train_loss: 3.1046 train_time: 3.6m tok/s: 7710059
+2200/20000 train_loss: 3.1188 train_time: 3.7m tok/s: 7709758
+2300/20000 train_loss: 3.0215 train_time: 3.9m tok/s: 7710085
+2400/20000 train_loss: 3.0965 train_time: 4.1m tok/s: 7709674
+2500/20000 train_loss: 3.0687 train_time: 4.2m tok/s: 7710119
+2600/20000 train_loss: 3.1309 train_time: 4.4m tok/s: 7709930
+2700/20000 train_loss: 3.1143 train_time: 4.6m tok/s: 7709856
+2800/20000 train_loss: 3.0173 train_time: 4.8m tok/s: 7709755
+2900/20000 train_loss: 3.0747 train_time: 4.9m tok/s: 7708499
+3000/20000 train_loss: 3.1011 train_time: 5.1m tok/s: 7708622
+recurrence:activated at step 3000, virtual_layers=[0, 1, 2, 3, 4, 5, 3, 4, 5, 6, 7, 8, 9, 10]
+3100/20000 train_loss: 3.0346 train_time: 5.5m tok/s: 7398667
+3200/20000 train_loss: 2.8725 train_time: 5.7m tok/s: 7357215
+3300/20000 train_loss: 3.0066 train_time: 5.9m tok/s: 7318800
+3400/20000 train_loss: 2.9229 train_time: 6.1m tok/s: 7282813
+3500/20000 train_loss: 2.9698 train_time: 6.3m tok/s: 7249444
+3600/20000 train_loss: 2.8924 train_time: 6.5m tok/s: 7218287
+3700/20000 train_loss: 2.9080 train_time: 6.7m tok/s: 7188914
+3800/20000 train_loss: 2.8544 train_time: 7.0m tok/s: 7161527
+3900/20000 train_loss: 2.9406 train_time: 7.2m tok/s: 7135368
+4000/20000 train_loss: 2.9348 train_time: 7.4m tok/s: 7110936
+4100/20000 train_loss: 2.8921 train_time: 7.6m tok/s: 7088002
+4200/20000 train_loss: 2.9488 train_time: 7.8m tok/s: 7066174
+4300/20000 train_loss: 2.8627 train_time: 8.0m tok/s: 7045514
+4400/20000 train_loss: 2.9783 train_time: 8.2m tok/s: 7025884
+4500/20000 train_loss: 2.9004 train_time: 8.4m tok/s: 7007245
+4600/20000 train_loss: 2.8390 train_time: 8.6m tok/s: 6989323
+4700/20000 train_loss: 2.9516 train_time: 8.8m tok/s: 6972193
+4800/20000 train_loss: 2.8686 train_time: 9.0m tok/s: 6956108
+4900/20000 train_loss: 2.9392 train_time: 9.3m tok/s: 6940723
+5000/20000 train_loss: 2.8181 train_time: 9.5m tok/s: 6925969
+5100/20000 train_loss: 2.8543 train_time: 9.7m tok/s: 6911937
+5200/20000 train_loss: 2.9011 train_time: 9.9m tok/s: 6898663
+5258/20000 val_loss: 2.8243 val_bpb: 1.0936
+stopping_early: wallclock_cap train_time: 600090ms step: 5258/20000
+peak memory allocated: 33093 MiB reserved: 33112 MiB
+ema:applying EMA weights
+pre-quantization post-ema val_loss:2.80058233 val_bpb:1.08438276 eval_time:1968ms
+Serialized model: 137649093 bytes
+Code size: 136256 bytes
+selective_prune: unpruned=15.98MB target=16.0MB
+selective_prune: already fits, no pruning needed
+Serialized model int6+brotli: 15845793 bytes
+Total submission size int6+brotli: 15982049 bytes
+SKIP_EVAL=1 — exiting after serialize, eval runs on 1× via eval_saved_artifact.py
+stage_b_timers total_wallclock_s:763.579 effective_training_wallclock_s:600.090
+real_wallclock_s=777 rc=0
+relocated final_model.pt → /workspace/parameter-golf/stage_recur_homotopy/outputs/hard_onset_seed314/final_model.pt
+relocated final_model.int6.ptz → /workspace/parameter-golf/stage_recur_homotopy/outputs/hard_onset_seed314/final_model.int6.ptz
+=== RUN C COMPLETE seed=314 rc=0 2026-04-16T07:07:11Z ===
+  artifacts: /workspace/parameter-golf/stage_recur_homotopy/outputs/hard_onset_seed314
+  NEXT: run_eval_only.sh /workspace/parameter-golf/stage_recur_homotopy/outputs/hard_onset_seed314/final_model.pt → gate number for hard onset

--- a/records/track_10min_16mb/2026-04-16_SP8192_3LayerRecur_HardOnset_NoTTT/train_seed42.log
+++ b/records/track_10min_16mb/2026-04-16_SP8192_3LayerRecur_HardOnset_NoTTT/train_seed42.log
@@ -1,0 +1,232 @@
+=== PRE-LAUNCH CHECKS ===
+  shards: 30
+  output: /workspace/parameter-golf/stage_recur_homotopy/outputs/hard_onset_seed42
+=== CONFIG ===
+  seed=42 tag=hard_onset_seed42
+  RECUR_HOMOTOPY=0 (hard onset at RECUR_START_STEP=3000)
+  SKIP_EVAL=1 GPTQ_ENABLED=0 VAL_LOSS_EVERY=99999
+=== RUN C START seed=42 2026-04-16T06:40:45Z ===
+W0416 06:40:47.632000 63811 torch/distributed/run.py:803] 
+W0416 06:40:47.632000 63811 torch/distributed/run.py:803] *****************************************
+W0416 06:40:47.632000 63811 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0416 06:40:47.632000 63811 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  beta1: 0.9
+  beta2: 0.95
+  bigram_dim: 112
+  bigram_enabled: False
+  bigram_vocab_size: 3072
+  clip_reg_lambda: 0.0
+  compressor: brotli
+  contractive_rho_enabled: False
+  contractive_rho_init: 5.0
+  data_dir: ./data/
+  datasets_dir: /dev/shm/fineweb10B_sp8192
+  distributed: True
+  ema_decay: 0.9965
+  embed_lr: 0.6
+  embed_wd: 0.095
+  embedding_dim: 512
+  eval_seq_len: 2048
+  eval_stride: 64
+  gptq_calibration_batches: 64
+  gptq_enabled: False
+  gptq_reserve_seconds: 0.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  haqr_lambda: 0.0
+  haqr_onset: 0.7
+  head_lr: 0.008
+  is_main_process: True
+  iterations: 20000
+  late_ste_enabled: False
+  late_ste_onset: 0.85
+  late_ste_ramp: 0.0
+  ln_scale: True
+  load_checkpoint_path: 
+  local_attn_start_layer: 8
+  local_attn_window: -1
+  local_rank: 0
+  logfile: logs/hard_onset_seed42_20260416T064045Z.txt
+  logit_softcap: 30.0
+  matrix_lr: 0.022
+  max_wallclock_seconds: 600.0
+  min_lr: 0.1
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: final_model.pt
+  muon_backend_steps: 5
+  muon_beta2: 0.95
+  muon_momentum: 0.99
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_wd: 0.095
+  normuon_enabled: False
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  parallel_start_layer: 7
+  prequant_ttt_batch_seqs: 32
+  prequant_ttt_cosine_decay: True
+  prequant_ttt_enabled: False
+  prequant_ttt_epochs: 6
+  prequant_ttt_freeze_blocks: 2
+  prequant_ttt_grad_clip: 1.0
+  prequant_ttt_lr: 0.0005
+  qk_gain_init: 5.25
+  quantized_model_path: final_model.int6.ptz
+  rank: 0
+  recur_homotopy: False
+  recur_homotopy_beta: 20.0
+  recur_homotopy_tau: -1.0
+  recur_homotopy_tmid: -1
+  recur_layers: 3,4,5
+  recur_start_step: 3000
+  ridge_chunk_tokens: 65536
+  ridge_enabled: False
+  ridge_lambda: 1.0
+  ridge_rank: 32
+  ridge_resolve_every: 1
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  run_id: hard_onset_seed42_20260416T064045Z
+  scalar_lr: 0.02
+  sdclip_k: 12.85
+  sdclip_k_attn: 12.85
+  sdclip_k_early: 12.85
+  sdclip_k_embed: 20.0
+  sdclip_k_late: 12.85
+  sdclip_k_mlp: 12.85
+  sdclip_k_other: 12.85
+  sdclip_k_recur: 12.85
+  seed: 42
+  skip_gates_enabled: True
+  sliding_window_enabled: True
+  swc_lambda: 0.0
+  swc_window: 512
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  titans_enabled: False
+  titans_eta: 0.05
+  titans_gate_init: -5.0
+  titans_layers: 5,8
+  titans_mem_dim: 256
+  titans_momentum: 0.9
+  tokenizer_path: /workspace/parameter-golf/data/tokenizers/fineweb_8192_bpe.model
+  train_batch_tokens: 786432
+  train_files: /dev/shm/fineweb10B_sp8192/fineweb_train_*.bin
+  train_log_every: 100
+  train_seq_len: 2048
+  ttt_batch_seqs: 32
+  ttt_chunk_tokens: 32768
+  ttt_enabled: False
+  ttt_epochs: 3
+  ttt_freeze_blocks: 0
+  ttt_grad_clip: 1.0
+  ttt_lr: 0.002
+  ttt_momentum: 0.9
+  val_batch_tokens: 524288
+  val_files: /dev/shm/fineweb10B_sp8192/fineweb_val_*.bin
+  val_loss_every: 99999
+  ve_dim: 128
+  ve_enabled: True
+  ve_layers: 9,10
+  vocab_size: 8192
+  vpd_enabled: False
+  vpd_init: 0.01
+  warmdown_frac: 0.72
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+  zloss_alpha: 0.0
+train_shards: 30
+val_tokens: 40546304
+model_params:37022812
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+0/20000 val_loss: 9.0096 val_bpb: 3.4885
+1/20000 train_loss: 9.0114 train_time: 0.0m tok/s: 8371361
+2/20000 train_loss: 12.2089 train_time: 0.0m tok/s: 7797099
+3/20000 train_loss: 10.9336 train_time: 0.0m tok/s: 7560742
+4/20000 train_loss: 9.2964 train_time: 0.0m tok/s: 7484824
+5/20000 train_loss: 8.1925 train_time: 0.0m tok/s: 7206270
+100/20000 train_loss: 4.3642 train_time: 0.2m tok/s: 7668437
+200/20000 train_loss: 3.6203 train_time: 0.3m tok/s: 7680535
+300/20000 train_loss: 3.4660 train_time: 0.5m tok/s: 7683961
+400/20000 train_loss: 3.4095 train_time: 0.7m tok/s: 7103463
+500/20000 train_loss: 3.3617 train_time: 0.9m tok/s: 7175808
+600/20000 train_loss: 3.3001 train_time: 1.1m tok/s: 7260747
+700/20000 train_loss: 3.2596 train_time: 1.3m tok/s: 7322440
+800/20000 train_loss: 3.2154 train_time: 1.4m tok/s: 7369677
+900/20000 train_loss: 3.2294 train_time: 1.6m tok/s: 7406456
+1000/20000 train_loss: 3.2315 train_time: 1.8m tok/s: 7436696
+1100/20000 train_loss: 3.2672 train_time: 1.9m tok/s: 7461278
+1200/20000 train_loss: 3.2023 train_time: 2.1m tok/s: 7481928
+1300/20000 train_loss: 3.1937 train_time: 2.3m tok/s: 7498766
+1400/20000 train_loss: 3.2090 train_time: 2.4m tok/s: 7513734
+1500/20000 train_loss: 3.1873 train_time: 2.6m tok/s: 7525949
+1600/20000 train_loss: 3.1602 train_time: 2.8m tok/s: 7537088
+1700/20000 train_loss: 3.2316 train_time: 3.0m tok/s: 7546644
+1800/20000 train_loss: 3.1161 train_time: 3.1m tok/s: 7555346
+1900/20000 train_loss: 3.1092 train_time: 3.3m tok/s: 7563381
+2000/20000 train_loss: 3.0441 train_time: 3.5m tok/s: 7570368
+2100/20000 train_loss: 3.1067 train_time: 3.6m tok/s: 7576317
+2200/20000 train_loss: 3.1179 train_time: 3.8m tok/s: 7582165
+2300/20000 train_loss: 3.0254 train_time: 4.0m tok/s: 7587320
+2400/20000 train_loss: 3.0974 train_time: 4.1m tok/s: 7591870
+2500/20000 train_loss: 3.0699 train_time: 4.3m tok/s: 7596289
+2600/20000 train_loss: 3.1316 train_time: 4.5m tok/s: 7599912
+2700/20000 train_loss: 3.1163 train_time: 4.7m tok/s: 7603704
+2800/20000 train_loss: 3.0190 train_time: 4.8m tok/s: 7607339
+2900/20000 train_loss: 3.0731 train_time: 5.0m tok/s: 7610686
+3000/20000 train_loss: 3.1002 train_time: 5.2m tok/s: 7614003
+recurrence:activated at step 3000, virtual_layers=[0, 1, 2, 3, 4, 5, 3, 4, 5, 6, 7, 8, 9, 10]
+3100/20000 train_loss: 3.0318 train_time: 6.0m tok/s: 6827684
+3200/20000 train_loss: 2.8598 train_time: 6.2m tok/s: 6808492
+3300/20000 train_loss: 2.9978 train_time: 6.4m tok/s: 6789950
+3400/20000 train_loss: 2.9114 train_time: 6.6m tok/s: 6773006
+3500/20000 train_loss: 2.9564 train_time: 6.8m tok/s: 6757310
+3600/20000 train_loss: 2.8829 train_time: 7.0m tok/s: 6742502
+3700/20000 train_loss: 2.8956 train_time: 7.2m tok/s: 6728479
+3800/20000 train_loss: 2.8439 train_time: 7.4m tok/s: 6715158
+3900/20000 train_loss: 2.9270 train_time: 7.6m tok/s: 6702492
+4000/20000 train_loss: 2.9254 train_time: 7.8m tok/s: 6690751
+4100/20000 train_loss: 2.8765 train_time: 8.0m tok/s: 6679626
+4200/20000 train_loss: 2.9366 train_time: 8.3m tok/s: 6668864
+4300/20000 train_loss: 2.8457 train_time: 8.5m tok/s: 6658782
+4400/20000 train_loss: 2.9610 train_time: 8.7m tok/s: 6648324
+4500/20000 train_loss: 2.8785 train_time: 8.9m tok/s: 6639127
+4600/20000 train_loss: 2.8189 train_time: 9.1m tok/s: 6630477
+4700/20000 train_loss: 2.9333 train_time: 9.3m tok/s: 6622021
+4800/20000 train_loss: 2.8529 train_time: 9.5m tok/s: 6613870
+4900/20000 train_loss: 2.9383 train_time: 9.7m tok/s: 6606400
+5000/20000 train_loss: 2.8189 train_time: 9.9m tok/s: 6599190
+5033/20000 val_loss: 2.8301 val_bpb: 1.0958
+stopping_early: wallclock_cap train_time: 600009ms step: 5033/20000
+peak memory allocated: 33136 MiB reserved: 33162 MiB
+ema:applying EMA weights
+pre-quantization post-ema val_loss:2.80689243 val_bpb:1.08682603 eval_time:1961ms
+Serialized model: 137649093 bytes
+Code size: 136256 bytes
+selective_prune: unpruned=16.00MB target=16.0MB
+selective_prune: pruning 24504/10785830 lowest-error ±1 values (excess=3063B)
+Serialized model int6+brotli: 15862052 bytes
+Total submission size int6+brotli: 15998308 bytes
+SKIP_EVAL=1 — exiting after serialize, eval runs on 1× via eval_saved_artifact.py
+stage_b_timers total_wallclock_s:789.178 effective_training_wallclock_s:600.009
+real_wallclock_s=803 rc=0
+relocated final_model.pt → /workspace/parameter-golf/stage_recur_homotopy/outputs/hard_onset_seed42/final_model.pt
+relocated final_model.int6.ptz → /workspace/parameter-golf/stage_recur_homotopy/outputs/hard_onset_seed42/final_model.int6.ptz
+=== RUN C COMPLETE seed=42 rc=0 2026-04-16T06:54:08Z ===
+  artifacts: /workspace/parameter-golf/stage_recur_homotopy/outputs/hard_onset_seed42
+  NEXT: run_eval_only.sh /workspace/parameter-golf/stage_recur_homotopy/outputs/hard_onset_seed42/final_model.pt → gate number for hard onset


### PR DESCRIPTION
This line reaches 1.0862 sliding val_bpb (3-seed mean, std 0.0023) at ~15.94 MB on 8x H100 in 600s.

The main change here is recurrence activation: using a hard onset at step 3000 for the 3-layer recurrence stack gave the best final artifact metric in this line.

Recipe:
- SP8192
- 3-layer recurrence on layers 3-5
- hard onset at step 3000
- GPTQ int6 + brotli
- EMA 0.9965
- SDClip 12.85

Results:

| Seed | Steps | Post-EMA fp32 val_bpb | Sliding val_bpb | Artifact bytes |
|------|------:|----------------------:|----------------:|---------------:|
| 314  |  5258 |               1.08438 |       1.08424   |   15,998,501   |
| 1337 |  5247 |               1.08536 |       1.08582   |   15,857,563   |
| 42   |  5033 |               1.08683 |       1.08868   |   15,974,578   |
| Mean |       |               1.08552 |       1.08625   |                |

Notes:
- VAL_LOSS_EVERY=99999 removes mid-training validation passes and increases realized training steps within the same 600s wallclock budget.
- Hard onset outperformed the smooth-onset variants on the final artifact metric in this recurrence line.