### PR TITLE
Record: CaseOps Tokenizer + Tapered WD - val_bpb 1.0678 (3-seed mean)

### DIFF
--- a/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/README.md
+++ b/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/README.md
@@ -1,0 +1,219 @@
+# Record: CaseOps Tokenizer + Mild WD Taper
+
+**val_bpb: 1.06780** (3-seed mean, std 0.00037) | **2.33674 nats** | **~15.94 MB** | 8xH100 SXM, ~596s train + ~488s TTT eval
+
+This record builds directly on PR #1626's legal multi-phase TTT stack and adds two changes:
+
+1. A lossless case-operations tokenizer/data export, hosted publicly at [romeerp/parameter-golf-caseops-v1](https://huggingface.co/datasets/romeerp/parameter-golf-caseops-v1)
+2. A mild late Muon weight-decay taper (`WD_TAPER_START_FRAC=0.70`, `WD_TAPER_FINAL_MULT=0.50`)
+
+The tokenizer/data are not checked into this PR; they are downloaded from the Hugging Face dataset above with the included `cached_challenge_fineweb.py`.
+
+## Results (8xH100 80GB SXM, PyTorch 2.9.1+cu128, Phased TTT)
+
+| Seed | Steps | Pre-Quant BPB | Quantized BPB | **Post-TTT BPB** | Artifact |
+|------|-------|---------------|---------------|------------------|----------|
+| 0 | 4,921 | 1.07032992 | 1.08152131 | **1.06805820** | 15,932,307 |
+| 42 | 4,866 | 1.07065549 | 1.08171495 | **1.06806595** | 15,935,802 |
+| 1234 | 4,870 | 1.06971629 | 1.08036614 | **1.06727867** | 15,943,106 |
+| **Mean** | | **1.07023390** | **1.08120080** | **1.06780094** | **15,937,072** |
+
+## Supplemental Diagnostics
+
+| Seed | Pre-Quant BPB | Quantized BPB | Post-TTT BPB | val_loss (nats) | Code size | Total | Train time | Eval time |
+|------|---------------|---------------|--------------|-----------------|-----------|-------|------------|-----------|
+| 0 | 1.07032992 | 1.08152131 | 1.06805820 | 2.33730724 | 28,320 | 15,932,307 | 596.1s | 488.8s |
+| 42 | 1.07065549 | 1.08171495 | 1.06806595 | 2.33732420 | 30,985 | 15,935,802 | 596.1s | 482.0s |
+| 1234 | 1.06971629 | 1.08036614 | 1.06727867 | 2.33560135 | 30,985 | 15,943,106 | 596.1s | 494.6s |
+
+## Tokenizer: Lossless Case-Ops
+
+
+The tokenizer uses a lossless text transform, `lossless_caps_caseops_v1`, that factorizes text into:
+
+- a lowercase lexical stream
+- a tiny reserved capitalization side-channel
+
+Reserved control symbols:
+
+- `TITLE`
+- `ALLCAPS`
+- `CAPNEXT`
+- `ESC`
+
+Behavior over maximal ASCII alphabetic runs:
+
+- lowercase words stay lowercase
+- `TitleCase` becomes `TITLE + lowercase(word)`
+- `ALLCAPS` becomes `ALLCAPS + lowercase(word)`
+- mixed-case words use sparse `CAPNEXT` markers
+- control symbols themselves are escaped losslessly with `ESC`
+
+Examples:
+
+- `The NASA Launch` -> `TITLE the ALLCAPS nasa TITLE launch`
+- `iPhone OpenAI` -> `i CAPNEXT phone TITLE open CAPNEXT a CAPNEXT i`
+
+The point is to remove redundant case variation from the main lexical token stream without losing any information. At evaluation time, BPB is still charged against the original raw UTF-8 bytes, not the transformed stream.
+
+## Why This Is Still Real BPB
+
+The exporter writes validation byte sidecars:
+
+- `fineweb_val_000000.bin`
+- `fineweb_val_bytes_000000.bin`
+
+The trainer then loads the byte sidecar directly and reports:
+
+- `val_bpb:byte_sidecar:enabled`
+
+So scoring is done against exact original-byte counts rather than tokenized/transformed length. This preserves a true byte-level objective even though the tokenizer uses a reversible preprocessing transform.
+
+## Main Idea
+
+The core intuition is that standard `sp8192` still makes the model represent a lot of casing variation directly in the lexical stream. By transforming capital tokens to sentinel+lowercase, we free up vocabulary for more useful tokens, and possibly may provide some sort of inductive bias helping the model learn capitalization as a rule. The intuition behind tapered weight decay is that the purpose of a high weight decay in this challenge is to make weights more compressible by reducing entropy. While this is necessary at the beginning of training, near the end of training weights tend to be more settled, and therefore unlikely to spike and become outliers, so reducing the weight decay in favor of a better optimization may provide a benefit.
+
+This submission keeps the legal PR #1626 architecture and phased-TTT evaluation path, but swaps in the lossless case-ops tokenizer/data export above. On top of that, it adds a mild late taper on Muon weight decay:
+
+- full Muon WD until 70% of training
+- then linearly taper to 50% of the base WD by the end
+
+This combination improves pretrained BPB and quantized phased-TTT BPB while staying under the 16 MB artifact cap.
+
+## Changes from PR #1626
+
+| Change | Source | Effect |
+|--------|--------|--------|
+| CaseOps tokenizer + exported dataset | **Novel (this work)** | cleaner lexical stream, exact byte-sidecar eval |
+| Validation byte-sidecar BPB accounting | **Novel (this work)** | exact raw-byte metric with transformed tokenizer |
+| Mild late Muon WD taper (`0.70 -> 0.50`) | This work | small but consistent BPB win |
+| Public HF dataset/tokenizer download path | This work | reproducible on fresh pods |
+
+## Rule Compliance
+
+- **Causal:** all scoring remains autoregressive / causal.
+- **Normalized:** scoring uses standard cross-entropy over the full vocabulary.
+- **Score-before-update:** phased TTT remains PR #1626 style legal score-first TTT.
+- **Single pass:** no rescoring of validation tokens.
+- **No validation during training:** training uses only train shards.
+- **Full validation split:** the full exported validation split is scored.
+- **Byte accounting:** BPB is computed from the validation byte sidecar, which exactly matches the raw UTF-8 byte total of the exported docs.
+
+## Public Artifacts
+
+- Dataset + tokenizer: [romeerp/parameter-golf-caseops-v1](https://huggingface.co/datasets/romeerp/parameter-golf-caseops-v1)
+
+The HF dataset repo contains:
+
+- the caseops tokenizer model / vocab
+- the exported train shards
+- the exported validation shard
+- the validation byte-sidecar shard
+- `manifest.json`
+
+## Requirements
+
+Python >= 3.12. Flash Attention 3 (Hopper) required.
+
+```bash
+pip install flash_attn_3 --find-links https://windreamer.github.io/flash-attention3-wheels/cu128_torch291
+pip install -r requirements.txt
+```
+
+## Run Instructions
+
+Run the commands in this section from the record directory:
+
+```bash
+cd records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper
+```
+
+Prepare the public Hugging Face tokenizer + dataset on a fresh pod:
+
+```bash
+MATCHED_FINEWEB_REPO_ID=romeerp/parameter-golf-caseops-v1 \
+MATCHED_FINEWEB_REMOTE_ROOT_PREFIX=datasets \
+python3 cached_challenge_fineweb.py \
+  --variant sp8192_lossless_caps_caseops_v1_reserved \
+  --train-shards 80
+```
+
+This downloads both:
+
+- the exported caseops dataset shards
+- the caseops SentencePiece tokenizer artifact
+
+from [romeerp/parameter-golf-caseops-v1](https://huggingface.co/datasets/romeerp/parameter-golf-caseops-v1).
+
+From this record directory, train + quantize + phased eval for one seed:
+
+```bash
+NCCL_NET=Socket \
+SEED=0 \
+TOKENIZER_PATH=./tokenizers/fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model \
+DATASETS_DIR=./datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved \
+torchrun --standalone --nproc_per_node=8 train_gpt.py \
+  > train_seed0.log 2>&1
+```
+
+The submission script itself contains the intended defaults, including:
+
+- `PHASED_TTT_ENABLED=1`
+- `PHASED_TTT_NUM_PHASES=3`
+- `EMBED_BITS=7`
+- `EMBED_CLIP_SIGMAS=15.0`
+- `MLP_CLIP_SIGMAS=12.0`
+- `WD_TAPER_START_FRAC=0.70`
+- `WD_TAPER_FINAL_MULT=0.50`
+
+## Rebuilding the Tokenizer / Dataset
+
+The PR includes the actual Python sources used to create the tokenizer and exported dataset:
+
+- `download_hf_docs_and_tokenize.py`
+- `cached_challenge_fineweb.py`
+- `lossless_caps.py`
+- `tokenizer_specs_export_caseops_v1_reserved_only.json`
+
+Tokenizer export spec:
+
+```json
+{
+  "tokenizers": [
+    {
+      "name": "sp_bpe_8192_lossless_caps_caseops_v1_reserved",
+      "dataset_suffix": "sp8192_lossless_caps_caseops_v1_reserved",
+      "vocab_size": 8192,
+      "text_transform": "lossless_caps_caseops_v1",
+      "reserve_text_transform_controls": true,
+      "model_prefix": "fineweb_8192_bpe_lossless_caps_caseops_v1_reserved"
+    }
+  ]
+}
+```
+
+To rebuild the HF artifacts from public docs instead of downloading the prebuilt dataset:
+
+```bash
+python3 download_hf_docs_and_tokenize.py \
+  --repo-id willdepueoai/parameter-golf \
+  --remote-root datasets \
+  --output-root data/caseops_export_rebuilt \
+  --tokenizer-config tokenizer_specs_export_caseops_v1_reserved_only.json \
+  --max-train-shards 80
+```
+
+That program imports the lossless transform implementation from `lossless_caps.py`, trains the SentencePiece model with the case-ops transform, exports the `80` train shards, exports the validation shard, and writes the validation byte-sidecar needed for exact BPB scoring.
+
+## Included Files
+
+- `train_gpt.py`
+- `requirements.txt`
+- `README.md`
+- `cached_challenge_fineweb.py`
+- `download_hf_docs_and_tokenize.py`
+- `lossless_caps.py`
+- `tokenizer_specs_export_caseops_v1_reserved_only.json`
+- `train_seed0.log`
+- `train_seed42.log`
+- `train_seed1234.log`

--- a/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/cached_challenge_fineweb.py
+++ b/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/cached_challenge_fineweb.py
@@ -1,0 +1,163 @@
+import argparse
+import json
+import os
+import shutil
+from pathlib import Path
+
+from huggingface_hub import hf_hub_download
+
+
+REPO_ID = os.environ.get("MATCHED_FINEWEB_REPO_ID", "willdepueoai/parameter-golf")
+REMOTE_ROOT_PREFIX = os.environ.get("MATCHED_FINEWEB_REMOTE_ROOT_PREFIX", "datasets")
+ROOT = Path(__file__).resolve().parent
+DATASETS_DIR = ROOT / "datasets"
+TOKENIZERS_DIR = ROOT / "tokenizers"
+
+def dataset_dir_for_variant(name: str) -> str:
+    if name == "byte260":
+        return "fineweb10B_byte260"
+    if name.startswith("sp") and name[2:].isdigit():
+        return f"fineweb10B_{name}"
+    if name.startswith("sp"):
+        return f"fineweb10B_{name}"
+    raise ValueError(f"unsupported variant {name!r}; expected byte260 or sp<VOCAB_SIZE>")
+
+
+def local_path_for_remote(relative_path: str) -> Path:
+    remote_path = Path(relative_path)
+    if REMOTE_ROOT_PREFIX and remote_path.parts[:1] == (REMOTE_ROOT_PREFIX,):
+        remote_path = remote_path.relative_to(REMOTE_ROOT_PREFIX)
+    if remote_path.parts[:1] == ("datasets",):
+        return DATASETS_DIR.joinpath(*remote_path.parts[1:])
+    if remote_path.parts[:1] == ("tokenizers",):
+        return TOKENIZERS_DIR.joinpath(*remote_path.parts[1:])
+    return ROOT / remote_path
+
+
+def get(relative_path: str) -> None:
+    destination = local_path_for_remote(relative_path)
+    if destination.exists():
+        return
+    if destination.is_symlink():
+        destination.unlink()
+
+    remote_path = Path(relative_path)
+    cached_path = Path(
+        hf_hub_download(
+            repo_id=REPO_ID,
+            filename=remote_path.name,
+            subfolder=remote_path.parent.as_posix() if remote_path.parent != Path(".") else None,
+            repo_type="dataset",
+        )
+    )
+    # HF cache entries may be snapshot symlinks. Resolve to the underlying blob so we
+    # always materialize a real file in data/, not a broken relative symlink.
+    cached_source = cached_path.resolve(strict=True)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.link(cached_source, destination)
+    except OSError:
+        shutil.copy2(cached_source, destination)
+
+
+def manifest_path() -> Path:
+    return local_path_for_remote(f"{REMOTE_ROOT_PREFIX}/manifest.json")
+
+
+def load_manifest(*, skip_manifest_download: bool) -> dict:
+    path = manifest_path()
+    if not path.is_file():
+        if skip_manifest_download:
+            raise FileNotFoundError(
+                f"manifest.json is required for manifest-driven shard counts but is not present locally at {path}"
+            )
+        get(f"{REMOTE_ROOT_PREFIX}/manifest.json")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def artifact_paths_for_tokenizer(tokenizer_entry: dict) -> list[str]:
+    artifacts = []
+    for key in ("model_path", "vocab_path", "path"):
+        value = tokenizer_entry.get(key)
+        if value:
+            artifacts.append(str(value))
+    if not artifacts:
+        raise ValueError(f"tokenizer entry is missing downloadable artifacts: {tokenizer_entry}")
+    return artifacts
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Download challenge FineWeb shards from Hugging Face")
+    parser.add_argument(
+        "train_shards_positional",
+        nargs="?",
+        type=int,
+        default=None,
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--train-shards",
+        type=int,
+        default=80,
+        help="Number of training shards to download for the selected variant. Defaults to 80.",
+    )
+    parser.add_argument(
+        "--variant",
+        default="sp1024",
+        help="Tokenizer family to download, for example sp1024, sp4096, or byte260.",
+    )
+    parser.add_argument(
+        "--skip-manifest",
+        action="store_true",
+        help="Skip downloading manifest.json.",
+    )
+    parser.add_argument(
+        "--with-docs",
+        action="store_true",
+        help="Also download docs_selected.jsonl and its sidecar for tokenizer retraining or dataset re-export.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    dataset_dir = dataset_dir_for_variant(args.variant)
+    train_shards = args.train_shards_positional if args.train_shards_positional is not None else args.train_shards
+    if train_shards < 0:
+        raise ValueError("train_shards must be non-negative")
+
+    manifest = load_manifest(skip_manifest_download=args.skip_manifest)
+    dataset_entry = next((x for x in manifest.get("datasets", []) if x.get("name") == dataset_dir), None)
+    if dataset_entry is None:
+        raise ValueError(f"dataset {dataset_dir} not found in {REMOTE_ROOT_PREFIX}/manifest.json")
+    max_train_shards = int((dataset_entry.get("stats") or {}).get("files_train"))
+    val_shards = int((dataset_entry.get("stats") or {}).get("files_val"))
+    if train_shards > max_train_shards:
+        raise ValueError(
+            f"{args.variant} only has {max_train_shards} training shards on {REPO_ID}, requested {train_shards}"
+        )
+    tokenizer_name = dataset_entry.get("tokenizer_name")
+    tokenizer_entry = next((x for x in manifest.get("tokenizers", []) if x.get("name") == tokenizer_name), None)
+    if tokenizer_entry is None:
+        raise ValueError(f"tokenizer {tokenizer_name} not found in {REMOTE_ROOT_PREFIX}/manifest.json")
+
+    if args.with_docs:
+        get(f"{REMOTE_ROOT_PREFIX}/docs_selected.jsonl")
+        get(f"{REMOTE_ROOT_PREFIX}/docs_selected.source_manifest.json")
+
+    dataset_prefix = f"{REMOTE_ROOT_PREFIX}/datasets/{dataset_dir}"
+    for i in range(val_shards):
+        get(f"{dataset_prefix}/fineweb_val_{i:06d}.bin")
+    val_bytes_glob = dataset_entry.get("val_bytes_glob")
+    if val_bytes_glob:
+        for i in range(val_shards):
+            get(f"{dataset_prefix}/fineweb_val_bytes_{i:06d}.bin")
+    for i in range(train_shards):
+        get(f"{dataset_prefix}/fineweb_train_{i:06d}.bin")
+
+    for artifact_path in artifact_paths_for_tokenizer(tokenizer_entry):
+        get(f"{REMOTE_ROOT_PREFIX}/{artifact_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/download_hf_docs_and_tokenize.py
+++ b/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/download_hf_docs_and_tokenize.py
@@ -1,0 +1,764 @@
+"""Download docs_selected.jsonl from Hugging Face and tokenize it locally.
+
+This script is standalone. It does not import any local exporter or tokenizer
+helpers. Tokenizer configs are JSON only and currently support the built-in
+pure-byte and SentencePiece tokenizer definitions in `data/tokenizer_specs.json`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import os
+import shutil
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from huggingface_hub import hf_hub_download
+from huggingface_hub.utils import EntryNotFoundError
+try:
+    from lossless_caps import (
+        IDENTITY,
+        get_text_transform,
+        get_text_transform_control_symbols,
+        surface_piece_original_byte_counts,
+    )
+except ImportError:
+    from data.lossless_caps import (
+        IDENTITY,
+        get_text_transform,
+        get_text_transform_control_symbols,
+        surface_piece_original_byte_counts,
+    )
+
+
+DOCS_FILENAME = "docs_selected.jsonl"
+SIDECAR_FILENAME = "docs_selected.source_manifest.json"
+VERSION = "10B"
+NUM_VAL_DOCS = 50_000
+SHARD_SIZE = 10**8
+APPEND_EOS = False
+DATAFILE_MAGIC = 20240520
+DATAFILE_VERSION = 1
+DEFAULT_REPO_ID = os.environ.get("MATCHED_FINEWEB_REPO_ID", "willdepueoai/parameter-golf")
+DEFAULT_REMOTE_ROOT = os.environ.get("MATCHED_FINEWEB_REMOTE_ROOT_PREFIX", "datasets")
+DEFAULT_CONFIG = Path(__file__).with_name("tokenizer_specs.json")
+TOKENIZER_THREADS = max(1, int(os.environ.get("MATCHED_FINEWEB_TOKENIZER_THREADS", str(os.cpu_count() or 8))))
+SP_BATCH_SIZE = max(1, int(os.environ.get("MATCHED_FINEWEB_SP_BATCH_SIZE", "1024")))
+
+
+@dataclass(frozen=True)
+class PureByteTokenizer:
+    pad_id: int = 0
+    bos_id: int = 1
+    eos_id: int = 2
+    unk_id: int = 3
+    byte_offset: int = 4
+    byte_count: int = 256
+
+    @property
+    def vocab_size(self) -> int:
+        return self.byte_offset + self.byte_count
+
+    def encode(self, text: str) -> np.ndarray:
+        data = text.encode("utf-8", errors="replace")
+        return np.frombuffer(data, dtype=np.uint8).astype(np.uint16, copy=False) + self.byte_offset
+
+    def encode_batch(self, texts: list[str]) -> list[np.ndarray]:
+        return [self.encode(text) for text in texts]
+
+    def save_json(self, path: str | Path) -> None:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "tokenizer_type": "pure_byte",
+            "config": asdict(self),
+            "vocab_size": self.vocab_size,
+        }
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def default_pure_byte_tokenizer() -> PureByteTokenizer:
+    return PureByteTokenizer()
+
+
+def docs_sidecar_path(docs_jsonl: Path) -> Path:
+    return docs_jsonl.with_name(f"{docs_jsonl.stem}.source_manifest.json")
+
+
+def maybe_load_docs_sidecar_meta(docs_jsonl: Path) -> dict[str, Any] | None:
+    sidecar_path = docs_sidecar_path(docs_jsonl)
+    if not sidecar_path.is_file():
+        return None
+    payload = json.loads(sidecar_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"docs sidecar must be a JSON object: {sidecar_path}")
+    return payload
+
+
+def copy_from_hf_cache(*, repo_id: str, remote_root: str, filename: str, destination: Path) -> bool:
+    if destination.exists():
+        return True
+    remote_path = Path(remote_root) / filename if remote_root else Path(filename)
+    try:
+        cached_path = Path(
+            hf_hub_download(
+                repo_id=repo_id,
+                filename=remote_path.name,
+                subfolder=remote_path.parent.as_posix() if remote_path.parent != Path(".") else None,
+                repo_type="dataset",
+            )
+        )
+    except EntryNotFoundError:
+        return False
+
+    source = cached_path.resolve(strict=True)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.link(source, destination)
+    except OSError:
+        shutil.copy2(source, destination)
+    return True
+
+
+def iter_docs(path: Path):
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            yield json.loads(line)["text"]
+
+
+def count_docs(path: Path) -> int:
+    with path.open("r", encoding="utf-8") as f:
+        return sum(1 for _ in f)
+
+
+def batched_docs_jsonl(path: Path, batch_size: int):
+    batch: list[str] = []
+    for text in iter_docs(path):
+        batch.append(text)
+        if len(batch) == batch_size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def write_datafile(path: Path, toks: Any) -> None:
+    if len(toks) >= 2**31:
+        raise ValueError("token count too large")
+    header = np.zeros(256, dtype="<i4")
+    header[0] = DATAFILE_MAGIC
+    header[1] = DATAFILE_VERSION
+    header[2] = len(toks)
+    toks = np.asarray(toks)
+    if toks.dtype != np.uint16:
+        if not ((0 <= toks).all() and (toks < 2**16).all()):
+            raise ValueError("token dictionary too large for uint16")
+        toks = toks.astype("<u2", copy=False)
+    else:
+        toks = toks.astype("<u2", copy=False)
+    with path.open("wb") as f:
+        f.write(header.tobytes())
+        f.write(toks.tobytes())
+
+
+def relativize_manifest_paths(value: Any, root: Path) -> Any:
+    if isinstance(value, dict):
+        return {k: relativize_manifest_paths(v, root) for k, v in value.items()}
+    if isinstance(value, list):
+        return [relativize_manifest_paths(v, root) for v in value]
+    if isinstance(value, str):
+        path = Path(value)
+        if path.is_absolute():
+            try:
+                return path.relative_to(root).as_posix()
+            except ValueError:
+                return value
+    return value
+
+
+def parse_reuse_sp_models(values: list[str]) -> dict[int, Path]:
+    reuse_models: dict[int, Path] = {}
+    for value in values:
+        vocab_size_str, model_path = value.split("=", 1)
+        vocab_size = int(vocab_size_str)
+        if vocab_size in reuse_models:
+            raise ValueError(f"duplicate --reuse_sp_model for vocab_size={vocab_size}")
+        reuse_models[vocab_size] = Path(model_path).expanduser().resolve()
+    return reuse_models
+
+
+def load_specs(config_path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict):
+        specs = payload.get("tokenizer_specs", payload.get("tokenizers"))
+    else:
+        specs = payload
+    if not isinstance(specs, list) or not specs:
+        raise ValueError("tokenizer_config must define a non-empty list")
+    if not all(isinstance(spec, dict) for spec in specs):
+        raise ValueError("each tokenizer spec must be a JSON object")
+    return [dict(spec) for spec in specs]
+
+
+def tokenizer_kind(spec: dict[str, Any]) -> str:
+    kind = spec.get("kind")
+    if kind in {"byte", "pure_byte"}:
+        return "byte"
+    if kind in {"sentencepiece_bpe", "sentencepiece"}:
+        return "sentencepiece_bpe"
+    builder = str(spec.get("builder", ""))
+    builder_name = builder.rsplit(":", 1)[-1]
+    if builder_name == "build_pure_byte_tokenizer":
+        return "byte"
+    if builder_name == "build_sentencepiece_tokenizer":
+        return "sentencepiece_bpe"
+    if spec.get("dataset_suffix") == "byte260":
+        return "byte"
+    if "vocab_size" in spec:
+        return "sentencepiece_bpe"
+    raise ValueError(
+        f"unsupported tokenizer spec {spec.get('name', '<unnamed>')!r}: "
+        "expected a built-in pure-byte or sentencepiece builder"
+    )
+
+
+def write_tokenizer_config_export(output_root: Path, selected_specs: list[dict[str, Any]]) -> Path:
+    path = output_root / "tokenizer_config.export.json"
+    path.write_text(json.dumps({"tokenizers": selected_specs}, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _iter_sentencepiece_text(
+    docs_jsonl: Path,
+    *,
+    max_docs: int | None = None,
+    text_transform_name: str | None = None,
+):
+    text_transform = get_text_transform(text_transform_name)
+    with docs_jsonl.open("r", encoding="utf-8") as f:
+        for i, line in enumerate(f):
+            if max_docs is not None and i >= max_docs:
+                break
+            text = json.loads(line)["text"].replace("\x00", " ").strip()
+            if text:
+                yield text_transform(text)
+
+
+def build_pure_byte_tokenizer(*, spec: dict[str, Any], docs_jsonl: Path, tokenizers_dir: Path) -> dict[str, Any]:
+    del docs_jsonl
+    text_transform_name = str(spec.get("text_transform") or IDENTITY)
+    if text_transform_name != IDENTITY:
+        raise ValueError(
+            f"pure byte tokenizer does not support text_transform={text_transform_name!r}"
+        )
+    tok = default_pure_byte_tokenizer()
+    path = tokenizers_dir / spec.get("filename", "fineweb_pure_byte_260.json")
+    tok.save_json(path)
+    return {
+        "name": spec.get("name", "pure_byte_260"),
+        "kind": "byte",
+        "dataset_suffix": spec.get("dataset_suffix", "byte260"),
+        "vocab_size": tok.vocab_size,
+        "bos_id": tok.bos_id,
+        "eos_id": tok.eos_id,
+        "encode": tok.encode,
+        "encode_batch": tok.encode_batch,
+        "encode_with_original_byte_counts": lambda text, tok=tok: (
+            tok.encode(text),
+            np.ones((len(tok.encode(text)),), dtype=np.uint16),
+        ),
+        "text_transform": text_transform_name,
+        "manifest": {
+            "path": str(path),
+            "pad_id": tok.pad_id,
+            "unk_id": tok.unk_id,
+            "text_transform": text_transform_name,
+        },
+    }
+
+
+def build_sentencepiece_tokenizer(*, spec: dict[str, Any], docs_jsonl: Path, tokenizers_dir: Path) -> dict[str, Any]:
+    try:
+        import sentencepiece as spm
+    except ImportError as exc:
+        raise RuntimeError("sentencepiece is required for SentencePiece tokenizer exports") from exc
+
+    text_transform_name = str(spec.get("text_transform") or IDENTITY)
+    text_transform = get_text_transform(text_transform_name)
+    vocab_size = int(spec["vocab_size"])
+    prefix = tokenizers_dir / spec.get("model_prefix", f"fineweb_{vocab_size}_bpe")
+    model_path = prefix.with_suffix(".model")
+    vocab_path = prefix.with_suffix(".vocab")
+    prefix.parent.mkdir(parents=True, exist_ok=True)
+    for artifact in (model_path, vocab_path):
+        if artifact.exists():
+            artifact.unlink()
+
+    reuse_model_path = spec.get("reuse_model_path")
+    if reuse_model_path is not None:
+        reuse_model_path = Path(reuse_model_path).expanduser().resolve()
+        if not reuse_model_path.is_file():
+            raise FileNotFoundError(reuse_model_path)
+        shutil.copy2(reuse_model_path, model_path)
+        reuse_vocab_path = reuse_model_path.with_suffix(".vocab")
+        if reuse_vocab_path.is_file():
+            shutil.copy2(reuse_vocab_path, vocab_path)
+    else:
+        trainer_overrides = dict(spec.get("trainer_overrides") or {})
+        if bool(spec.get("reserve_text_transform_controls")):
+            control_symbols = get_text_transform_control_symbols(text_transform_name)
+            if control_symbols:
+                existing = trainer_overrides.get("user_defined_symbols")
+                merged_symbols: list[str] = []
+                if isinstance(existing, str):
+                    merged_symbols.extend(symbol for symbol in existing.split(",") if symbol)
+                elif isinstance(existing, (list, tuple)):
+                    merged_symbols.extend(str(symbol) for symbol in existing if str(symbol))
+                elif existing is not None:
+                    raise TypeError("trainer_overrides.user_defined_symbols must be a string or sequence")
+                for symbol in control_symbols:
+                    if symbol not in merged_symbols:
+                        merged_symbols.append(symbol)
+                trainer_overrides["user_defined_symbols"] = merged_symbols
+        kwargs = {
+            "sentence_iterator": _iter_sentencepiece_text(
+                docs_jsonl,
+                max_docs=None if spec.get("tokenizer_train_docs") is None else int(spec["tokenizer_train_docs"]),
+                text_transform_name=text_transform_name,
+            ),
+            "model_prefix": str(prefix),
+            "model_type": "bpe",
+            "vocab_size": vocab_size,
+            "character_coverage": 0.999,
+            "byte_fallback": True,
+            "split_digits": True,
+            "normalization_rule_name": "nmt_nfkc",
+            "add_dummy_prefix": False,
+            "pad_id": 0,
+            "bos_id": 1,
+            "eos_id": 2,
+            "unk_id": 3,
+            "hard_vocab_limit": False,
+        }
+        kwargs.update(trainer_overrides)
+        spm.SentencePieceTrainer.train(**kwargs)
+
+    tok = spm.SentencePieceProcessor(model_file=str(model_path))
+
+    def encode_with_original_byte_counts(
+        text: str,
+        *,
+        tok=tok,
+        transform=text_transform,
+        text_transform_name=text_transform_name,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        transformed = transform(text)
+        proto = tok.encode_as_immutable_proto(transformed)
+        token_ids = np.fromiter((piece.id for piece in proto.pieces), dtype=np.int32)
+        byte_counts = np.asarray(
+            surface_piece_original_byte_counts(
+                (piece.surface for piece in proto.pieces),
+                text_transform_name=text_transform_name,
+            ),
+            dtype=np.uint16,
+        )
+        if token_ids.shape[0] != byte_counts.shape[0]:
+            raise ValueError("token id count and byte count length disagree")
+        return token_ids, byte_counts
+
+    return {
+        "name": spec.get("name", f"sp_bpe_{vocab_size}"),
+        "kind": "sentencepiece_bpe",
+        "dataset_suffix": spec.get("dataset_suffix", f"sp{vocab_size}"),
+        "vocab_size": int(tok.vocab_size()),
+        "bos_id": int(tok.bos_id()),
+        "eos_id": int(tok.eos_id()),
+        "encode": lambda text, tok=tok, transform=text_transform: tok.encode(
+            transform(text), out_type=int
+        ),
+        "encode_batch": lambda texts, tok=tok, transform=text_transform: tok.encode(
+            [transform(text) for text in texts], out_type=int, num_threads=TOKENIZER_THREADS
+        ),
+        "encode_with_original_byte_counts": encode_with_original_byte_counts,
+        "text_transform": text_transform_name,
+        "manifest": {
+            "model_path": str(model_path),
+            "vocab_path": str(vocab_path),
+            "text_transform": text_transform_name,
+            "reserve_text_transform_controls": bool(spec.get("reserve_text_transform_controls")),
+        },
+    }
+
+
+def export_shards(
+    docs_jsonl: Path,
+    tok: dict[str, Any],
+    output_dir: Path,
+    *,
+    num_val_docs: int,
+    shard_size: int,
+    docs_total: int,
+    max_train_shards: int | None = None,
+) -> dict[str, int]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for pattern in ("fineweb_train_*.bin", "fineweb_val_*.bin"):
+        for stale in output_dir.glob(pattern):
+            stale.unlink()
+
+    stats = {
+        "docs_total": 0,
+        "docs_val": 0,
+        "docs_train": 0,
+        "files_total": 0,
+        "files_val": 0,
+        "files_train": 0,
+        "tokens_total": 0,
+        "tokens_val": 0,
+        "tokens_train": 0,
+    }
+    buf = np.empty((shard_size,), dtype=np.uint16)
+    val_byte_buf = np.empty((shard_size,), dtype=np.uint16)
+    fill = 0
+    split = "val"
+    shards = {"val": 0, "train": 0}
+    stop_after_flush = False
+
+    def flush() -> None:
+        nonlocal fill, stop_after_flush
+        if fill == 0:
+            return
+        shard_index = shards[split]
+        write_datafile(output_dir / f"fineweb_{split}_{shard_index:06d}.bin", buf[:fill])
+        if split == "val":
+            write_datafile(output_dir / f"fineweb_val_bytes_{shard_index:06d}.bin", val_byte_buf[:fill])
+        stats["files_total"] += 1
+        stats[f"files_{split}"] += 1
+        shards[split] = shard_index + 1
+        if split == "train" and max_train_shards is not None and shards["train"] >= max_train_shards:
+            stop_after_flush = True
+        fill = 0
+
+    vocab_size = int(tok["vocab_size"])
+    if vocab_size > 2**16:
+        raise ValueError(f"vocab_size={vocab_size} is too large for uint16 shard storage")
+
+    batch_encode = tok.get("encode_batch")
+    encode_with_original_byte_counts = tok.get("encode_with_original_byte_counts")
+    batch_size = SP_BATCH_SIZE if callable(batch_encode) else 1
+
+    for texts in batched_docs_jsonl(docs_jsonl, batch_size):
+        encoded_docs = batch_encode(texts) if callable(batch_encode) else [tok["encode"](text) for text in texts]
+        byte_counts_docs: list[np.ndarray | None] = [None] * len(encoded_docs)
+        if callable(encode_with_original_byte_counts):
+            val_docs_remaining = max(0, num_val_docs - stats["docs_total"])
+            if val_docs_remaining:
+                for idx, text in enumerate(texts[:val_docs_remaining]):
+                    _, byte_counts_arr = encode_with_original_byte_counts(text)
+                    byte_counts_docs[idx] = byte_counts_arr
+
+        for text, encoded, byte_counts_arr in zip(texts, encoded_docs, byte_counts_docs, strict=True):
+                split_for_doc = "val" if stats["docs_total"] < num_val_docs else "train"
+                if split_for_doc != split:
+                    flush()
+                    split = split_for_doc
+
+                encoded_arr = np.asarray(encoded, dtype=np.int32)
+                if byte_counts_arr is not None and byte_counts_arr.shape[0] != encoded_arr.shape[0]:
+                    raise ValueError("encoded token count and original byte count length disagree")
+                toks = np.empty((encoded_arr.size + 1 + int(APPEND_EOS),), dtype=np.int32)
+                toks[0] = tok["bos_id"]
+                toks[1 : 1 + encoded_arr.size] = encoded_arr
+                if APPEND_EOS:
+                    toks[-1] = tok["eos_id"]
+                val_byte_counts = None
+                if split == "val":
+                    val_byte_counts = np.zeros((toks.size,), dtype=np.int32)
+                    if byte_counts_arr is not None:
+                        val_byte_counts[1 : 1 + encoded_arr.size] = byte_counts_arr.astype(np.int32, copy=False)
+                    elif tok["kind"] == "byte":
+                        val_byte_counts[1 : 1 + encoded_arr.size] = 1
+                if not ((0 <= toks).all() and (toks < vocab_size).all()):
+                    bad = int(toks[(toks < 0) | (toks >= vocab_size)][0])
+                    raise ValueError(f"token id {bad} outside declared vocab_size={vocab_size}")
+                toks = toks.astype("<u2", copy=False)
+                if val_byte_counts is not None:
+                    if not ((0 <= val_byte_counts).all() and (val_byte_counts < 2**16).all()):
+                        raise ValueError("validation byte counts must fit in uint16")
+                    val_byte_counts = val_byte_counts.astype("<u2", copy=False)
+
+                stats["docs_total"] += 1
+                stats[f"docs_{split}"] += 1
+                stats["tokens_total"] += len(toks)
+                stats[f"tokens_{split}"] += len(toks)
+
+                pos = 0
+                while pos < len(toks):
+                    take = min(shard_size - fill, len(toks) - pos)
+                    buf[fill : fill + take] = toks[pos : pos + take]
+                    if split == "val":
+                        val_byte_buf[fill : fill + take] = val_byte_counts[pos : pos + take]
+                    fill += take
+                    pos += take
+                    if fill == shard_size:
+                        flush()
+                        if stop_after_flush:
+                            break
+                if stop_after_flush:
+                    break
+
+        if stats["docs_total"] and stats["docs_total"] % 100_000 == 0:
+            print(f"{output_dir.name}: {stats['docs_total']}/{docs_total} docs", flush=True)
+        if stop_after_flush:
+            break
+
+    flush()
+    if max_train_shards is None and stats["docs_total"] != docs_total:
+        raise ValueError(f"expected {docs_total} docs, exported {stats['docs_total']}")
+    return stats
+
+
+def build_tokenizers(
+    *,
+    specs: list[dict[str, Any]],
+    docs_jsonl: Path,
+    tokenizers_dir: Path,
+    tokenizer_train_docs: int | None,
+    skip_byte: bool,
+    reuse_sp_models: dict[int, Path],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    tokenizers: list[dict[str, Any]] = []
+    selected_specs: list[dict[str, Any]] = []
+    seen_names: set[str] = set()
+    seen_datasets: set[str] = set()
+
+    for raw_spec in specs:
+        spec = dict(raw_spec)
+        kind = tokenizer_kind(spec)
+        if skip_byte and kind == "byte":
+            continue
+        if kind == "sentencepiece_bpe":
+            if tokenizer_train_docs is not None:
+                spec["tokenizer_train_docs"] = int(tokenizer_train_docs)
+            vocab_size = int(spec["vocab_size"])
+            if vocab_size in reuse_sp_models:
+                spec["reuse_model_path"] = str(reuse_sp_models[vocab_size])
+
+        selected_specs.append(spec)
+        built = (
+            build_pure_byte_tokenizer(spec=spec, docs_jsonl=docs_jsonl, tokenizers_dir=tokenizers_dir)
+            if kind == "byte"
+            else build_sentencepiece_tokenizer(spec=spec, docs_jsonl=docs_jsonl, tokenizers_dir=tokenizers_dir)
+        )
+        name = str(built["name"])
+        dataset_suffix = built.get("dataset_suffix")
+        dataset_name = str(built.get("dataset_name", f"fineweb{VERSION}_{dataset_suffix}"))
+        if name in seen_names:
+            raise ValueError(f"duplicate tokenizer name: {name}")
+        if dataset_name in seen_datasets:
+            raise ValueError(f"duplicate dataset name: {dataset_name}")
+        seen_names.add(name)
+        seen_datasets.add(dataset_name)
+        vocab_size = int(built["vocab_size"])
+        recommended_bigram_vocab_size = int(
+            built.get("recommended_bigram_vocab_size", ((vocab_size + 127) // 128) * 128 * 5)
+        )
+        tokenizers.append(
+            {
+                "name": name,
+                "kind": str(built["kind"]),
+                "dataset_name": dataset_name,
+                "vocab_size": vocab_size,
+                "bos_id": int(built["bos_id"]),
+                "eos_id": int(built["eos_id"]),
+                "encode": built["encode"],
+                "encode_batch": built.get("encode_batch"),
+                "encode_with_original_byte_counts": built.get("encode_with_original_byte_counts"),
+                "recommended_bigram_vocab_size": recommended_bigram_vocab_size,
+                "text_transform": str(built.get("text_transform", IDENTITY)),
+                "manifest": {
+                    "name": name,
+                    "kind": str(built["kind"]),
+                    "vocab_size": vocab_size,
+                    "bos_id": int(built["bos_id"]),
+                    "eos_id": int(built["eos_id"]),
+                    "recommended_bigram_vocab_size": recommended_bigram_vocab_size,
+                    "text_transform": str(built.get("text_transform", IDENTITY)),
+                    "source_spec": spec,
+                    **(built.get("manifest") or {}),
+                },
+            }
+        )
+    if not tokenizers:
+        raise ValueError("tokenizer_config produced no tokenizers after filtering")
+    return tokenizers, selected_specs
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Download docs_selected.jsonl from a Hugging Face dataset repo and tokenize it locally"
+    )
+    parser.add_argument(
+        "--repo-id",
+        default=DEFAULT_REPO_ID,
+        help="Hugging Face dataset repo id, for example user/dataset",
+    )
+    parser.add_argument(
+        "--remote-root",
+        default=DEFAULT_REMOTE_ROOT,
+        help="Optional subdirectory inside the dataset repo that contains docs_selected.jsonl",
+    )
+    parser.add_argument("--output-root", required=True, help="Directory where docs, tokenizers, shards, and manifest are written")
+    parser.add_argument(
+        "--tokenizer-config",
+        default=str(DEFAULT_CONFIG),
+        help="Local tokenizer config JSON. Defaults to data/tokenizer_specs.json.",
+    )
+    parser.add_argument(
+        "--num-val-docs",
+        type=int,
+        default=None,
+        help="Validation document count. Defaults to the downloaded sidecar when present, otherwise 50000.",
+    )
+    parser.add_argument("--chunk-tokens", type=int, default=SHARD_SIZE, help="Shard size in tokens.")
+    parser.add_argument(
+        "--max-train-shards",
+        type=int,
+        default=None,
+        help="Stop export after writing this many training shards for each tokenizer.",
+    )
+    parser.add_argument(
+        "--tokenizer-train-docs",
+        type=int,
+        default=None,
+        help="Limit the number of docs used for tokenizer training.",
+    )
+    parser.add_argument("--skip-byte", action="store_true", help="Skip byte-tokenizer export.")
+    parser.add_argument(
+        "--reuse-sp-model",
+        action="append",
+        default=[],
+        metavar="VOCAB=MODEL",
+        help="Reuse an existing SentencePiece model for the given vocab size instead of retraining it.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    if args.chunk_tokens <= 0:
+        raise ValueError(f"--chunk_tokens must be positive, got {args.chunk_tokens}")
+
+    output_root = Path(args.output_root).expanduser().resolve()
+    output_root.mkdir(parents=True, exist_ok=True)
+    tokenizers_dir = output_root / "tokenizers"
+    datasets_dir = output_root / "datasets"
+    tokenizers_dir.mkdir(parents=True, exist_ok=True)
+    datasets_dir.mkdir(parents=True, exist_ok=True)
+
+    docs_jsonl = output_root / DOCS_FILENAME
+    sidecar = output_root / SIDECAR_FILENAME
+    if not copy_from_hf_cache(
+        repo_id=args.repo_id,
+        remote_root=args.remote_root,
+        filename=DOCS_FILENAME,
+        destination=docs_jsonl,
+    ):
+        remote = f"{args.remote_root}/{DOCS_FILENAME}" if args.remote_root else DOCS_FILENAME
+        raise FileNotFoundError(f"{remote} not found in Hugging Face dataset repo {args.repo_id}")
+    if not copy_from_hf_cache(
+        repo_id=args.repo_id,
+        remote_root=args.remote_root,
+        filename=SIDECAR_FILENAME,
+        destination=sidecar,
+    ):
+        sidecar.unlink(missing_ok=True)
+
+    docs_sidecar = maybe_load_docs_sidecar_meta(docs_jsonl)
+    docs_total = int(docs_sidecar["num_docs"]) if docs_sidecar is not None and docs_sidecar.get("num_docs") is not None else count_docs(docs_jsonl)
+    if args.num_val_docs is not None:
+        num_val_docs = int(args.num_val_docs)
+    elif docs_sidecar is not None and docs_sidecar.get("docs_val") is not None:
+        num_val_docs = int(docs_sidecar["docs_val"])
+    else:
+        num_val_docs = NUM_VAL_DOCS
+    if not (0 <= num_val_docs <= docs_total):
+        raise ValueError(f"num_val_docs must be in [0, {docs_total}], got {num_val_docs}")
+
+    specs = load_specs(Path(args.tokenizer_config).expanduser().resolve())
+    reuse_sp_models = parse_reuse_sp_models(args.reuse_sp_model)
+    tokenizers, selected_specs = build_tokenizers(
+        specs=specs,
+        docs_jsonl=docs_jsonl,
+        tokenizers_dir=tokenizers_dir,
+        tokenizer_train_docs=args.tokenizer_train_docs,
+        skip_byte=args.skip_byte,
+        reuse_sp_models=reuse_sp_models,
+    )
+    write_tokenizer_config_export(output_root, selected_specs)
+
+    docs_meta = {
+        "remote_repo_id": args.repo_id,
+        "remote_root": args.remote_root,
+        "num_docs": docs_total,
+        "docs_sha256": None if docs_sidecar is None else docs_sidecar.get("docs_sha256"),
+        "source_manifest": str(docs_sidecar_path(docs_jsonl)) if docs_sidecar is not None else None,
+    }
+    if docs_sidecar is not None:
+        docs_meta["source_sidecar"] = docs_sidecar
+
+    manifest = {
+        "version": VERSION,
+        "num_docs": docs_total,
+        "num_val_docs": num_val_docs,
+        "shuffle_seed": None if docs_sidecar is None else docs_sidecar.get("shuffle_seed"),
+        "shard_size": int(args.chunk_tokens),
+        "append_eos": APPEND_EOS,
+        "docs_jsonl": str(docs_jsonl),
+        "docs_meta": docs_meta,
+        "tokenizer_specs": selected_specs,
+        "tokenizers": [],
+        "datasets": [],
+    }
+
+    for tok in tokenizers:
+        output_dir = datasets_dir / tok["dataset_name"]
+        print(f"Exporting dataset: {tok['dataset_name']}", flush=True)
+        stats = export_shards(
+            docs_jsonl,
+            tok,
+            output_dir,
+            num_val_docs=num_val_docs,
+            shard_size=int(args.chunk_tokens),
+            docs_total=docs_total,
+            max_train_shards=args.max_train_shards,
+        )
+        manifest["tokenizers"].append(tok["manifest"])
+        manifest["datasets"].append(
+            {
+                "name": tok["dataset_name"],
+                "tokenizer_name": tok["name"],
+                "tokenizer_kind": tok["kind"],
+                "path": str(output_dir),
+                "train_glob": str(output_dir / "fineweb_train_*.bin"),
+                "val_glob": str(output_dir / "fineweb_val_*.bin"),
+                "vocab_size": tok["vocab_size"],
+                "bos_id": tok["bos_id"],
+                "eos_id": tok["eos_id"],
+                "recommended_bigram_vocab_size": tok["recommended_bigram_vocab_size"],
+                "val_bytes_glob": str(output_dir / "fineweb_val_bytes_*.bin"),
+                "stats": stats,
+            }
+        )
+
+    manifest = relativize_manifest_paths(manifest, output_root)
+    manifest_path = output_root / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(f"Done. Manifest: {manifest_path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/lossless_caps.py
+++ b/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/lossless_caps.py
@@ -1,0 +1,833 @@
+"""Lossless capitalization pre-encoding helpers.
+
+This module provides a narrow, reversible transform that only touches
+ASCII capital letters `A-Z`. Each uppercase ASCII letter is rewritten as
+`<sentinel><lowercase>`, where `sentinel` is a private-use Unicode
+character that is escaped by doubling if it appears literally in the
+input text.
+
+Example with the default sentinel `\\uE000`:
+
+    "The NASA Launch" -> "\\uE000the \\uE000n\\uE000a\\uE000s\\uE000a \\uE000launch"
+
+The transform is intentionally simple for v1:
+
+- lowercase ASCII letters are unchanged
+- uppercase ASCII letters become sentinel + lowercase letter
+- non-ASCII characters are left untouched
+- literal sentinel characters are escaped as sentinel + sentinel
+
+This makes the transform exactly invertible while allowing a downstream
+tokenizer to reuse lowercase subwords across case variants.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable, Iterable
+
+LOSSLESS_CAPS_V1 = "lossless_caps_v1"
+LOSSLESS_CAPS_V2 = "lossless_caps_v2"
+LOSSLESS_CAPS_V3 = "lossless_caps_v3"
+LOSSLESS_CAPS_V4 = "lossless_caps_v4"
+LOSSLESS_CAPS_V5 = "lossless_caps_v5"
+LOSSLESS_CAPS_V6 = "lossless_caps_v6"
+LOSSLESS_CAPS_V7 = "lossless_caps_v7"
+LOSSLESS_CAPS_CASEOPS_V1 = "lossless_caps_caseops_v1"
+IDENTITY = "identity"
+DEFAULT_SENTINEL = "\uE000"
+DEFAULT_V2_TITLE = "\uE001"
+DEFAULT_V2_ALLCAPS = "\uE002"
+DEFAULT_V2_CAPNEXT = "\uE003"
+DEFAULT_V2_ESC = "\uE004"
+DEFAULT_V5_TITLE_MIN_LEN = 7
+DEFAULT_V6_ALLCAPS_MIN_LEN = 3
+DEFAULT_V7_ALLCAPS_MIN_LEN = 4
+
+
+class LosslessCapsError(ValueError):
+    """Raised when a transformed string is malformed."""
+
+
+def _is_ascii_upper(ch: str) -> bool:
+    return "A" <= ch <= "Z"
+
+
+def _is_ascii_lower(ch: str) -> bool:
+    return "a" <= ch <= "z"
+
+
+def _is_ascii_alpha(ch: str) -> bool:
+    return _is_ascii_lower(ch) or _is_ascii_upper(ch)
+
+
+def _validate_distinct_single_chars(*chars: str) -> None:
+    if any(len(ch) != 1 for ch in chars):
+        raise ValueError("all control characters must be exactly one character")
+    if len(set(chars)) != len(chars):
+        raise ValueError("control characters must be distinct")
+
+
+def encode_lossless_caps_v1(text: str, *, sentinel: str = DEFAULT_SENTINEL) -> str:
+    """Encode ASCII capitals reversibly using a one-character sentinel."""
+    if len(sentinel) != 1:
+        raise ValueError("sentinel must be exactly one character")
+    out: list[str] = []
+    for ch in text:
+        if ch == sentinel:
+            out.append(sentinel)
+            out.append(sentinel)
+        elif _is_ascii_upper(ch):
+            out.append(sentinel)
+            out.append(ch.lower())
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def decode_lossless_caps_v1(text: str, *, sentinel: str = DEFAULT_SENTINEL) -> str:
+    """Decode the `lossless_caps_v1` transform back to the original text."""
+    if len(sentinel) != 1:
+        raise ValueError("sentinel must be exactly one character")
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch != sentinel:
+            out.append(ch)
+            i += 1
+            continue
+        if i + 1 >= n:
+            raise LosslessCapsError("dangling capitalization sentinel at end of string")
+        nxt = text[i + 1]
+        if nxt == sentinel:
+            out.append(sentinel)
+        elif _is_ascii_lower(nxt):
+            out.append(nxt.upper())
+        else:
+            raise LosslessCapsError(
+                f"invalid sentinel escape sequence {sentinel + nxt!r}; "
+                "expected doubled sentinel or sentinel + lowercase ASCII letter"
+            )
+        i += 2
+    return "".join(out)
+
+
+def encode_lossless_caps_v2(
+    text: str,
+    *,
+    title: str = DEFAULT_V2_TITLE,
+    allcaps: str = DEFAULT_V2_ALLCAPS,
+    capnext: str = DEFAULT_V2_CAPNEXT,
+    esc: str = DEFAULT_V2_ESC,
+) -> str:
+    """Encode ASCII word capitalization with cheap word-level markers.
+
+    Rules over maximal ASCII alphabetic runs:
+    - lowercase words stay unchanged
+    - TitleCase words become `title + lowercase(word)`
+    - ALLCAPS words become `allcaps + lowercase(word)`
+    - mixed-case words use:
+      - optional `title` when the first letter is uppercase
+      - `capnext + lowercase(letter)` for subsequent uppercase letters
+    - literal control characters are escaped as `esc + literal`
+    """
+    _validate_distinct_single_chars(title, allcaps, capnext, esc)
+    controls = {title, allcaps, capnext, esc}
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch in controls:
+            out.append(esc)
+            out.append(ch)
+            i += 1
+            continue
+        if not _is_ascii_alpha(ch):
+            out.append(ch)
+            i += 1
+            continue
+
+        j = i + 1
+        while j < n and _is_ascii_alpha(text[j]):
+            j += 1
+        word = text[i:j]
+        lower_word = word.lower()
+
+        if word.islower():
+            out.append(word)
+        elif len(word) >= 2 and word.isupper():
+            out.append(allcaps)
+            out.append(lower_word)
+        elif _is_ascii_upper(word[0]) and word[1:].islower():
+            out.append(title)
+            out.append(lower_word)
+        else:
+            if _is_ascii_upper(word[0]):
+                out.append(title)
+            out.append(lower_word[0])
+            for orig_ch, lower_ch in zip(word[1:], lower_word[1:], strict=True):
+                if _is_ascii_upper(orig_ch):
+                    out.append(capnext)
+                out.append(lower_ch)
+        i = j
+    return "".join(out)
+
+
+def decode_lossless_caps_v2(
+    text: str,
+    *,
+    title: str = DEFAULT_V2_TITLE,
+    allcaps: str = DEFAULT_V2_ALLCAPS,
+    capnext: str = DEFAULT_V2_CAPNEXT,
+    esc: str = DEFAULT_V2_ESC,
+) -> str:
+    """Decode the `lossless_caps_v2` transform back to the original text."""
+    _validate_distinct_single_chars(title, allcaps, capnext, esc)
+    out: list[str] = []
+    pending_escape = False
+    pending_word_mode: str | None = None
+    active_allcaps = False
+    pending_capnext = False
+    in_ascii_word = False
+
+    for ch in text:
+        if pending_escape:
+            if pending_word_mode is not None and not _is_ascii_alpha(ch):
+                raise LosslessCapsError("escaped control char cannot satisfy pending word capitalization mode")
+            out.append(ch)
+            pending_escape = False
+            if _is_ascii_alpha(ch):
+                in_ascii_word = True
+            else:
+                in_ascii_word = False
+                active_allcaps = False
+            continue
+
+        if ch == esc:
+            pending_escape = True
+            continue
+        if ch == title:
+            if pending_word_mode is not None or in_ascii_word or pending_capnext:
+                raise LosslessCapsError("invalid title marker placement")
+            pending_word_mode = "title"
+            continue
+        if ch == allcaps:
+            if pending_word_mode is not None or in_ascii_word or pending_capnext:
+                raise LosslessCapsError("invalid allcaps marker placement")
+            pending_word_mode = "allcaps"
+            continue
+        if ch == capnext:
+            if pending_capnext:
+                raise LosslessCapsError("duplicate capnext marker")
+            pending_capnext = True
+            continue
+
+        if _is_ascii_alpha(ch):
+            at_word_start = not in_ascii_word
+            if at_word_start:
+                if pending_word_mode == "allcaps":
+                    out.append(ch.upper())
+                    active_allcaps = True
+                elif pending_word_mode == "title":
+                    out.append(ch.upper())
+                elif pending_capnext:
+                    out.append(ch.upper())
+                else:
+                    out.append(ch)
+                pending_word_mode = None
+                pending_capnext = False
+                in_ascii_word = True
+                continue
+
+            if pending_word_mode is not None:
+                raise LosslessCapsError("word capitalization marker leaked into the middle of a word")
+            if active_allcaps:
+                out.append(ch.upper())
+            elif pending_capnext:
+                out.append(ch.upper())
+            else:
+                out.append(ch)
+            pending_capnext = False
+            continue
+
+        if pending_word_mode is not None or pending_capnext:
+            raise LosslessCapsError("capitalization marker not followed by an ASCII letter")
+        out.append(ch)
+        in_ascii_word = False
+        active_allcaps = False
+
+    if pending_escape:
+        raise LosslessCapsError("dangling escape marker at end of string")
+    if pending_word_mode is not None or pending_capnext:
+        raise LosslessCapsError("dangling capitalization marker at end of string")
+    return "".join(out)
+
+
+def encode_lossless_caps_v3(
+    text: str,
+    *,
+    title: str = DEFAULT_V2_TITLE,
+    allcaps: str = DEFAULT_V2_ALLCAPS,
+    esc: str = DEFAULT_V2_ESC,
+) -> str:
+    """Encode only common word-level capitalization patterns.
+
+    Rules over maximal ASCII alphabetic runs:
+    - lowercase words stay unchanged
+    - TitleCase words become `title + lowercase(word)`
+    - ALLCAPS words become `allcaps + lowercase(word)`
+    - all other mixed-case words are left unchanged
+    - literal control characters are escaped as `esc + literal`
+    """
+    _validate_distinct_single_chars(title, allcaps, esc)
+    controls = {title, allcaps, esc}
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch in controls:
+            out.append(esc)
+            out.append(ch)
+            i += 1
+            continue
+        if not _is_ascii_alpha(ch):
+            out.append(ch)
+            i += 1
+            continue
+
+        j = i + 1
+        while j < n and _is_ascii_alpha(text[j]):
+            j += 1
+        word = text[i:j]
+
+        if word.islower():
+            out.append(word)
+        elif len(word) >= 2 and word.isupper():
+            out.append(allcaps)
+            out.append(word.lower())
+        elif _is_ascii_upper(word[0]) and word[1:].islower():
+            out.append(title)
+            out.append(word.lower())
+        else:
+            out.append(word)
+        i = j
+    return "".join(out)
+
+
+def decode_lossless_caps_v3(
+    text: str,
+    *,
+    title: str = DEFAULT_V2_TITLE,
+    allcaps: str = DEFAULT_V2_ALLCAPS,
+    esc: str = DEFAULT_V2_ESC,
+) -> str:
+    """Decode the `lossless_caps_v3` transform back to the original text."""
+    _validate_distinct_single_chars(title, allcaps, esc)
+    out: list[str] = []
+    pending_escape = False
+    pending_word_mode: str | None = None
+    active_allcaps = False
+    in_ascii_word = False
+
+    for ch in text:
+        if pending_escape:
+            if pending_word_mode is not None and not _is_ascii_alpha(ch):
+                raise LosslessCapsError("escaped control char cannot satisfy pending word capitalization mode")
+            out.append(ch)
+            pending_escape = False
+            if _is_ascii_alpha(ch):
+                in_ascii_word = True
+            else:
+                in_ascii_word = False
+                active_allcaps = False
+            continue
+
+        if ch == esc:
+            pending_escape = True
+            continue
+        if ch == title:
+            if pending_word_mode is not None or in_ascii_word:
+                raise LosslessCapsError("invalid title marker placement")
+            pending_word_mode = "title"
+            continue
+        if ch == allcaps:
+            if pending_word_mode is not None or in_ascii_word:
+                raise LosslessCapsError("invalid allcaps marker placement")
+            pending_word_mode = "allcaps"
+            continue
+
+        if _is_ascii_alpha(ch):
+            at_word_start = not in_ascii_word
+            if at_word_start:
+                if pending_word_mode == "allcaps":
+                    out.append(ch.upper())
+                    active_allcaps = True
+                elif pending_word_mode == "title":
+                    out.append(ch.upper())
+                else:
+                    out.append(ch)
+                pending_word_mode = None
+                in_ascii_word = True
+                continue
+
+            if pending_word_mode is not None:
+                raise LosslessCapsError("word capitalization marker leaked into the middle of a word")
+            out.append(ch.upper() if active_allcaps else ch)
+            continue
+
+        if pending_word_mode is not None:
+            raise LosslessCapsError("capitalization marker not followed by an ASCII letter")
+        out.append(ch)
+        in_ascii_word = False
+        active_allcaps = False
+
+    if pending_escape:
+        raise LosslessCapsError("dangling escape marker at end of string")
+    if pending_word_mode is not None:
+        raise LosslessCapsError("dangling capitalization marker at end of string")
+    return "".join(out)
+
+
+def encode_lossless_caps_v4(
+    text: str,
+    *,
+    allcaps: str = DEFAULT_V2_ALLCAPS,
+    esc: str = DEFAULT_V2_ESC,
+) -> str:
+    """Encode only ALLCAPS ASCII words, leaving all other case untouched."""
+    _validate_distinct_single_chars(allcaps, esc)
+    controls = {allcaps, esc}
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch in controls:
+            out.append(esc)
+            out.append(ch)
+            i += 1
+            continue
+        if not _is_ascii_alpha(ch):
+            out.append(ch)
+            i += 1
+            continue
+        j = i + 1
+        while j < n and _is_ascii_alpha(text[j]):
+            j += 1
+        word = text[i:j]
+        if len(word) >= 2 and word.isupper():
+            out.append(allcaps)
+            out.append(word.lower())
+        else:
+            out.append(word)
+        i = j
+    return "".join(out)
+
+
+def decode_lossless_caps_v4(
+    text: str,
+    *,
+    allcaps: str = DEFAULT_V2_ALLCAPS,
+    esc: str = DEFAULT_V2_ESC,
+) -> str:
+    """Decode the `lossless_caps_v4` transform back to the original text."""
+    _validate_distinct_single_chars(allcaps, esc)
+    out: list[str] = []
+    pending_escape = False
+    pending_allcaps = False
+    in_ascii_word = False
+    active_allcaps = False
+
+    for ch in text:
+        if pending_escape:
+            if pending_allcaps and not _is_ascii_alpha(ch):
+                raise LosslessCapsError("escaped control char cannot satisfy pending allcaps mode")
+            out.append(ch)
+            pending_escape = False
+            if _is_ascii_alpha(ch):
+                in_ascii_word = True
+            else:
+                in_ascii_word = False
+                active_allcaps = False
+            continue
+
+        if ch == esc:
+            pending_escape = True
+            continue
+        if ch == allcaps:
+            if pending_allcaps or in_ascii_word:
+                raise LosslessCapsError("invalid allcaps marker placement")
+            pending_allcaps = True
+            continue
+
+        if _is_ascii_alpha(ch):
+            if not in_ascii_word:
+                active_allcaps = pending_allcaps
+                pending_allcaps = False
+                in_ascii_word = True
+            out.append(ch.upper() if active_allcaps else ch)
+            continue
+
+        if pending_allcaps:
+            raise LosslessCapsError("allcaps marker not followed by an ASCII letter")
+        out.append(ch)
+        in_ascii_word = False
+        active_allcaps = False
+
+    if pending_escape:
+        raise LosslessCapsError("dangling escape marker at end of string")
+    if pending_allcaps:
+        raise LosslessCapsError("dangling allcaps marker at end of string")
+    return "".join(out)
+
+
+def encode_lossless_caps_v5(
+    text: str,
+    *,
+    title: str = DEFAULT_V2_TITLE,
+    allcaps: str = DEFAULT_V2_ALLCAPS,
+    esc: str = DEFAULT_V2_ESC,
+    title_min_len: int = DEFAULT_V5_TITLE_MIN_LEN,
+) -> str:
+    """Encode ALLCAPS words and only sufficiently long TitleCase words."""
+    _validate_distinct_single_chars(title, allcaps, esc)
+    controls = {title, allcaps, esc}
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch in controls:
+            out.append(esc)
+            out.append(ch)
+            i += 1
+            continue
+        if not _is_ascii_alpha(ch):
+            out.append(ch)
+            i += 1
+            continue
+        j = i + 1
+        while j < n and _is_ascii_alpha(text[j]):
+            j += 1
+        word = text[i:j]
+        if len(word) >= 2 and word.isupper():
+            out.append(allcaps)
+            out.append(word.lower())
+        elif len(word) >= title_min_len and _is_ascii_upper(word[0]) and word[1:].islower():
+            out.append(title)
+            out.append(word.lower())
+        else:
+            out.append(word)
+        i = j
+    return "".join(out)
+
+
+def decode_lossless_caps_v5(
+    text: str,
+    *,
+    title: str = DEFAULT_V2_TITLE,
+    allcaps: str = DEFAULT_V2_ALLCAPS,
+    esc: str = DEFAULT_V2_ESC,
+) -> str:
+    """Decode the `lossless_caps_v5` transform back to the original text."""
+    return decode_lossless_caps_v3(text, title=title, allcaps=allcaps, esc=esc)
+
+
+def encode_lossless_caps_v6(
+    text: str,
+    *,
+    allcaps: str = DEFAULT_V2_ALLCAPS,
+    esc: str = DEFAULT_V2_ESC,
+    allcaps_min_len: int = DEFAULT_V6_ALLCAPS_MIN_LEN,
+) -> str:
+    """Encode only ALLCAPS words with length >= allcaps_min_len."""
+    _validate_distinct_single_chars(allcaps, esc)
+    controls = {allcaps, esc}
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch in controls:
+            out.append(esc)
+            out.append(ch)
+            i += 1
+            continue
+        if not _is_ascii_alpha(ch):
+            out.append(ch)
+            i += 1
+            continue
+        j = i + 1
+        while j < n and _is_ascii_alpha(text[j]):
+            j += 1
+        word = text[i:j]
+        if len(word) >= allcaps_min_len and word.isupper():
+            out.append(allcaps)
+            out.append(word.lower())
+        else:
+            out.append(word)
+        i = j
+    return "".join(out)
+
+
+def decode_lossless_caps_v6(
+    text: str,
+    *,
+    allcaps: str = DEFAULT_V2_ALLCAPS,
+    esc: str = DEFAULT_V2_ESC,
+) -> str:
+    """Decode the `lossless_caps_v6` transform back to the original text."""
+    return decode_lossless_caps_v4(text, allcaps=allcaps, esc=esc)
+
+
+def encode_lossless_caps_v7(
+    text: str,
+    *,
+    allcaps: str = DEFAULT_V2_ALLCAPS,
+    esc: str = DEFAULT_V2_ESC,
+    allcaps_min_len: int = DEFAULT_V7_ALLCAPS_MIN_LEN,
+) -> str:
+    """Encode only ALLCAPS words with length >= 4."""
+    return encode_lossless_caps_v6(
+        text,
+        allcaps=allcaps,
+        esc=esc,
+        allcaps_min_len=allcaps_min_len,
+    )
+
+
+def decode_lossless_caps_v7(
+    text: str,
+    *,
+    allcaps: str = DEFAULT_V2_ALLCAPS,
+    esc: str = DEFAULT_V2_ESC,
+) -> str:
+    """Decode the `lossless_caps_v7` transform back to the original text."""
+    return decode_lossless_caps_v6(text, allcaps=allcaps, esc=esc)
+
+
+def get_text_transform(name: str | None) -> Callable[[str], str]:
+    """Return the forward text transform for the given config name."""
+    normalized = IDENTITY if name in {None, "", IDENTITY} else str(name)
+    if normalized == IDENTITY:
+        return lambda text: text
+    if normalized == LOSSLESS_CAPS_V1:
+        return encode_lossless_caps_v1
+    if normalized == LOSSLESS_CAPS_V2:
+        return encode_lossless_caps_v2
+    if normalized == LOSSLESS_CAPS_V3:
+        return encode_lossless_caps_v3
+    if normalized == LOSSLESS_CAPS_V4:
+        return encode_lossless_caps_v4
+    if normalized == LOSSLESS_CAPS_V5:
+        return encode_lossless_caps_v5
+    if normalized == LOSSLESS_CAPS_V6:
+        return encode_lossless_caps_v6
+    if normalized == LOSSLESS_CAPS_V7:
+        return encode_lossless_caps_v7
+    if normalized == LOSSLESS_CAPS_CASEOPS_V1:
+        return encode_lossless_caps_v2
+    raise ValueError(f"unsupported text_transform={name!r}")
+
+
+def get_text_inverse_transform(name: str | None) -> Callable[[str], str]:
+    """Return the inverse transform for the given config name."""
+    normalized = IDENTITY if name in {None, "", IDENTITY} else str(name)
+    if normalized == IDENTITY:
+        return lambda text: text
+    if normalized == LOSSLESS_CAPS_V1:
+        return decode_lossless_caps_v1
+    if normalized == LOSSLESS_CAPS_V2:
+        return decode_lossless_caps_v2
+    if normalized == LOSSLESS_CAPS_V3:
+        return decode_lossless_caps_v3
+    if normalized == LOSSLESS_CAPS_V4:
+        return decode_lossless_caps_v4
+    if normalized == LOSSLESS_CAPS_V5:
+        return decode_lossless_caps_v5
+    if normalized == LOSSLESS_CAPS_V6:
+        return decode_lossless_caps_v6
+    if normalized == LOSSLESS_CAPS_V7:
+        return decode_lossless_caps_v7
+    if normalized == LOSSLESS_CAPS_CASEOPS_V1:
+        return decode_lossless_caps_v2
+    raise ValueError(f"unsupported text_transform={name!r}")
+
+
+def normalize_text_transform_name(name: str | None) -> str:
+    """Normalize empty/None transform names to the identity transform."""
+    return IDENTITY if name in {None, "", IDENTITY} else str(name)
+
+
+def get_text_transform_control_symbols(name: str | None) -> list[str]:
+    """Return reserved control symbols used by a transform, if any."""
+    normalized = normalize_text_transform_name(name)
+    if normalized == IDENTITY:
+        return []
+    if normalized == LOSSLESS_CAPS_V1:
+        return [DEFAULT_SENTINEL]
+    if normalized == LOSSLESS_CAPS_V2:
+        return [DEFAULT_V2_TITLE, DEFAULT_V2_ALLCAPS, DEFAULT_V2_CAPNEXT, DEFAULT_V2_ESC]
+    if normalized == LOSSLESS_CAPS_CASEOPS_V1:
+        return [DEFAULT_V2_TITLE, DEFAULT_V2_ALLCAPS, DEFAULT_V2_CAPNEXT, DEFAULT_V2_ESC]
+    if normalized in {LOSSLESS_CAPS_V3, LOSSLESS_CAPS_V5}:
+        return [DEFAULT_V2_TITLE, DEFAULT_V2_ALLCAPS, DEFAULT_V2_ESC]
+    if normalized in {LOSSLESS_CAPS_V4, LOSSLESS_CAPS_V6, LOSSLESS_CAPS_V7}:
+        return [DEFAULT_V2_ALLCAPS, DEFAULT_V2_ESC]
+    raise ValueError(f"unsupported text_transform={name!r}")
+
+
+def infer_text_transform_from_manifest(tokenizer_path: str | Path) -> str:
+    """Best-effort lookup of a tokenizer's text transform from a local manifest."""
+    tokenizer_path = Path(tokenizer_path).expanduser().resolve()
+    manifest_candidates = [
+        tokenizer_path.parent.parent / "manifest.json",
+        tokenizer_path.parent / "manifest.json",
+    ]
+    for manifest_path in manifest_candidates:
+        if not manifest_path.is_file():
+            continue
+        try:
+            payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        tokenizers = payload.get("tokenizers")
+        if not isinstance(tokenizers, list):
+            continue
+        for tokenizer_meta in tokenizers:
+            if not isinstance(tokenizer_meta, dict):
+                continue
+            model_path = tokenizer_meta.get("model_path") or tokenizer_meta.get("path")
+            if not model_path:
+                continue
+            candidate = (manifest_path.parent / str(model_path)).resolve()
+            if candidate == tokenizer_path:
+                return normalize_text_transform_name(tokenizer_meta.get("text_transform"))
+    return IDENTITY
+
+
+def surface_piece_original_byte_counts(
+    surfaces: Iterable[str],
+    *,
+    text_transform_name: str | None = None,
+    sentinel: str = DEFAULT_SENTINEL,
+) -> list[int]:
+    """Return exact original UTF-8 byte counts contributed by each surface piece.
+
+    `surfaces` must be the exact decoded text fragments emitted by SentencePiece
+    in order, e.g. `piece.surface` from `encode_as_immutable_proto`.
+    """
+    normalized = normalize_text_transform_name(text_transform_name)
+    if normalized == IDENTITY:
+        return [len(surface.encode("utf-8")) for surface in surfaces]
+    if normalized == LOSSLESS_CAPS_V1:
+        if len(sentinel) != 1:
+            raise ValueError("sentinel must be exactly one character")
+        sentinel_bytes = len(sentinel.encode("utf-8"))
+        pending_sentinel = False
+        counts: list[int] = []
+        for surface in surfaces:
+            piece_bytes = 0
+            for ch in surface:
+                if pending_sentinel:
+                    if ch == sentinel:
+                        piece_bytes += sentinel_bytes
+                    elif _is_ascii_lower(ch):
+                        piece_bytes += 1
+                    else:
+                        raise LosslessCapsError(
+                            f"invalid continuation {ch!r} after capitalization sentinel"
+                        )
+                    pending_sentinel = False
+                    continue
+                if ch == sentinel:
+                    pending_sentinel = True
+                else:
+                    piece_bytes += len(ch.encode("utf-8"))
+            counts.append(piece_bytes)
+        if pending_sentinel:
+            raise LosslessCapsError("dangling capitalization sentinel across piece boundary")
+        return counts
+    if normalized not in {LOSSLESS_CAPS_V2, LOSSLESS_CAPS_V3, LOSSLESS_CAPS_V4, LOSSLESS_CAPS_V5, LOSSLESS_CAPS_V6, LOSSLESS_CAPS_V7, LOSSLESS_CAPS_CASEOPS_V1}:
+        raise ValueError(f"unsupported text_transform={text_transform_name!r}")
+
+    title = DEFAULT_V2_TITLE
+    allcaps = DEFAULT_V2_ALLCAPS
+    capnext = DEFAULT_V2_CAPNEXT
+    esc = DEFAULT_V2_ESC
+    if normalized in {LOSSLESS_CAPS_V2, LOSSLESS_CAPS_CASEOPS_V1}:
+        _validate_distinct_single_chars(title, allcaps, capnext, esc)
+    elif normalized in {LOSSLESS_CAPS_V4, LOSSLESS_CAPS_V6, LOSSLESS_CAPS_V7}:
+        _validate_distinct_single_chars(allcaps, esc)
+    else:
+        _validate_distinct_single_chars(title, allcaps, esc)
+    pending_escape = False
+    pending_word_mode: str | None = None
+    active_allcaps = False
+    pending_capnext = False
+    in_ascii_word = False
+    counts: list[int] = []
+    for surface in surfaces:
+        piece_bytes = 0
+        for ch in surface:
+            if pending_escape:
+                if pending_word_mode is not None and not _is_ascii_alpha(ch):
+                    raise LosslessCapsError("escaped control char cannot satisfy pending word capitalization mode")
+                piece_bytes += len(ch.encode("utf-8"))
+                pending_escape = False
+                if _is_ascii_alpha(ch):
+                    in_ascii_word = True
+                else:
+                    in_ascii_word = False
+                    active_allcaps = False
+                continue
+            if ch == esc:
+                pending_escape = True
+                continue
+            if normalized in {LOSSLESS_CAPS_V2, LOSSLESS_CAPS_V3, LOSSLESS_CAPS_V5, LOSSLESS_CAPS_CASEOPS_V1} and ch == title:
+                if pending_word_mode is not None or in_ascii_word or pending_capnext:
+                    raise LosslessCapsError("invalid title marker placement")
+                pending_word_mode = "title"
+                continue
+            if ch == allcaps:
+                if pending_word_mode is not None or in_ascii_word or pending_capnext:
+                    raise LosslessCapsError("invalid allcaps marker placement")
+                pending_word_mode = "allcaps"
+                continue
+            if normalized in {LOSSLESS_CAPS_V2, LOSSLESS_CAPS_CASEOPS_V1} and ch == capnext:
+                if pending_capnext:
+                    raise LosslessCapsError("duplicate capnext marker")
+                pending_capnext = True
+                continue
+
+            if _is_ascii_alpha(ch):
+                at_word_start = not in_ascii_word
+                if at_word_start:
+                    piece_bytes += 1
+                    active_allcaps = pending_word_mode == "allcaps"
+                    pending_word_mode = None
+                    pending_capnext = False
+                    in_ascii_word = True
+                    continue
+                if pending_word_mode is not None:
+                    raise LosslessCapsError("word capitalization marker leaked into the middle of a word")
+                piece_bytes += 1
+                pending_capnext = False
+                continue
+
+            if pending_word_mode is not None or pending_capnext:
+                raise LosslessCapsError("capitalization marker not followed by an ASCII letter")
+            piece_bytes += len(ch.encode("utf-8"))
+            in_ascii_word = False
+            active_allcaps = False
+        counts.append(piece_bytes)
+    if pending_escape:
+        raise LosslessCapsError("dangling escape marker across piece boundary")
+    if pending_word_mode is not None or pending_capnext:
+        raise LosslessCapsError("dangling capitalization marker across piece boundary")
+    return counts

--- a/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/requirements.txt
+++ b/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/requirements.txt
@@ -1,0 +1,16 @@
+# FlashAttention 3 must be installed separately; see README.md
+# PyTorch 2.9.1+cu128 required; install using:
+# uv pip install torch==2.9.1+cu128 --extra-index-url https://download.pytorch.org/whl/cu128
+numpy
+tqdm
+torch
+huggingface-hub
+kernels
+setuptools
+typing-extensions==4.15.0
+datasets
+tiktoken
+sentencepiece
+zstandard
+brotli
+python-minifier

--- a/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/submission.json
+++ b/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/submission.json
@@ -1,0 +1,38 @@
+{
+  "author": "romeerp",
+  "github_id": "romeerp",
+  "name": "CaseOps Tokenizer + Mild WD Taper",
+  "date": "2026-04-18",
+  "track": "10min_16mb",
+  "val_loss": 2.33674426,
+  "val_bpb": 1.06780094,
+  "val_bpb_std": 0.00036931,
+  "seeds": [0, 42, 1234],
+  "seed_results": {
+    "0": {
+      "val_bpb": 1.06805820,
+      "artifact_bytes": 15932307
+    },
+    "42": {
+      "val_bpb": 1.06806595,
+      "artifact_bytes": 15935802
+    },
+    "1234": {
+      "val_bpb": 1.06727867,
+      "artifact_bytes": 15943106
+    }
+  },
+  "compliance": {
+    "train_under_600s": true,
+    "artifact_under_16mb": true,
+    "eval_under_600s": true,
+    "no_slot": true,
+    "no_pre_quant_ttt": true,
+    "no_etlb": true,
+    "no_ngram_cache": true,
+    "score_first_ttt": true,
+    "three_seeds": true
+  },
+  "hardware": "8xH100 80GB SXM",
+  "pytorch_version": "2.9.1+cu128"
+}

--- a/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/tokenizer_specs_export_caseops_v1_reserved_only.json
+++ b/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/tokenizer_specs_export_caseops_v1_reserved_only.json
@@ -1,0 +1,12 @@
+{
+  "tokenizers": [
+    {
+      "name": "sp_bpe_8192_lossless_caps_caseops_v1_reserved",
+      "dataset_suffix": "sp8192_lossless_caps_caseops_v1_reserved",
+      "vocab_size": 8192,
+      "text_transform": "lossless_caps_caseops_v1",
+      "reserve_text_transform_controls": true,
+      "model_prefix": "fineweb_8192_bpe_lossless_caps_caseops_v1_reserved"
+    }
+  ]
+}

--- a/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/train_gpt.py
+++ b/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/train_gpt.py
@@ -1,0 +1,3042 @@
+import base64, collections, copy, fcntl, glob, io, json, lzma, math, os
+from pathlib import Path
+import random, re, subprocess, sys, time, uuid, numpy as np, sentencepiece as spm, torch, torch.distributed as dist, torch.nn.functional as F
+from torch import nn
+from flash_attn_interface import (
+    flash_attn_func as flash_attn_3_func,
+    flash_attn_varlen_func,
+)
+from concurrent.futures import ThreadPoolExecutor
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+class Hyperparameters:
+    data_dir = os.environ.get("DATA_DIR", "./data/")
+    seed = int(os.environ.get("SEED", 1337))
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.75))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 6e2))
+    val_batch_tokens = int(os.environ.get("VAL_BATCH_TOKENS", 524288))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    sliding_window_enabled = bool(int(os.environ.get("SLIDING_WINDOW_ENABLED", "0")))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 8192))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 4.0))
+    skip_gates_enabled = bool(int(os.environ.get("SKIP_GATES_ENABLED", "1")))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 3e1))
+    rope_base = float(os.environ.get("ROPE_BASE", 1e4))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    rope_train_seq_len = int(os.environ.get("ROPE_TRAIN_SEQ_LEN", 2048))
+    rope_yarn = bool(int(os.environ.get("ROPE_YARN", "0")))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 5.0))
+    num_loops = int(os.environ.get("NUM_LOOPS", 2))
+    loop_start = int(os.environ.get("LOOP_START", 3))
+    loop_end = int(os.environ.get("LOOP_END", 5))
+    enable_looping_at = float(os.environ.get("ENABLE_LOOPING_AT", 0.35))
+    parallel_start_layer = int(os.environ.get("PARALLEL_START_LAYER", 8))
+    parallel_final_lane = os.environ.get("PARALLEL_FINAL_LANE", "mean")
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.026))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.97))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-08))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.02))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    wd_taper_start_frac = float(os.environ.get("WD_TAPER_START_FRAC", 0.70))
+    wd_taper_final_mult = float(os.environ.get("WD_TAPER_FINAL_MULT", 0.50))
+    skip_post_train_eval = bool(int(os.environ.get("SKIP_POST_TRAIN_EVAL", "0")))
+    ttt_only = bool(int(os.environ.get("TTT_ONLY", "0")))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_lora_rank = int(os.environ.get("TTT_LORA_RANK", 96))
+    ttt_lora_lr = float(os.environ.get("TTT_LORA_LR", 0.0001))
+    ttt_chunk_size = int(os.environ.get("TTT_CHUNK_SIZE", 48))
+    ttt_eval_seq_len = int(os.environ.get("TTT_EVAL_SEQ_LEN", 2048))
+    ttt_batch_size = int(os.environ.get("TTT_BATCH_SIZE", 64))
+    ttt_grad_steps = int(os.environ.get("TTT_GRAD_STEPS", 1))
+    ttt_weight_decay = float(os.environ.get("TTT_WEIGHT_DECAY", 0.5))
+    ttt_beta1 = float(os.environ.get("TTT_BETA1", 0))
+    ttt_beta2 = float(os.environ.get("TTT_BETA2", 0.999))
+    ttt_k_lora = bool(int(os.environ.get("TTT_K_LORA", "1")))
+    ttt_mlp_lora = bool(int(os.environ.get("TTT_MLP_LORA", "1")))
+    ttt_o_lora = bool(int(os.environ.get("TTT_O_LORA", "1")))
+    ttt_optimizer = os.environ.get("TTT_OPTIMIZER", "adam")
+    ttt_eval_batches = os.environ.get("TTT_EVAL_BATCHES", "")
+    val_doc_fraction = float(os.environ.get("VAL_DOC_FRACTION", 1.0))
+    compressor = os.environ.get("COMPRESSOR", "brotli")
+    gptq_calibration_batches = int(os.environ.get("GPTQ_CALIBRATION_BATCHES", 16))
+    gptq_reserve_seconds = float(os.environ.get("GPTQ_RESERVE_SECONDS", 4.0))
+    phased_ttt_enabled = bool(int(os.environ.get("PHASED_TTT_ENABLED", "1")))
+    phased_ttt_prefix_docs = int(os.environ.get("PHASED_TTT_PREFIX_DOCS", 2000))
+    phased_ttt_num_phases = int(os.environ.get("PHASED_TTT_NUM_PHASES", 3))
+    global_ttt_lr = float(os.environ.get("GLOBAL_TTT_LR", 0.001))
+    global_ttt_momentum = float(os.environ.get("GLOBAL_TTT_MOMENTUM", 0.9))
+    global_ttt_epochs = int(os.environ.get("GLOBAL_TTT_EPOCHS", 1))
+    global_ttt_chunk_tokens = int(os.environ.get("GLOBAL_TTT_CHUNK_TOKENS", 32768))
+    global_ttt_batch_seqs = int(os.environ.get("GLOBAL_TTT_BATCH_SEQS", 32))
+    global_ttt_warmup_start_lr = float(os.environ.get("GLOBAL_TTT_WARMUP_START_LR", 0.0))
+    global_ttt_warmup_chunks = int(os.environ.get("GLOBAL_TTT_WARMUP_CHUNKS", 0))
+    global_ttt_grad_clip = float(os.environ.get("GLOBAL_TTT_GRAD_CLIP", 1.0))
+    global_ttt_respect_doc_boundaries = bool(int(os.environ.get("GLOBAL_TTT_RESPECT_DOC_BOUNDARIES", "1")))
+    matrix_bits = int(os.environ.get("MATRIX_BITS", 6))
+    embed_bits = int(os.environ.get("EMBED_BITS", 7))
+    matrix_clip_sigmas = float(os.environ.get("MATRIX_CLIP_SIGMAS", 12.85))
+    embed_clip_sigmas = float(os.environ.get("EMBED_CLIP_SIGMAS", 15.0))
+    mlp_clip_sigmas = float(os.environ.get("MLP_CLIP_SIGMAS", 12.0))
+    attn_clip_sigmas = float(os.environ.get("ATTN_CLIP_SIGMAS", 13.0))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_main_process = rank == 0
+    grad_accum_steps = 8 // world_size
+    default_datasets_dir = os.path.join(data_dir, "datasets", f"fineweb10B_sp{vocab_size}")
+    datasets_dir = os.environ.get("DATASETS_DIR", default_datasets_dir)
+    train_files = os.environ.get("TRAIN_FILES", os.path.join(datasets_dir, "fineweb_train_*.bin"))
+    val_files = os.environ.get("VAL_FILES", os.path.join(datasets_dir, "fineweb_val_[0-9][0-9][0-9][0-9][0-9][0-9].bin"))
+    tokenizer_path = os.environ.get(
+        "TOKENIZER_PATH", os.path.join(data_dir, "tokenizers", f"fineweb_{vocab_size}_bpe.model")
+    )
+    artifact_dir = os.environ.get("ARTIFACT_DIR", "")
+    logfile = (
+        os.path.join(artifact_dir, f"{run_id}.txt")
+        if artifact_dir
+        else f"logs/{run_id}.txt"
+    )
+    model_path = (
+        os.path.join(artifact_dir, "final_model.pt")
+        if artifact_dir
+        else "final_model.pt"
+    )
+    quantized_model_path = (
+        os.path.join(artifact_dir, "final_model.int6.ptz")
+        if artifact_dir
+        else "final_model.int6.ptz"
+    )
+
+
+_logger_hparams = None
+
+
+def set_logging_hparams(h):
+    global _logger_hparams
+    _logger_hparams = h
+
+
+def log(msg, console=True):
+    if _logger_hparams is None:
+        print(msg)
+        return
+    if _logger_hparams.is_main_process:
+        if console:
+            print(msg)
+        if _logger_hparams.logfile is not None:
+            with open(_logger_hparams.logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+
+class ValidationData:
+    def __init__(self, h, device):
+        self.sp = spm.SentencePieceProcessor(model_file=h.tokenizer_path)
+        if int(self.sp.vocab_size()) != h.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={h.vocab_size} does not match tokenizer vocab_size={int(self.sp.vocab_size())}"
+            )
+        self.val_tokens = load_validation_tokens(h.val_files, h.eval_seq_len)
+        self.val_token_bytes = load_validation_token_bytes(h.val_files, self.val_tokens.numel())
+        (
+            self.base_bytes_lut,
+            self.has_leading_space_lut,
+            self.is_boundary_token_lut,
+        ) = build_sentencepiece_luts(self.sp, h.vocab_size, device)
+
+
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sp_vocab_size = int(sp.vocab_size())
+    assert (
+        sp.piece_to_id("▁") != sp.unk_id()
+    ), "Tokenizer must have '▁' (space) as its own token for correct BPB byte counting"
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = (tokens.numel() - 1) // seq_len * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def load_validation_token_bytes(pattern, expected_len):
+    bytes_pattern = pattern.replace("fineweb_val_", "fineweb_val_bytes_")
+    if bytes_pattern == pattern:
+        return None
+    files = [Path(p) for p in sorted(glob.glob(bytes_pattern))]
+    if not files:
+        return None
+    token_bytes = torch.cat([load_data_shard(file) for file in files]).to(torch.int32).contiguous()
+    if token_bytes.numel() < expected_len:
+        raise ValueError(
+            f"Validation byte sidecar is too short: expected at least {expected_len}, got {token_bytes.numel()}"
+        )
+    if token_bytes.numel() > expected_len:
+        token_bytes = token_bytes[:expected_len]
+    return token_bytes
+
+
+def load_data_shard(file):
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE = {}
+_MMAP_CACHE = {}
+
+
+def _read_num_tokens(file):
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+
+def _get_shard_memmap(file):
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode="r", dtype="<u2", offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+BOS_ID = None
+
+
+def get_next_multiple_of_n(v, n):
+    return ((v + n - 1) // n) * n
+
+
+def _build_cu_seqlens(bos_pos, total_len, device, max_doc_len=0, bucket_size=64):
+    if not bos_pos or bos_pos[0] != 0:
+        bos_pos = [0] + bos_pos
+    seg_starts = []
+    starts_with_end = bos_pos + [total_len]
+    for i in range(len(starts_with_end) - 1):
+        start = starts_with_end[i]
+        end = starts_with_end[i + 1]
+        if max_doc_len > 0:
+            pos = start
+            while pos < end:
+                seg_starts.append(pos)
+                pos += max_doc_len
+        else:
+            seg_starts.append(start)
+    boundaries = seg_starts + [total_len]
+    padded_len = get_next_multiple_of_n(len(boundaries), bucket_size)
+    cu = torch.full((padded_len,), total_len, dtype=torch.int32, device=device)
+    cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+    seg_ends = seg_starts[1:] + [total_len]
+    max_seqlen = max(end - start for start, end in zip(seg_starts, seg_ends))
+    return cu, max_seqlen
+
+class DocumentPackingLoader:
+    _shard_pool = ThreadPoolExecutor(1)
+
+    def __init__(self, h, device, cu_bucket_size=64):
+        self.rank = h.rank
+        self.world_size = h.world_size
+        self.device = device
+        self.cu_bucket_size = cu_bucket_size
+        self.max_seq_len = h.train_seq_len
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files
+        self.file_iter = iter(self.files)
+        self._init_shard(load_data_shard(next(self.file_iter)))
+        self._next_shard = self._submit_next_shard()
+        self._batch_pool = ThreadPoolExecutor(1)
+        self._next_batch = None
+
+    def _init_shard(self, tokens):
+        global BOS_ID
+        self.tokens = tokens
+        self.shard_size = tokens.numel()
+        if BOS_ID is None:
+            BOS_ID = 1
+        self.bos_idx = (
+            (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        )
+        if self.bos_idx.size == 0:
+            self.bos_idx = np.array([0], dtype=np.int64)
+        self.cursor = int(self.bos_idx[0])
+
+    def _submit_next_shard(self):
+        try:
+            path = next(self.file_iter)
+            return self._shard_pool.submit(load_data_shard, path)
+        except StopIteration:
+            return None
+
+    def _advance_shard(self):
+        if self._next_shard is None:
+            self.file_iter = iter(self.files)
+            self._next_shard = self._shard_pool.submit(
+                load_data_shard, next(self.file_iter)
+            )
+        self._init_shard(self._next_shard.result())
+        self._next_shard = self._submit_next_shard()
+
+    def _local_doc_starts(self, local_start, total_len):
+        lo = np.searchsorted(self.bos_idx, local_start, side="left")
+        hi = np.searchsorted(self.bos_idx, local_start + total_len, side="left")
+        return (self.bos_idx[lo:hi] - local_start).tolist()
+
+    def _prepare_batch(self, num_tokens_local, max_seq_len):
+        per_rank_span = num_tokens_local + 1
+        global_span = per_rank_span * self.world_size
+        while self.cursor + global_span > self.shard_size:
+            self._advance_shard()
+        local_start = self.cursor + self.rank * per_rank_span
+        buf = self.tokens[local_start : local_start + per_rank_span]
+        inputs = buf[:-1].to(dtype=torch.int64).pin_memory()
+        targets = buf[1:].to(dtype=torch.int64).pin_memory()
+        starts = self._local_doc_starts(local_start, inputs.numel())
+        cu_seqlens, max_seqlen = _build_cu_seqlens(
+            starts, inputs.numel(), inputs.device, max_seq_len, self.cu_bucket_size
+        )
+        cu_seqlens = cu_seqlens.pin_memory()
+        self.cursor += global_span
+        return inputs, targets, cu_seqlens, max_seqlen
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        num_tokens_local = global_tokens // (self.world_size * grad_accum_steps)
+        if self._next_batch is not None:
+            inputs, targets, cu_seqlens, max_seqlen = self._next_batch.result()
+        else:
+            inputs, targets, cu_seqlens, max_seqlen = self._prepare_batch(
+                num_tokens_local, self.max_seq_len
+            )
+        self._next_batch = self._batch_pool.submit(
+            self._prepare_batch, num_tokens_local, self.max_seq_len
+        )
+        return (
+            inputs[None].to(self.device, non_blocking=True),
+            targets[None].to(self.device, non_blocking=True),
+            cu_seqlens.to(self.device, non_blocking=True),
+            max_seqlen,
+        )
+
+
+class ShuffledSequenceLoader:
+    def __init__(self, h, device):
+        self.world_size = h.world_size
+        self.seq_len = h.train_seq_len
+        self.device = device
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files[h.rank :: h.world_size]
+        self.rng = np.random.Generator(np.random.PCG64(h.rank))
+        self.num_tokens = [_read_num_tokens(f) for f in self.files]
+        self.start_inds = [[] for _ in self.files]
+        for si in range(len(self.files)):
+            self._reset_shard(si)
+
+    def _reset_shard(self, si):
+        max_phase = min(
+            self.seq_len - 1, max(0, self.num_tokens[si] - self.seq_len - 1)
+        )
+        phase = int(self.rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        num_sequences = (self.num_tokens[si] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[si] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for bi in range(device_batch_size):
+            total = remaining.sum()
+            if total <= 0:
+                for si in range(len(self.files)):
+                    self._reset_shard(si)
+                remaining = np.array(
+                    [len(s) for s in self.start_inds], dtype=np.float64
+                )
+                total = remaining.sum()
+            probs = remaining / total
+            si = int(self.rng.choice(len(self.files), p=probs))
+            start_ind = self.start_inds[si].pop()
+            remaining[si] -= 1
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[bi] = window[:-1]
+            y[bi] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x):
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+@triton.jit
+def linear_leaky_relu_square_kernel(
+    a_desc,
+    b_desc,
+    c_desc,
+    aux_desc,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    FORWARD: tl.constexpr,
+):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+    tile_id_c = start_pid - NUM_SMS
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+        tile_id_c += NUM_SMS
+        offs_am_c = offs_am
+        offs_bn_c = offs_bn
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+        c0 = acc0.to(dtype)
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            pre0 = aux_desc.load([offs_am_c, offs_bn_c])
+            pre1 = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c0 = c0 * tl.where(pre0 > 0, 2.0 * pre0, 0.5 * pre0)
+            c1 = c1 * tl.where(pre1 > 0, 2.0 * pre1, 0.5 * pre1)
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+        if FORWARD:
+            aux0 = tl.where(c0 > 0, c0, 0.5 * c0)
+            aux1 = tl.where(c1 > 0, c1, 0.5 * c1)
+            aux_desc.store([offs_am_c, offs_bn_c], aux0 * aux0)
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], aux1 * aux1)
+
+
+def linear_leaky_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K2 = b.shape
+    assert K == K2
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    forward = aux is None
+    if aux is None:
+        aux = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 256, 64
+    num_stages = 4 if forward else 3
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    grid = lambda _meta: (
+        min(num_sms, triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N)),
+    )
+    linear_leaky_relu_square_kernel[grid](
+        a_desc,
+        b_desc,
+        c_desc,
+        aux_desc,
+        M,
+        N,
+        K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        NUM_SMS=num_sms,
+        FORWARD=forward,
+        num_stages=num_stages,
+        num_warps=8,
+    )
+    if forward:
+        return c, aux
+    return c
+
+
+class FusedLinearLeakyReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, w1, w2):
+        x_flat = x.reshape(-1, x.shape[-1])
+        pre, post = linear_leaky_relu_square(x_flat, w1)
+        out = F.linear(post, w2)
+        ctx.save_for_backward(x, w1, w2, pre, post)
+        return out.view(*x.shape[:-1], out.shape[-1])
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, w1, w2, pre, post = ctx.saved_tensors
+        x_flat = x.reshape(-1, x.shape[-1])
+        grad_output_flat = grad_output.reshape(-1, grad_output.shape[-1])
+        dw2 = grad_output_flat.T @ post
+        dpre = linear_leaky_relu_square(grad_output_flat, w2.T.contiguous(), aux=pre)
+        dw1 = dpre.T @ x_flat
+        dx = dpre @ w1
+        return dx.view_as(x), dw1, dw2
+
+
+FusedLeakyReLUSquareMLP = FusedLinearLeakyReLUSquareFunction.apply
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=1e4, train_seq_len=1024, rope_dims=0, yarn=True):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.yarn = yarn
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / base ** (
+            torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+
+    def forward(self, seq_len, device, dtype):
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached < seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if self.yarn and seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * scale ** (rd / (rd - 2))
+                inv_freq = 1.0 / new_base ** (
+                    torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd
+                )
+            else:
+                inv_freq = self.inv_freq.float().to(device)
+            t = torch.arange(seq_len, device=device, dtype=torch.float32)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached[:, :seq_len].to(dtype=dtype), self._sin_cached[:, :seq_len].to(dtype=dtype)
+
+
+def apply_rotary_emb(x, cos, sin, rope_dims=0):
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=True
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len, yarn=yarn)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x, q_w, k_w, v_w, out_w, cu_seqlens=None, max_seqlen=0):
+        bsz, seqlen, dim = x.shape
+        q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if cu_seqlens is not None:
+            y = flash_attn_varlen_func(
+                q[0],
+                k[0],
+                v[0],
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+                causal=True,
+                window_size=(-1, -1),
+            )[None]
+        else:
+            y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        self._last_proj_input = y.detach() if getattr(self, "_calib", False) else None
+        return F.linear(y, out_w.to(x.dtype))
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        self.use_fused = True
+
+    def forward(self, x, up_w, down_w):
+        if self.training and self.use_fused:
+            return FusedLeakyReLUSquareMLP(x, up_w.to(x.dtype), down_w.to(x.dtype))
+        hidden = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5).square()
+        self._last_down_input = hidden.detach() if getattr(self, "_calib", False) else None
+        return F.linear(hidden, down_w.to(x.dtype))
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        num_kv_heads,
+        mlp_mult,
+        rope_base,
+        qk_gain_init,
+        train_seq_len,
+        layer_idx=0,
+        ln_scale=False,
+        yarn=True,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=yarn
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(
+            torch.stack((torch.ones(dim), torch.zeros(dim))).float()
+        )
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+
+    def forward(self, x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=None, max_seqlen=0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(
+            self.attn_norm(x_in) * self.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[
+            None, None, :
+        ] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        return x_out
+
+class GPT(nn.Module):
+    def __init__(self, h):
+        super().__init__()
+        if h.logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {h.logit_softcap}")
+        self.tie_embeddings = h.tie_embeddings
+        self.tied_embed_init_std = h.tied_embed_init_std
+        self.logit_softcap = h.logit_softcap
+        self.tok_emb = nn.Embedding(h.vocab_size, h.model_dim)
+        self.num_layers = h.num_layers
+        head_dim = h.model_dim // h.num_heads
+        kv_dim = h.num_kv_heads * head_dim
+        hidden_dim = int(h.mlp_mult * h.model_dim)
+        self.qo_bank = nn.Parameter(torch.empty(2 * h.num_layers, h.model_dim, h.model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * h.num_layers, kv_dim, h.model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(h.num_layers, hidden_dim, h.model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(h.num_layers, h.model_dim, hidden_dim))
+        self.num_encoder_layers = h.num_layers // 2
+        self.num_decoder_layers = h.num_layers - self.num_encoder_layers
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    h.model_dim,
+                    h.num_heads,
+                    h.num_kv_heads,
+                    h.mlp_mult,
+                    h.rope_base,
+                    h.qk_gain_init,
+                    h.train_seq_len,
+                    layer_idx=i,
+                    ln_scale=h.ln_scale,
+                    yarn=h.rope_yarn,
+                )
+                for i in range(h.num_layers)
+            ]
+        )
+        if h.rope_dims > 0:
+            head_dim = h.model_dim // h.num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = h.rope_dims
+                block.attn.rotary = Rotary(
+                    head_dim,
+                    base=h.rope_base,
+                    train_seq_len=h.train_seq_len,
+                    rope_dims=h.rope_dims,
+                    yarn=h.rope_yarn,
+                )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None
+            if h.tie_embeddings
+            else CastedLinear(h.model_dim, h.vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if h.xsa_last_n > 0:
+            for i in range(max(0, h.num_layers - h.xsa_last_n), h.num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self.looping_active = False
+        if h.num_loops > 0:
+            loop_seg = list(range(h.loop_start, h.loop_end + 1))
+            all_indices = list(range(h.loop_start))
+            for _ in range(h.num_loops + 1):
+                all_indices.extend(loop_seg)
+            all_indices.extend(range(h.loop_end + 1, h.num_layers))
+            num_enc = len(all_indices) // 2
+            self.encoder_indices = all_indices[:num_enc]
+            self.decoder_indices = all_indices[num_enc:]
+        else:
+            self.encoder_indices = list(range(self.num_encoder_layers))
+            self.decoder_indices = list(range(self.num_encoder_layers, h.num_layers))
+        self.num_skip_weights = min(
+            len(self.encoder_indices), len(self.decoder_indices)
+        )
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+        )
+        self.skip_gates = (
+            nn.Parameter(
+                torch.zeros(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+            )
+            if h.skip_gates_enabled
+            else None
+        )
+        self.parallel_start_layer = h.parallel_start_layer
+        self.parallel_final_lane = h.parallel_final_lane.lower()
+        self.parallel_post_lambdas = nn.Parameter(
+            torch.ones(h.num_layers, 2, 2, dtype=torch.float32)
+        )
+        self.parallel_resid_lambdas = nn.Parameter(
+            torch.full((h.num_layers, 2), 1.1, dtype=torch.float32)
+        )
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.qo_bank.data[n + i])
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)
+        for i in range(n):
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.mlp_down_bank.data[i])
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _bank_weights(self, i):
+        n = self.num_layers
+        return (
+            self.qo_bank[i],
+            self.kv_bank[i],
+            self.kv_bank[n + i],
+            self.qo_bank[n + i],
+            self.mlp_up_bank[i],
+            self.mlp_down_bank[i],
+        )
+
+    def _parallel_block(
+        self, block_idx, lane0, lane1, x0,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+        cu_seqlens=None, max_seqlen=0,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        attn_out = block.attn(
+            block.attn_norm(attn_read) * block.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+        )
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * block.mlp(
+            block.mlp_norm(mlp_read) * block.ln_scale_factor, up_w, down_w
+        )
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+    def _final_parallel_hidden(self, lane0, lane1):
+        if self.parallel_final_lane == "mlp":
+            return lane1
+        if self.parallel_final_lane == "attn":
+            return lane0
+        return 0.5 * (lane0 + lane1)
+
+    def forward_logits(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else range(self.num_encoder_layers)
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else range(
+                self.num_encoder_layers,
+                self.num_encoder_layers + self.num_decoder_layers,
+            )
+        )
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block(
+                    i, lane0, lane1, x0, q_w, k_w, v_w, out_w, up_w, down_w,
+                    cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(self, input_ids, target_ids, cu_seqlens=None, max_seqlen=0):
+        logits = self.forward_logits(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        return F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            target_ids.reshape(-1),
+            reduction="mean",
+        )
+
+    def forward_ttt(self, input_ids, target_ids, lora):
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else list(range(self.num_encoder_layers))
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else list(
+                range(
+                    self.num_encoder_layers,
+                    self.num_encoder_layers + self.num_decoder_layers,
+                )
+            )
+        )
+        slot = 0
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block_with_lora(
+                    i, lane0, lane1, x0, lora, slot,
+                    q_w, k_w, v_w, out_w, up_w, down_w,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits = F.linear(x, self.tok_emb.weight)
+        else:
+            logits = self.lm_head(x)
+        logits = logits + lora.lm_head_lora(x)
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        bsz, sl, V = logits.shape
+        return F.cross_entropy(
+            logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none"
+        ).reshape(bsz, sl)
+
+    def _block_with_lora(self, block, x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w):
+        mix = block.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = block.attn_norm(x_in) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q = (F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_heads, attn.head_dim
+        )
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        x_out = x_in + block.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        mlp_n = block.mlp_norm(x_out) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        x_out = x_out + block.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * mlp_out
+        return x_out
+
+    def _parallel_block_with_lora(
+        self, block_idx, lane0, lane1, x0, lora, slot,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        n = block.attn_norm(attn_read) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q = (F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_heads, attn.head_dim
+        )
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_n = block.mlp_norm(mlp_read) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * mlp_out
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+
+class BatchedLinearLoRA(nn.Module):
+    def __init__(self, bsz, in_features, out_features, rank):
+        super().__init__()
+        self._bound = 1.0 / math.sqrt(in_features)
+        self.A = nn.Parameter(
+            torch.empty(bsz, rank, in_features).uniform_(-self._bound, self._bound)
+        )
+        self.B = nn.Parameter(torch.zeros(bsz, out_features, rank))
+
+    def reset(self):
+        with torch.no_grad():
+            self.A.uniform_(-self._bound, self._bound)
+            self.B.zero_()
+
+    def forward(self, x):
+        return (x @ self.A.transpose(1, 2)) @ self.B.transpose(1, 2)
+
+
+class BatchedTTTLoRA(nn.Module):
+    def __init__(self, bsz, model, rank, k_lora=True, mlp_lora=True, o_lora=True):
+        super().__init__()
+        self.bsz = bsz
+        dim = model.qo_bank.shape[-1]
+        vocab = model.tok_emb.num_embeddings
+        if getattr(model, "looping_active", False):
+            num_slots = len(model.encoder_indices) + len(model.decoder_indices)
+        else:
+            num_slots = len(model.blocks)
+        kv_dim = model.blocks[0].attn.num_kv_heads * (
+            dim // model.blocks[0].attn.num_heads
+        )
+        embed_dim = model.tok_emb.embedding_dim
+        self.lm_head_lora = BatchedLinearLoRA(bsz, embed_dim, vocab, rank)
+        self.q_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+        )
+        self.v_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+        )
+        self.k_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+            )
+            if k_lora
+            else None
+        )
+        self.mlp_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if mlp_lora
+            else None
+        )
+        self.o_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if o_lora
+            else None
+        )
+
+    def reset(self):
+        with torch.no_grad():
+            self.lm_head_lora.reset()
+            for loras in [self.q_loras, self.v_loras, self.k_loras,
+                          self.mlp_loras, self.o_loras]:
+                if loras is not None:
+                    for lora in loras:
+                        lora.reset()
+
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps=10, eps=1e-07):
+    a, b, c = 3.4445, -4.775, 2.0315
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr,
+        momentum,
+        backend_steps,
+        nesterov=True,
+        weight_decay=0.0,
+        row_normalize=False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append({
+                    "p": p,
+                    "B": B,
+                    "padded_grad": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard_mom": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "full_update": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "scale": max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                })
+        self._bank_meta.sort(key=lambda m: -m["p"].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m["p"]
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m["padded_grad"]
+            pg[: m["B"]].copy_(p.grad.bfloat16())
+            if pg.shape[0] > m["B"]:
+                pg[m["B"] :].zero_()
+            fut = dist.reduce_scatter_tensor(
+                m["shard"], pg, op=dist.ReduceOp.AVG, async_op=True
+            )
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        if not self._built:
+            self._build()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+            row_normalize = group.get("row_normalize", False)
+            prev_ag_handle = None
+            prev_m = None
+            sharded = self._distributed and hasattr(self, "_rs_futures")
+            for idx, m in enumerate(self._bank_meta):
+                p = m["p"]
+                if p.grad is None:
+                    continue
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m["p"]
+                    upd = prev_m["full_update"][: prev_m["B"]]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+                if sharded and self._rs_futures[idx] is not None:
+                    self._rs_futures[idx].wait()
+                    g = m["shard"]
+                    buf = m["shard_mom"]
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+                if row_normalize:
+                    rn = update.float().norm(dim=-1, keepdim=True).clamp_min(1e-07)
+                    update = update / rn.to(update.dtype)
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m["full_update"], update, async_op=True
+                    )
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update.to(dtype=p.dtype), alpha=-lr * m["scale"])
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m["p"]
+                upd = prev_m["full_update"][: prev_m["B"]]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+            if hasattr(self, "_rs_futures"):
+                del self._rs_futures
+        return loss
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,parallel_post_lambdas,parallel_resid_lambdas",
+    ).split(",")
+    if pattern
+)
+
+
+PACKED_REPLICATED_GRAD_MAX_NUMEL = 1 << 15
+
+
+class Optimizers:
+    def __init__(self, h, base_model):
+        matrix_params = [
+            base_model.qo_bank,
+            base_model.kv_bank,
+            base_model.mlp_up_bank,
+            base_model.mlp_down_bank,
+        ]
+        block_named_params = list(base_model.blocks.named_parameters())
+        scalar_params = [
+            p
+            for (name, p) in block_named_params
+            if p.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        if base_model.skip_weights.numel() > 0:
+            scalar_params.append(base_model.skip_weights)
+        if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
+            scalar_params.append(base_model.skip_gates)
+        if base_model.parallel_post_lambdas is not None:
+            scalar_params.append(base_model.parallel_post_lambdas)
+        if base_model.parallel_resid_lambdas is not None:
+            scalar_params.append(base_model.parallel_resid_lambdas)
+        token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
+        tok_params = [
+            {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+        ]
+        self.optimizer_tok = torch.optim.AdamW(
+            tok_params,
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.embed_wd,
+            fused=True,
+        )
+        self.optimizer_muon = Muon(
+            matrix_params,
+            lr=h.matrix_lr,
+            momentum=h.muon_momentum,
+            backend_steps=h.muon_backend_steps,
+            weight_decay=h.muon_wd,
+            row_normalize=h.muon_row_normalize,
+        )
+        for group in self.optimizer_muon.param_groups:
+            group["base_lr"] = h.matrix_lr
+        self.optimizer_scalar = torch.optim.AdamW(
+            [{"params": scalar_params, "lr": h.scalar_lr, "base_lr": h.scalar_lr}],
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.adam_wd,
+            fused=True,
+        )
+        self.optimizers = [
+            self.optimizer_tok,
+            self.optimizer_muon,
+            self.optimizer_scalar,
+        ]
+        self.replicated_params = list(tok_params[0]["params"])
+        self.replicated_params.extend(scalar_params)
+        self.replicated_large_params = []
+        self.replicated_packed_params = []
+        for p in self.replicated_params:
+            if p.numel() <= PACKED_REPLICATED_GRAD_MAX_NUMEL:
+                self.replicated_packed_params.append(p)
+            else:
+                self.replicated_large_params.append(p)
+
+    def __iter__(self):
+        return iter(self.optimizers)
+
+    def zero_grad_all(self):
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    def _all_reduce_packed_grads(self):
+        grads_by_key = collections.defaultdict(list)
+        for p in self.replicated_packed_params:
+            if p.grad is not None:
+                grads_by_key[(p.grad.device, p.grad.dtype)].append(p.grad)
+        for grads in grads_by_key.values():
+            flat = torch.empty(
+                sum(g.numel() for g in grads),
+                device=grads[0].device,
+                dtype=grads[0].dtype,
+            )
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                flat[offset : offset + n].copy_(g.contiguous().view(-1))
+                offset += n
+            dist.all_reduce(flat, op=dist.ReduceOp.AVG)
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                g.copy_(flat[offset : offset + n].view_as(g))
+                offset += n
+
+    def step(self, distributed=False):
+        self.optimizer_muon.launch_reduce_scatters()
+        if distributed:
+            reduce_handles = [
+                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG, async_op=True)
+                for p in self.replicated_large_params
+                if p.grad is not None
+            ]
+            self._all_reduce_packed_grads()
+            for handle in reduce_handles:
+                handle.wait()
+        self.optimizer_tok.step()
+        self.optimizer_scalar.step()
+        self.optimizer_muon.step()
+        self.zero_grad_all()
+
+
+def restore_fp32_params(model):
+    for module in model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    for name, param in model.named_parameters():
+        if (
+            param.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ) and param.dtype != torch.float32:
+            param.data = param.data.float()
+    if hasattr(model, "qo_bank") and model.qo_bank is not None:
+        model.qo_bank.data = model.qo_bank.data.float()
+        model.kv_bank.data = model.kv_bank.data.float()
+    model.mlp_up_bank.data = model.mlp_up_bank.data.float()
+    model.mlp_down_bank.data = model.mlp_down_bank.data.float()
+
+
+def collect_hessians(model, train_loader, h, device, n_calibration_batches=64):
+    hessians = {}
+    hooks = []
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = True
+        block.mlp._calib = True
+        block.mlp.use_fused = False
+
+    def make_attn_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            for suffix in ["c_q", "c_k", "c_v"]:
+                name = f"blocks.{layer_idx}.attn.{suffix}.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            y = module._last_proj_input
+            if y is not None:
+                y = y.float()
+                if y.ndim == 3:
+                    y = y.reshape(-1, y.shape[-1])
+                name = f"blocks.{layer_idx}.attn.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        y.shape[1], y.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(y.T, y)
+        return hook_fn
+
+    def make_mlp_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            name = f"blocks.{layer_idx}.mlp.fc.weight"
+            if name not in hessians:
+                hessians[name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[name].addmm_(x.T, x)
+            h_act = module._last_down_input
+            if h_act is not None:
+                h_act = h_act.float()
+                if h_act.ndim == 3:
+                    h_act = h_act.reshape(-1, h_act.shape[-1])
+                name = f"blocks.{layer_idx}.mlp.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        h_act.shape[1], h_act.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(h_act.T, h_act)
+        return hook_fn
+
+    for i, block in enumerate(model.blocks):
+        hooks.append(block.attn.register_forward_hook(make_attn_hook(i)))
+        hooks.append(block.mlp.register_forward_hook(make_mlp_hook(i)))
+
+    # Hessian hooks for embedding factorization projection layers
+    def make_linear_input_hook(weight_name):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            if weight_name not in hessians:
+                hessians[weight_name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[weight_name].addmm_(x.T, x)
+        return hook_fn
+
+    if model.tie_embeddings:
+        hook_module = model.final_norm
+
+        def make_output_hook(name):
+            def hook_fn(module, inp, out):
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            return hook_fn
+
+        hooks.append(
+            hook_module.register_forward_hook(make_output_hook("tok_emb.weight"))
+        )
+    model.eval()
+    with torch.no_grad():
+        for _ in range(n_calibration_batches):
+            x, _ = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+            model.forward_logits(x)
+    for hook in hooks:
+        hook.remove()
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = False
+        block.mlp._calib = False
+        block.mlp.use_fused = True
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / n_calibration_batches
+    return hessians
+
+
+def gptq_quantize_weight(w, H, clip_sigmas=3.0, clip_range=63, block_size=128):
+    W_orig = w.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * H.diag().mean()
+    H.diagonal().add_(damp)
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+    Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    row_std = W_orig.std(dim=1)
+    s = (clip_sigmas * row_std / clip_range).clamp_min(1e-10).to(torch.float16)
+    sf = s.float()
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    W_work = W_perm.clone()
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W_work[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros(rows, i2 - i1)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            d = Hinv_block[j, j]
+            q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - q_col.float() * sf) / d
+            Err[:, j] = err
+            W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+        if i2 < cols:
+            W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+    return Q[:, invperm], s
+
+
+def gptq_mixed_quantize(state_dict, hessians, h):
+    result = {}
+    meta = {}
+    for (name, tensor) in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough (float16)"
+            continue
+        if "tok_emb" in name:
+            cs = h.embed_clip_sigmas
+        elif ".mlp." in name:
+            cs = h.mlp_clip_sigmas
+        elif ".attn." in name:
+            cs = h.attn_clip_sigmas
+        else:
+            cs = h.matrix_clip_sigmas
+        bits = h.embed_bits if "tok_emb" in name else h.matrix_bits
+        clip_range = 2 ** (bits - 1) - 1
+        ret = gptq_quantize_weight(
+            t, hessians[name], clip_sigmas=cs, clip_range=clip_range
+        )
+        q, s = ret
+        result[name + ".q"] = q
+        result[name + ".scale"] = s
+        meta[name] = f"gptq (int{bits})"
+    categories = collections.defaultdict(set)
+    for (name, cat) in meta.items():
+        short = re.sub("\\.\\d+$", "", re.sub("blocks\\.\\d+", "blocks", name))
+        categories[cat].add(short)
+    log("Quantized weights:")
+    for cat in sorted(categories):
+        log(f"  {cat}: {', '.join(sorted(categories[cat]))}")
+    return result, meta
+
+
+def dequantize_mixed(result, meta, template_sd):
+    out = {}
+    for (name, orig) in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if "passthrough" in info:
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (
+                q.float() * s.float().view(q.shape[0], *[1] * (q.ndim - 1))
+            ).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+_BSHF_MAGIC = b"BSHF"
+
+
+def _byte_shuffle(data, stride=2):
+    if stride <= 1 or len(data) < stride:
+        return data
+    src = np.frombuffer(data, dtype=np.uint8)
+    n = len(src)
+    out = np.empty(n, dtype=np.uint8)
+    dest_off = 0
+    for pos in range(stride):
+        chunk = src[pos::stride]
+        out[dest_off : dest_off + len(chunk)] = chunk
+        dest_off += len(chunk)
+    return _BSHF_MAGIC + bytes([stride]) + out.tobytes()
+
+
+def _byte_unshuffle(data):
+    if len(data) < 5 or data[:4] != _BSHF_MAGIC:
+        return data
+    stride = data[4]
+    if stride < 2:
+        return data[5:]
+    payload = np.frombuffer(data, dtype=np.uint8, offset=5)
+    n = len(payload)
+    out = np.empty(n, dtype=np.uint8)
+    src_off = 0
+    for pos in range(stride):
+        chunk_len = n // stride + (1 if pos < n % stride else 0)
+        out[pos::stride][:chunk_len] = payload[src_off : src_off + chunk_len]
+        src_off += chunk_len
+    return out.tobytes()
+
+
+def _compress(data, compressor):
+    data = _byte_shuffle(data)
+    if compressor == "lzma":
+        return lzma.compress(data, preset=6)
+    elif compressor == "brotli":
+        import brotli
+
+        return brotli.compress(data, quality=11)
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def _decompress(data, compressor):
+    if compressor == "lzma":
+        raw = lzma.decompress(data)
+    elif compressor == "brotli":
+        import brotli
+
+        raw = brotli.decompress(data)
+    else:
+        raise ValueError(f"Unknown compressor: {compressor!r}")
+    raw = _byte_unshuffle(raw)
+    return raw
+
+
+def _unbank_state_dict(state_dict, num_layers):
+    sd = {}
+    n = num_layers
+    for k, v in state_dict.items():
+        t = v.detach().cpu() if v is not None else None
+        if k == "qo_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_q.weight"] = t[i]
+                sd[f"blocks.{i}.attn.proj.weight"] = t[n + i]
+        elif k == "kv_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_k.weight"] = t[i]
+                sd[f"blocks.{i}.attn.c_v.weight"] = t[n + i]
+        elif k == "mlp_up_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.fc.weight"] = t[i]
+        elif k == "mlp_down_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.proj.weight"] = t[i]
+        else:
+            if t is not None:
+                sd[k] = t
+    return sd
+
+
+def _rebank_state_dict(flat_sd, num_layers, model_dim, kv_dim, hidden_dim):
+    sd = {}
+    n = num_layers
+    sd["qo_bank"] = torch.zeros(2 * n, model_dim, model_dim)
+    sd["kv_bank"] = torch.zeros(2 * n, kv_dim, model_dim)
+    for i in range(n):
+        sd["qo_bank"][i] = flat_sd[f"blocks.{i}.attn.c_q.weight"]
+        sd["qo_bank"][n + i] = flat_sd[f"blocks.{i}.attn.proj.weight"]
+        sd["kv_bank"][i] = flat_sd[f"blocks.{i}.attn.c_k.weight"]
+        sd["kv_bank"][n + i] = flat_sd[f"blocks.{i}.attn.c_v.weight"]
+    sd["mlp_up_bank"] = torch.zeros(n, hidden_dim, model_dim)
+    sd["mlp_down_bank"] = torch.zeros(n, model_dim, hidden_dim)
+    for i in range(n):
+        sd["mlp_up_bank"][i] = flat_sd[f"blocks.{i}.mlp.fc.weight"]
+        sd["mlp_down_bank"][i] = flat_sd[f"blocks.{i}.mlp.proj.weight"]
+    for k, v in flat_sd.items():
+        if not (
+            k.startswith("blocks.")
+            and any(
+                p in k
+                for p in [
+                    ".attn.c_q.", ".attn.c_k.", ".attn.c_v.",
+                    ".attn.proj.", ".mlp.fc.", ".mlp.proj.",
+                ]
+            )
+        ):
+            sd[k] = v
+    return sd
+
+
+
+def _compressed_code_size(code):
+    code_raw = code.encode("utf-8")
+    try:
+        minified = subprocess.run(
+            ["pyminify", "--no-rename-locals", "--no-hoist-literals", "--remove-literal-statements", "-"],
+            input=code_raw, capture_output=True, check=True,
+        ).stdout
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        minified = code_raw
+    compressed = lzma.compress(minified)
+    encoded = base64.b85encode(compressed)
+    wrapper = b'import lzma as L,base64 as B\nexec(L.decompress(B.b85decode("' + encoded + b'")))\n'
+    return len(code_raw), len(wrapper)
+
+
+def serialize(h, base_model, code):
+    code_bytes_uncompressed, code_bytes = _compressed_code_size(code)
+    if h.is_main_process:
+        torch.save(base_model.state_dict(), h.model_path)
+        model_bytes = os.path.getsize(h.model_path)
+        log(f"Serialized model: {model_bytes} bytes")
+        log(f"Code size (uncompressed): {code_bytes_uncompressed} bytes")
+        log(f"Code size (compressed): {code_bytes} bytes")
+    sd_cpu = _unbank_state_dict(base_model.state_dict(), h.num_layers)
+    device = torch.device("cuda", h.local_rank)
+    log("GPTQ:collecting Hessians from calibration data...")
+    t0 = time.perf_counter()
+    calib_loader = ShuffledSequenceLoader(h, device)
+    hessians = collect_hessians(
+        base_model,
+        calib_loader,
+        h,
+        device,
+        n_calibration_batches=h.gptq_calibration_batches,
+    )
+    log(f"GPTQ:collected {len(hessians)} Hessians in {time.perf_counter()-t0:.1f}s")
+    quant_result, quant_meta = gptq_mixed_quantize(sd_cpu, hessians, h)
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = _compress(quant_raw, h.compressor)
+    quant_file_bytes = len(quant_blob)
+    bytes_total = quant_file_bytes + code_bytes
+    if h.is_main_process:
+        with open(h.quantized_model_path, "wb") as f:
+            f.write(quant_blob)
+        log(f"Serialized model quantized+{h.compressor}: {quant_file_bytes} bytes")
+        log(f"Total submission size quantized+{h.compressor}: {bytes_total} bytes")
+    return bytes_total, quant_file_bytes
+
+
+def deserialize(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    flat_template = _unbank_state_dict(eval_model.state_dict(), h.num_layers)
+    with open(h.quantized_model_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(_decompress(quant_blob_disk, h.compressor)), map_location="cpu"
+    )
+    deq_flat = dequantize_mixed(quant_state["w"], quant_state["m"], flat_template)
+    head_dim = h.model_dim // h.num_heads
+    kv_dim = h.num_kv_heads * head_dim
+    hidden_dim = int(h.mlp_mult * h.model_dim)
+    deq_state = _rebank_state_dict(deq_flat, h.num_layers, h.model_dim, kv_dim, hidden_dim)
+    eval_model.load_state_dict(deq_state, strict=True)
+    return eval_model
+
+
+def _loss_bpb(loss_sum, token_count, byte_count):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    return val_loss, val_bpb
+
+
+def eval_val(h, device, val_data, model, forward_logits_fn=None):
+    seq_len = h.eval_seq_len
+    local_batch_tokens = h.val_batch_tokens // (h.world_size * h.grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            f"VAL_BATCH_SIZE must provide at least one sequence per rank; got VAL_BATCH_SIZE={h.val_batch_tokens}, WORLD_SIZE={h.world_size}, GRAD_ACCUM_STEPS={h.grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = total_seqs * h.rank // h.world_size
+    seq_end = total_seqs * (h.rank + 1) // h.world_size
+
+    # TODO: Don't truncate this.
+    seq_end = seq_start + ((seq_end - seq_start) // local_batch_seqs) * local_batch_seqs
+
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    run_forward_logits = (
+        (model.module.forward_logits if hasattr(model, "module") else model.forward_logits)
+        if forward_logits_fn is None
+        else forward_logits_fn
+    )
+    model.eval()
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    with torch.no_grad():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_data.val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1]
+            y = local[1:]
+            bos_pos = (x == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                bos_pos, x.numel(), x.device, h.eval_seq_len, 64
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = run_forward_logits(
+                    x[None], cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                ).detach()
+            per_token_loss = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y.reshape(-1),
+                reduction="none",
+            )
+            val_loss_sum += per_token_loss.to(torch.float64).sum()
+            val_token_count += float(y.numel())
+            if val_data.val_token_bytes is not None:
+                token_bytes = val_data.val_token_bytes[raw_start + 1 : raw_end].to(
+                    device=device, dtype=torch.float64, non_blocking=True
+                ).reshape_as(y)
+                val_byte_count += token_bytes.sum()
+            else:
+                prev_ids = x
+                tgt_ids = y
+                token_bytes = val_data.base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                token_bytes += (
+                    val_data.has_leading_space_lut[tgt_ids]
+                    & ~val_data.is_boundary_token_lut[prev_ids]
+                ).to(dtype=torch.int16)
+                val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    model.train()
+    return _loss_bpb(val_loss_sum, val_token_count, val_byte_count)
+
+
+def eval_val_sliding(h, device, val_data, base_model, forward_logits_fn=None, batch_seqs=32):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    run_forward_logits = base_model.forward_logits if forward_logits_fn is None else forward_logits_fn
+    seq_len = h.eval_seq_len
+    stride = h.eval_stride
+    total_tokens = val_data.val_tokens.numel() - 1
+    context_size = seq_len - stride
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if ws + context_size < total_tokens]
+    total_windows = len(window_starts)
+    my_s = (total_windows * h.rank) // h.world_size
+    my_e = (total_windows * (h.rank + 1)) // h.world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    total_batches = (len(my_windows) + batch_seqs - 1) // batch_seqs
+    is_master = h.rank == 0
+    cu_bucket = 64
+    t_sw_start = time.perf_counter()
+    with torch.no_grad():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_idx = bi // batch_seqs
+            if is_master and (batch_idx % 50 == 0 or batch_idx == total_batches - 1):
+                elapsed = time.perf_counter() - t_sw_start
+                rl = float(loss_sum.item() / token_count.item()) if token_count.item() > 0 else 0.0
+                rb = float((rl / math.log(2.0)) * token_count.item() / byte_count.item()) if byte_count.item() > 0 else 0.0
+                log(f"sliding_progress: batch {batch_idx+1}/{total_batches} "
+                    f"tokens:{int(token_count.item())} running_loss:{rl:.4f} running_bpb:{rb:.4f} "
+                    f"elapsed:{elapsed:.1f}s")
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            x_parts = []
+            y_parts = []
+            cu_starts = []
+            score_ranges = []
+            offset = 0
+            for ws in batch_ws:
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                chunk_cpu = val_data.val_tokens[ws:end + 1]
+                bos_pos = (chunk_cpu[:-1] == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+                if not bos_pos or bos_pos[0] != 0:
+                    bos_pos = [0] + bos_pos
+                cu_starts.extend(offset + pos for pos in bos_pos)
+                chunk = chunk_cpu.to(dtype=torch.int64, device=device)
+                x_parts.append(chunk[:-1])
+                y_parts.append(chunk[1:])
+                score_ranges.append((offset, wlen, ws))
+                offset += wlen
+            x_cat = torch.cat(x_parts, dim=0)[None]
+            y_cat = torch.cat(y_parts, dim=0)
+            boundaries = cu_starts + [offset]
+            padded_len = get_next_multiple_of_n(len(boundaries), cu_bucket)
+            cu_seqlens = torch.full((padded_len,), offset, dtype=torch.int32, device=device)
+            cu_seqlens[:len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = run_forward_logits(x_cat, cu_seqlens=cu_seqlens, max_seqlen=seq_len)
+            flat_nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_cat,
+                reduction="none",
+            )
+            flat_x = x_cat.reshape(-1)
+            for off, wlen, ws in score_ranges:
+                s = 0 if ws == 0 else context_size
+                lo = off + s
+                hi = off + wlen
+                scored_nll = flat_nll[lo:hi].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(hi - lo)
+                if val_data.val_token_bytes is not None:
+                    tb = val_data.val_token_bytes[ws + s + 1 : ws + wlen + 1].to(
+                        device=device, dtype=torch.float64, non_blocking=True
+                    )
+                    byte_count += tb.sum()
+                else:
+                    tgt = y_cat[lo:hi]
+                    prev = flat_x[lo:hi]
+                    tb = val_data.base_bytes_lut[tgt].to(torch.float64)
+                    tb += (val_data.has_leading_space_lut[tgt] & ~val_data.is_boundary_token_lut[prev]).to(torch.float64)
+                    byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    base_model.train()
+    return _loss_bpb(loss_sum, token_count, byte_count)
+
+
+def _find_docs(all_tokens):
+    bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0].numpy()
+    docs = []
+    for i in range(len(bos_positions)):
+        start = int(bos_positions[i])
+        end = (
+            int(bos_positions[i + 1])
+            if i + 1 < len(bos_positions)
+            else all_tokens.numel()
+        )
+        if i + 1 < len(bos_positions):
+            end += 1
+        assert end - start >= 2
+        docs.append((start, end - start))
+    return docs
+
+
+def _build_ttt_global_batches(doc_entries, h, ascending=False):
+    batch_size = h.ttt_batch_size
+    global_doc_entries = sorted(doc_entries, key=lambda x: x[1][1])
+    global_batches = [
+        global_doc_entries[i : i + batch_size]
+        for i in range(0, len(global_doc_entries), batch_size)
+    ]
+    indexed = list(enumerate(global_batches))
+    if not ascending:
+        indexed.sort(key=lambda ib: -max(dl for _, (_, dl) in ib[1]))
+    return indexed
+
+
+def _init_batch_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(4, "little"))
+
+
+def _claim_next_batch(counter_path, queue_len):
+    try:
+        with open(counter_path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            idx = int.from_bytes(f.read(4), "little")
+            f.seek(0)
+            f.write((idx + 1).to_bytes(4, "little"))
+            f.flush()
+    except FileNotFoundError:
+        return queue_len
+    return idx
+
+
+def _compute_chunk_window(ci, pred_len, num_chunks, chunk_size, eval_seq_len):
+    chunk_end = pred_len if ci == num_chunks - 1 else (ci + 1) * chunk_size
+    win_start = max(0, chunk_end - eval_seq_len)
+    win_len = chunk_end - win_start
+    chunk_start = ci * chunk_size
+    chunk_offset = chunk_start - win_start
+    chunk_len = chunk_end - chunk_start
+    return win_start, win_len, chunk_offset, chunk_len
+
+
+def _accumulate_bpb(
+    ptl,
+    x,
+    y,
+    chunk_offsets,
+    chunk_lens,
+    pos_idx,
+    base_bytes_lut,
+    has_leading_space_lut,
+    is_boundary_token_lut,
+    token_bytes_override,
+    loss_sum,
+    byte_sum,
+    token_count,
+):
+    pos = pos_idx[: x.size(1)].unsqueeze(0)
+    mask = (
+        (chunk_lens.unsqueeze(1) > 0)
+        & (pos >= chunk_offsets.unsqueeze(1))
+        & (pos < (chunk_offsets + chunk_lens).unsqueeze(1))
+    )
+    mask_f64 = mask.to(torch.float64)
+    if token_bytes_override is not None:
+        tok_bytes = token_bytes_override
+    else:
+        tok_bytes = base_bytes_lut[y].to(torch.float64)
+        tok_bytes += (has_leading_space_lut[y] & ~is_boundary_token_lut[x]).to(
+            torch.float64
+        )
+    loss_sum += (ptl.to(torch.float64) * mask_f64).sum()
+    byte_sum += (tok_bytes * mask_f64).sum()
+    token_count += chunk_lens.to(torch.float64).sum()
+
+
+def _loss_bpb_from_sums(loss_sum, token_count, byte_sum):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_sum.item())
+    return val_loss, val_bpb
+
+
+def _split_doc_entries_for_phased(doc_entries, prefix_docs):
+    prefix_docs = max(0, min(len(doc_entries), int(prefix_docs)))
+    return doc_entries[:prefix_docs], doc_entries[prefix_docs:]
+
+
+def _add_to_counter(path, delta):
+    try:
+        with open(path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            cur = int.from_bytes(f.read(8), "little", signed=True)
+            cur += int(delta)
+            f.seek(0)
+            f.write(int(cur).to_bytes(8, "little", signed=True))
+            f.flush()
+            return cur
+    except FileNotFoundError:
+        return int(delta)
+
+
+def _init_int64_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(8, "little", signed=True))
+
+
+def _select_ttt_doc_entries(docs, h):
+    doc_entries = list(enumerate(docs))
+    if h.val_doc_fraction < 1.0:
+        sample_n = max(1, int(round(len(docs) * h.val_doc_fraction)))
+        sampled_indices = sorted(
+            random.Random(h.seed).sample(range(len(docs)), sample_n)
+        )
+        return [(i, docs[i]) for i in sampled_indices]
+    return doc_entries
+
+
+def train_val_ttt_global_sgd_distributed(h, device, val_data, base_model, val_tokens, batch_seqs=None):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    seq_len = h.eval_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = h.global_ttt_chunk_tokens
+    batch_seqs = h.global_ttt_batch_seqs if batch_seqs is None else batch_seqs
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    ttt_params = [p for p in base_model.parameters()]
+    for p in ttt_params:
+        p.requires_grad_(True)
+    optimizer = torch.optim.SGD(
+        ttt_params, lr=h.global_ttt_lr, momentum=h.global_ttt_momentum
+    )
+    t_start = time.perf_counter()
+    for ci in range(num_chunks):
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+        is_last_chunk = ci == num_chunks - 1
+        if is_last_chunk or h.global_ttt_epochs <= 0:
+            continue
+        base_model.train()
+        chunk_seqs = (chunk_end - chunk_start) // seq_len
+        if chunk_seqs <= 0:
+            continue
+        warmup_chunks = max(0, min(h.global_ttt_warmup_chunks, num_chunks - 1))
+        if warmup_chunks > 0 and ci < warmup_chunks:
+            warmup_denom = max(warmup_chunks - 1, 1)
+            warmup_t = ci / warmup_denom
+            lr_now = (
+                h.global_ttt_warmup_start_lr
+                + (h.global_ttt_lr - h.global_ttt_warmup_start_lr) * warmup_t
+            )
+        else:
+            decay_steps = max(num_chunks - 1 - warmup_chunks, 1)
+            decay_ci = max(ci - warmup_chunks, 0)
+            lr_now = h.global_ttt_lr * 0.5 * (
+                1.0 + math.cos(math.pi * decay_ci / decay_steps)
+            )
+        for pg in optimizer.param_groups:
+            pg["lr"] = lr_now
+        my_seq_s = chunk_seqs * h.rank // h.world_size
+        my_seq_e = chunk_seqs * (h.rank + 1) // h.world_size
+        my_chunk_seqs = my_seq_e - my_seq_s
+        for _ in range(h.global_ttt_epochs):
+            for bs in range(0, my_chunk_seqs, batch_seqs):
+                be = min(bs + batch_seqs, my_chunk_seqs)
+                actual_bs = my_seq_s + bs
+                start_tok = chunk_start + actual_bs * seq_len
+                end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                if end_tok > val_tokens.numel():
+                    continue
+                local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                x_flat = local[:-1]
+                y_flat = local[1:]
+                optimizer.zero_grad(set_to_none=True)
+                with torch.enable_grad():
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        if h.global_ttt_respect_doc_boundaries:
+                            bos_pos = (x_flat == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+                            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                                bos_pos, x_flat.numel(), x_flat.device, h.eval_seq_len, 64
+                            )
+                            loss = base_model(
+                                x_flat[None],
+                                y_flat[None],
+                                cu_seqlens=cu_seqlens,
+                                max_seqlen=max_seqlen,
+                            )
+                        else:
+                            x = x_flat.reshape(-1, seq_len)
+                            y = y_flat.reshape(-1, seq_len)
+                            loss = base_model(x, y)
+                loss.backward()
+                if dist.is_available() and dist.is_initialized():
+                    for p in ttt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+                            p.grad.mul_(1.0 / h.world_size)
+                if h.global_ttt_grad_clip > 0:
+                    torch.nn.utils.clip_grad_norm_(ttt_params, h.global_ttt_grad_clip)
+                optimizer.step()
+        base_model.eval()
+        if h.rank == 0:
+            elapsed = time.perf_counter() - t_start
+            log(
+                f"tttg: c{ci+1}/{num_chunks} lr:{lr_now:.6f} t:{elapsed:.1f}s"
+            )
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+
+def eval_val_ttt_phased(h, base_model, device, val_data, forward_ttt_train):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+    all_tokens = val_data.val_tokens
+    all_tokens_idx = all_tokens.to(torch.int32)
+    docs = _find_docs(all_tokens)
+    doc_entries = _select_ttt_doc_entries(docs, h)
+    prefix_doc_limit = max(0, min(len(doc_entries), int(h.phased_ttt_prefix_docs)))
+    num_phases = max(1, int(h.phased_ttt_num_phases))
+    phase_boundaries = []
+    for pi in range(num_phases):
+        boundary = prefix_doc_limit * (pi + 1) // num_phases
+        phase_boundaries.append(boundary)
+    current_phase = 0
+    current_phase_boundary = phase_boundaries[0]
+    log(
+        "ttt_phased:"
+        f" total_docs:{len(doc_entries)} prefix_docs:{prefix_doc_limit} "
+        f"suffix_docs:{len(doc_entries) - prefix_doc_limit}"
+        f" num_phases:{num_phases} boundaries:{phase_boundaries}"
+    )
+    chunk_size, eval_seq_len = h.ttt_chunk_size, h.ttt_eval_seq_len
+    eval_batch_set = None
+    if h.ttt_eval_batches:
+        eval_batch_set = set(int(x) for x in h.ttt_eval_batches.split(",") if x.strip())
+    use_ascending = eval_batch_set is not None
+    global_batches_sorted = _build_ttt_global_batches(
+        doc_entries, h, ascending=use_ascending
+    )
+    queue_len = len(global_batches_sorted)
+    counter_path = f"/tmp/ttt_counter_{h.run_id}"
+    prefix_counter_path = f"/tmp/ttt_prefix_counter_{h.run_id}"
+    pause_flag_path = f"/tmp/ttt_pause_flag_{h.run_id}"
+    if h.rank == 0:
+        _init_batch_counter(counter_path)
+        _init_int64_counter(prefix_counter_path)
+        try:
+            os.remove(pause_flag_path)
+        except FileNotFoundError:
+            pass
+    if dist.is_available() and dist.is_initialized():
+        path_list = [counter_path, prefix_counter_path, pause_flag_path]
+        dist.broadcast_object_list(path_list, src=0)
+        counter_path, prefix_counter_path, pause_flag_path = path_list
+        dist.barrier()
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    t_start = time.perf_counter()
+    reusable_lora = BatchedTTTLoRA(
+        h.ttt_batch_size, base_model, h.ttt_lora_rank,
+        k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+    ).to(device)
+
+    def _build_opt(lora):
+        if h.ttt_optimizer == "sgd":
+            return torch.optim.SGD(
+                lora.parameters(), lr=h.ttt_lora_lr,
+                momentum=h.ttt_beta1, weight_decay=h.ttt_weight_decay,
+            )
+        return torch.optim.AdamW(
+            lora.parameters(), lr=h.ttt_lora_lr,
+            betas=(h.ttt_beta1, h.ttt_beta2),
+            eps=1e-10, weight_decay=h.ttt_weight_decay, fused=True,
+        )
+
+    reusable_opt = _build_opt(reusable_lora)
+    local_scored_docs = []
+    global_ttt_done = prefix_doc_limit == 0
+    try:
+      while True:
+        queue_idx = _claim_next_batch(counter_path, queue_len)
+        if queue_idx >= queue_len:
+            break
+        orig_batch_idx, batch_entries = global_batches_sorted[queue_idx]
+        batch = [doc for _, doc in batch_entries]
+        bsz = len(batch)
+        prev_loss = loss_sum.item()
+        prev_bytes = byte_sum.item()
+        prev_tokens = token_count.item()
+        if bsz == reusable_lora.bsz:
+            reusable_lora.reset()
+            for s in reusable_opt.state.values():
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor):
+                        v.zero_()
+                    elif k == "step":
+                        s[k] = 0
+            cur_lora = reusable_lora
+            cur_opt = reusable_opt
+        else:
+            cur_lora = BatchedTTTLoRA(
+                bsz, base_model, h.ttt_lora_rank,
+                k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+            ).to(device)
+            cur_opt = _build_opt(cur_lora)
+        pred_lens = [doc_len - 1 for _, doc_len in batch]
+        num_chunks = [(pl + chunk_size - 1) // chunk_size for pl in pred_lens]
+        max_nc = max(num_chunks)
+        num_chunks_t = torch.tensor(num_chunks, dtype=torch.int64, device=device)
+        for ci in range(max_nc):
+            active = [ci < nc for nc in num_chunks]
+            needs_train = any(ci < nc - 1 for nc in num_chunks)
+            tok_starts = torch.zeros(bsz, dtype=torch.int64)
+            tok_wls = torch.zeros(bsz, dtype=torch.int64)
+            chunk_offsets_cpu = torch.zeros(bsz, dtype=torch.int64)
+            chunk_lens_cpu = torch.zeros(bsz, dtype=torch.int64)
+            for b in range(bsz):
+                if not active[b]:
+                    continue
+                doc_start, doc_len = batch[b]
+                win_start, win_len, chunk_offset, chunk_len = _compute_chunk_window(
+                    ci, pred_lens[b], num_chunks[b], chunk_size, eval_seq_len
+                )
+                tok_starts[b] = doc_start + win_start
+                tok_wls[b] = win_len
+                chunk_offsets_cpu[b] = chunk_offset
+                chunk_lens_cpu[b] = chunk_len
+            _, context_size, chunk_offset, _ = _compute_chunk_window(
+                ci, (ci + 1) * chunk_size, ci + 1, chunk_size, eval_seq_len
+            )
+            col_idx = torch.arange(context_size + 1)
+            idx = tok_starts.unsqueeze(1) + col_idx.unsqueeze(0)
+            idx.clamp_(max=all_tokens.numel() - 1)
+            gathered_gpu = all_tokens_idx[idx].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            token_bytes_override = None
+            if val_data.val_token_bytes is not None:
+                token_bytes_override = val_data.val_token_bytes[idx[:, 1 : context_size + 1]].to(
+                    device=device, dtype=torch.float64, non_blocking=True
+                )
+            valid = (col_idx[:context_size].unsqueeze(0) < tok_wls.unsqueeze(1)).to(
+                device, non_blocking=True
+            )
+            chunk_offsets = chunk_offsets_cpu.to(device, non_blocking=True)
+            chunk_lens = chunk_lens_cpu.to(device, non_blocking=True)
+            x = torch.where(valid, gathered_gpu[:, :context_size], 0)
+            y = torch.where(valid, gathered_gpu[:, 1 : context_size + 1], 0)
+            ctx_pos = torch.arange(context_size, device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+            with torch.no_grad():
+                _accumulate_bpb(
+                    per_tok_loss,
+                    x,
+                    y,
+                    chunk_offsets,
+                    chunk_lens,
+                    ctx_pos,
+                    val_data.base_bytes_lut,
+                    val_data.has_leading_space_lut,
+                    val_data.is_boundary_token_lut,
+                    token_bytes_override,
+                    loss_sum,
+                    byte_sum,
+                    token_count,
+                )
+            if needs_train:
+                activate_chunk_mask = (num_chunks_t - 1 > ci).float()
+                for gi in range(h.ttt_grad_steps):
+                    if gi > 0:
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+                    per_doc = per_tok_loss[
+                        :, chunk_offset : chunk_offset + chunk_size
+                    ].mean(dim=-1)
+                    cur_opt.zero_grad(set_to_none=True)
+                    (per_doc * activate_chunk_mask).sum().backward()
+                    cur_opt.step()
+            else:
+                del per_tok_loss
+        batch_num = orig_batch_idx + 1
+        doc_lens = [dl for _, dl in batch]
+        should_report = batch_num in eval_batch_set if eval_batch_set is not None else True
+        if should_report:
+            cur_tokens = token_count.item()
+            cur_loss_val = loss_sum.item()
+            cur_bytes_val = byte_sum.item()
+            dt = cur_tokens - prev_tokens
+            db = cur_bytes_val - prev_bytes
+            if dt > 0 and db > 0:
+                b_loss = (cur_loss_val - prev_loss) / dt
+                b_bpb = b_loss / math.log(2.0) * (dt / db)
+            else:
+                b_loss = b_bpb = 0.0
+            r_loss = cur_loss_val / max(cur_tokens, 1)
+            r_bpb = r_loss / math.log(2.0) * (cur_tokens / max(cur_bytes_val, 1))
+            elapsed = time.perf_counter() - t_start
+            log(
+                f"ttp: b{batch_num}/{queue_len} bl:{b_loss:.4f} bb:{b_bpb:.4f} "
+                f"rl:{r_loss:.4f} rb:{r_bpb:.4f} dl:{min(doc_lens)}-{max(doc_lens)} "
+                f"gd:{int(global_ttt_done)}"
+            )
+        if not global_ttt_done:
+            local_scored_docs.extend(
+                (orig_batch_idx, pos, doc_start, doc_len)
+                for pos, (doc_start, doc_len) in enumerate(batch)
+            )
+            prefix_done = _add_to_counter(prefix_counter_path, len(batch_entries))
+            if prefix_done >= current_phase_boundary:
+                try:
+                    with open(pause_flag_path, "x"):
+                        pass
+                except FileExistsError:
+                    pass
+            should_pause = os.path.exists(pause_flag_path)
+            if should_pause:
+                if dist.is_available() and dist.is_initialized():
+                    dist.barrier()
+                gathered_scored_docs = [None] * h.world_size
+                if dist.is_available() and dist.is_initialized():
+                    dist.all_gather_object(gathered_scored_docs, local_scored_docs)
+                else:
+                    gathered_scored_docs = [local_scored_docs]
+                scored_docs_for_global = []
+                for rank_docs in gathered_scored_docs:
+                    if rank_docs:
+                        scored_docs_for_global.extend(rank_docs)
+                scored_docs_for_global.sort(key=lambda x: (x[0], x[1]))
+                scored_docs_for_global = scored_docs_for_global[:current_phase_boundary]
+                scored_token_chunks = [
+                    val_data.val_tokens[doc_start : doc_start + doc_len]
+                    for _, _, doc_start, doc_len in scored_docs_for_global
+                ]
+                if scored_token_chunks:
+                    global_ttt_tokens = torch.cat(scored_token_chunks)
+                else:
+                    global_ttt_tokens = val_data.val_tokens[:0]
+                if h.rank == 0:
+                    prefix_done = 0
+                    try:
+                        with open(prefix_counter_path, "rb") as f:
+                            prefix_done = int.from_bytes(
+                                f.read(8), "little", signed=True
+                            )
+                    except FileNotFoundError:
+                        pass
+                    log(
+                        f"ttpp: phase:{current_phase + 1}/{num_phases} pd:{prefix_done} "
+                        f"gd:{len(scored_docs_for_global)} "
+                        f"t:{time.perf_counter() - t_start:.1f}s"
+                    )
+                train_val_ttt_global_sgd_distributed(
+                    h, device, val_data, base_model, global_ttt_tokens
+                )
+                for p in base_model.parameters():
+                    p.requires_grad_(False)
+                reusable_lora = BatchedTTTLoRA(
+                    h.ttt_batch_size, base_model, h.ttt_lora_rank,
+                    k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+                ).to(device)
+                reusable_opt = _build_opt(reusable_lora)
+                current_phase += 1
+                if current_phase >= num_phases:
+                    global_ttt_done = True
+                else:
+                    current_phase_boundary = phase_boundaries[current_phase]
+                    if h.rank == 0:
+                        try:
+                            os.remove(pause_flag_path)
+                        except FileNotFoundError:
+                            pass
+                if dist.is_available() and dist.is_initialized():
+                    dist.barrier()
+                if h.rank == 0:
+                    log(f"ttpr: phase:{current_phase}/{num_phases} t:{time.perf_counter() - t_start:.1f}s")
+        del cur_lora, cur_opt
+    finally:
+        pass
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.train()
+    return _loss_bpb_from_sums(loss_sum, token_count, byte_sum)
+
+
+def timed_eval(label, fn, *args, **kwargs):
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    val_loss, val_bpb = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    elapsed_ms = 1e3 * (time.perf_counter() - t0)
+    log(
+        f"{label} val_loss:{val_loss:.8f} val_bpb:{val_bpb:.8f} eval_time:{elapsed_ms:.0f}ms"
+    )
+    return val_loss, val_bpb
+
+
+def train_model(h, device, val_data):
+    base_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        base_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    model = compiled_model
+    log(f"model_params:{sum(p.numel()for p in base_model.parameters())}")
+    optimizers = Optimizers(h, base_model)
+    train_loader = DocumentPackingLoader(h, device)
+    max_wallclock_ms = (
+        1e3 * h.max_wallclock_seconds if h.max_wallclock_seconds > 0 else None
+    )
+    if max_wallclock_ms is not None:
+        max_wallclock_ms -= h.gptq_reserve_seconds * 1e3
+        log(
+            f"gptq:reserving {h.gptq_reserve_seconds:.0f}s, effective={max_wallclock_ms:.0f}ms"
+        )
+
+    def training_frac(step, elapsed_ms):
+        if max_wallclock_ms is None:
+            return step / max(h.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-09)
+
+    def lr_mul(frac):
+        if h.warmdown_frac <= 0:
+            return 1.0
+        if frac >= 1.0 - h.warmdown_frac:
+            return max((1.0 - frac) / h.warmdown_frac, h.min_lr)
+        return 1.0
+
+    def wd_mul(frac):
+        start = min(max(h.wd_taper_start_frac, 0.0), 1.0)
+        final_mult = max(h.wd_taper_final_mult, 0.0)
+        if frac <= start or start >= 1.0:
+            return 1.0
+        progress = min(max((frac - start) / max(1.0 - start, 1e-9), 0.0), 1.0)
+        return 1.0 + (final_mult - 1.0) * progress
+
+    def step_fn(step, lr_scale, wd_scale):
+        optimizers.zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(h.grad_accum_steps):
+            x, y, cu_seqlens, _max_seqlen = train_loader.next_batch(
+                h.train_batch_tokens, h.grad_accum_steps
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y, cu_seqlens=cu_seqlens, max_seqlen=h.train_seq_len)
+            train_loss += loss.detach()
+            (loss / h.grad_accum_steps).backward()
+        train_loss /= h.grad_accum_steps
+        frac = (
+            min(step / h.muon_momentum_warmup_steps, 1.0)
+            if h.muon_momentum_warmup_steps > 0
+            else 1.0
+        )
+        muon_momentum = (
+            1 - frac
+        ) * h.muon_momentum_warmup_start + frac * h.muon_momentum
+        for group in optimizers.optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+            group["weight_decay"] = h.muon_wd * wd_scale
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * lr_scale
+        if h.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), h.grad_clip_norm)
+        optimizers.step(distributed=h.distributed)
+        return train_loss
+
+    if h.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for (name, tensor) in base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in optimizers
+        ]
+        model.train()
+        num_tokens_local = h.train_batch_tokens // h.world_size
+        for blk in base_model.blocks:
+            blk.attn.rotary(num_tokens_local, device, torch.bfloat16)
+        cu_bucket_size = train_loader.cu_bucket_size
+        warmup_cu_buckets = tuple(cu_bucket_size * i for i in range(1, 5))
+        warmup_cu_iters = 3
+        x, y, cu_seqlens, _ = train_loader.next_batch(
+            h.train_batch_tokens, h.grad_accum_steps
+        )
+        log(f"warmup_cu_buckets:{','.join(str(b) for b in warmup_cu_buckets)} iters_each:{warmup_cu_iters}")
+        def _run_cu_bucket_warmup():
+            for bucket_len in warmup_cu_buckets:
+                boundaries = list(range(0, x.size(1), max(h.train_seq_len, 1)))
+                if boundaries[-1] != x.size(1):
+                    boundaries.append(x.size(1))
+                cu = torch.full((bucket_len,), x.size(1), dtype=torch.int32, device=device)
+                cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+                for _ in range(warmup_cu_iters):
+                    optimizers.zero_grad_all()
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                        wloss = model(x, y, cu_seqlens=cu, max_seqlen=h.train_seq_len)
+                    (wloss / h.grad_accum_steps).backward()
+            optimizers.zero_grad_all()
+        _run_cu_bucket_warmup()
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            _run_cu_bucket_warmup()
+            base_model.looping_active = False
+        for warmup_step in range(h.warmup_steps):
+            step_fn(warmup_step, 1.0, 1.0)
+            if (
+                warmup_step <= 5
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == h.warmup_steps
+            ):
+                log(f"warmup_step: {warmup_step+1}/{h.warmup_steps}")
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            log(
+                f"loop_warmup:enabled encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            for warmup_step in range(h.warmup_steps):
+                step_fn(warmup_step, 1.0, 1.0)
+                if (
+                    warmup_step <= 5
+                    or (warmup_step + 1) % 10 == 0
+                    or warmup_step + 1 == h.warmup_steps
+                ):
+                    log(f"loop_warmup_step: {warmup_step+1}/{h.warmup_steps}")
+            base_model.looping_active = False
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for (opt, state) in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        optimizers.zero_grad_all()
+        train_loader = DocumentPackingLoader(h, device)
+    ema_state = {
+        name: t.detach().float().clone()
+        for (name, t) in base_model.state_dict().items()
+    }
+    ema_decay = h.ema_decay
+    training_time_ms = 0.0
+    stop_after_step = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = (
+            step == h.iterations
+            or stop_after_step is not None
+            and step >= stop_after_step
+        )
+        should_validate = (
+            last_step or h.val_loss_every > 0 and step % h.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1e3 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                h, device, val_data, model, compiled_forward_logits
+            )
+            log(
+                f"{step}/{h.iterations} val_loss: {val_loss:.4f} val_bpb: {val_bpb:.4f}"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < h.iterations:
+                log(
+                    f"stopping_early: wallclock_cap train_time: {training_time_ms:.0f}ms step: {step}/{h.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        frac = training_frac(step, elapsed_ms)
+        scale = lr_mul(frac)
+        wd_scale = wd_mul(frac)
+        if (
+            h.num_loops > 0
+            and not base_model.looping_active
+            and frac >= h.enable_looping_at
+        ):
+            base_model.looping_active = True
+            log(
+                f"layer_loop:enabled step:{step} frac:{frac:.3f} encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+        train_loss = step_fn(step, scale, wd_scale)
+        with torch.no_grad():
+            for (name, t) in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(
+                    t.detach().float(), alpha=1.0 - ema_decay
+                )
+        step += 1
+        approx_training_time_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        should_log_train = h.train_log_every > 0 and (
+            step <= 5 or step % h.train_log_every == 0 or stop_after_step is not None
+        )
+        if should_log_train:
+            tok_per_sec = step * h.train_batch_tokens / (approx_training_time_ms / 1e3)
+            log(
+                f"{step}/{h.iterations} train_loss: {train_loss.item():.4f} train_time: {approx_training_time_ms/60000:.1f}m tok/s: {tok_per_sec:.0f}"
+            )
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if h.distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated()//1024//1024} MiB reserved: {torch.cuda.max_memory_reserved()//1024//1024} MiB"
+    )
+    log("ema:applying EMA weights")
+    current_state = base_model.state_dict()
+    avg_state = {
+        name: t.to(dtype=current_state[name].dtype) for (name, t) in ema_state.items()
+    }
+    base_model.load_state_dict(avg_state, strict=True)
+    return base_model, compiled_model, compiled_forward_logits
+
+
+def train_and_eval(h, device):
+    random.seed(h.seed)
+    np.random.seed(h.seed)
+    torch.manual_seed(h.seed)
+    torch.cuda.manual_seed_all(h.seed)
+    if h.artifact_dir and h.is_main_process:
+        os.makedirs(h.artifact_dir, exist_ok=True)
+    val_data = ValidationData(h, device)
+    log(f"val_bpb:byte_sidecar:{'enabled' if val_data.val_token_bytes is not None else 'disabled'}")
+    log(
+        f"train_shards: {len(list(Path(h.datasets_dir).resolve().glob('fineweb_train_*.bin')))}"
+    )
+    log(f"val_tokens: {val_data.val_tokens.numel()-1}")
+    if h.ttt_only:
+        log("ttt_only: skipping training/pre-quant/quantized eval")
+    else:
+        base_model, compiled_model, compiled_forward_logits = train_model(
+            h, device, val_data
+        )
+        if h.skip_post_train_eval:
+            log("skip_post_train_eval: enabled; exiting after training")
+            return
+        torch._dynamo.reset()
+        timed_eval(
+            "diagnostic pre-quantization post-ema",
+            eval_val,
+            h,
+            device,
+            val_data,
+            compiled_model,
+            compiled_forward_logits,
+        )
+        serialize(h, base_model, Path(__file__).read_text(encoding="utf-8"))
+        if h.distributed:
+            dist.barrier()
+        eval_model = deserialize(h, device)
+        if h.num_loops > 0:
+            eval_model.looping_active = True
+        compiled_model = torch.compile(eval_model, dynamic=False, fullgraph=True)
+        compiled_forward_logits = torch.compile(
+            eval_model.forward_logits, dynamic=False, fullgraph=True
+        )
+        timed_eval(
+            "diagnostic quantized",
+            eval_val,
+            h,
+            device,
+            val_data,
+            compiled_model,
+            compiled_forward_logits,
+        )
+        if h.sliding_window_enabled:
+            timed_eval(
+                "diagnostic quantized_sliding_window",
+                eval_val_sliding,
+                h,
+                device,
+                val_data,
+                eval_model,
+                forward_logits_fn=compiled_forward_logits,
+            )
+    if h.ttt_enabled:
+        if not h.ttt_only:
+            del eval_model, compiled_model
+        torch._dynamo.reset()
+        torch.cuda.empty_cache()
+        ttt_model = deserialize(h, device)
+        if h.num_loops > 0:
+            ttt_model.looping_active = True
+        for p in ttt_model.parameters():
+            p.requires_grad_(False)
+
+        if h.rope_yarn:
+            _yarn_seqlen = h.train_batch_tokens // h.grad_accum_steps
+            for block in ttt_model.blocks:
+                block.attn.rotary(_yarn_seqlen, device, torch.bfloat16)
+        else:
+            for block in ttt_model.blocks:
+                block.attn.rotary._cos_cached = None
+                block.attn.rotary._sin_cached = None
+                block.attn.rotary._seq_len_cached = 0
+                block.attn.rotary(h.ttt_eval_seq_len, device, torch.bfloat16)
+
+        def _fwd_ttt_inner(input_ids, target_ids, lora):
+            return ttt_model.forward_ttt(input_ids, target_ids, lora=lora)
+
+        _fwd_ttt_compiled_inner = None
+
+        def _fwd_ttt(input_ids, target_ids, lora):
+            nonlocal _fwd_ttt_compiled_inner
+            if _fwd_ttt_compiled_inner is None:
+                _fwd_ttt_compiled_inner = torch.compile(_fwd_ttt_inner, dynamic=True)
+            return _fwd_ttt_compiled_inner(input_ids, target_ids, lora=lora)
+
+        fwd_ttt_compiled = _fwd_ttt
+        log(f"ttt_lora:warming up compile (random tokens, no val data)")
+        global BOS_ID
+        if BOS_ID is None:
+            BOS_ID = 1
+        t_warmup = time.perf_counter()
+        warmup_bszes = [h.ttt_batch_size]
+        for bsz in warmup_bszes:
+            wl = BatchedTTTLoRA(
+                bsz, ttt_model, h.ttt_lora_rank,
+                k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+            ).to(device)
+            wo = torch.optim.AdamW(
+                wl.parameters(),
+                lr=h.ttt_lora_lr,
+                betas=(h.ttt_beta1, h.ttt_beta2),
+                eps=1e-10,
+                weight_decay=h.ttt_weight_decay,
+                fused=True,
+            )
+            for ctx_len in (h.ttt_chunk_size, h.ttt_eval_seq_len):
+                xw = torch.randint(0, h.vocab_size, (bsz, ctx_len), device=device, dtype=torch.int64)
+                yw = torch.randint(0, h.vocab_size, (bsz, ctx_len), device=device, dtype=torch.int64)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    ptl = fwd_ttt_compiled(xw, yw, lora=wl)
+                ptl[:, : min(h.ttt_chunk_size, ctx_len)].mean(dim=-1).sum().backward()
+                wo.step()
+                wo.zero_grad(set_to_none=True)
+            del wl, wo
+        torch.cuda.empty_cache()
+        compile_elapsed = time.perf_counter() - t_warmup
+        log(f"ttt_lora:compile warmup done ({compile_elapsed:.1f}s)")
+        log("\nbeginning TTT eval timer")
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_val_loss, ttt_val_bpb = eval_val_ttt_phased(
+            h, ttt_model, device, val_data, forward_ttt_train=fwd_ttt_compiled
+        )
+        torch.cuda.synchronize()
+        ttt_eval_elapsed = time.perf_counter() - t_ttt
+        log(
+            "quantized_ttt_phased "
+            f"val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f} "
+            f"eval_time:{1e3*ttt_eval_elapsed:.0f}ms"
+        )
+        log(f"total_eval_time:{ttt_eval_elapsed:.1f}s")
+        del ttt_model
+
+
+def main():
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    torch._dynamo.config.optimize_ddp = False
+    torch._dynamo.config.cache_size_limit = 16
+    h = Hyperparameters()
+    set_logging_hparams(h)
+    if h.is_main_process:
+        os.makedirs(h.artifact_dir if h.artifact_dir else "logs", exist_ok=True)
+        log(100 * "=", console=False)
+        log("Hyperparameters:", console=True)
+        for (k, v) in sorted(vars(type(h)).items()):
+            if not k.startswith("_"):
+                log(f"  {k}: {v}", console=True)
+        log("=" * 100, console=False)
+        log("Source code:", console=False)
+        log("=" * 100, console=False)
+        with open(__file__, "r", encoding="utf-8") as _src:
+            log(_src.read(), console=False)
+        log("=" * 100, console=False)
+        log(f"Running Python {sys.version}", console=False)
+        log(f"Running PyTorch {torch.__version__}", console=False)
+        log("=" * 100, console=False)
+    train_and_eval(h, device)
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/train_seed0.log
+++ b/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/train_seed0.log
@@ -1,0 +1,829 @@
+start 2026-04-19T01:16:29+00:00
+Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
+
+*****************************************
+Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+*****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  artifact_dir: 
+  attn_clip_sigmas: 13.0
+  beta1: 0.9
+  beta2: 0.95
+  compressor: brotli
+  data_dir: ./data/
+  datasets_dir: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved
+  default_datasets_dir: ./data/datasets/fineweb10B_sp8192
+  distributed: True
+  ema_decay: 0.9965
+  embed_bits: 7
+  embed_clip_sigmas: 15.0
+  embed_lr: 0.6
+  embed_wd: 0.085
+  enable_looping_at: 0.35
+  eval_seq_len: 2048
+  eval_stride: 64
+  global_ttt_batch_seqs: 32
+  global_ttt_chunk_tokens: 32768
+  global_ttt_epochs: 1
+  global_ttt_grad_clip: 1.0
+  global_ttt_lr: 0.001
+  global_ttt_momentum: 0.9
+  global_ttt_respect_doc_boundaries: True
+  global_ttt_warmup_chunks: 0
+  global_ttt_warmup_start_lr: 0.0
+  gptq_calibration_batches: 16
+  gptq_reserve_seconds: 4.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  is_main_process: True
+  iterations: 20000
+  ln_scale: True
+  local_rank: 0
+  logfile: logs/68320eb7-c6f5-4095-932f-893401542a55.txt
+  logit_softcap: 30.0
+  loop_end: 5
+  loop_start: 3
+  matrix_bits: 6
+  matrix_clip_sigmas: 12.85
+  matrix_lr: 0.026
+  max_wallclock_seconds: 600.0
+  min_lr: 0.0
+  mlp_clip_sigmas: 12.0
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: final_model.pt
+  muon_backend_steps: 5
+  muon_momentum: 0.97
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_row_normalize: True
+  muon_wd: 0.095
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  num_loops: 2
+  parallel_final_lane: mean
+  parallel_start_layer: 8
+  phased_ttt_enabled: True
+  phased_ttt_num_phases: 3
+  phased_ttt_prefix_docs: 2000
+  qk_gain_init: 5.0
+  quantized_model_path: final_model.int6.ptz
+  rank: 0
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  rope_yarn: False
+  run_id: 68320eb7-c6f5-4095-932f-893401542a55
+  scalar_lr: 0.02
+  seed: 1337
+  skip_gates_enabled: True
+  skip_post_train_eval: False
+  sliding_window_enabled: False
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  tokenizer_path: /workspace/parameter-golf/data/tokenizers/fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model
+  train_batch_tokens: 786432
+  train_files: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_train_*.bin
+  train_log_every: 500
+  train_seq_len: 2048
+  ttt_batch_size: 64
+  ttt_beta1: 0.0
+  ttt_beta2: 0.999
+  ttt_chunk_size: 48
+  ttt_enabled: True
+  ttt_eval_batches: 
+  ttt_eval_seq_len: 2048
+  ttt_grad_steps: 1
+  ttt_k_lora: True
+  ttt_lora_lr: 0.0001
+  ttt_lora_rank: 96
+  ttt_mlp_lora: True
+  ttt_o_lora: True
+  ttt_only: False
+  ttt_optimizer: adam
+  ttt_weight_decay: 0.5
+  val_batch_tokens: 524288
+  val_doc_fraction: 1.0
+  val_files: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_val_[0-9][0-9][0-9][0-9][0-9][0-9].bin
+  val_loss_every: 4000
+  vocab_size: 8192
+  warmdown_frac: 0.75
+  warmup_steps: 20
+  wd_taper_final_mult: 0.5
+  wd_taper_start_frac: 0.7
+  world_size: 8
+  xsa_last_n: 11
+val_bpb:byte_sidecar:enabled
+train_shards: 80
+val_tokens: 47851520
+model_params:35944602
+gptq:reserving 4s, effective=596000ms
+warmup_cu_buckets:64,128,192,256 iters_each:3
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup:enabled encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+loop_warmup_step: 1/20
+loop_warmup_step: 2/20
+loop_warmup_step: 3/20
+loop_warmup_step: 4/20
+loop_warmup_step: 5/20
+loop_warmup_step: 6/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+0/20000 val_loss: 9.0018 val_bpb: 4.1132
+1/20000 train_loss: 9.0029 train_time: 0.0m tok/s: 11852905
+2/20000 train_loss: 12.9195 train_time: 0.0m tok/s: 12044953
+3/20000 train_loss: 10.2466 train_time: 0.0m tok/s: 10478448
+4/20000 train_loss: 8.7448 train_time: 0.0m tok/s: 9939564
+5/20000 train_loss: 7.9417 train_time: 0.0m tok/s: 9638859
+500/20000 train_loss: 2.5840 train_time: 0.8m tok/s: 8236755
+1000/20000 train_loss: 2.8193 train_time: 1.6m tok/s: 8182229
+1500/20000 train_loss: 2.6516 train_time: 2.4m tok/s: 8164286
+2000/20000 train_loss: 2.6802 train_time: 3.2m tok/s: 8162053
+layer_loop:enabled step:2163 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2500/20000 train_loss: 2.5620 train_time: 4.3m tok/s: 7683111
+3000/20000 train_loss: 2.5784 train_time: 5.4m tok/s: 7232209
+3500/20000 train_loss: 2.5776 train_time: 6.6m tok/s: 6941410
+4000/20000 train_loss: 2.4198 train_time: 7.8m tok/s: 6738866
+4000/20000 val_loss: 2.4422 val_bpb: 1.1159
+4500/20000 train_loss: 2.2910 train_time: 8.9m tok/s: 6591079
+4921/20000 val_loss: 2.3434 val_bpb: 1.0708
+stopping_early: wallclock_cap train_time: 596107ms step: 4921/20000
+peak memory allocated: 40029 MiB reserved: 44036 MiB
+ema:applying EMA weights
+diagnostic pre-quantization post-ema val_loss:2.34243071 val_bpb:1.07032992 eval_time:6889ms
+Serialized model: 135409136 bytes
+Code size (uncompressed): 125671 bytes
+Code size (compressed): 28320 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 3.4s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int7): tok_emb.weight
+  passthrough (float16): blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, skip_gates, skip_weights
+Serialized model quantized+brotli: 15903987 bytes
+Total submission size quantized+brotli: 15932307 bytes
+diagnostic quantized val_loss:2.36692321 val_bpb:1.08152131 eval_time:55988ms
+ttt_lora:warming up compile (random tokens, no val data)
+ttt_lora:compile warmup done (147.1s)
+
+beginning TTT eval timer
+ttt_phased: total_docs:50000 prefix_docs:2000 suffix_docs:48000 num_phases:3 boundaries:[666, 1333, 2000]
+ttp: b781/782 bl:2.1722 bb:1.0628 rl:2.1722 rb:1.0628 dl:17258-30330 gd:0
+ttpp: phase:1/3 pd:1104 gd:666 t:211.4s
+tttg: c1/111 lr:0.001000 t:2.0s
+tttg: c2/111 lr:0.001000 t:2.0s
+tttg: c3/111 lr:0.000999 t:2.1s
+tttg: c4/111 lr:0.000998 t:2.2s
+tttg: c5/111 lr:0.000997 t:2.3s
+tttg: c6/111 lr:0.000995 t:2.3s
+tttg: c7/111 lr:0.000993 t:2.4s
+tttg: c8/111 lr:0.000990 t:2.5s
+tttg: c9/111 lr:0.000987 t:2.6s
+tttg: c10/111 lr:0.000984 t:2.6s
+tttg: c11/111 lr:0.000980 t:2.7s
+tttg: c12/111 lr:0.000976 t:2.8s
+tttg: c13/111 lr:0.000971 t:2.8s
+tttg: c14/111 lr:0.000966 t:2.9s
+tttg: c15/111 lr:0.000961 t:3.0s
+tttg: c16/111 lr:0.000955 t:3.0s
+tttg: c17/111 lr:0.000949 t:3.1s
+tttg: c18/111 lr:0.000942 t:3.2s
+tttg: c19/111 lr:0.000935 t:3.3s
+tttg: c20/111 lr:0.000928 t:3.3s
+tttg: c21/111 lr:0.000921 t:3.4s
+tttg: c22/111 lr:0.000913 t:3.5s
+tttg: c23/111 lr:0.000905 t:3.6s
+tttg: c24/111 lr:0.000896 t:3.6s
+tttg: c25/111 lr:0.000887 t:3.7s
+tttg: c26/111 lr:0.000878 t:3.8s
+tttg: c27/111 lr:0.000868 t:3.8s
+tttg: c28/111 lr:0.000859 t:3.9s
+tttg: c29/111 lr:0.000848 t:4.0s
+tttg: c30/111 lr:0.000838 t:4.1s
+tttg: c31/111 lr:0.000827 t:4.1s
+tttg: c32/111 lr:0.000817 t:4.2s
+tttg: c33/111 lr:0.000805 t:4.3s
+tttg: c34/111 lr:0.000794 t:4.3s
+tttg: c35/111 lr:0.000782 t:4.4s
+tttg: c36/111 lr:0.000770 t:4.5s
+tttg: c37/111 lr:0.000758 t:4.6s
+tttg: c38/111 lr:0.000746 t:4.6s
+tttg: c39/111 lr:0.000733 t:4.7s
+tttg: c40/111 lr:0.000721 t:4.8s
+tttg: c41/111 lr:0.000708 t:4.8s
+tttg: c42/111 lr:0.000695 t:4.9s
+tttg: c43/111 lr:0.000681 t:5.0s
+tttg: c44/111 lr:0.000668 t:5.1s
+tttg: c45/111 lr:0.000655 t:5.1s
+tttg: c46/111 lr:0.000641 t:5.2s
+tttg: c47/111 lr:0.000627 t:5.3s
+tttg: c48/111 lr:0.000613 t:5.3s
+tttg: c49/111 lr:0.000599 t:5.4s
+tttg: c50/111 lr:0.000585 t:5.5s
+tttg: c51/111 lr:0.000571 t:5.6s
+tttg: c52/111 lr:0.000557 t:5.6s
+tttg: c53/111 lr:0.000543 t:5.7s
+tttg: c54/111 lr:0.000529 t:5.8s
+tttg: c55/111 lr:0.000514 t:5.9s
+tttg: c56/111 lr:0.000500 t:5.9s
+tttg: c57/111 lr:0.000486 t:6.0s
+tttg: c58/111 lr:0.000471 t:6.1s
+tttg: c59/111 lr:0.000457 t:6.1s
+tttg: c60/111 lr:0.000443 t:6.2s
+tttg: c61/111 lr:0.000429 t:6.3s
+tttg: c62/111 lr:0.000415 t:6.4s
+tttg: c63/111 lr:0.000401 t:6.4s
+tttg: c64/111 lr:0.000387 t:6.5s
+tttg: c65/111 lr:0.000373 t:6.6s
+tttg: c66/111 lr:0.000359 t:6.7s
+tttg: c67/111 lr:0.000345 t:6.7s
+tttg: c68/111 lr:0.000332 t:6.8s
+tttg: c69/111 lr:0.000319 t:6.9s
+tttg: c70/111 lr:0.000305 t:6.9s
+tttg: c71/111 lr:0.000292 t:7.0s
+tttg: c72/111 lr:0.000279 t:7.1s
+tttg: c73/111 lr:0.000267 t:7.1s
+tttg: c74/111 lr:0.000254 t:7.2s
+tttg: c75/111 lr:0.000242 t:7.3s
+tttg: c76/111 lr:0.000230 t:7.4s
+tttg: c77/111 lr:0.000218 t:7.4s
+tttg: c78/111 lr:0.000206 t:7.5s
+tttg: c79/111 lr:0.000195 t:7.6s
+tttg: c80/111 lr:0.000183 t:7.7s
+tttg: c81/111 lr:0.000173 t:7.7s
+tttg: c82/111 lr:0.000162 t:7.8s
+tttg: c83/111 lr:0.000152 t:7.9s
+tttg: c84/111 lr:0.000141 t:8.0s
+tttg: c85/111 lr:0.000132 t:8.0s
+tttg: c86/111 lr:0.000122 t:8.1s
+tttg: c87/111 lr:0.000113 t:8.2s
+tttg: c88/111 lr:0.000104 t:8.3s
+tttg: c89/111 lr:0.000095 t:8.3s
+tttg: c90/111 lr:0.000087 t:8.4s
+tttg: c91/111 lr:0.000079 t:8.5s
+tttg: c92/111 lr:0.000072 t:8.5s
+tttg: c93/111 lr:0.000065 t:8.6s
+tttg: c94/111 lr:0.000058 t:8.7s
+tttg: c95/111 lr:0.000051 t:8.8s
+tttg: c96/111 lr:0.000045 t:8.8s
+tttg: c97/111 lr:0.000039 t:8.9s
+tttg: c98/111 lr:0.000034 t:9.0s
+tttg: c99/111 lr:0.000029 t:9.1s
+tttg: c100/111 lr:0.000024 t:9.1s
+tttg: c101/111 lr:0.000020 t:9.2s
+tttg: c102/111 lr:0.000016 t:9.3s
+tttg: c103/111 lr:0.000013 t:9.3s
+tttg: c104/111 lr:0.000010 t:9.4s
+tttg: c105/111 lr:0.000007 t:9.5s
+tttg: c106/111 lr:0.000005 t:9.6s
+tttg: c107/111 lr:0.000003 t:9.6s
+tttg: c108/111 lr:0.000002 t:9.7s
+tttg: c109/111 lr:0.000001 t:9.8s
+tttg: c110/111 lr:0.000000 t:9.8s
+ttpr: phase:1/3 t:223.4s
+ttp: b759/782 bl:2.3872 bb:1.0870 rl:2.2037 rb:1.0666 dl:3741-3817 gd:0
+ttp: b756/782 bl:2.3461 bb:1.0442 rl:2.2207 rb:1.0637 dl:3466-3549 gd:0
+ttpp: phase:2/3 pd:1808 gd:1333 t:336.6s
+tttg: c1/185 lr:0.001000 t:0.1s
+tttg: c2/185 lr:0.001000 t:0.1s
+tttg: c3/185 lr:0.001000 t:0.2s
+tttg: c4/185 lr:0.000999 t:0.3s
+tttg: c5/185 lr:0.000999 t:0.4s
+tttg: c6/185 lr:0.000998 t:0.4s
+tttg: c7/185 lr:0.000997 t:0.5s
+tttg: c8/185 lr:0.000996 t:0.6s
+tttg: c9/185 lr:0.000995 t:0.7s
+tttg: c10/185 lr:0.000994 t:0.7s
+tttg: c11/185 lr:0.000993 t:0.8s
+tttg: c12/185 lr:0.000991 t:0.9s
+tttg: c13/185 lr:0.000990 t:0.9s
+tttg: c14/185 lr:0.000988 t:1.0s
+tttg: c15/185 lr:0.000986 t:1.1s
+tttg: c16/185 lr:0.000984 t:1.2s
+tttg: c17/185 lr:0.000981 t:1.2s
+tttg: c18/185 lr:0.000979 t:1.3s
+tttg: c19/185 lr:0.000977 t:1.4s
+tttg: c20/185 lr:0.000974 t:1.4s
+tttg: c21/185 lr:0.000971 t:1.5s
+tttg: c22/185 lr:0.000968 t:1.6s
+tttg: c23/185 lr:0.000965 t:1.7s
+tttg: c24/185 lr:0.000962 t:1.7s
+tttg: c25/185 lr:0.000959 t:1.8s
+tttg: c26/185 lr:0.000955 t:1.9s
+tttg: c27/185 lr:0.000952 t:2.0s
+tttg: c28/185 lr:0.000948 t:2.0s
+tttg: c29/185 lr:0.000944 t:2.1s
+tttg: c30/185 lr:0.000940 t:2.2s
+tttg: c31/185 lr:0.000936 t:2.2s
+tttg: c32/185 lr:0.000932 t:2.3s
+tttg: c33/185 lr:0.000927 t:2.4s
+tttg: c34/185 lr:0.000923 t:2.5s
+tttg: c35/185 lr:0.000918 t:2.5s
+tttg: c36/185 lr:0.000913 t:2.6s
+tttg: c37/185 lr:0.000908 t:2.7s
+tttg: c38/185 lr:0.000904 t:2.8s
+tttg: c39/185 lr:0.000898 t:2.8s
+tttg: c40/185 lr:0.000893 t:2.9s
+tttg: c41/185 lr:0.000888 t:3.0s
+tttg: c42/185 lr:0.000882 t:3.0s
+tttg: c43/185 lr:0.000877 t:3.1s
+tttg: c44/185 lr:0.000871 t:3.2s
+tttg: c45/185 lr:0.000865 t:3.3s
+tttg: c46/185 lr:0.000860 t:3.3s
+tttg: c47/185 lr:0.000854 t:3.4s
+tttg: c48/185 lr:0.000847 t:3.5s
+tttg: c49/185 lr:0.000841 t:3.5s
+tttg: c50/185 lr:0.000835 t:3.6s
+tttg: c51/185 lr:0.000829 t:3.7s
+tttg: c52/185 lr:0.000822 t:3.8s
+tttg: c53/185 lr:0.000816 t:3.8s
+tttg: c54/185 lr:0.000809 t:3.9s
+tttg: c55/185 lr:0.000802 t:4.0s
+tttg: c56/185 lr:0.000795 t:4.1s
+tttg: c57/185 lr:0.000788 t:4.1s
+tttg: c58/185 lr:0.000781 t:4.2s
+tttg: c59/185 lr:0.000774 t:4.3s
+tttg: c60/185 lr:0.000767 t:4.3s
+tttg: c61/185 lr:0.000760 t:4.4s
+tttg: c62/185 lr:0.000752 t:4.5s
+tttg: c63/185 lr:0.000745 t:4.6s
+tttg: c64/185 lr:0.000738 t:4.6s
+tttg: c65/185 lr:0.000730 t:4.7s
+tttg: c66/185 lr:0.000722 t:4.8s
+tttg: c67/185 lr:0.000715 t:4.8s
+tttg: c68/185 lr:0.000707 t:4.9s
+tttg: c69/185 lr:0.000699 t:5.0s
+tttg: c70/185 lr:0.000691 t:5.1s
+tttg: c71/185 lr:0.000683 t:5.1s
+tttg: c72/185 lr:0.000675 t:5.2s
+tttg: c73/185 lr:0.000667 t:5.3s
+tttg: c74/185 lr:0.000659 t:5.4s
+tttg: c75/185 lr:0.000651 t:5.4s
+tttg: c76/185 lr:0.000643 t:5.5s
+tttg: c77/185 lr:0.000635 t:5.6s
+tttg: c78/185 lr:0.000627 t:5.6s
+tttg: c79/185 lr:0.000618 t:5.7s
+tttg: c80/185 lr:0.000610 t:5.8s
+tttg: c81/185 lr:0.000602 t:5.9s
+tttg: c82/185 lr:0.000593 t:5.9s
+tttg: c83/185 lr:0.000585 t:6.0s
+tttg: c84/185 lr:0.000577 t:6.1s
+tttg: c85/185 lr:0.000568 t:6.2s
+tttg: c86/185 lr:0.000560 t:6.2s
+tttg: c87/185 lr:0.000551 t:6.3s
+tttg: c88/185 lr:0.000543 t:6.4s
+tttg: c89/185 lr:0.000534 t:6.4s
+tttg: c90/185 lr:0.000526 t:6.5s
+tttg: c91/185 lr:0.000517 t:6.6s
+tttg: c92/185 lr:0.000509 t:6.7s
+tttg: c93/185 lr:0.000500 t:6.7s
+tttg: c94/185 lr:0.000491 t:6.8s
+tttg: c95/185 lr:0.000483 t:6.9s
+tttg: c96/185 lr:0.000474 t:7.0s
+tttg: c97/185 lr:0.000466 t:7.0s
+tttg: c98/185 lr:0.000457 t:7.1s
+tttg: c99/185 lr:0.000449 t:7.2s
+tttg: c100/185 lr:0.000440 t:7.2s
+tttg: c101/185 lr:0.000432 t:7.3s
+tttg: c102/185 lr:0.000423 t:7.4s
+tttg: c103/185 lr:0.000415 t:7.4s
+tttg: c104/185 lr:0.000407 t:7.5s
+tttg: c105/185 lr:0.000398 t:7.6s
+tttg: c106/185 lr:0.000390 t:7.7s
+tttg: c107/185 lr:0.000382 t:7.7s
+tttg: c108/185 lr:0.000373 t:7.8s
+tttg: c109/185 lr:0.000365 t:7.9s
+tttg: c110/185 lr:0.000357 t:8.0s
+tttg: c111/185 lr:0.000349 t:8.0s
+tttg: c112/185 lr:0.000341 t:8.1s
+tttg: c113/185 lr:0.000333 t:8.2s
+tttg: c114/185 lr:0.000325 t:8.2s
+tttg: c115/185 lr:0.000317 t:8.3s
+tttg: c116/185 lr:0.000309 t:8.4s
+tttg: c117/185 lr:0.000301 t:8.4s
+tttg: c118/185 lr:0.000293 t:8.5s
+tttg: c119/185 lr:0.000285 t:8.6s
+tttg: c120/185 lr:0.000278 t:8.7s
+tttg: c121/185 lr:0.000270 t:8.7s
+tttg: c122/185 lr:0.000262 t:8.8s
+tttg: c123/185 lr:0.000255 t:8.9s
+tttg: c124/185 lr:0.000248 t:9.0s
+tttg: c125/185 lr:0.000240 t:9.0s
+tttg: c126/185 lr:0.000233 t:9.1s
+tttg: c127/185 lr:0.000226 t:9.2s
+tttg: c128/185 lr:0.000219 t:9.2s
+tttg: c129/185 lr:0.000212 t:9.3s
+tttg: c130/185 lr:0.000205 t:9.4s
+tttg: c131/185 lr:0.000198 t:9.5s
+tttg: c132/185 lr:0.000191 t:9.5s
+tttg: c133/185 lr:0.000184 t:9.6s
+tttg: c134/185 lr:0.000178 t:9.7s
+tttg: c135/185 lr:0.000171 t:9.7s
+tttg: c136/185 lr:0.000165 t:9.8s
+tttg: c137/185 lr:0.000159 t:9.9s
+tttg: c138/185 lr:0.000153 t:10.0s
+tttg: c139/185 lr:0.000146 t:10.0s
+tttg: c140/185 lr:0.000140 t:10.1s
+tttg: c141/185 lr:0.000135 t:10.2s
+tttg: c142/185 lr:0.000129 t:10.3s
+tttg: c143/185 lr:0.000123 t:10.3s
+tttg: c144/185 lr:0.000118 t:10.4s
+tttg: c145/185 lr:0.000112 t:10.5s
+tttg: c146/185 lr:0.000107 t:10.5s
+tttg: c147/185 lr:0.000102 t:10.6s
+tttg: c148/185 lr:0.000096 t:10.7s
+tttg: c149/185 lr:0.000092 t:10.8s
+tttg: c150/185 lr:0.000087 t:10.8s
+tttg: c151/185 lr:0.000082 t:10.9s
+tttg: c152/185 lr:0.000077 t:11.0s
+tttg: c153/185 lr:0.000073 t:11.1s
+tttg: c154/185 lr:0.000068 t:11.1s
+tttg: c155/185 lr:0.000064 t:11.2s
+tttg: c156/185 lr:0.000060 t:11.3s
+tttg: c157/185 lr:0.000056 t:11.3s
+tttg: c158/185 lr:0.000052 t:11.4s
+tttg: c159/185 lr:0.000048 t:11.5s
+tttg: c160/185 lr:0.000045 t:11.5s
+tttg: c161/185 lr:0.000041 t:11.6s
+tttg: c162/185 lr:0.000038 t:11.7s
+tttg: c163/185 lr:0.000035 t:11.8s
+tttg: c164/185 lr:0.000032 t:11.8s
+tttg: c165/185 lr:0.000029 t:11.9s
+tttg: c166/185 lr:0.000026 t:12.0s
+tttg: c167/185 lr:0.000023 t:12.1s
+tttg: c168/185 lr:0.000021 t:12.1s
+tttg: c169/185 lr:0.000019 t:12.2s
+tttg: c170/185 lr:0.000016 t:12.3s
+tttg: c171/185 lr:0.000014 t:12.3s
+tttg: c172/185 lr:0.000012 t:12.4s
+tttg: c173/185 lr:0.000010 t:12.5s
+tttg: c174/185 lr:0.000009 t:12.6s
+tttg: c175/185 lr:0.000007 t:12.6s
+tttg: c176/185 lr:0.000006 t:12.7s
+tttg: c177/185 lr:0.000005 t:12.8s
+tttg: c178/185 lr:0.000004 t:12.9s
+tttg: c179/185 lr:0.000003 t:12.9s
+tttg: c180/185 lr:0.000002 t:13.0s
+tttg: c181/185 lr:0.000001 t:13.1s
+tttg: c182/185 lr:0.000001 t:13.1s
+tttg: c183/185 lr:0.000000 t:13.2s
+tttg: c184/185 lr:0.000000 t:13.3s
+ttpr: phase:2/3 t:352.1s
+ttp: b748/782 bl:2.3337 bb:1.0891 rl:2.2312 rb:1.0661 dl:2992-3039 gd:0
+ttpp: phase:3/3 pd:2448 gd:2000 t:368.8s
+tttg: c1/250 lr:0.001000 t:0.1s
+tttg: c2/250 lr:0.001000 t:0.1s
+tttg: c3/250 lr:0.001000 t:0.2s
+tttg: c4/250 lr:0.001000 t:0.3s
+tttg: c5/250 lr:0.000999 t:0.4s
+tttg: c6/250 lr:0.000999 t:0.4s
+tttg: c7/250 lr:0.000999 t:0.5s
+tttg: c8/250 lr:0.000998 t:0.6s
+tttg: c9/250 lr:0.000997 t:0.6s
+tttg: c10/250 lr:0.000997 t:0.7s
+tttg: c11/250 lr:0.000996 t:0.8s
+tttg: c12/250 lr:0.000995 t:0.9s
+tttg: c13/250 lr:0.000994 t:0.9s
+tttg: c14/250 lr:0.000993 t:1.0s
+tttg: c15/250 lr:0.000992 t:1.1s
+tttg: c16/250 lr:0.000991 t:1.1s
+tttg: c17/250 lr:0.000990 t:1.2s
+tttg: c18/250 lr:0.000989 t:1.3s
+tttg: c19/250 lr:0.000987 t:1.4s
+tttg: c20/250 lr:0.000986 t:1.4s
+tttg: c21/250 lr:0.000984 t:1.5s
+tttg: c22/250 lr:0.000983 t:1.6s
+tttg: c23/250 lr:0.000981 t:1.7s
+tttg: c24/250 lr:0.000979 t:1.7s
+tttg: c25/250 lr:0.000977 t:1.8s
+tttg: c26/250 lr:0.000975 t:1.9s
+tttg: c27/250 lr:0.000973 t:1.9s
+tttg: c28/250 lr:0.000971 t:2.0s
+tttg: c29/250 lr:0.000969 t:2.1s
+tttg: c30/250 lr:0.000967 t:2.2s
+tttg: c31/250 lr:0.000965 t:2.2s
+tttg: c32/250 lr:0.000962 t:2.3s
+tttg: c33/250 lr:0.000960 t:2.4s
+tttg: c34/250 lr:0.000957 t:2.4s
+tttg: c35/250 lr:0.000955 t:2.5s
+tttg: c36/250 lr:0.000952 t:2.6s
+tttg: c37/250 lr:0.000949 t:2.7s
+tttg: c38/250 lr:0.000947 t:2.7s
+tttg: c39/250 lr:0.000944 t:2.8s
+tttg: c40/250 lr:0.000941 t:2.9s
+tttg: c41/250 lr:0.000938 t:2.9s
+tttg: c42/250 lr:0.000935 t:3.0s
+tttg: c43/250 lr:0.000931 t:3.1s
+tttg: c44/250 lr:0.000928 t:3.1s
+tttg: c45/250 lr:0.000925 t:3.2s
+tttg: c46/250 lr:0.000922 t:3.3s
+tttg: c47/250 lr:0.000918 t:3.4s
+tttg: c48/250 lr:0.000915 t:3.4s
+tttg: c49/250 lr:0.000911 t:3.5s
+tttg: c50/250 lr:0.000907 t:3.6s
+tttg: c51/250 lr:0.000904 t:3.7s
+tttg: c52/250 lr:0.000900 t:3.7s
+tttg: c53/250 lr:0.000896 t:3.8s
+tttg: c54/250 lr:0.000892 t:3.9s
+tttg: c55/250 lr:0.000888 t:3.9s
+tttg: c56/250 lr:0.000884 t:4.0s
+tttg: c57/250 lr:0.000880 t:4.1s
+tttg: c58/250 lr:0.000876 t:4.2s
+tttg: c59/250 lr:0.000872 t:4.2s
+tttg: c60/250 lr:0.000868 t:4.3s
+tttg: c61/250 lr:0.000863 t:4.4s
+tttg: c62/250 lr:0.000859 t:4.5s
+tttg: c63/250 lr:0.000855 t:4.5s
+tttg: c64/250 lr:0.000850 t:4.6s
+tttg: c65/250 lr:0.000846 t:4.7s
+tttg: c66/250 lr:0.000841 t:4.7s
+tttg: c67/250 lr:0.000836 t:4.8s
+tttg: c68/250 lr:0.000832 t:4.9s
+tttg: c69/250 lr:0.000827 t:5.0s
+tttg: c70/250 lr:0.000822 t:5.0s
+tttg: c71/250 lr:0.000817 t:5.1s
+tttg: c72/250 lr:0.000812 t:5.2s
+tttg: c73/250 lr:0.000807 t:5.3s
+tttg: c74/250 lr:0.000803 t:5.3s
+tttg: c75/250 lr:0.000797 t:5.4s
+tttg: c76/250 lr:0.000792 t:5.5s
+tttg: c77/250 lr:0.000787 t:5.6s
+tttg: c78/250 lr:0.000782 t:5.6s
+tttg: c79/250 lr:0.000777 t:5.7s
+tttg: c80/250 lr:0.000772 t:5.8s
+tttg: c81/250 lr:0.000766 t:5.8s
+tttg: c82/250 lr:0.000761 t:5.9s
+tttg: c83/250 lr:0.000755 t:6.0s
+tttg: c84/250 lr:0.000750 t:6.1s
+tttg: c85/250 lr:0.000745 t:6.1s
+tttg: c86/250 lr:0.000739 t:6.2s
+tttg: c87/250 lr:0.000733 t:6.3s
+tttg: c88/250 lr:0.000728 t:6.3s
+tttg: c89/250 lr:0.000722 t:6.4s
+tttg: c90/250 lr:0.000717 t:6.5s
+tttg: c91/250 lr:0.000711 t:6.6s
+tttg: c92/250 lr:0.000705 t:6.6s
+tttg: c93/250 lr:0.000699 t:6.7s
+tttg: c94/250 lr:0.000694 t:6.8s
+tttg: c95/250 lr:0.000688 t:6.9s
+tttg: c96/250 lr:0.000682 t:6.9s
+tttg: c97/250 lr:0.000676 t:7.0s
+tttg: c98/250 lr:0.000670 t:7.1s
+tttg: c99/250 lr:0.000664 t:7.1s
+tttg: c100/250 lr:0.000658 t:7.2s
+tttg: c101/250 lr:0.000652 t:7.3s
+tttg: c102/250 lr:0.000646 t:7.4s
+tttg: c103/250 lr:0.000640 t:7.4s
+tttg: c104/250 lr:0.000634 t:7.5s
+tttg: c105/250 lr:0.000628 t:7.6s
+tttg: c106/250 lr:0.000622 t:7.6s
+tttg: c107/250 lr:0.000616 t:7.7s
+tttg: c108/250 lr:0.000610 t:7.8s
+tttg: c109/250 lr:0.000603 t:7.9s
+tttg: c110/250 lr:0.000597 t:7.9s
+tttg: c111/250 lr:0.000591 t:8.0s
+tttg: c112/250 lr:0.000585 t:8.1s
+tttg: c113/250 lr:0.000579 t:8.2s
+tttg: c114/250 lr:0.000572 t:8.2s
+tttg: c115/250 lr:0.000566 t:8.3s
+tttg: c116/250 lr:0.000560 t:8.4s
+tttg: c117/250 lr:0.000554 t:8.5s
+tttg: c118/250 lr:0.000547 t:8.5s
+tttg: c119/250 lr:0.000541 t:8.6s
+tttg: c120/250 lr:0.000535 t:8.7s
+tttg: c121/250 lr:0.000528 t:8.7s
+tttg: c122/250 lr:0.000522 t:8.8s
+tttg: c123/250 lr:0.000516 t:8.9s
+tttg: c124/250 lr:0.000509 t:9.0s
+tttg: c125/250 lr:0.000503 t:9.0s
+tttg: c126/250 lr:0.000497 t:9.1s
+tttg: c127/250 lr:0.000491 t:9.2s
+tttg: c128/250 lr:0.000484 t:9.2s
+tttg: c129/250 lr:0.000478 t:9.3s
+tttg: c130/250 lr:0.000472 t:9.4s
+tttg: c131/250 lr:0.000465 t:9.5s
+tttg: c132/250 lr:0.000459 t:9.5s
+tttg: c133/250 lr:0.000453 t:9.6s
+tttg: c134/250 lr:0.000446 t:9.7s
+tttg: c135/250 lr:0.000440 t:9.8s
+tttg: c136/250 lr:0.000434 t:9.8s
+tttg: c137/250 lr:0.000428 t:9.9s
+tttg: c138/250 lr:0.000421 t:10.0s
+tttg: c139/250 lr:0.000415 t:10.0s
+tttg: c140/250 lr:0.000409 t:10.1s
+tttg: c141/250 lr:0.000403 t:10.2s
+tttg: c142/250 lr:0.000397 t:10.3s
+tttg: c143/250 lr:0.000390 t:10.3s
+tttg: c144/250 lr:0.000384 t:10.4s
+tttg: c145/250 lr:0.000378 t:10.5s
+tttg: c146/250 lr:0.000372 t:10.6s
+tttg: c147/250 lr:0.000366 t:10.6s
+tttg: c148/250 lr:0.000360 t:10.7s
+tttg: c149/250 lr:0.000354 t:10.8s
+tttg: c150/250 lr:0.000348 t:10.8s
+tttg: c151/250 lr:0.000342 t:10.9s
+tttg: c152/250 lr:0.000336 t:11.0s
+tttg: c153/250 lr:0.000330 t:11.1s
+tttg: c154/250 lr:0.000324 t:11.1s
+tttg: c155/250 lr:0.000318 t:11.2s
+tttg: c156/250 lr:0.000312 t:11.3s
+tttg: c157/250 lr:0.000306 t:11.4s
+tttg: c158/250 lr:0.000301 t:11.4s
+tttg: c159/250 lr:0.000295 t:11.5s
+tttg: c160/250 lr:0.000289 t:11.6s
+tttg: c161/250 lr:0.000283 t:11.6s
+tttg: c162/250 lr:0.000278 t:11.7s
+tttg: c163/250 lr:0.000272 t:11.8s
+tttg: c164/250 lr:0.000267 t:11.9s
+tttg: c165/250 lr:0.000261 t:11.9s
+tttg: c166/250 lr:0.000255 t:12.0s
+tttg: c167/250 lr:0.000250 t:12.1s
+tttg: c168/250 lr:0.000245 t:12.1s
+tttg: c169/250 lr:0.000239 t:12.2s
+tttg: c170/250 lr:0.000234 t:12.3s
+tttg: c171/250 lr:0.000228 t:12.4s
+tttg: c172/250 lr:0.000223 t:12.4s
+tttg: c173/250 lr:0.000218 t:12.5s
+tttg: c174/250 lr:0.000213 t:12.6s
+tttg: c175/250 lr:0.000208 t:12.6s
+tttg: c176/250 lr:0.000203 t:12.7s
+tttg: c177/250 lr:0.000197 t:12.8s
+tttg: c178/250 lr:0.000193 t:12.9s
+tttg: c179/250 lr:0.000188 t:12.9s
+tttg: c180/250 lr:0.000183 t:13.0s
+tttg: c181/250 lr:0.000178 t:13.1s
+tttg: c182/250 lr:0.000173 t:13.2s
+tttg: c183/250 lr:0.000168 t:13.2s
+tttg: c184/250 lr:0.000164 t:13.3s
+tttg: c185/250 lr:0.000159 t:13.4s
+tttg: c186/250 lr:0.000154 t:13.4s
+tttg: c187/250 lr:0.000150 t:13.5s
+tttg: c188/250 lr:0.000145 t:13.6s
+tttg: c189/250 lr:0.000141 t:13.7s
+tttg: c190/250 lr:0.000137 t:13.7s
+tttg: c191/250 lr:0.000132 t:13.8s
+tttg: c192/250 lr:0.000128 t:13.9s
+tttg: c193/250 lr:0.000124 t:14.0s
+tttg: c194/250 lr:0.000120 t:14.0s
+tttg: c195/250 lr:0.000116 t:14.1s
+tttg: c196/250 lr:0.000112 t:14.2s
+tttg: c197/250 lr:0.000108 t:14.2s
+tttg: c198/250 lr:0.000104 t:14.3s
+tttg: c199/250 lr:0.000100 t:14.4s
+tttg: c200/250 lr:0.000096 t:14.5s
+tttg: c201/250 lr:0.000093 t:14.5s
+tttg: c202/250 lr:0.000089 t:14.6s
+tttg: c203/250 lr:0.000085 t:14.7s
+tttg: c204/250 lr:0.000082 t:14.8s
+tttg: c205/250 lr:0.000078 t:14.8s
+tttg: c206/250 lr:0.000075 t:14.9s
+tttg: c207/250 lr:0.000072 t:15.0s
+tttg: c208/250 lr:0.000069 t:15.0s
+tttg: c209/250 lr:0.000065 t:15.1s
+tttg: c210/250 lr:0.000062 t:15.2s
+tttg: c211/250 lr:0.000059 t:15.3s
+tttg: c212/250 lr:0.000056 t:15.4s
+tttg: c213/250 lr:0.000053 t:15.4s
+tttg: c214/250 lr:0.000051 t:15.5s
+tttg: c215/250 lr:0.000048 t:15.6s
+tttg: c216/250 lr:0.000045 t:15.6s
+tttg: c217/250 lr:0.000043 t:15.7s
+tttg: c218/250 lr:0.000040 t:15.8s
+tttg: c219/250 lr:0.000038 t:15.8s
+tttg: c220/250 lr:0.000035 t:15.9s
+tttg: c221/250 lr:0.000033 t:16.0s
+tttg: c222/250 lr:0.000031 t:16.1s
+tttg: c223/250 lr:0.000029 t:16.1s
+tttg: c224/250 lr:0.000027 t:16.2s
+tttg: c225/250 lr:0.000025 t:16.3s
+tttg: c226/250 lr:0.000023 t:16.3s
+tttg: c227/250 lr:0.000021 t:16.4s
+tttg: c228/250 lr:0.000019 t:16.5s
+tttg: c229/250 lr:0.000017 t:16.6s
+tttg: c230/250 lr:0.000016 t:16.6s
+tttg: c231/250 lr:0.000014 t:16.7s
+tttg: c232/250 lr:0.000013 t:16.8s
+tttg: c233/250 lr:0.000011 t:16.9s
+tttg: c234/250 lr:0.000010 t:16.9s
+tttg: c235/250 lr:0.000009 t:17.0s
+tttg: c236/250 lr:0.000008 t:17.1s
+tttg: c237/250 lr:0.000007 t:17.2s
+tttg: c238/250 lr:0.000006 t:17.2s
+tttg: c239/250 lr:0.000005 t:17.3s
+tttg: c240/250 lr:0.000004 t:17.4s
+tttg: c241/250 lr:0.000003 t:17.5s
+tttg: c242/250 lr:0.000003 t:17.5s
+tttg: c243/250 lr:0.000002 t:17.6s
+tttg: c244/250 lr:0.000001 t:17.7s
+tttg: c245/250 lr:0.000001 t:17.7s
+tttg: c246/250 lr:0.000001 t:17.8s
+tttg: c247/250 lr:0.000000 t:17.9s
+tttg: c248/250 lr:0.000000 t:18.0s
+tttg: c249/250 lr:0.000000 t:18.0s
+ttpr: phase:3/3 t:389.0s
+ttp: b742/782 bl:2.3399 bb:1.0535 rl:2.2397 rb:1.0651 dl:2730-2762 gd:1
+ttp: b729/782 bl:2.3224 bb:1.0849 rl:2.2449 rb:1.0663 dl:2325-2352 gd:1
+ttp: b721/782 bl:2.3219 bb:1.0311 rl:2.2491 rb:1.0643 dl:2144-2163 gd:1
+ttp: b717/782 bl:2.2723 bb:1.0404 rl:2.2502 rb:1.0631 dl:2070-2088 gd:1
+ttp: b706/782 bl:2.4162 bb:1.0806 rl:2.2575 rb:1.0639 dl:1898-1910 gd:1
+ttp: b702/782 bl:2.4430 bb:1.0886 rl:2.2651 rb:1.0649 dl:1847-1858 gd:1
+ttp: b690/782 bl:2.3114 bb:1.0730 rl:2.2667 rb:1.0652 dl:1715-1725 gd:1
+ttp: b686/782 bl:2.4552 bb:1.0808 rl:2.2732 rb:1.0658 dl:1675-1685 gd:1
+ttp: b672/782 bl:2.3422 bb:1.0540 rl:2.2754 rb:1.0654 dl:1553-1562 gd:1
+ttp: b668/782 bl:2.3531 bb:1.0758 rl:2.2776 rb:1.0657 dl:1521-1530 gd:1
+ttp: b660/782 bl:2.3911 bb:1.0570 rl:2.2808 rb:1.0655 dl:1466-1474 gd:1
+ttp: b653/782 bl:2.3071 bb:1.0460 rl:2.2815 rb:1.0650 dl:1419-1425 gd:1
+ttp: b644/782 bl:2.3798 bb:1.0566 rl:2.2838 rb:1.0647 dl:1362-1367 gd:1
+ttp: b635/782 bl:2.3568 bb:1.0635 rl:2.2855 rb:1.0647 dl:1308-1314 gd:1
+ttp: b626/782 bl:2.3274 bb:1.0342 rl:2.2864 rb:1.0640 dl:1260-1265 gd:1
+ttp: b618/782 bl:2.4279 bb:1.0806 rl:2.2893 rb:1.0644 dl:1216-1221 gd:1
+ttp: b610/782 bl:2.2696 bb:1.0149 rl:2.2889 rb:1.0634 dl:1177-1182 gd:1
+ttp: b603/782 bl:2.4419 bb:1.0695 rl:2.2917 rb:1.0635 dl:1146-1150 gd:1
+ttp: b599/782 bl:2.3783 bb:1.0759 rl:2.2933 rb:1.0637 dl:1129-1133 gd:1
+ttp: b590/782 bl:2.3284 bb:1.0669 rl:2.2939 rb:1.0638 dl:1089-1093 gd:1
+ttp: b581/782 bl:2.3353 bb:1.0421 rl:2.2945 rb:1.0634 dl:1052-1056 gd:1
+ttp: b575/782 bl:2.3052 bb:1.0491 rl:2.2947 rb:1.0632 dl:1029-1033 gd:1
+ttp: b566/782 bl:2.3131 bb:1.0332 rl:2.2950 rb:1.0627 dl:997-1001 gd:1
+ttp: b557/782 bl:2.3574 bb:1.0589 rl:2.2958 rb:1.0627 dl:965-968 gd:1
+ttp: b545/782 bl:2.3478 bb:1.0382 rl:2.2965 rb:1.0623 dl:927-930 gd:1
+ttp: b537/782 bl:2.3906 bb:1.0783 rl:2.2977 rb:1.0626 dl:902-905 gd:1
+ttp: b533/782 bl:2.3861 bb:1.0734 rl:2.2988 rb:1.0627 dl:890-892 gd:1
+ttp: b525/782 bl:2.3647 bb:1.0249 rl:2.2996 rb:1.0622 dl:866-869 gd:1
+ttp: b513/782 bl:2.3857 bb:1.0474 rl:2.3006 rb:1.0620 dl:832-835 gd:1
+ttp: b505/782 bl:2.3442 bb:1.0720 rl:2.3011 rb:1.0621 dl:809-812 gd:1
+ttp: b501/782 bl:2.3948 bb:1.0580 rl:2.3021 rb:1.0621 dl:799-802 gd:1
+ttp: b493/782 bl:2.3844 bb:1.0525 rl:2.3029 rb:1.0620 dl:778-780 gd:1
+ttp: b484/782 bl:2.3833 bb:1.0561 rl:2.3037 rb:1.0619 dl:756-759 gd:1
+ttp: b476/782 bl:2.2912 bb:1.0384 rl:2.3036 rb:1.0617 dl:738-740 gd:1
+ttp: b468/782 bl:2.3722 bb:1.0678 rl:2.3043 rb:1.0618 dl:719-721 gd:1
+ttp: b462/782 bl:2.3500 bb:1.0430 rl:2.3047 rb:1.0616 dl:706-708 gd:1
+ttp: b453/782 bl:2.3537 bb:1.0635 rl:2.3051 rb:1.0616 dl:687-689 gd:1
+ttp: b445/782 bl:2.3774 bb:1.0566 rl:2.3057 rb:1.0616 dl:670-672 gd:1
+ttp: b439/782 bl:2.3423 bb:1.0452 rl:2.3060 rb:1.0614 dl:657-659 gd:1
+ttp: b431/782 bl:2.3868 bb:1.0589 rl:2.3067 rb:1.0614 dl:642-643 gd:1
+ttp: b423/782 bl:2.3231 bb:1.0599 rl:2.3068 rb:1.0614 dl:626-629 gd:1
+ttp: b409/782 bl:2.3418 bb:1.0748 rl:2.3070 rb:1.0615 dl:598-601 gd:1
+ttp: b400/782 bl:2.3238 bb:1.0456 rl:2.3072 rb:1.0614 dl:582-584 gd:1
+ttp: b392/782 bl:2.2650 bb:1.0418 rl:2.3069 rb:1.0612 dl:568-570 gd:1
+ttp: b385/782 bl:2.4184 bb:1.0785 rl:2.3076 rb:1.0614 dl:555-557 gd:1
+ttp: b377/782 bl:2.2500 bb:1.0308 rl:2.3072 rb:1.0612 dl:542-544 gd:1
+ttp: b370/782 bl:2.3863 bb:1.0924 rl:2.3077 rb:1.0614 dl:530-532 gd:1
+ttp: b360/782 bl:2.3231 bb:1.0868 rl:2.3078 rb:1.0615 dl:513-515 gd:1
+ttp: b352/782 bl:2.4324 bb:1.1007 rl:2.3085 rb:1.0617 dl:499-501 gd:1
+ttp: b344/782 bl:2.4013 bb:1.0701 rl:2.3091 rb:1.0618 dl:488-489 gd:1
+ttp: b336/782 bl:2.4246 bb:1.0927 rl:2.3097 rb:1.0620 dl:476-477 gd:1
+ttp: b332/782 bl:2.3210 bb:1.0506 rl:2.3098 rb:1.0619 dl:469-471 gd:1
+ttp: b323/782 bl:2.3995 bb:1.0833 rl:2.3102 rb:1.0620 dl:457-458 gd:1
+ttp: b315/782 bl:2.4229 bb:1.1131 rl:2.3108 rb:1.0623 dl:444-445 gd:1
+ttp: b308/782 bl:2.4217 bb:1.0984 rl:2.3113 rb:1.0624 dl:433-435 gd:1
+ttp: b296/782 bl:2.4041 bb:1.1069 rl:2.3118 rb:1.0626 dl:415-417 gd:1
+ttp: b288/782 bl:2.2503 bb:1.0243 rl:2.3115 rb:1.0625 dl:403-405 gd:1
+ttp: b280/782 bl:2.3484 bb:1.0949 rl:2.3116 rb:1.0626 dl:392-394 gd:1
+ttp: b272/782 bl:2.3766 bb:1.0977 rl:2.3119 rb:1.0628 dl:382-383 gd:1
+ttp: b267/782 bl:2.4373 bb:1.1519 rl:2.3124 rb:1.0631 dl:375-376 gd:1
+ttp: b259/782 bl:2.3582 bb:1.1059 rl:2.3126 rb:1.0633 dl:365-366 gd:1
+ttp: b250/782 bl:2.3341 bb:1.0822 rl:2.3127 rb:1.0634 dl:354-355 gd:1
+ttp: b242/782 bl:2.3946 bb:1.1085 rl:2.3130 rb:1.0635 dl:344-345 gd:1
+ttp: b234/782 bl:2.4312 bb:1.1520 rl:2.3134 rb:1.0638 dl:334-335 gd:1
+ttp: b224/782 bl:2.3962 bb:1.0980 rl:2.3137 rb:1.0640 dl:322-323 gd:1
+ttp: b216/782 bl:2.4927 bb:1.1559 rl:2.3143 rb:1.0643 dl:313-314 gd:1
+ttp: b208/782 bl:2.4085 bb:1.1401 rl:2.3146 rb:1.0645 dl:304-305 gd:1
+ttp: b200/782 bl:2.3787 bb:1.0998 rl:2.3148 rb:1.0646 dl:296-297 gd:1
+ttp: b193/782 bl:2.3775 bb:1.1401 rl:2.3150 rb:1.0648 dl:288-289 gd:1
+ttp: b190/782 bl:2.3586 bb:1.0844 rl:2.3152 rb:1.0649 dl:284-285 gd:1
+ttp: b181/782 bl:2.3526 bb:1.1361 rl:2.3153 rb:1.0651 dl:275-276 gd:1
+ttp: b172/782 bl:2.5364 bb:1.1629 rl:2.3159 rb:1.0654 dl:266-267 gd:1
+ttp: b165/782 bl:2.3722 bb:1.1265 rl:2.3161 rb:1.0655 dl:260-260 gd:1
+ttp: b157/782 bl:2.3698 bb:1.1350 rl:2.3162 rb:1.0657 dl:252-253 gd:1
+ttp: b149/782 bl:2.3919 bb:1.1651 rl:2.3164 rb:1.0660 dl:244-245 gd:1
+ttp: b142/782 bl:2.3983 bb:1.1164 rl:2.3166 rb:1.0661 dl:237-238 gd:1
+ttp: b133/782 bl:2.3778 bb:1.1406 rl:2.3167 rb:1.0662 dl:229-230 gd:1
+ttp: b124/782 bl:2.4084 bb:1.1765 rl:2.3170 rb:1.0665 dl:220-222 gd:1
+ttp: b117/782 bl:2.4991 bb:1.2143 rl:2.3174 rb:1.0668 dl:214-215 gd:1
+ttp: b110/782 bl:2.3844 bb:1.1316 rl:2.3175 rb:1.0669 dl:208-208 gd:1
+ttp: b100/782 bl:2.4411 bb:1.1678 rl:2.3178 rb:1.0671 dl:199-200 gd:1
+ttp: b92/782 bl:2.4496 bb:1.1655 rl:2.3180 rb:1.0673 dl:191-192 gd:1
+ttp: b85/782 bl:2.5207 bb:1.2072 rl:2.3184 rb:1.0676 dl:185-186 gd:1
+ttp: b75/782 bl:2.5906 bb:1.2011 rl:2.3189 rb:1.0678 dl:176-177 gd:1
+ttp: b67/782 bl:2.5501 bb:1.2072 rl:2.3193 rb:1.0681 dl:169-170 gd:1
+ttp: b60/782 bl:2.4862 bb:1.1950 rl:2.3196 rb:1.0683 dl:163-164 gd:1
+ttp: b52/782 bl:2.6915 bb:1.2564 rl:2.3202 rb:1.0685 dl:155-156 gd:1
+ttp: b44/782 bl:2.5749 bb:1.2015 rl:2.3205 rb:1.0687 dl:147-148 gd:1
+ttp: b37/782 bl:2.5969 bb:1.2240 rl:2.3209 rb:1.0690 dl:140-141 gd:1
+ttp: b29/782 bl:2.6446 bb:1.2234 rl:2.3214 rb:1.0692 dl:132-133 gd:1
+ttp: b21/782 bl:2.6318 bb:1.2415 rl:2.3218 rb:1.0694 dl:123-124 gd:1
+ttp: b13/782 bl:2.6849 bb:1.2164 rl:2.3222 rb:1.0696 dl:112-114 gd:1
+ttp: b5/782 bl:2.7233 bb:1.2391 rl:2.3226 rb:1.0697 dl:96-99 gd:1
+quantized_ttt_phased val_loss:2.33730724 val_bpb:1.06805820 eval_time:488803ms
+total_eval_time:488.8s

--- a/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/train_seed1234.log
+++ b/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/train_seed1234.log
@@ -1,0 +1,828 @@
+W0418 21:17:14.974000 362153 torch/distributed/run.py:803] 
+W0418 21:17:14.974000 362153 torch/distributed/run.py:803] *****************************************
+W0418 21:17:14.974000 362153 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0418 21:17:14.974000 362153 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  artifact_dir: 
+  attn_clip_sigmas: 13.0
+  beta1: 0.9
+  beta2: 0.95
+  compressor: brotli
+  data_dir: ./data/
+  datasets_dir: /workspace/caseops_export/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved
+  default_datasets_dir: ./data/datasets/fineweb10B_sp8192
+  distributed: True
+  ema_decay: 0.9965
+  embed_bits: 7
+  embed_clip_sigmas: 15.0
+  embed_lr: 0.6
+  embed_wd: 0.085
+  enable_looping_at: 0.35
+  eval_seq_len: 2048
+  eval_stride: 64
+  global_ttt_batch_seqs: 32
+  global_ttt_chunk_tokens: 32768
+  global_ttt_epochs: 1
+  global_ttt_grad_clip: 1.0
+  global_ttt_lr: 0.001
+  global_ttt_momentum: 0.9
+  global_ttt_respect_doc_boundaries: True
+  global_ttt_warmup_chunks: 0
+  global_ttt_warmup_start_lr: 0.0
+  gptq_calibration_batches: 16
+  gptq_reserve_seconds: 4.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  is_main_process: True
+  iterations: 20000
+  ln_scale: True
+  local_rank: 0
+  logfile: logs/pr1626_caseops_seed1234_0418.txt
+  logit_softcap: 30.0
+  loop_end: 5
+  loop_start: 3
+  matrix_bits: 6
+  matrix_clip_sigmas: 12.85
+  matrix_lr: 0.026
+  max_wallclock_seconds: 600.0
+  min_lr: 0.0
+  mlp_clip_sigmas: 12.0
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: final_model.pt
+  muon_backend_steps: 5
+  muon_momentum: 0.97
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_row_normalize: True
+  muon_wd: 0.095
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  num_loops: 2
+  parallel_final_lane: mean
+  parallel_start_layer: 8
+  phased_ttt_enabled: True
+  phased_ttt_num_phases: 3
+  phased_ttt_prefix_docs: 2000
+  qk_gain_init: 5.0
+  quantized_model_path: final_model.int6.ptz
+  rank: 0
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  rope_yarn: False
+  run_id: pr1626_caseops_seed1234_0418
+  scalar_lr: 0.02
+  seed: 1234
+  skip_gates_enabled: True
+  skip_post_train_eval: False
+  sliding_window_enabled: False
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  tokenizer_path: /workspace/caseops_export/tokenizers/fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model
+  train_batch_tokens: 786432
+  train_files: /workspace/caseops_export/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_train_*.bin
+  train_log_every: 500
+  train_seq_len: 2048
+  ttt_batch_size: 64
+  ttt_beta1: 0.0
+  ttt_beta2: 0.999
+  ttt_chunk_size: 48
+  ttt_enabled: True
+  ttt_eval_batches: 
+  ttt_eval_seq_len: 2048
+  ttt_grad_steps: 1
+  ttt_k_lora: True
+  ttt_lora_lr: 0.0001
+  ttt_lora_rank: 96
+  ttt_mlp_lora: True
+  ttt_o_lora: True
+  ttt_only: False
+  ttt_optimizer: adam
+  ttt_weight_decay: 0.5
+  val_batch_tokens: 524288
+  val_doc_fraction: 1.0
+  val_files: /workspace/caseops_export/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_val_[0-9][0-9][0-9][0-9][0-9][0-9].bin
+  val_loss_every: 4000
+  vocab_size: 8192
+  warmdown_frac: 0.75
+  warmup_steps: 20
+  wd_taper_final_mult: 0.5
+  wd_taper_start_frac: 0.7
+  world_size: 8
+  xsa_last_n: 11
+val_bpb:byte_sidecar:enabled
+train_shards: 80
+val_tokens: 47851520
+model_params:35944602
+gptq:reserving 4s, effective=596000ms
+warmup_cu_buckets:64,128,192,256 iters_each:3
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup:enabled encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+loop_warmup_step: 1/20
+loop_warmup_step: 2/20
+loop_warmup_step: 3/20
+loop_warmup_step: 4/20
+loop_warmup_step: 5/20
+loop_warmup_step: 6/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+0/20000 val_loss: 9.0060 val_bpb: 4.1151
+1/20000 train_loss: 9.0077 train_time: 0.0m tok/s: 16086212
+2/20000 train_loss: 12.8764 train_time: 0.0m tok/s: 12774429
+3/20000 train_loss: 10.2544 train_time: 0.0m tok/s: 10899800
+4/20000 train_loss: 8.7818 train_time: 0.0m tok/s: 10198228
+5/20000 train_loss: 8.0062 train_time: 0.0m tok/s: 9807966
+500/20000 train_loss: 2.5898 train_time: 0.8m tok/s: 8215657
+1000/20000 train_loss: 2.8166 train_time: 1.6m tok/s: 8172671
+1500/20000 train_loss: 2.6500 train_time: 2.4m tok/s: 8155906
+2000/20000 train_loss: 2.6797 train_time: 3.2m tok/s: 8151588
+layer_loop:enabled step:2160 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2500/20000 train_loss: 2.5640 train_time: 4.3m tok/s: 7671247
+3000/20000 train_loss: 2.5773 train_time: 5.4m tok/s: 7220814
+3500/20000 train_loss: 2.5729 train_time: 6.6m tok/s: 6931502
+4000/20000 train_loss: 2.4143 train_time: 7.8m tok/s: 6729990
+4000/20000 val_loss: 2.4392 val_bpb: 1.1145
+4500/20000 train_loss: 2.2815 train_time: 9.1m tok/s: 6506943
+4870/20000 val_loss: 2.3418 val_bpb: 1.0700
+stopping_early: wallclock_cap train_time: 596099ms step: 4870/20000
+peak memory allocated: 40029 MiB reserved: 44036 MiB
+ema:applying EMA weights
+diagnostic pre-quantization post-ema val_loss:2.34108777 val_bpb:1.06971629 eval_time:11017ms
+Serialized model: 135409136 bytes
+Code size (uncompressed): 125670 bytes
+Code size (compressed): 30985 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 3.4s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int7): tok_emb.weight
+  passthrough (float16): blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, skip_gates, skip_weights
+Serialized model quantized+brotli: 15912121 bytes
+Total submission size quantized+brotli: 15943106 bytes
+diagnostic quantized val_loss:2.36439510 val_bpb:1.08036614 eval_time:61226ms
+ttt_lora:warming up compile (random tokens, no val data)
+ttt_lora:compile warmup done (146.1s)
+
+beginning TTT eval timer
+ttt_phased: total_docs:50000 prefix_docs:2000 suffix_docs:48000 num_phases:3 boundaries:[666, 1333, 2000]
+ttp: b777/782 bl:2.3280 bb:1.0910 rl:2.3280 rb:1.0910 dl:8452-9229 gd:0
+ttp: b772/782 bl:2.3411 bb:1.1034 rl:2.3332 rb:1.0959 dl:5762-6095 gd:0
+ttp: b769/782 bl:2.3426 bb:1.0905 rl:2.3357 rb:1.0945 dl:5097-5309 gd:0
+ttpp: phase:1/3 pd:1104 gd:666 t:211.3s
+tttg: c1/111 lr:0.001000 t:0.3s
+tttg: c2/111 lr:0.001000 t:0.4s
+tttg: c3/111 lr:0.000999 t:0.5s
+tttg: c4/111 lr:0.000998 t:0.6s
+tttg: c5/111 lr:0.000997 t:0.7s
+tttg: c6/111 lr:0.000995 t:0.7s
+tttg: c7/111 lr:0.000993 t:0.8s
+tttg: c8/111 lr:0.000990 t:0.9s
+tttg: c9/111 lr:0.000987 t:0.9s
+tttg: c10/111 lr:0.000984 t:1.0s
+tttg: c11/111 lr:0.000980 t:1.1s
+tttg: c12/111 lr:0.000976 t:1.2s
+tttg: c13/111 lr:0.000971 t:1.2s
+tttg: c14/111 lr:0.000966 t:1.3s
+tttg: c15/111 lr:0.000961 t:1.4s
+tttg: c16/111 lr:0.000955 t:1.5s
+tttg: c17/111 lr:0.000949 t:1.5s
+tttg: c18/111 lr:0.000942 t:1.6s
+tttg: c19/111 lr:0.000935 t:1.7s
+tttg: c20/111 lr:0.000928 t:1.8s
+tttg: c21/111 lr:0.000921 t:1.8s
+tttg: c22/111 lr:0.000913 t:1.9s
+tttg: c23/111 lr:0.000905 t:2.0s
+tttg: c24/111 lr:0.000896 t:2.1s
+tttg: c25/111 lr:0.000887 t:2.1s
+tttg: c26/111 lr:0.000878 t:2.2s
+tttg: c27/111 lr:0.000868 t:2.3s
+tttg: c28/111 lr:0.000859 t:2.4s
+tttg: c29/111 lr:0.000848 t:2.4s
+tttg: c30/111 lr:0.000838 t:2.5s
+tttg: c31/111 lr:0.000827 t:2.6s
+tttg: c32/111 lr:0.000817 t:2.6s
+tttg: c33/111 lr:0.000805 t:2.7s
+tttg: c34/111 lr:0.000794 t:2.8s
+tttg: c35/111 lr:0.000782 t:2.9s
+tttg: c36/111 lr:0.000770 t:3.0s
+tttg: c37/111 lr:0.000758 t:3.0s
+tttg: c38/111 lr:0.000746 t:3.1s
+tttg: c39/111 lr:0.000733 t:3.2s
+tttg: c40/111 lr:0.000721 t:3.2s
+tttg: c41/111 lr:0.000708 t:3.3s
+tttg: c42/111 lr:0.000695 t:3.4s
+tttg: c43/111 lr:0.000681 t:3.5s
+tttg: c44/111 lr:0.000668 t:3.5s
+tttg: c45/111 lr:0.000655 t:3.6s
+tttg: c46/111 lr:0.000641 t:3.7s
+tttg: c47/111 lr:0.000627 t:3.8s
+tttg: c48/111 lr:0.000613 t:3.9s
+tttg: c49/111 lr:0.000599 t:3.9s
+tttg: c50/111 lr:0.000585 t:4.0s
+tttg: c51/111 lr:0.000571 t:4.1s
+tttg: c52/111 lr:0.000557 t:4.2s
+tttg: c53/111 lr:0.000543 t:4.2s
+tttg: c54/111 lr:0.000529 t:4.3s
+tttg: c55/111 lr:0.000514 t:4.4s
+tttg: c56/111 lr:0.000500 t:4.5s
+tttg: c57/111 lr:0.000486 t:4.5s
+tttg: c58/111 lr:0.000471 t:4.6s
+tttg: c59/111 lr:0.000457 t:4.7s
+tttg: c60/111 lr:0.000443 t:4.8s
+tttg: c61/111 lr:0.000429 t:4.8s
+tttg: c62/111 lr:0.000415 t:4.9s
+tttg: c63/111 lr:0.000401 t:5.0s
+tttg: c64/111 lr:0.000387 t:5.1s
+tttg: c65/111 lr:0.000373 t:5.1s
+tttg: c66/111 lr:0.000359 t:5.2s
+tttg: c67/111 lr:0.000345 t:5.3s
+tttg: c68/111 lr:0.000332 t:5.4s
+tttg: c69/111 lr:0.000319 t:5.4s
+tttg: c70/111 lr:0.000305 t:5.5s
+tttg: c71/111 lr:0.000292 t:5.6s
+tttg: c72/111 lr:0.000279 t:5.7s
+tttg: c73/111 lr:0.000267 t:5.7s
+tttg: c74/111 lr:0.000254 t:5.8s
+tttg: c75/111 lr:0.000242 t:5.9s
+tttg: c76/111 lr:0.000230 t:6.0s
+tttg: c77/111 lr:0.000218 t:6.1s
+tttg: c78/111 lr:0.000206 t:6.1s
+tttg: c79/111 lr:0.000195 t:6.2s
+tttg: c80/111 lr:0.000183 t:6.3s
+tttg: c81/111 lr:0.000173 t:6.4s
+tttg: c82/111 lr:0.000162 t:6.4s
+tttg: c83/111 lr:0.000152 t:6.5s
+tttg: c84/111 lr:0.000141 t:6.6s
+tttg: c85/111 lr:0.000132 t:6.7s
+tttg: c86/111 lr:0.000122 t:6.7s
+tttg: c87/111 lr:0.000113 t:6.8s
+tttg: c88/111 lr:0.000104 t:6.9s
+tttg: c89/111 lr:0.000095 t:7.0s
+tttg: c90/111 lr:0.000087 t:7.0s
+tttg: c91/111 lr:0.000079 t:7.1s
+tttg: c92/111 lr:0.000072 t:7.2s
+tttg: c93/111 lr:0.000065 t:7.3s
+tttg: c94/111 lr:0.000058 t:7.3s
+tttg: c95/111 lr:0.000051 t:7.4s
+tttg: c96/111 lr:0.000045 t:7.5s
+tttg: c97/111 lr:0.000039 t:7.6s
+tttg: c98/111 lr:0.000034 t:7.6s
+tttg: c99/111 lr:0.000029 t:7.7s
+tttg: c100/111 lr:0.000024 t:7.8s
+tttg: c101/111 lr:0.000020 t:7.9s
+tttg: c102/111 lr:0.000016 t:7.9s
+tttg: c103/111 lr:0.000013 t:8.0s
+tttg: c104/111 lr:0.000010 t:8.1s
+tttg: c105/111 lr:0.000007 t:8.2s
+tttg: c106/111 lr:0.000005 t:8.2s
+tttg: c107/111 lr:0.000003 t:8.3s
+tttg: c108/111 lr:0.000002 t:8.4s
+tttg: c109/111 lr:0.000001 t:8.5s
+tttg: c110/111 lr:0.000000 t:8.5s
+ttpr: phase:1/3 t:221.9s
+ttp: b760/782 bl:2.3625 bb:1.0461 rl:2.3400 rb:1.0863 dl:3817-3916 gd:0
+ttpp: phase:2/3 pd:1808 gd:1333 t:331.4s
+tttg: c1/185 lr:0.001000 t:0.1s
+tttg: c2/185 lr:0.001000 t:0.1s
+tttg: c3/185 lr:0.001000 t:0.2s
+tttg: c4/185 lr:0.000999 t:0.3s
+tttg: c5/185 lr:0.000999 t:0.4s
+tttg: c6/185 lr:0.000998 t:0.4s
+tttg: c7/185 lr:0.000997 t:0.5s
+tttg: c8/185 lr:0.000996 t:0.6s
+tttg: c9/185 lr:0.000995 t:0.7s
+tttg: c10/185 lr:0.000994 t:0.7s
+tttg: c11/185 lr:0.000993 t:0.8s
+tttg: c12/185 lr:0.000991 t:0.9s
+tttg: c13/185 lr:0.000990 t:1.0s
+tttg: c14/185 lr:0.000988 t:1.1s
+tttg: c15/185 lr:0.000986 t:1.1s
+tttg: c16/185 lr:0.000984 t:1.2s
+tttg: c17/185 lr:0.000981 t:1.3s
+tttg: c18/185 lr:0.000979 t:1.4s
+tttg: c19/185 lr:0.000977 t:1.4s
+tttg: c20/185 lr:0.000974 t:1.5s
+tttg: c21/185 lr:0.000971 t:1.6s
+tttg: c22/185 lr:0.000968 t:1.7s
+tttg: c23/185 lr:0.000965 t:1.8s
+tttg: c24/185 lr:0.000962 t:1.8s
+tttg: c25/185 lr:0.000959 t:1.9s
+tttg: c26/185 lr:0.000955 t:2.0s
+tttg: c27/185 lr:0.000952 t:2.1s
+tttg: c28/185 lr:0.000948 t:2.1s
+tttg: c29/185 lr:0.000944 t:2.2s
+tttg: c30/185 lr:0.000940 t:2.3s
+tttg: c31/185 lr:0.000936 t:2.4s
+tttg: c32/185 lr:0.000932 t:2.4s
+tttg: c33/185 lr:0.000927 t:2.5s
+tttg: c34/185 lr:0.000923 t:2.6s
+tttg: c35/185 lr:0.000918 t:2.7s
+tttg: c36/185 lr:0.000913 t:2.7s
+tttg: c37/185 lr:0.000908 t:2.8s
+tttg: c38/185 lr:0.000904 t:2.9s
+tttg: c39/185 lr:0.000898 t:3.0s
+tttg: c40/185 lr:0.000893 t:3.0s
+tttg: c41/185 lr:0.000888 t:3.1s
+tttg: c42/185 lr:0.000882 t:3.2s
+tttg: c43/185 lr:0.000877 t:3.3s
+tttg: c44/185 lr:0.000871 t:3.3s
+tttg: c45/185 lr:0.000865 t:3.4s
+tttg: c46/185 lr:0.000860 t:3.5s
+tttg: c47/185 lr:0.000854 t:3.6s
+tttg: c48/185 lr:0.000847 t:3.6s
+tttg: c49/185 lr:0.000841 t:3.7s
+tttg: c50/185 lr:0.000835 t:3.8s
+tttg: c51/185 lr:0.000829 t:3.9s
+tttg: c52/185 lr:0.000822 t:4.0s
+tttg: c53/185 lr:0.000816 t:4.0s
+tttg: c54/185 lr:0.000809 t:4.1s
+tttg: c55/185 lr:0.000802 t:4.2s
+tttg: c56/185 lr:0.000795 t:4.3s
+tttg: c57/185 lr:0.000788 t:4.3s
+tttg: c58/185 lr:0.000781 t:4.4s
+tttg: c59/185 lr:0.000774 t:4.5s
+tttg: c60/185 lr:0.000767 t:4.6s
+tttg: c61/185 lr:0.000760 t:4.6s
+tttg: c62/185 lr:0.000752 t:4.7s
+tttg: c63/185 lr:0.000745 t:4.8s
+tttg: c64/185 lr:0.000738 t:4.9s
+tttg: c65/185 lr:0.000730 t:4.9s
+tttg: c66/185 lr:0.000722 t:5.0s
+tttg: c67/185 lr:0.000715 t:5.1s
+tttg: c68/185 lr:0.000707 t:5.2s
+tttg: c69/185 lr:0.000699 t:5.2s
+tttg: c70/185 lr:0.000691 t:5.3s
+tttg: c71/185 lr:0.000683 t:5.4s
+tttg: c72/185 lr:0.000675 t:5.5s
+tttg: c73/185 lr:0.000667 t:5.5s
+tttg: c74/185 lr:0.000659 t:5.6s
+tttg: c75/185 lr:0.000651 t:5.7s
+tttg: c76/185 lr:0.000643 t:5.8s
+tttg: c77/185 lr:0.000635 t:5.8s
+tttg: c78/185 lr:0.000627 t:5.9s
+tttg: c79/185 lr:0.000618 t:6.0s
+tttg: c80/185 lr:0.000610 t:6.1s
+tttg: c81/185 lr:0.000602 t:6.1s
+tttg: c82/185 lr:0.000593 t:6.2s
+tttg: c83/185 lr:0.000585 t:6.3s
+tttg: c84/185 lr:0.000577 t:6.4s
+tttg: c85/185 lr:0.000568 t:6.5s
+tttg: c86/185 lr:0.000560 t:6.5s
+tttg: c87/185 lr:0.000551 t:6.6s
+tttg: c88/185 lr:0.000543 t:6.7s
+tttg: c89/185 lr:0.000534 t:6.7s
+tttg: c90/185 lr:0.000526 t:6.8s
+tttg: c91/185 lr:0.000517 t:6.9s
+tttg: c92/185 lr:0.000509 t:7.0s
+tttg: c93/185 lr:0.000500 t:7.0s
+tttg: c94/185 lr:0.000491 t:7.1s
+tttg: c95/185 lr:0.000483 t:7.2s
+tttg: c96/185 lr:0.000474 t:7.3s
+tttg: c97/185 lr:0.000466 t:7.3s
+tttg: c98/185 lr:0.000457 t:7.4s
+tttg: c99/185 lr:0.000449 t:7.5s
+tttg: c100/185 lr:0.000440 t:7.6s
+tttg: c101/185 lr:0.000432 t:7.6s
+tttg: c102/185 lr:0.000423 t:7.7s
+tttg: c103/185 lr:0.000415 t:7.8s
+tttg: c104/185 lr:0.000407 t:7.9s
+tttg: c105/185 lr:0.000398 t:8.0s
+tttg: c106/185 lr:0.000390 t:8.0s
+tttg: c107/185 lr:0.000382 t:8.1s
+tttg: c108/185 lr:0.000373 t:8.2s
+tttg: c109/185 lr:0.000365 t:8.3s
+tttg: c110/185 lr:0.000357 t:8.3s
+tttg: c111/185 lr:0.000349 t:8.4s
+tttg: c112/185 lr:0.000341 t:8.5s
+tttg: c113/185 lr:0.000333 t:8.6s
+tttg: c114/185 lr:0.000325 t:8.6s
+tttg: c115/185 lr:0.000317 t:8.7s
+tttg: c116/185 lr:0.000309 t:8.8s
+tttg: c117/185 lr:0.000301 t:8.9s
+tttg: c118/185 lr:0.000293 t:8.9s
+tttg: c119/185 lr:0.000285 t:9.0s
+tttg: c120/185 lr:0.000278 t:9.1s
+tttg: c121/185 lr:0.000270 t:9.2s
+tttg: c122/185 lr:0.000262 t:9.2s
+tttg: c123/185 lr:0.000255 t:9.3s
+tttg: c124/185 lr:0.000248 t:9.4s
+tttg: c125/185 lr:0.000240 t:9.5s
+tttg: c126/185 lr:0.000233 t:9.5s
+tttg: c127/185 lr:0.000226 t:9.6s
+tttg: c128/185 lr:0.000219 t:9.7s
+tttg: c129/185 lr:0.000212 t:9.8s
+tttg: c130/185 lr:0.000205 t:9.8s
+tttg: c131/185 lr:0.000198 t:9.9s
+tttg: c132/185 lr:0.000191 t:10.0s
+tttg: c133/185 lr:0.000184 t:10.1s
+tttg: c134/185 lr:0.000178 t:10.1s
+tttg: c135/185 lr:0.000171 t:10.2s
+tttg: c136/185 lr:0.000165 t:10.3s
+tttg: c137/185 lr:0.000159 t:10.4s
+tttg: c138/185 lr:0.000153 t:10.4s
+tttg: c139/185 lr:0.000146 t:10.5s
+tttg: c140/185 lr:0.000140 t:10.6s
+tttg: c141/185 lr:0.000135 t:10.7s
+tttg: c142/185 lr:0.000129 t:10.7s
+tttg: c143/185 lr:0.000123 t:10.8s
+tttg: c144/185 lr:0.000118 t:10.9s
+tttg: c145/185 lr:0.000112 t:11.0s
+tttg: c146/185 lr:0.000107 t:11.1s
+tttg: c147/185 lr:0.000102 t:11.1s
+tttg: c148/185 lr:0.000096 t:11.2s
+tttg: c149/185 lr:0.000092 t:11.3s
+tttg: c150/185 lr:0.000087 t:11.4s
+tttg: c151/185 lr:0.000082 t:11.4s
+tttg: c152/185 lr:0.000077 t:11.5s
+tttg: c153/185 lr:0.000073 t:11.6s
+tttg: c154/185 lr:0.000068 t:11.7s
+tttg: c155/185 lr:0.000064 t:11.7s
+tttg: c156/185 lr:0.000060 t:11.8s
+tttg: c157/185 lr:0.000056 t:11.9s
+tttg: c158/185 lr:0.000052 t:12.0s
+tttg: c159/185 lr:0.000048 t:12.0s
+tttg: c160/185 lr:0.000045 t:12.1s
+tttg: c161/185 lr:0.000041 t:12.2s
+tttg: c162/185 lr:0.000038 t:12.3s
+tttg: c163/185 lr:0.000035 t:12.3s
+tttg: c164/185 lr:0.000032 t:12.4s
+tttg: c165/185 lr:0.000029 t:12.5s
+tttg: c166/185 lr:0.000026 t:12.6s
+tttg: c167/185 lr:0.000023 t:12.6s
+tttg: c168/185 lr:0.000021 t:12.7s
+tttg: c169/185 lr:0.000019 t:12.8s
+tttg: c170/185 lr:0.000016 t:12.9s
+tttg: c171/185 lr:0.000014 t:13.0s
+tttg: c172/185 lr:0.000012 t:13.0s
+tttg: c173/185 lr:0.000010 t:13.1s
+tttg: c174/185 lr:0.000009 t:13.2s
+tttg: c175/185 lr:0.000007 t:13.3s
+tttg: c176/185 lr:0.000006 t:13.3s
+tttg: c177/185 lr:0.000005 t:13.4s
+tttg: c178/185 lr:0.000004 t:13.5s
+tttg: c179/185 lr:0.000003 t:13.6s
+tttg: c180/185 lr:0.000002 t:13.6s
+tttg: c181/185 lr:0.000001 t:13.7s
+tttg: c182/185 lr:0.000001 t:13.8s
+tttg: c183/185 lr:0.000000 t:13.9s
+tttg: c184/185 lr:0.000000 t:13.9s
+ttpr: phase:2/3 t:347.4s
+ttp: b752/782 bl:2.3448 bb:1.0779 rl:2.3406 rb:1.0853 dl:3222-3283 gd:0
+ttpp: phase:3/3 pd:2448 gd:2000 t:364.2s
+tttg: c1/250 lr:0.001000 t:0.1s
+tttg: c2/250 lr:0.001000 t:0.1s
+tttg: c3/250 lr:0.001000 t:0.2s
+tttg: c4/250 lr:0.001000 t:0.3s
+tttg: c5/250 lr:0.000999 t:0.4s
+tttg: c6/250 lr:0.000999 t:0.4s
+tttg: c7/250 lr:0.000999 t:0.5s
+tttg: c8/250 lr:0.000998 t:0.6s
+tttg: c9/250 lr:0.000997 t:0.7s
+tttg: c10/250 lr:0.000997 t:0.7s
+tttg: c11/250 lr:0.000996 t:0.8s
+tttg: c12/250 lr:0.000995 t:0.9s
+tttg: c13/250 lr:0.000994 t:0.9s
+tttg: c14/250 lr:0.000993 t:1.0s
+tttg: c15/250 lr:0.000992 t:1.1s
+tttg: c16/250 lr:0.000991 t:1.2s
+tttg: c17/250 lr:0.000990 t:1.2s
+tttg: c18/250 lr:0.000989 t:1.3s
+tttg: c19/250 lr:0.000987 t:1.4s
+tttg: c20/250 lr:0.000986 t:1.5s
+tttg: c21/250 lr:0.000984 t:1.6s
+tttg: c22/250 lr:0.000983 t:1.6s
+tttg: c23/250 lr:0.000981 t:1.7s
+tttg: c24/250 lr:0.000979 t:1.8s
+tttg: c25/250 lr:0.000977 t:1.9s
+tttg: c26/250 lr:0.000975 t:1.9s
+tttg: c27/250 lr:0.000973 t:2.0s
+tttg: c28/250 lr:0.000971 t:2.1s
+tttg: c29/250 lr:0.000969 t:2.2s
+tttg: c30/250 lr:0.000967 t:2.2s
+tttg: c31/250 lr:0.000965 t:2.3s
+tttg: c32/250 lr:0.000962 t:2.4s
+tttg: c33/250 lr:0.000960 t:2.5s
+tttg: c34/250 lr:0.000957 t:2.5s
+tttg: c35/250 lr:0.000955 t:2.6s
+tttg: c36/250 lr:0.000952 t:2.7s
+tttg: c37/250 lr:0.000949 t:2.8s
+tttg: c38/250 lr:0.000947 t:2.8s
+tttg: c39/250 lr:0.000944 t:2.9s
+tttg: c40/250 lr:0.000941 t:3.0s
+tttg: c41/250 lr:0.000938 t:3.1s
+tttg: c42/250 lr:0.000935 t:3.1s
+tttg: c43/250 lr:0.000931 t:3.2s
+tttg: c44/250 lr:0.000928 t:3.3s
+tttg: c45/250 lr:0.000925 t:3.4s
+tttg: c46/250 lr:0.000922 t:3.5s
+tttg: c47/250 lr:0.000918 t:3.5s
+tttg: c48/250 lr:0.000915 t:3.6s
+tttg: c49/250 lr:0.000911 t:3.7s
+tttg: c50/250 lr:0.000907 t:3.8s
+tttg: c51/250 lr:0.000904 t:3.8s
+tttg: c52/250 lr:0.000900 t:3.9s
+tttg: c53/250 lr:0.000896 t:4.0s
+tttg: c54/250 lr:0.000892 t:4.1s
+tttg: c55/250 lr:0.000888 t:4.1s
+tttg: c56/250 lr:0.000884 t:4.2s
+tttg: c57/250 lr:0.000880 t:4.3s
+tttg: c58/250 lr:0.000876 t:4.4s
+tttg: c59/250 lr:0.000872 t:4.4s
+tttg: c60/250 lr:0.000868 t:4.5s
+tttg: c61/250 lr:0.000863 t:4.6s
+tttg: c62/250 lr:0.000859 t:4.7s
+tttg: c63/250 lr:0.000855 t:4.7s
+tttg: c64/250 lr:0.000850 t:4.8s
+tttg: c65/250 lr:0.000846 t:4.9s
+tttg: c66/250 lr:0.000841 t:5.0s
+tttg: c67/250 lr:0.000836 t:5.0s
+tttg: c68/250 lr:0.000832 t:5.1s
+tttg: c69/250 lr:0.000827 t:5.2s
+tttg: c70/250 lr:0.000822 t:5.3s
+tttg: c71/250 lr:0.000817 t:5.3s
+tttg: c72/250 lr:0.000812 t:5.4s
+tttg: c73/250 lr:0.000807 t:5.5s
+tttg: c74/250 lr:0.000803 t:5.6s
+tttg: c75/250 lr:0.000797 t:5.6s
+tttg: c76/250 lr:0.000792 t:5.7s
+tttg: c77/250 lr:0.000787 t:5.8s
+tttg: c78/250 lr:0.000782 t:5.9s
+tttg: c79/250 lr:0.000777 t:5.9s
+tttg: c80/250 lr:0.000772 t:6.0s
+tttg: c81/250 lr:0.000766 t:6.1s
+tttg: c82/250 lr:0.000761 t:6.2s
+tttg: c83/250 lr:0.000755 t:6.2s
+tttg: c84/250 lr:0.000750 t:6.3s
+tttg: c85/250 lr:0.000745 t:6.4s
+tttg: c86/250 lr:0.000739 t:6.5s
+tttg: c87/250 lr:0.000733 t:6.5s
+tttg: c88/250 lr:0.000728 t:6.6s
+tttg: c89/250 lr:0.000722 t:6.7s
+tttg: c90/250 lr:0.000717 t:6.8s
+tttg: c91/250 lr:0.000711 t:6.9s
+tttg: c92/250 lr:0.000705 t:6.9s
+tttg: c93/250 lr:0.000699 t:7.0s
+tttg: c94/250 lr:0.000694 t:7.1s
+tttg: c95/250 lr:0.000688 t:7.2s
+tttg: c96/250 lr:0.000682 t:7.2s
+tttg: c97/250 lr:0.000676 t:7.3s
+tttg: c98/250 lr:0.000670 t:7.4s
+tttg: c99/250 lr:0.000664 t:7.5s
+tttg: c100/250 lr:0.000658 t:7.5s
+tttg: c101/250 lr:0.000652 t:7.6s
+tttg: c102/250 lr:0.000646 t:7.7s
+tttg: c103/250 lr:0.000640 t:7.8s
+tttg: c104/250 lr:0.000634 t:7.8s
+tttg: c105/250 lr:0.000628 t:7.9s
+tttg: c106/250 lr:0.000622 t:8.0s
+tttg: c107/250 lr:0.000616 t:8.1s
+tttg: c108/250 lr:0.000610 t:8.1s
+tttg: c109/250 lr:0.000603 t:8.2s
+tttg: c110/250 lr:0.000597 t:8.3s
+tttg: c111/250 lr:0.000591 t:8.4s
+tttg: c112/250 lr:0.000585 t:8.4s
+tttg: c113/250 lr:0.000579 t:8.5s
+tttg: c114/250 lr:0.000572 t:8.6s
+tttg: c115/250 lr:0.000566 t:8.7s
+tttg: c116/250 lr:0.000560 t:8.7s
+tttg: c117/250 lr:0.000554 t:8.8s
+tttg: c118/250 lr:0.000547 t:8.9s
+tttg: c119/250 lr:0.000541 t:9.0s
+tttg: c120/250 lr:0.000535 t:9.0s
+tttg: c121/250 lr:0.000528 t:9.1s
+tttg: c122/250 lr:0.000522 t:9.2s
+tttg: c123/250 lr:0.000516 t:9.3s
+tttg: c124/250 lr:0.000509 t:9.3s
+tttg: c125/250 lr:0.000503 t:9.4s
+tttg: c126/250 lr:0.000497 t:9.5s
+tttg: c127/250 lr:0.000491 t:9.6s
+tttg: c128/250 lr:0.000484 t:9.6s
+tttg: c129/250 lr:0.000478 t:9.7s
+tttg: c130/250 lr:0.000472 t:9.8s
+tttg: c131/250 lr:0.000465 t:9.9s
+tttg: c132/250 lr:0.000459 t:10.0s
+tttg: c133/250 lr:0.000453 t:10.0s
+tttg: c134/250 lr:0.000446 t:10.1s
+tttg: c135/250 lr:0.000440 t:10.2s
+tttg: c136/250 lr:0.000434 t:10.3s
+tttg: c137/250 lr:0.000428 t:10.3s
+tttg: c138/250 lr:0.000421 t:10.4s
+tttg: c139/250 lr:0.000415 t:10.5s
+tttg: c140/250 lr:0.000409 t:10.6s
+tttg: c141/250 lr:0.000403 t:10.6s
+tttg: c142/250 lr:0.000397 t:10.7s
+tttg: c143/250 lr:0.000390 t:10.8s
+tttg: c144/250 lr:0.000384 t:10.9s
+tttg: c145/250 lr:0.000378 t:10.9s
+tttg: c146/250 lr:0.000372 t:11.0s
+tttg: c147/250 lr:0.000366 t:11.1s
+tttg: c148/250 lr:0.000360 t:11.2s
+tttg: c149/250 lr:0.000354 t:11.2s
+tttg: c150/250 lr:0.000348 t:11.3s
+tttg: c151/250 lr:0.000342 t:11.4s
+tttg: c152/250 lr:0.000336 t:11.5s
+tttg: c153/250 lr:0.000330 t:11.5s
+tttg: c154/250 lr:0.000324 t:11.6s
+tttg: c155/250 lr:0.000318 t:11.7s
+tttg: c156/250 lr:0.000312 t:11.8s
+tttg: c157/250 lr:0.000306 t:11.9s
+tttg: c158/250 lr:0.000301 t:11.9s
+tttg: c159/250 lr:0.000295 t:12.0s
+tttg: c160/250 lr:0.000289 t:12.1s
+tttg: c161/250 lr:0.000283 t:12.2s
+tttg: c162/250 lr:0.000278 t:12.2s
+tttg: c163/250 lr:0.000272 t:12.3s
+tttg: c164/250 lr:0.000267 t:12.4s
+tttg: c165/250 lr:0.000261 t:12.5s
+tttg: c166/250 lr:0.000255 t:12.5s
+tttg: c167/250 lr:0.000250 t:12.6s
+tttg: c168/250 lr:0.000245 t:12.7s
+tttg: c169/250 lr:0.000239 t:12.8s
+tttg: c170/250 lr:0.000234 t:12.8s
+tttg: c171/250 lr:0.000228 t:12.9s
+tttg: c172/250 lr:0.000223 t:13.0s
+tttg: c173/250 lr:0.000218 t:13.1s
+tttg: c174/250 lr:0.000213 t:13.1s
+tttg: c175/250 lr:0.000208 t:13.2s
+tttg: c176/250 lr:0.000203 t:13.3s
+tttg: c177/250 lr:0.000197 t:13.4s
+tttg: c178/250 lr:0.000193 t:13.4s
+tttg: c179/250 lr:0.000188 t:13.5s
+tttg: c180/250 lr:0.000183 t:13.6s
+tttg: c181/250 lr:0.000178 t:13.7s
+tttg: c182/250 lr:0.000173 t:13.8s
+tttg: c183/250 lr:0.000168 t:13.8s
+tttg: c184/250 lr:0.000164 t:13.9s
+tttg: c185/250 lr:0.000159 t:14.0s
+tttg: c186/250 lr:0.000154 t:14.1s
+tttg: c187/250 lr:0.000150 t:14.1s
+tttg: c188/250 lr:0.000145 t:14.2s
+tttg: c189/250 lr:0.000141 t:14.3s
+tttg: c190/250 lr:0.000137 t:14.4s
+tttg: c191/250 lr:0.000132 t:14.4s
+tttg: c192/250 lr:0.000128 t:14.5s
+tttg: c193/250 lr:0.000124 t:14.6s
+tttg: c194/250 lr:0.000120 t:14.7s
+tttg: c195/250 lr:0.000116 t:14.7s
+tttg: c196/250 lr:0.000112 t:14.8s
+tttg: c197/250 lr:0.000108 t:14.9s
+tttg: c198/250 lr:0.000104 t:15.0s
+tttg: c199/250 lr:0.000100 t:15.0s
+tttg: c200/250 lr:0.000096 t:15.1s
+tttg: c201/250 lr:0.000093 t:15.2s
+tttg: c202/250 lr:0.000089 t:15.3s
+tttg: c203/250 lr:0.000085 t:15.3s
+tttg: c204/250 lr:0.000082 t:15.4s
+tttg: c205/250 lr:0.000078 t:15.5s
+tttg: c206/250 lr:0.000075 t:15.6s
+tttg: c207/250 lr:0.000072 t:15.6s
+tttg: c208/250 lr:0.000069 t:15.7s
+tttg: c209/250 lr:0.000065 t:15.8s
+tttg: c210/250 lr:0.000062 t:15.9s
+tttg: c211/250 lr:0.000059 t:15.9s
+tttg: c212/250 lr:0.000056 t:16.0s
+tttg: c213/250 lr:0.000053 t:16.1s
+tttg: c214/250 lr:0.000051 t:16.2s
+tttg: c215/250 lr:0.000048 t:16.2s
+tttg: c216/250 lr:0.000045 t:16.3s
+tttg: c217/250 lr:0.000043 t:16.4s
+tttg: c218/250 lr:0.000040 t:16.5s
+tttg: c219/250 lr:0.000038 t:16.5s
+tttg: c220/250 lr:0.000035 t:16.6s
+tttg: c221/250 lr:0.000033 t:16.7s
+tttg: c222/250 lr:0.000031 t:16.8s
+tttg: c223/250 lr:0.000029 t:16.8s
+tttg: c224/250 lr:0.000027 t:16.9s
+tttg: c225/250 lr:0.000025 t:17.0s
+tttg: c226/250 lr:0.000023 t:17.1s
+tttg: c227/250 lr:0.000021 t:17.1s
+tttg: c228/250 lr:0.000019 t:17.2s
+tttg: c229/250 lr:0.000017 t:17.3s
+tttg: c230/250 lr:0.000016 t:17.4s
+tttg: c231/250 lr:0.000014 t:17.4s
+tttg: c232/250 lr:0.000013 t:17.5s
+tttg: c233/250 lr:0.000011 t:17.6s
+tttg: c234/250 lr:0.000010 t:17.7s
+tttg: c235/250 lr:0.000009 t:17.7s
+tttg: c236/250 lr:0.000008 t:17.8s
+tttg: c237/250 lr:0.000007 t:17.9s
+tttg: c238/250 lr:0.000006 t:18.0s
+tttg: c239/250 lr:0.000005 t:18.0s
+tttg: c240/250 lr:0.000004 t:18.1s
+tttg: c241/250 lr:0.000003 t:18.2s
+tttg: c242/250 lr:0.000003 t:18.3s
+tttg: c243/250 lr:0.000002 t:18.4s
+tttg: c244/250 lr:0.000001 t:18.4s
+tttg: c245/250 lr:0.000001 t:18.5s
+tttg: c246/250 lr:0.000001 t:18.6s
+tttg: c247/250 lr:0.000000 t:18.7s
+tttg: c248/250 lr:0.000000 t:18.7s
+tttg: c249/250 lr:0.000000 t:18.8s
+ttpr: phase:3/3 t:385.1s
+ttp: b738/782 bl:2.3222 bb:1.0515 rl:2.3390 rb:1.0822 dl:2583-2618 gd:1
+ttp: b733/782 bl:2.3931 bb:1.0715 rl:2.3431 rb:1.0814 dl:2441-2468 gd:1
+ttp: b722/782 bl:2.3573 bb:1.0563 rl:2.3440 rb:1.0798 dl:2163-2185 gd:1
+ttp: b717/782 bl:2.2708 bb:1.0397 rl:2.3398 rb:1.0775 dl:2070-2088 gd:1
+ttp: b706/782 bl:2.4168 bb:1.0809 rl:2.3437 rb:1.0776 dl:1898-1910 gd:1
+ttp: b703/782 bl:2.3544 bb:1.0358 rl:2.3442 rb:1.0756 dl:1859-1872 gd:1
+ttp: b690/782 bl:2.3091 bb:1.0719 rl:2.3427 rb:1.0755 dl:1715-1725 gd:1
+ttp: b687/782 bl:2.3276 bb:1.0629 rl:2.3421 rb:1.0750 dl:1685-1696 gd:1
+ttp: b673/782 bl:2.3778 bb:1.0674 rl:2.3434 rb:1.0747 dl:1562-1571 gd:1
+ttp: b669/782 bl:2.3485 bb:1.0500 rl:2.3435 rb:1.0739 dl:1530-1537 gd:1
+ttp: b663/782 bl:2.3400 bb:1.0466 rl:2.3434 rb:1.0730 dl:1486-1493 gd:1
+ttp: b648/782 bl:2.3007 bb:1.0153 rl:2.3422 rb:1.0713 dl:1387-1392 gd:1
+ttp: b647/782 bl:2.2916 bb:1.0400 rl:2.3409 rb:1.0705 dl:1382-1387 gd:1
+ttp: b638/782 bl:2.3554 bb:1.0732 rl:2.3412 rb:1.0705 dl:1325-1331 gd:1
+ttp: b629/782 bl:2.3621 bb:1.0165 rl:2.3417 rb:1.0692 dl:1276-1280 gd:1
+ttp: b619/782 bl:2.3392 bb:1.0668 rl:2.3417 rb:1.0691 dl:1221-1226 gd:1
+ttp: b611/782 bl:2.3100 bb:1.0315 rl:2.3410 rb:1.0683 dl:1182-1186 gd:1
+ttp: b604/782 bl:2.3969 bb:1.0521 rl:2.3421 rb:1.0680 dl:1150-1154 gd:1
+ttp: b592/782 bl:2.2392 bb:0.9997 rl:2.3402 rb:1.0666 dl:1098-1103 gd:1
+ttp: b591/782 bl:2.3240 bb:1.0400 rl:2.3399 rb:1.0661 dl:1093-1098 gd:1
+ttp: b583/782 bl:2.3379 bb:1.0389 rl:2.3399 rb:1.0656 dl:1060-1064 gd:1
+ttp: b570/782 bl:2.3667 bb:1.0600 rl:2.3403 rb:1.0656 dl:1010-1014 gd:1
+ttp: b560/782 bl:2.2847 bb:1.0167 rl:2.3394 rb:1.0648 dl:975-979 gd:1
+ttp: b552/782 bl:2.2902 bb:1.0260 rl:2.3387 rb:1.0642 dl:949-952 gd:1
+ttp: b548/782 bl:2.2579 bb:1.0548 rl:2.3375 rb:1.0640 dl:937-939 gd:1
+ttp: b539/782 bl:2.3506 bb:1.0420 rl:2.3377 rb:1.0637 dl:909-912 gd:1
+ttp: b535/782 bl:2.3954 bb:1.0389 rl:2.3385 rb:1.0634 dl:896-899 gd:1
+ttp: b526/782 bl:2.3380 bb:1.0305 rl:2.3385 rb:1.0629 dl:869-872 gd:1
+ttp: b515/782 bl:2.3570 bb:1.0495 rl:2.3387 rb:1.0628 dl:838-841 gd:1
+ttp: b509/782 bl:2.3754 bb:1.0429 rl:2.3391 rb:1.0625 dl:820-823 gd:1
+ttp: b497/782 bl:2.3555 bb:1.0505 rl:2.3393 rb:1.0624 dl:788-791 gd:1
+ttp: b489/782 bl:2.4009 bb:1.0802 rl:2.3400 rb:1.0626 dl:769-771 gd:1
+ttp: b480/782 bl:2.4505 bb:1.0911 rl:2.3412 rb:1.0629 dl:747-749 gd:1
+ttp: b472/782 bl:2.3987 bb:1.0888 rl:2.3417 rb:1.0631 dl:728-730 gd:1
+ttp: b464/782 bl:2.2808 bb:1.0221 rl:2.3411 rb:1.0627 dl:710-712 gd:1
+ttp: b459/782 bl:2.2949 bb:1.0507 rl:2.3407 rb:1.0626 dl:700-701 gd:1
+ttp: b451/782 bl:2.4139 bb:1.0923 rl:2.3414 rb:1.0629 dl:682-685 gd:1
+ttp: b443/782 bl:2.2518 bb:1.0595 rl:2.3406 rb:1.0629 dl:666-668 gd:1
+ttp: b437/782 bl:2.3110 bb:1.0633 rl:2.3403 rb:1.0629 dl:653-655 gd:1
+ttp: b429/782 bl:2.2623 bb:1.0318 rl:2.3397 rb:1.0626 dl:638-640 gd:1
+ttp: b421/782 bl:2.3066 bb:1.0099 rl:2.3394 rb:1.0622 dl:622-624 gd:1
+ttp: b414/782 bl:2.2219 bb:1.0173 rl:2.3385 rb:1.0618 dl:609-611 gd:1
+ttp: b406/782 bl:2.3271 bb:1.0717 rl:2.3384 rb:1.0619 dl:593-595 gd:1
+ttp: b398/782 bl:2.2574 bb:1.0081 rl:2.3378 rb:1.0615 dl:579-581 gd:1
+ttp: b386/782 bl:2.3551 bb:1.1060 rl:2.3379 rb:1.0618 dl:557-559 gd:1
+ttp: b378/782 bl:2.4430 bb:1.0601 rl:2.3386 rb:1.0618 dl:544-545 gd:1
+ttp: b370/782 bl:2.3812 bb:1.0901 rl:2.3389 rb:1.0620 dl:530-532 gd:1
+ttp: b361/782 bl:2.3605 bb:1.1020 rl:2.3390 rb:1.0622 dl:515-517 gd:1
+ttp: b353/782 bl:2.2156 bb:1.0132 rl:2.3383 rb:1.0619 dl:501-503 gd:1
+ttp: b345/782 bl:2.3792 bb:1.0831 rl:2.3385 rb:1.0620 dl:489-491 gd:1
+ttp: b338/782 bl:2.3769 bb:1.1070 rl:2.3387 rb:1.0623 dl:478-480 gd:1
+ttp: b335/782 bl:2.3836 bb:1.0798 rl:2.3390 rb:1.0624 dl:474-476 gd:1
+ttp: b326/782 bl:2.3338 bb:1.0687 rl:2.3390 rb:1.0624 dl:461-462 gd:1
+ttp: b317/782 bl:2.3176 bb:1.0530 rl:2.3389 rb:1.0624 dl:446-448 gd:1
+ttp: b309/782 bl:2.4267 bb:1.1135 rl:2.3393 rb:1.0626 dl:435-437 gd:1
+ttp: b298/782 bl:2.4368 bb:1.1096 rl:2.3398 rb:1.0629 dl:418-420 gd:1
+ttp: b291/782 bl:2.2798 bb:1.0194 rl:2.3395 rb:1.0627 dl:407-409 gd:1
+ttp: b284/782 bl:2.4623 bb:1.1465 rl:2.3401 rb:1.0630 dl:398-399 gd:1
+ttp: b276/782 bl:2.4046 bb:1.1115 rl:2.3404 rb:1.0633 dl:387-388 gd:1
+ttp: b266/782 bl:2.3846 bb:1.1095 rl:2.3406 rb:1.0635 dl:374-375 gd:1
+ttp: b258/782 bl:2.4572 bb:1.1025 rl:2.3411 rb:1.0636 dl:364-365 gd:1
+ttp: b251/782 bl:2.3867 bb:1.1034 rl:2.3413 rb:1.0638 dl:355-356 gd:1
+ttp: b243/782 bl:2.3719 bb:1.0884 rl:2.3414 rb:1.0639 dl:345-346 gd:1
+ttp: b236/782 bl:2.3488 bb:1.0810 rl:2.3414 rb:1.0640 dl:336-337 gd:1
+ttp: b231/782 bl:2.3200 bb:1.0898 rl:2.3413 rb:1.0640 dl:330-331 gd:1
+ttp: b223/782 bl:2.3520 bb:1.1355 rl:2.3414 rb:1.0643 dl:321-322 gd:1
+ttp: b214/782 bl:2.3514 bb:1.1252 rl:2.3414 rb:1.0645 dl:310-312 gd:1
+ttp: b206/782 bl:2.4190 bb:1.1128 rl:2.3417 rb:1.0647 dl:302-303 gd:1
+ttp: b198/782 bl:2.4090 bb:1.0657 rl:2.3419 rb:1.0647 dl:294-295 gd:1
+ttp: b190/782 bl:2.3501 bb:1.0805 rl:2.3419 rb:1.0647 dl:284-285 gd:1
+ttp: b182/782 bl:2.3674 bb:1.1256 rl:2.3420 rb:1.0649 dl:276-277 gd:1
+ttp: b174/782 bl:2.4586 bb:1.1596 rl:2.3423 rb:1.0652 dl:268-269 gd:1
+ttp: b166/782 bl:2.4919 bb:1.1138 rl:2.3428 rb:1.0653 dl:260-262 gd:1
+ttp: b158/782 bl:2.3519 bb:1.1120 rl:2.3428 rb:1.0654 dl:253-254 gd:1
+ttp: b150/782 bl:2.3417 bb:1.1119 rl:2.3428 rb:1.0656 dl:245-246 gd:1
+ttp: b142/782 bl:2.4057 bb:1.1198 rl:2.3430 rb:1.0657 dl:237-238 gd:1
+ttp: b134/782 bl:2.4406 bb:1.1445 rl:2.3432 rb:1.0659 dl:230-231 gd:1
+ttp: b126/782 bl:2.4137 bb:1.1499 rl:2.3434 rb:1.0661 dl:222-223 gd:1
+ttp: b119/782 bl:2.3947 bb:1.1659 rl:2.3435 rb:1.0663 dl:216-217 gd:1
+ttp: b112/782 bl:2.5009 bb:1.1936 rl:2.3439 rb:1.0666 dl:210-210 gd:1
+ttp: b102/782 bl:2.6014 bb:1.2058 rl:2.3444 rb:1.0669 dl:201-202 gd:1
+ttp: b95/782 bl:2.3383 bb:1.1431 rl:2.3444 rb:1.0670 dl:194-195 gd:1
+ttp: b86/782 bl:2.4740 bb:1.1414 rl:2.3447 rb:1.0672 dl:186-187 gd:1
+ttp: b78/782 bl:2.5635 bb:1.2001 rl:2.3451 rb:1.0674 dl:179-180 gd:1
+ttp: b71/782 bl:2.4822 bb:1.1863 rl:2.3454 rb:1.0676 dl:173-173 gd:1
+ttp: b63/782 bl:2.5337 bb:1.2086 rl:2.3457 rb:1.0679 dl:166-166 gd:1
+ttp: b54/782 bl:2.4917 bb:1.2223 rl:2.3460 rb:1.0681 dl:157-158 gd:1
+ttp: b46/782 bl:2.5577 bb:1.2213 rl:2.3463 rb:1.0684 dl:149-150 gd:1
+ttp: b38/782 bl:2.6232 bb:1.2031 rl:2.3467 rb:1.0686 dl:141-142 gd:1
+ttp: b30/782 bl:2.6133 bb:1.2742 rl:2.3471 rb:1.0688 dl:133-134 gd:1
+ttp: b22/782 bl:2.5650 bb:1.2007 rl:2.3474 rb:1.0690 dl:124-126 gd:1
+ttp: b14/782 bl:2.6074 bb:1.1903 rl:2.3477 rb:1.0692 dl:114-115 gd:1
+ttp: b6/782 bl:2.7312 bb:1.2177 rl:2.3481 rb:1.0693 dl:99-101 gd:1
+quantized_ttt_phased val_loss:2.33560135 val_bpb:1.06727867 eval_time:494588ms
+total_eval_time:494.6s

--- a/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/train_seed42.log
+++ b/records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper/train_seed42.log
@@ -1,0 +1,827 @@
+W0418 20:36:48.591000 258212 torch/distributed/run.py:803] 
+W0418 20:36:48.591000 258212 torch/distributed/run.py:803] *****************************************
+W0418 20:36:48.591000 258212 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0418 20:36:48.591000 258212 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  artifact_dir: 
+  attn_clip_sigmas: 13.0
+  beta1: 0.9
+  beta2: 0.95
+  compressor: brotli
+  data_dir: ./data/
+  datasets_dir: /workspace/caseops_export/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved
+  default_datasets_dir: ./data/datasets/fineweb10B_sp8192
+  distributed: True
+  ema_decay: 0.9965
+  embed_bits: 7
+  embed_clip_sigmas: 15.0
+  embed_lr: 0.6
+  embed_wd: 0.085
+  enable_looping_at: 0.35
+  eval_seq_len: 2048
+  eval_stride: 64
+  global_ttt_batch_seqs: 32
+  global_ttt_chunk_tokens: 32768
+  global_ttt_epochs: 1
+  global_ttt_grad_clip: 1.0
+  global_ttt_lr: 0.001
+  global_ttt_momentum: 0.9
+  global_ttt_respect_doc_boundaries: True
+  global_ttt_warmup_chunks: 0
+  global_ttt_warmup_start_lr: 0.0
+  gptq_calibration_batches: 16
+  gptq_reserve_seconds: 4.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  is_main_process: True
+  iterations: 20000
+  ln_scale: True
+  local_rank: 0
+  logfile: logs/pr1626_caseops_seed42_0418.txt
+  logit_softcap: 30.0
+  loop_end: 5
+  loop_start: 3
+  matrix_bits: 6
+  matrix_clip_sigmas: 12.85
+  matrix_lr: 0.026
+  max_wallclock_seconds: 600.0
+  min_lr: 0.0
+  mlp_clip_sigmas: 12.0
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: final_model.pt
+  muon_backend_steps: 5
+  muon_momentum: 0.97
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_row_normalize: True
+  muon_wd: 0.095
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  num_loops: 2
+  parallel_final_lane: mean
+  parallel_start_layer: 8
+  phased_ttt_enabled: True
+  phased_ttt_num_phases: 3
+  phased_ttt_prefix_docs: 2000
+  qk_gain_init: 5.0
+  quantized_model_path: final_model.int6.ptz
+  rank: 0
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  rope_yarn: False
+  run_id: pr1626_caseops_seed42_0418
+  scalar_lr: 0.02
+  seed: 42
+  skip_gates_enabled: True
+  skip_post_train_eval: False
+  sliding_window_enabled: False
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  tokenizer_path: /workspace/caseops_export/tokenizers/fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model
+  train_batch_tokens: 786432
+  train_files: /workspace/caseops_export/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_train_*.bin
+  train_log_every: 500
+  train_seq_len: 2048
+  ttt_batch_size: 64
+  ttt_beta1: 0.0
+  ttt_beta2: 0.999
+  ttt_chunk_size: 48
+  ttt_enabled: True
+  ttt_eval_batches: 
+  ttt_eval_seq_len: 2048
+  ttt_grad_steps: 1
+  ttt_k_lora: True
+  ttt_lora_lr: 0.0001
+  ttt_lora_rank: 96
+  ttt_mlp_lora: True
+  ttt_o_lora: True
+  ttt_only: False
+  ttt_optimizer: adam
+  ttt_weight_decay: 0.5
+  val_batch_tokens: 524288
+  val_doc_fraction: 1.0
+  val_files: /workspace/caseops_export/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_val_[0-9][0-9][0-9][0-9][0-9][0-9].bin
+  val_loss_every: 4000
+  vocab_size: 8192
+  warmdown_frac: 0.75
+  warmup_steps: 20
+  wd_taper_final_mult: 0.5
+  wd_taper_start_frac: 0.7
+  world_size: 8
+  xsa_last_n: 11
+val_bpb:byte_sidecar:enabled
+train_shards: 80
+val_tokens: 47851520
+model_params:35944602
+gptq:reserving 4s, effective=596000ms
+warmup_cu_buckets:64,128,192,256 iters_each:3
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup:enabled encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+loop_warmup_step: 1/20
+loop_warmup_step: 2/20
+loop_warmup_step: 3/20
+loop_warmup_step: 4/20
+loop_warmup_step: 5/20
+loop_warmup_step: 6/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+0/20000 val_loss: 9.0157 val_bpb: 4.1195
+1/20000 train_loss: 9.0168 train_time: 0.0m tok/s: 16488651
+2/20000 train_loss: 12.8302 train_time: 0.0m tok/s: 12713043
+3/20000 train_loss: 10.1939 train_time: 0.0m tok/s: 10865487
+4/20000 train_loss: 8.7032 train_time: 0.0m tok/s: 10180692
+5/20000 train_loss: 7.9755 train_time: 0.0m tok/s: 9788163
+500/20000 train_loss: 2.5896 train_time: 0.8m tok/s: 8222012
+1000/20000 train_loss: 2.8187 train_time: 1.6m tok/s: 8168135
+1500/20000 train_loss: 2.6433 train_time: 2.4m tok/s: 8152138
+2000/20000 train_loss: 2.6747 train_time: 3.2m tok/s: 8149134
+layer_loop:enabled step:2160 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2500/20000 train_loss: 2.5609 train_time: 4.3m tok/s: 7666950
+3000/20000 train_loss: 2.5778 train_time: 5.4m tok/s: 7216013
+3500/20000 train_loss: 2.5785 train_time: 6.6m tok/s: 6926721
+4000/20000 train_loss: 2.4198 train_time: 7.8m tok/s: 6723552
+4000/20000 val_loss: 2.4406 val_bpb: 1.1152
+4500/20000 train_loss: 2.2894 train_time: 9.0m tok/s: 6537333
+4866/20000 val_loss: 2.3441 val_bpb: 1.0711
+stopping_early: wallclock_cap train_time: 596114ms step: 4866/20000
+peak memory allocated: 40029 MiB reserved: 44036 MiB
+ema:applying EMA weights
+diagnostic pre-quantization post-ema val_loss:2.34314321 val_bpb:1.07065549 eval_time:10659ms
+Serialized model: 135409136 bytes
+Code size (uncompressed): 125670 bytes
+Code size (compressed): 30985 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 3.4s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int7): tok_emb.weight
+  passthrough (float16): blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, skip_gates, skip_weights
+Serialized model quantized+brotli: 15904817 bytes
+Total submission size quantized+brotli: 15935802 bytes
+diagnostic quantized val_loss:2.36734699 val_bpb:1.08171495 eval_time:56304ms
+ttt_lora:warming up compile (random tokens, no val data)
+ttt_lora:compile warmup done (151.4s)
+
+beginning TTT eval timer
+ttt_phased: total_docs:50000 prefix_docs:2000 suffix_docs:48000 num_phases:3 boundaries:[666, 1333, 2000]
+ttp: b781/782 bl:2.1720 bb:1.0627 rl:2.1720 rb:1.0627 dl:17258-30330 gd:0
+ttpp: phase:1/3 pd:1104 gd:666 t:213.1s
+tttg: c1/111 lr:0.001000 t:0.3s
+tttg: c2/111 lr:0.001000 t:0.4s
+tttg: c3/111 lr:0.000999 t:0.5s
+tttg: c4/111 lr:0.000998 t:0.6s
+tttg: c5/111 lr:0.000997 t:0.7s
+tttg: c6/111 lr:0.000995 t:0.7s
+tttg: c7/111 lr:0.000993 t:0.8s
+tttg: c8/111 lr:0.000990 t:0.9s
+tttg: c9/111 lr:0.000987 t:1.0s
+tttg: c10/111 lr:0.000984 t:1.0s
+tttg: c11/111 lr:0.000980 t:1.1s
+tttg: c12/111 lr:0.000976 t:1.2s
+tttg: c13/111 lr:0.000971 t:1.3s
+tttg: c14/111 lr:0.000966 t:1.3s
+tttg: c15/111 lr:0.000961 t:1.4s
+tttg: c16/111 lr:0.000955 t:1.5s
+tttg: c17/111 lr:0.000949 t:1.5s
+tttg: c18/111 lr:0.000942 t:1.6s
+tttg: c19/111 lr:0.000935 t:1.7s
+tttg: c20/111 lr:0.000928 t:1.8s
+tttg: c21/111 lr:0.000921 t:1.8s
+tttg: c22/111 lr:0.000913 t:1.9s
+tttg: c23/111 lr:0.000905 t:2.0s
+tttg: c24/111 lr:0.000896 t:2.1s
+tttg: c25/111 lr:0.000887 t:2.1s
+tttg: c26/111 lr:0.000878 t:2.2s
+tttg: c27/111 lr:0.000868 t:2.3s
+tttg: c28/111 lr:0.000859 t:2.3s
+tttg: c29/111 lr:0.000848 t:2.4s
+tttg: c30/111 lr:0.000838 t:2.5s
+tttg: c31/111 lr:0.000827 t:2.6s
+tttg: c32/111 lr:0.000817 t:2.6s
+tttg: c33/111 lr:0.000805 t:2.7s
+tttg: c34/111 lr:0.000794 t:2.8s
+tttg: c35/111 lr:0.000782 t:2.9s
+tttg: c36/111 lr:0.000770 t:2.9s
+tttg: c37/111 lr:0.000758 t:3.0s
+tttg: c38/111 lr:0.000746 t:3.1s
+tttg: c39/111 lr:0.000733 t:3.1s
+tttg: c40/111 lr:0.000721 t:3.2s
+tttg: c41/111 lr:0.000708 t:3.3s
+tttg: c42/111 lr:0.000695 t:3.4s
+tttg: c43/111 lr:0.000681 t:3.4s
+tttg: c44/111 lr:0.000668 t:3.5s
+tttg: c45/111 lr:0.000655 t:3.6s
+tttg: c46/111 lr:0.000641 t:3.6s
+tttg: c47/111 lr:0.000627 t:3.7s
+tttg: c48/111 lr:0.000613 t:3.8s
+tttg: c49/111 lr:0.000599 t:3.9s
+tttg: c50/111 lr:0.000585 t:3.9s
+tttg: c51/111 lr:0.000571 t:4.0s
+tttg: c52/111 lr:0.000557 t:4.1s
+tttg: c53/111 lr:0.000543 t:4.1s
+tttg: c54/111 lr:0.000529 t:4.2s
+tttg: c55/111 lr:0.000514 t:4.3s
+tttg: c56/111 lr:0.000500 t:4.4s
+tttg: c57/111 lr:0.000486 t:4.4s
+tttg: c58/111 lr:0.000471 t:4.5s
+tttg: c59/111 lr:0.000457 t:4.6s
+tttg: c60/111 lr:0.000443 t:4.7s
+tttg: c61/111 lr:0.000429 t:4.7s
+tttg: c62/111 lr:0.000415 t:4.8s
+tttg: c63/111 lr:0.000401 t:4.9s
+tttg: c64/111 lr:0.000387 t:5.0s
+tttg: c65/111 lr:0.000373 t:5.0s
+tttg: c66/111 lr:0.000359 t:5.1s
+tttg: c67/111 lr:0.000345 t:5.2s
+tttg: c68/111 lr:0.000332 t:5.2s
+tttg: c69/111 lr:0.000319 t:5.3s
+tttg: c70/111 lr:0.000305 t:5.4s
+tttg: c71/111 lr:0.000292 t:5.5s
+tttg: c72/111 lr:0.000279 t:5.5s
+tttg: c73/111 lr:0.000267 t:5.6s
+tttg: c74/111 lr:0.000254 t:5.7s
+tttg: c75/111 lr:0.000242 t:5.7s
+tttg: c76/111 lr:0.000230 t:5.8s
+tttg: c77/111 lr:0.000218 t:5.9s
+tttg: c78/111 lr:0.000206 t:6.0s
+tttg: c79/111 lr:0.000195 t:6.0s
+tttg: c80/111 lr:0.000183 t:6.1s
+tttg: c81/111 lr:0.000173 t:6.2s
+tttg: c82/111 lr:0.000162 t:6.3s
+tttg: c83/111 lr:0.000152 t:6.3s
+tttg: c84/111 lr:0.000141 t:6.4s
+tttg: c85/111 lr:0.000132 t:6.5s
+tttg: c86/111 lr:0.000122 t:6.6s
+tttg: c87/111 lr:0.000113 t:6.6s
+tttg: c88/111 lr:0.000104 t:6.7s
+tttg: c89/111 lr:0.000095 t:6.8s
+tttg: c90/111 lr:0.000087 t:6.8s
+tttg: c91/111 lr:0.000079 t:6.9s
+tttg: c92/111 lr:0.000072 t:7.0s
+tttg: c93/111 lr:0.000065 t:7.1s
+tttg: c94/111 lr:0.000058 t:7.1s
+tttg: c95/111 lr:0.000051 t:7.2s
+tttg: c96/111 lr:0.000045 t:7.3s
+tttg: c97/111 lr:0.000039 t:7.3s
+tttg: c98/111 lr:0.000034 t:7.4s
+tttg: c99/111 lr:0.000029 t:7.5s
+tttg: c100/111 lr:0.000024 t:7.6s
+tttg: c101/111 lr:0.000020 t:7.6s
+tttg: c102/111 lr:0.000016 t:7.7s
+tttg: c103/111 lr:0.000013 t:7.8s
+tttg: c104/111 lr:0.000010 t:7.9s
+tttg: c105/111 lr:0.000007 t:7.9s
+tttg: c106/111 lr:0.000005 t:8.0s
+tttg: c107/111 lr:0.000003 t:8.1s
+tttg: c108/111 lr:0.000002 t:8.2s
+tttg: c109/111 lr:0.000001 t:8.2s
+tttg: c110/111 lr:0.000000 t:8.3s
+ttpr: phase:1/3 t:223.5s
+ttp: b758/782 bl:2.3195 bb:1.0811 rl:2.1931 rb:1.0655 dl:3634-3740 gd:0
+ttp: b754/782 bl:2.3002 bb:1.0640 rl:2.2055 rb:1.0653 dl:3345-3397 gd:0
+ttpp: phase:2/3 pd:1808 gd:1333 t:332.1s
+tttg: c1/185 lr:0.001000 t:0.1s
+tttg: c2/185 lr:0.001000 t:0.2s
+tttg: c3/185 lr:0.001000 t:0.2s
+tttg: c4/185 lr:0.000999 t:0.3s
+tttg: c5/185 lr:0.000999 t:0.4s
+tttg: c6/185 lr:0.000998 t:0.4s
+tttg: c7/185 lr:0.000997 t:0.5s
+tttg: c8/185 lr:0.000996 t:0.6s
+tttg: c9/185 lr:0.000995 t:0.7s
+tttg: c10/185 lr:0.000994 t:0.7s
+tttg: c11/185 lr:0.000993 t:0.8s
+tttg: c12/185 lr:0.000991 t:0.9s
+tttg: c13/185 lr:0.000990 t:0.9s
+tttg: c14/185 lr:0.000988 t:1.0s
+tttg: c15/185 lr:0.000986 t:1.1s
+tttg: c16/185 lr:0.000984 t:1.2s
+tttg: c17/185 lr:0.000981 t:1.2s
+tttg: c18/185 lr:0.000979 t:1.3s
+tttg: c19/185 lr:0.000977 t:1.4s
+tttg: c20/185 lr:0.000974 t:1.5s
+tttg: c21/185 lr:0.000971 t:1.5s
+tttg: c22/185 lr:0.000968 t:1.6s
+tttg: c23/185 lr:0.000965 t:1.7s
+tttg: c24/185 lr:0.000962 t:1.8s
+tttg: c25/185 lr:0.000959 t:1.8s
+tttg: c26/185 lr:0.000955 t:1.9s
+tttg: c27/185 lr:0.000952 t:2.0s
+tttg: c28/185 lr:0.000948 t:2.0s
+tttg: c29/185 lr:0.000944 t:2.1s
+tttg: c30/185 lr:0.000940 t:2.2s
+tttg: c31/185 lr:0.000936 t:2.3s
+tttg: c32/185 lr:0.000932 t:2.3s
+tttg: c33/185 lr:0.000927 t:2.4s
+tttg: c34/185 lr:0.000923 t:2.5s
+tttg: c35/185 lr:0.000918 t:2.6s
+tttg: c36/185 lr:0.000913 t:2.6s
+tttg: c37/185 lr:0.000908 t:2.7s
+tttg: c38/185 lr:0.000904 t:2.8s
+tttg: c39/185 lr:0.000898 t:2.8s
+tttg: c40/185 lr:0.000893 t:2.9s
+tttg: c41/185 lr:0.000888 t:3.0s
+tttg: c42/185 lr:0.000882 t:3.1s
+tttg: c43/185 lr:0.000877 t:3.1s
+tttg: c44/185 lr:0.000871 t:3.2s
+tttg: c45/185 lr:0.000865 t:3.3s
+tttg: c46/185 lr:0.000860 t:3.3s
+tttg: c47/185 lr:0.000854 t:3.4s
+tttg: c48/185 lr:0.000847 t:3.5s
+tttg: c49/185 lr:0.000841 t:3.6s
+tttg: c50/185 lr:0.000835 t:3.6s
+tttg: c51/185 lr:0.000829 t:3.7s
+tttg: c52/185 lr:0.000822 t:3.8s
+tttg: c53/185 lr:0.000816 t:3.9s
+tttg: c54/185 lr:0.000809 t:3.9s
+tttg: c55/185 lr:0.000802 t:4.0s
+tttg: c56/185 lr:0.000795 t:4.1s
+tttg: c57/185 lr:0.000788 t:4.1s
+tttg: c58/185 lr:0.000781 t:4.2s
+tttg: c59/185 lr:0.000774 t:4.3s
+tttg: c60/185 lr:0.000767 t:4.4s
+tttg: c61/185 lr:0.000760 t:4.4s
+tttg: c62/185 lr:0.000752 t:4.5s
+tttg: c63/185 lr:0.000745 t:4.6s
+tttg: c64/185 lr:0.000738 t:4.6s
+tttg: c65/185 lr:0.000730 t:4.7s
+tttg: c66/185 lr:0.000722 t:4.8s
+tttg: c67/185 lr:0.000715 t:4.9s
+tttg: c68/185 lr:0.000707 t:4.9s
+tttg: c69/185 lr:0.000699 t:5.0s
+tttg: c70/185 lr:0.000691 t:5.1s
+tttg: c71/185 lr:0.000683 t:5.2s
+tttg: c72/185 lr:0.000675 t:5.2s
+tttg: c73/185 lr:0.000667 t:5.3s
+tttg: c74/185 lr:0.000659 t:5.4s
+tttg: c75/185 lr:0.000651 t:5.4s
+tttg: c76/185 lr:0.000643 t:5.5s
+tttg: c77/185 lr:0.000635 t:5.6s
+tttg: c78/185 lr:0.000627 t:5.7s
+tttg: c79/185 lr:0.000618 t:5.7s
+tttg: c80/185 lr:0.000610 t:5.8s
+tttg: c81/185 lr:0.000602 t:5.9s
+tttg: c82/185 lr:0.000593 t:5.9s
+tttg: c83/185 lr:0.000585 t:6.0s
+tttg: c84/185 lr:0.000577 t:6.1s
+tttg: c85/185 lr:0.000568 t:6.2s
+tttg: c86/185 lr:0.000560 t:6.2s
+tttg: c87/185 lr:0.000551 t:6.3s
+tttg: c88/185 lr:0.000543 t:6.4s
+tttg: c89/185 lr:0.000534 t:6.5s
+tttg: c90/185 lr:0.000526 t:6.5s
+tttg: c91/185 lr:0.000517 t:6.6s
+tttg: c92/185 lr:0.000509 t:6.7s
+tttg: c93/185 lr:0.000500 t:6.7s
+tttg: c94/185 lr:0.000491 t:6.8s
+tttg: c95/185 lr:0.000483 t:6.9s
+tttg: c96/185 lr:0.000474 t:7.0s
+tttg: c97/185 lr:0.000466 t:7.0s
+tttg: c98/185 lr:0.000457 t:7.1s
+tttg: c99/185 lr:0.000449 t:7.2s
+tttg: c100/185 lr:0.000440 t:7.3s
+tttg: c101/185 lr:0.000432 t:7.3s
+tttg: c102/185 lr:0.000423 t:7.4s
+tttg: c103/185 lr:0.000415 t:7.5s
+tttg: c104/185 lr:0.000407 t:7.5s
+tttg: c105/185 lr:0.000398 t:7.6s
+tttg: c106/185 lr:0.000390 t:7.7s
+tttg: c107/185 lr:0.000382 t:7.8s
+tttg: c108/185 lr:0.000373 t:7.8s
+tttg: c109/185 lr:0.000365 t:7.9s
+tttg: c110/185 lr:0.000357 t:8.0s
+tttg: c111/185 lr:0.000349 t:8.0s
+tttg: c112/185 lr:0.000341 t:8.1s
+tttg: c113/185 lr:0.000333 t:8.2s
+tttg: c114/185 lr:0.000325 t:8.3s
+tttg: c115/185 lr:0.000317 t:8.4s
+tttg: c116/185 lr:0.000309 t:8.4s
+tttg: c117/185 lr:0.000301 t:8.5s
+tttg: c118/185 lr:0.000293 t:8.6s
+tttg: c119/185 lr:0.000285 t:8.6s
+tttg: c120/185 lr:0.000278 t:8.7s
+tttg: c121/185 lr:0.000270 t:8.8s
+tttg: c122/185 lr:0.000262 t:8.9s
+tttg: c123/185 lr:0.000255 t:8.9s
+tttg: c124/185 lr:0.000248 t:9.0s
+tttg: c125/185 lr:0.000240 t:9.1s
+tttg: c126/185 lr:0.000233 t:9.2s
+tttg: c127/185 lr:0.000226 t:9.2s
+tttg: c128/185 lr:0.000219 t:9.3s
+tttg: c129/185 lr:0.000212 t:9.4s
+tttg: c130/185 lr:0.000205 t:9.4s
+tttg: c131/185 lr:0.000198 t:9.5s
+tttg: c132/185 lr:0.000191 t:9.6s
+tttg: c133/185 lr:0.000184 t:9.7s
+tttg: c134/185 lr:0.000178 t:9.7s
+tttg: c135/185 lr:0.000171 t:9.8s
+tttg: c136/185 lr:0.000165 t:9.9s
+tttg: c137/185 lr:0.000159 t:10.0s
+tttg: c138/185 lr:0.000153 t:10.0s
+tttg: c139/185 lr:0.000146 t:10.1s
+tttg: c140/185 lr:0.000140 t:10.2s
+tttg: c141/185 lr:0.000135 t:10.2s
+tttg: c142/185 lr:0.000129 t:10.3s
+tttg: c143/185 lr:0.000123 t:10.4s
+tttg: c144/185 lr:0.000118 t:10.5s
+tttg: c145/185 lr:0.000112 t:10.5s
+tttg: c146/185 lr:0.000107 t:10.6s
+tttg: c147/185 lr:0.000102 t:10.7s
+tttg: c148/185 lr:0.000096 t:10.7s
+tttg: c149/185 lr:0.000092 t:10.8s
+tttg: c150/185 lr:0.000087 t:10.9s
+tttg: c151/185 lr:0.000082 t:11.0s
+tttg: c152/185 lr:0.000077 t:11.0s
+tttg: c153/185 lr:0.000073 t:11.1s
+tttg: c154/185 lr:0.000068 t:11.2s
+tttg: c155/185 lr:0.000064 t:11.3s
+tttg: c156/185 lr:0.000060 t:11.3s
+tttg: c157/185 lr:0.000056 t:11.4s
+tttg: c158/185 lr:0.000052 t:11.5s
+tttg: c159/185 lr:0.000048 t:11.5s
+tttg: c160/185 lr:0.000045 t:11.6s
+tttg: c161/185 lr:0.000041 t:11.7s
+tttg: c162/185 lr:0.000038 t:11.8s
+tttg: c163/185 lr:0.000035 t:11.8s
+tttg: c164/185 lr:0.000032 t:11.9s
+tttg: c165/185 lr:0.000029 t:12.0s
+tttg: c166/185 lr:0.000026 t:12.1s
+tttg: c167/185 lr:0.000023 t:12.1s
+tttg: c168/185 lr:0.000021 t:12.2s
+tttg: c169/185 lr:0.000019 t:12.3s
+tttg: c170/185 lr:0.000016 t:12.3s
+tttg: c171/185 lr:0.000014 t:12.4s
+tttg: c172/185 lr:0.000012 t:12.5s
+tttg: c173/185 lr:0.000010 t:12.6s
+tttg: c174/185 lr:0.000009 t:12.6s
+tttg: c175/185 lr:0.000007 t:12.7s
+tttg: c176/185 lr:0.000006 t:12.8s
+tttg: c177/185 lr:0.000005 t:12.8s
+tttg: c178/185 lr:0.000004 t:12.9s
+tttg: c179/185 lr:0.000003 t:13.0s
+tttg: c180/185 lr:0.000002 t:13.1s
+tttg: c181/185 lr:0.000001 t:13.1s
+tttg: c182/185 lr:0.000001 t:13.2s
+tttg: c183/185 lr:0.000000 t:13.3s
+tttg: c184/185 lr:0.000000 t:13.4s
+ttpr: phase:2/3 t:347.6s
+ttp: b749/782 bl:2.4089 bb:1.0930 rl:2.2249 rb:1.0681 dl:3039-3089 gd:0
+ttpp: phase:3/3 pd:2448 gd:2000 t:364.4s
+tttg: c1/250 lr:0.001000 t:0.1s
+tttg: c2/250 lr:0.001000 t:0.2s
+tttg: c3/250 lr:0.001000 t:0.2s
+tttg: c4/250 lr:0.001000 t:0.3s
+tttg: c5/250 lr:0.000999 t:0.4s
+tttg: c6/250 lr:0.000999 t:0.4s
+tttg: c7/250 lr:0.000999 t:0.5s
+tttg: c8/250 lr:0.000998 t:0.6s
+tttg: c9/250 lr:0.000997 t:0.6s
+tttg: c10/250 lr:0.000997 t:0.7s
+tttg: c11/250 lr:0.000996 t:0.8s
+tttg: c12/250 lr:0.000995 t:0.9s
+tttg: c13/250 lr:0.000994 t:0.9s
+tttg: c14/250 lr:0.000993 t:1.0s
+tttg: c15/250 lr:0.000992 t:1.1s
+tttg: c16/250 lr:0.000991 t:1.1s
+tttg: c17/250 lr:0.000990 t:1.2s
+tttg: c18/250 lr:0.000989 t:1.3s
+tttg: c19/250 lr:0.000987 t:1.4s
+tttg: c20/250 lr:0.000986 t:1.4s
+tttg: c21/250 lr:0.000984 t:1.5s
+tttg: c22/250 lr:0.000983 t:1.6s
+tttg: c23/250 lr:0.000981 t:1.6s
+tttg: c24/250 lr:0.000979 t:1.7s
+tttg: c25/250 lr:0.000977 t:1.8s
+tttg: c26/250 lr:0.000975 t:1.9s
+tttg: c27/250 lr:0.000973 t:1.9s
+tttg: c28/250 lr:0.000971 t:2.0s
+tttg: c29/250 lr:0.000969 t:2.1s
+tttg: c30/250 lr:0.000967 t:2.2s
+tttg: c31/250 lr:0.000965 t:2.2s
+tttg: c32/250 lr:0.000962 t:2.3s
+tttg: c33/250 lr:0.000960 t:2.4s
+tttg: c34/250 lr:0.000957 t:2.4s
+tttg: c35/250 lr:0.000955 t:2.5s
+tttg: c36/250 lr:0.000952 t:2.6s
+tttg: c37/250 lr:0.000949 t:2.7s
+tttg: c38/250 lr:0.000947 t:2.7s
+tttg: c39/250 lr:0.000944 t:2.8s
+tttg: c40/250 lr:0.000941 t:2.9s
+tttg: c41/250 lr:0.000938 t:3.0s
+tttg: c42/250 lr:0.000935 t:3.0s
+tttg: c43/250 lr:0.000931 t:3.1s
+tttg: c44/250 lr:0.000928 t:3.2s
+tttg: c45/250 lr:0.000925 t:3.3s
+tttg: c46/250 lr:0.000922 t:3.3s
+tttg: c47/250 lr:0.000918 t:3.4s
+tttg: c48/250 lr:0.000915 t:3.5s
+tttg: c49/250 lr:0.000911 t:3.5s
+tttg: c50/250 lr:0.000907 t:3.6s
+tttg: c51/250 lr:0.000904 t:3.7s
+tttg: c52/250 lr:0.000900 t:3.8s
+tttg: c53/250 lr:0.000896 t:3.8s
+tttg: c54/250 lr:0.000892 t:3.9s
+tttg: c55/250 lr:0.000888 t:4.0s
+tttg: c56/250 lr:0.000884 t:4.0s
+tttg: c57/250 lr:0.000880 t:4.1s
+tttg: c58/250 lr:0.000876 t:4.2s
+tttg: c59/250 lr:0.000872 t:4.3s
+tttg: c60/250 lr:0.000868 t:4.3s
+tttg: c61/250 lr:0.000863 t:4.4s
+tttg: c62/250 lr:0.000859 t:4.5s
+tttg: c63/250 lr:0.000855 t:4.5s
+tttg: c64/250 lr:0.000850 t:4.6s
+tttg: c65/250 lr:0.000846 t:4.7s
+tttg: c66/250 lr:0.000841 t:4.8s
+tttg: c67/250 lr:0.000836 t:4.8s
+tttg: c68/250 lr:0.000832 t:4.9s
+tttg: c69/250 lr:0.000827 t:5.0s
+tttg: c70/250 lr:0.000822 t:5.1s
+tttg: c71/250 lr:0.000817 t:5.1s
+tttg: c72/250 lr:0.000812 t:5.2s
+tttg: c73/250 lr:0.000807 t:5.3s
+tttg: c74/250 lr:0.000803 t:5.3s
+tttg: c75/250 lr:0.000797 t:5.4s
+tttg: c76/250 lr:0.000792 t:5.5s
+tttg: c77/250 lr:0.000787 t:5.6s
+tttg: c78/250 lr:0.000782 t:5.6s
+tttg: c79/250 lr:0.000777 t:5.7s
+tttg: c80/250 lr:0.000772 t:5.8s
+tttg: c81/250 lr:0.000766 t:5.8s
+tttg: c82/250 lr:0.000761 t:5.9s
+tttg: c83/250 lr:0.000755 t:6.0s
+tttg: c84/250 lr:0.000750 t:6.1s
+tttg: c85/250 lr:0.000745 t:6.1s
+tttg: c86/250 lr:0.000739 t:6.2s
+tttg: c87/250 lr:0.000733 t:6.3s
+tttg: c88/250 lr:0.000728 t:6.3s
+tttg: c89/250 lr:0.000722 t:6.4s
+tttg: c90/250 lr:0.000717 t:6.5s
+tttg: c91/250 lr:0.000711 t:6.6s
+tttg: c92/250 lr:0.000705 t:6.6s
+tttg: c93/250 lr:0.000699 t:6.7s
+tttg: c94/250 lr:0.000694 t:6.8s
+tttg: c95/250 lr:0.000688 t:6.9s
+tttg: c96/250 lr:0.000682 t:6.9s
+tttg: c97/250 lr:0.000676 t:7.0s
+tttg: c98/250 lr:0.000670 t:7.1s
+tttg: c99/250 lr:0.000664 t:7.1s
+tttg: c100/250 lr:0.000658 t:7.2s
+tttg: c101/250 lr:0.000652 t:7.3s
+tttg: c102/250 lr:0.000646 t:7.4s
+tttg: c103/250 lr:0.000640 t:7.4s
+tttg: c104/250 lr:0.000634 t:7.5s
+tttg: c105/250 lr:0.000628 t:7.6s
+tttg: c106/250 lr:0.000622 t:7.7s
+tttg: c107/250 lr:0.000616 t:7.7s
+tttg: c108/250 lr:0.000610 t:7.8s
+tttg: c109/250 lr:0.000603 t:7.9s
+tttg: c110/250 lr:0.000597 t:7.9s
+tttg: c111/250 lr:0.000591 t:8.0s
+tttg: c112/250 lr:0.000585 t:8.1s
+tttg: c113/250 lr:0.000579 t:8.2s
+tttg: c114/250 lr:0.000572 t:8.2s
+tttg: c115/250 lr:0.000566 t:8.3s
+tttg: c116/250 lr:0.000560 t:8.4s
+tttg: c117/250 lr:0.000554 t:8.4s
+tttg: c118/250 lr:0.000547 t:8.5s
+tttg: c119/250 lr:0.000541 t:8.6s
+tttg: c120/250 lr:0.000535 t:8.7s
+tttg: c121/250 lr:0.000528 t:8.7s
+tttg: c122/250 lr:0.000522 t:8.8s
+tttg: c123/250 lr:0.000516 t:8.9s
+tttg: c124/250 lr:0.000509 t:9.0s
+tttg: c125/250 lr:0.000503 t:9.0s
+tttg: c126/250 lr:0.000497 t:9.1s
+tttg: c127/250 lr:0.000491 t:9.2s
+tttg: c128/250 lr:0.000484 t:9.2s
+tttg: c129/250 lr:0.000478 t:9.3s
+tttg: c130/250 lr:0.000472 t:9.4s
+tttg: c131/250 lr:0.000465 t:9.5s
+tttg: c132/250 lr:0.000459 t:9.5s
+tttg: c133/250 lr:0.000453 t:9.6s
+tttg: c134/250 lr:0.000446 t:9.7s
+tttg: c135/250 lr:0.000440 t:9.7s
+tttg: c136/250 lr:0.000434 t:9.8s
+tttg: c137/250 lr:0.000428 t:9.9s
+tttg: c138/250 lr:0.000421 t:10.0s
+tttg: c139/250 lr:0.000415 t:10.0s
+tttg: c140/250 lr:0.000409 t:10.1s
+tttg: c141/250 lr:0.000403 t:10.2s
+tttg: c142/250 lr:0.000397 t:10.3s
+tttg: c143/250 lr:0.000390 t:10.3s
+tttg: c144/250 lr:0.000384 t:10.4s
+tttg: c145/250 lr:0.000378 t:10.5s
+tttg: c146/250 lr:0.000372 t:10.6s
+tttg: c147/250 lr:0.000366 t:10.6s
+tttg: c148/250 lr:0.000360 t:10.7s
+tttg: c149/250 lr:0.000354 t:10.8s
+tttg: c150/250 lr:0.000348 t:10.8s
+tttg: c151/250 lr:0.000342 t:10.9s
+tttg: c152/250 lr:0.000336 t:11.0s
+tttg: c153/250 lr:0.000330 t:11.1s
+tttg: c154/250 lr:0.000324 t:11.1s
+tttg: c155/250 lr:0.000318 t:11.2s
+tttg: c156/250 lr:0.000312 t:11.3s
+tttg: c157/250 lr:0.000306 t:11.4s
+tttg: c158/250 lr:0.000301 t:11.4s
+tttg: c159/250 lr:0.000295 t:11.5s
+tttg: c160/250 lr:0.000289 t:11.6s
+tttg: c161/250 lr:0.000283 t:11.6s
+tttg: c162/250 lr:0.000278 t:11.7s
+tttg: c163/250 lr:0.000272 t:11.8s
+tttg: c164/250 lr:0.000267 t:11.9s
+tttg: c165/250 lr:0.000261 t:11.9s
+tttg: c166/250 lr:0.000255 t:12.0s
+tttg: c167/250 lr:0.000250 t:12.1s
+tttg: c168/250 lr:0.000245 t:12.1s
+tttg: c169/250 lr:0.000239 t:12.2s
+tttg: c170/250 lr:0.000234 t:12.3s
+tttg: c171/250 lr:0.000228 t:12.4s
+tttg: c172/250 lr:0.000223 t:12.4s
+tttg: c173/250 lr:0.000218 t:12.5s
+tttg: c174/250 lr:0.000213 t:12.6s
+tttg: c175/250 lr:0.000208 t:12.6s
+tttg: c176/250 lr:0.000203 t:12.7s
+tttg: c177/250 lr:0.000197 t:12.8s
+tttg: c178/250 lr:0.000193 t:12.9s
+tttg: c179/250 lr:0.000188 t:12.9s
+tttg: c180/250 lr:0.000183 t:13.0s
+tttg: c181/250 lr:0.000178 t:13.1s
+tttg: c182/250 lr:0.000173 t:13.2s
+tttg: c183/250 lr:0.000168 t:13.2s
+tttg: c184/250 lr:0.000164 t:13.3s
+tttg: c185/250 lr:0.000159 t:13.4s
+tttg: c186/250 lr:0.000154 t:13.4s
+tttg: c187/250 lr:0.000150 t:13.5s
+tttg: c188/250 lr:0.000145 t:13.6s
+tttg: c189/250 lr:0.000141 t:13.7s
+tttg: c190/250 lr:0.000137 t:13.7s
+tttg: c191/250 lr:0.000132 t:13.8s
+tttg: c192/250 lr:0.000128 t:13.9s
+tttg: c193/250 lr:0.000124 t:14.0s
+tttg: c194/250 lr:0.000120 t:14.0s
+tttg: c195/250 lr:0.000116 t:14.1s
+tttg: c196/250 lr:0.000112 t:14.2s
+tttg: c197/250 lr:0.000108 t:14.2s
+tttg: c198/250 lr:0.000104 t:14.3s
+tttg: c199/250 lr:0.000100 t:14.4s
+tttg: c200/250 lr:0.000096 t:14.5s
+tttg: c201/250 lr:0.000093 t:14.5s
+tttg: c202/250 lr:0.000089 t:14.6s
+tttg: c203/250 lr:0.000085 t:14.7s
+tttg: c204/250 lr:0.000082 t:14.7s
+tttg: c205/250 lr:0.000078 t:14.8s
+tttg: c206/250 lr:0.000075 t:14.9s
+tttg: c207/250 lr:0.000072 t:15.0s
+tttg: c208/250 lr:0.000069 t:15.0s
+tttg: c209/250 lr:0.000065 t:15.1s
+tttg: c210/250 lr:0.000062 t:15.2s
+tttg: c211/250 lr:0.000059 t:15.3s
+tttg: c212/250 lr:0.000056 t:15.3s
+tttg: c213/250 lr:0.000053 t:15.4s
+tttg: c214/250 lr:0.000051 t:15.5s
+tttg: c215/250 lr:0.000048 t:15.5s
+tttg: c216/250 lr:0.000045 t:15.6s
+tttg: c217/250 lr:0.000043 t:15.7s
+tttg: c218/250 lr:0.000040 t:15.8s
+tttg: c219/250 lr:0.000038 t:15.8s
+tttg: c220/250 lr:0.000035 t:15.9s
+tttg: c221/250 lr:0.000033 t:16.0s
+tttg: c222/250 lr:0.000031 t:16.0s
+tttg: c223/250 lr:0.000029 t:16.1s
+tttg: c224/250 lr:0.000027 t:16.2s
+tttg: c225/250 lr:0.000025 t:16.3s
+tttg: c226/250 lr:0.000023 t:16.3s
+tttg: c227/250 lr:0.000021 t:16.4s
+tttg: c228/250 lr:0.000019 t:16.5s
+tttg: c229/250 lr:0.000017 t:16.6s
+tttg: c230/250 lr:0.000016 t:16.6s
+tttg: c231/250 lr:0.000014 t:16.7s
+tttg: c232/250 lr:0.000013 t:16.8s
+tttg: c233/250 lr:0.000011 t:16.8s
+tttg: c234/250 lr:0.000010 t:16.9s
+tttg: c235/250 lr:0.000009 t:17.0s
+tttg: c236/250 lr:0.000008 t:17.1s
+tttg: c237/250 lr:0.000007 t:17.1s
+tttg: c238/250 lr:0.000006 t:17.2s
+tttg: c239/250 lr:0.000005 t:17.3s
+tttg: c240/250 lr:0.000004 t:17.3s
+tttg: c241/250 lr:0.000003 t:17.4s
+tttg: c242/250 lr:0.000003 t:17.5s
+tttg: c243/250 lr:0.000002 t:17.6s
+tttg: c244/250 lr:0.000001 t:17.6s
+tttg: c245/250 lr:0.000001 t:17.7s
+tttg: c246/250 lr:0.000001 t:17.8s
+tttg: c247/250 lr:0.000000 t:17.9s
+tttg: c248/250 lr:0.000000 t:17.9s
+tttg: c249/250 lr:0.000000 t:18.0s
+ttpr: phase:3/3 t:384.5s
+ttp: b741/782 bl:2.3315 bb:1.0456 rl:2.2332 rb:1.0662 dl:2686-2730 gd:1
+ttp: b730/782 bl:2.2885 bb:1.0057 rl:2.2367 rb:1.0621 dl:2352-2376 gd:1
+ttp: b722/782 bl:2.3631 bb:1.0589 rl:2.2436 rb:1.0619 dl:2163-2185 gd:1
+ttp: b717/782 bl:2.2705 bb:1.0396 rl:2.2450 rb:1.0607 dl:2070-2088 gd:1
+ttp: b706/782 bl:2.4172 bb:1.0811 rl:2.2525 rb:1.0617 dl:1898-1910 gd:1
+ttp: b703/782 bl:2.3560 bb:1.0364 rl:2.2568 rb:1.0606 dl:1859-1872 gd:1
+ttp: b691/782 bl:2.4665 bb:1.0738 rl:2.2645 rb:1.0611 dl:1725-1737 gd:1
+ttp: b681/782 bl:2.3472 bb:1.0494 rl:2.2673 rb:1.0607 dl:1628-1637 gd:1
+ttp: b673/782 bl:2.3779 bb:1.0674 rl:2.2708 rb:1.0609 dl:1562-1571 gd:1
+ttp: b670/782 bl:2.3598 bb:1.0738 rl:2.2734 rb:1.0613 dl:1537-1544 gd:1
+ttp: b656/782 bl:2.3426 bb:1.1175 rl:2.2753 rb:1.0628 dl:1439-1445 gd:1
+ttp: b651/782 bl:2.4065 bb:1.0516 rl:2.2787 rb:1.0625 dl:1406-1411 gd:1
+ttp: b643/782 bl:2.3715 bb:1.0327 rl:2.2809 rb:1.0617 dl:1356-1362 gd:1
+ttp: b634/782 bl:2.3963 bb:1.0549 rl:2.2835 rb:1.0615 dl:1302-1308 gd:1
+ttp: b625/782 bl:2.4261 bb:1.0585 rl:2.2866 rb:1.0615 dl:1255-1260 gd:1
+ttp: b617/782 bl:2.3246 bb:1.0272 rl:2.2874 rb:1.0607 dl:1211-1216 gd:1
+ttp: b609/782 bl:2.2896 bb:1.0257 rl:2.2874 rb:1.0600 dl:1172-1177 gd:1
+ttp: b601/782 bl:2.3451 bb:1.0267 rl:2.2885 rb:1.0594 dl:1137-1141 gd:1
+ttp: b597/782 bl:2.3850 bb:1.0605 rl:2.2902 rb:1.0594 dl:1119-1124 gd:1
+ttp: b588/782 bl:2.3361 bb:1.0514 rl:2.2910 rb:1.0593 dl:1081-1086 gd:1
+ttp: b579/782 bl:2.3635 bb:1.0446 rl:2.2921 rb:1.0590 dl:1044-1048 gd:1
+ttp: b573/782 bl:2.3840 bb:1.0747 rl:2.2935 rb:1.0593 dl:1021-1025 gd:1
+ttp: b564/782 bl:2.3018 bb:1.0242 rl:2.2937 rb:1.0587 dl:990-993 gd:1
+ttp: b556/782 bl:2.3966 bb:1.0775 rl:2.2951 rb:1.0590 dl:961-965 gd:1
+ttp: b544/782 bl:2.3660 bb:1.0782 rl:2.2961 rb:1.0593 dl:924-927 gd:1
+ttp: b536/782 bl:2.3325 bb:1.0503 rl:2.2965 rb:1.0592 dl:899-902 gd:1
+ttp: b532/782 bl:2.4048 bb:1.0740 rl:2.2979 rb:1.0593 dl:887-889 gd:1
+ttp: b524/782 bl:2.3918 bb:1.0746 rl:2.2990 rb:1.0595 dl:863-866 gd:1
+ttp: b512/782 bl:2.3194 bb:1.0711 rl:2.2992 rb:1.0597 dl:829-832 gd:1
+ttp: b505/782 bl:2.3451 bb:1.0724 rl:2.2998 rb:1.0598 dl:809-812 gd:1
+ttp: b501/782 bl:2.3962 bb:1.0586 rl:2.3008 rb:1.0598 dl:799-802 gd:1
+ttp: b493/782 bl:2.3836 bb:1.0522 rl:2.3017 rb:1.0597 dl:778-780 gd:1
+ttp: b485/782 bl:2.3091 bb:1.0402 rl:2.3017 rb:1.0595 dl:759-761 gd:1
+ttp: b477/782 bl:2.4187 bb:1.0416 rl:2.3029 rb:1.0593 dl:740-742 gd:1
+ttp: b469/782 bl:2.3437 bb:1.0307 rl:2.3032 rb:1.0590 dl:721-724 gd:1
+ttp: b456/782 bl:2.3700 bb:1.0498 rl:2.3038 rb:1.0590 dl:693-695 gd:1
+ttp: b449/782 bl:2.4315 bb:1.0684 rl:2.3049 rb:1.0590 dl:678-680 gd:1
+ttp: b441/782 bl:2.3553 bb:1.0502 rl:2.3054 rb:1.0590 dl:662-664 gd:1
+ttp: b435/782 bl:2.3307 bb:1.0294 rl:2.3056 rb:1.0587 dl:648-651 gd:1
+ttp: b427/782 bl:2.2718 bb:1.0695 rl:2.3053 rb:1.0588 dl:634-636 gd:1
+ttp: b419/782 bl:2.3343 bb:1.0583 rl:2.3055 rb:1.0588 dl:618-620 gd:1
+ttp: b413/782 bl:2.3860 bb:1.0694 rl:2.3061 rb:1.0589 dl:607-609 gd:1
+ttp: b406/782 bl:2.3269 bb:1.0715 rl:2.3063 rb:1.0590 dl:593-595 gd:1
+ttp: b398/782 bl:2.2625 bb:1.0104 rl:2.3060 rb:1.0586 dl:579-581 gd:1
+ttp: b385/782 bl:2.4218 bb:1.0800 rl:2.3067 rb:1.0588 dl:555-557 gd:1
+ttp: b378/782 bl:2.4456 bb:1.0612 rl:2.3076 rb:1.0588 dl:544-545 gd:1
+ttp: b370/782 bl:2.3869 bb:1.0927 rl:2.3081 rb:1.0590 dl:530-532 gd:1
+ttp: b361/782 bl:2.3646 bb:1.1039 rl:2.3085 rb:1.0593 dl:515-517 gd:1
+ttp: b353/782 bl:2.2214 bb:1.0158 rl:2.3080 rb:1.0590 dl:501-503 gd:1
+ttp: b346/782 bl:2.3896 bb:1.0789 rl:2.3084 rb:1.0591 dl:491-492 gd:1
+ttp: b338/782 bl:2.3737 bb:1.1056 rl:2.3088 rb:1.0594 dl:478-480 gd:1
+ttp: b335/782 bl:2.3812 bb:1.0787 rl:2.3092 rb:1.0595 dl:474-476 gd:1
+ttp: b327/782 bl:2.3493 bb:1.0924 rl:2.3094 rb:1.0597 dl:462-463 gd:1
+ttp: b319/782 bl:2.4123 bb:1.0877 rl:2.3099 rb:1.0598 dl:450-451 gd:1
+ttp: b311/782 bl:2.3657 bb:1.0904 rl:2.3102 rb:1.0600 dl:438-439 gd:1
+ttp: b301/782 bl:2.3709 bb:1.1007 rl:2.3105 rb:1.0601 dl:422-424 gd:1
+ttp: b293/782 bl:2.4505 bb:1.1049 rl:2.3111 rb:1.0604 dl:410-412 gd:1
+ttp: b285/782 bl:2.3871 bb:1.0875 rl:2.3115 rb:1.0605 dl:399-400 gd:1
+ttp: b277/782 bl:2.2844 bb:1.0758 rl:2.3113 rb:1.0605 dl:388-389 gd:1
+ttp: b266/782 bl:2.3944 bb:1.1141 rl:2.3117 rb:1.0608 dl:374-375 gd:1
+ttp: b258/782 bl:2.4602 bb:1.1039 rl:2.3123 rb:1.0609 dl:364-365 gd:1
+ttp: b250/782 bl:2.3282 bb:1.0795 rl:2.3123 rb:1.0610 dl:354-355 gd:1
+ttp: b245/782 bl:2.3881 bb:1.1180 rl:2.3126 rb:1.0612 dl:347-349 gd:1
+ttp: b237/782 bl:2.3484 bb:1.1031 rl:2.3128 rb:1.0614 dl:337-338 gd:1
+ttp: b227/782 bl:2.5022 bb:1.1617 rl:2.3134 rb:1.0617 dl:325-327 gd:1
+ttp: b219/782 bl:2.3540 bb:1.1263 rl:2.3136 rb:1.0619 dl:316-317 gd:1
+ttp: b212/782 bl:2.3838 bb:1.0882 rl:2.3138 rb:1.0620 dl:308-309 gd:1
+ttp: b205/782 bl:2.3384 bb:1.1196 rl:2.3139 rb:1.0622 dl:301-302 gd:1
+ttp: b198/782 bl:2.4119 bb:1.0670 rl:2.3142 rb:1.0622 dl:294-295 gd:1
+ttp: b190/782 bl:2.3585 bb:1.0844 rl:2.3143 rb:1.0623 dl:284-285 gd:1
+ttp: b182/782 bl:2.3689 bb:1.1263 rl:2.3145 rb:1.0625 dl:276-277 gd:1
+ttp: b174/782 bl:2.4707 bb:1.1653 rl:2.3149 rb:1.0627 dl:268-269 gd:1
+ttp: b166/782 bl:2.4982 bb:1.1167 rl:2.3154 rb:1.0629 dl:260-262 gd:1
+ttp: b157/782 bl:2.3713 bb:1.1357 rl:2.3156 rb:1.0631 dl:252-253 gd:1
+ttp: b149/782 bl:2.3831 bb:1.1608 rl:2.3158 rb:1.0633 dl:244-245 gd:1
+ttp: b143/782 bl:2.4334 bb:1.1792 rl:2.3160 rb:1.0636 dl:238-239 gd:1
+ttp: b135/782 bl:2.4428 bb:1.1837 rl:2.3164 rb:1.0639 dl:231-232 gd:1
+ttp: b127/782 bl:2.4943 bb:1.1964 rl:2.3168 rb:1.0642 dl:223-224 gd:1
+ttp: b119/782 bl:2.3959 bb:1.1665 rl:2.3169 rb:1.0644 dl:216-217 gd:1
+ttp: b112/782 bl:2.4913 bb:1.1891 rl:2.3173 rb:1.0646 dl:210-210 gd:1
+ttp: b102/782 bl:2.6016 bb:1.2059 rl:2.3179 rb:1.0649 dl:201-202 gd:1
+ttp: b94/782 bl:2.5885 bb:1.2231 rl:2.3185 rb:1.0652 dl:193-194 gd:1
+ttp: b85/782 bl:2.5308 bb:1.2120 rl:2.3189 rb:1.0655 dl:185-186 gd:1
+ttp: b77/782 bl:2.5322 bb:1.2438 rl:2.3193 rb:1.0658 dl:178-179 gd:1
+ttp: b69/782 bl:2.4744 bb:1.2079 rl:2.3195 rb:1.0660 dl:171-172 gd:1
+ttp: b61/782 bl:2.4710 bb:1.2231 rl:2.3198 rb:1.0663 dl:164-165 gd:1
+ttp: b53/782 bl:2.5304 bb:1.2058 rl:2.3201 rb:1.0665 dl:156-157 gd:1
+ttp: b45/782 bl:2.4725 bb:1.1831 rl:2.3204 rb:1.0667 dl:148-149 gd:1
+ttp: b37/782 bl:2.5867 bb:1.2192 rl:2.3207 rb:1.0669 dl:140-141 gd:1
+ttp: b30/782 bl:2.6136 bb:1.2743 rl:2.3211 rb:1.0672 dl:133-134 gd:1
+ttp: b22/782 bl:2.5762 bb:1.2059 rl:2.3215 rb:1.0673 dl:124-126 gd:1
+ttp: b14/782 bl:2.6097 bb:1.1913 rl:2.3218 rb:1.0675 dl:114-115 gd:1
+ttp: b6/782 bl:2.7466 bb:1.2246 rl:2.3222 rb:1.0676 dl:99-101 gd:1
+quantized_ttt_phased val_loss:2.33732420 val_bpb:1.06806595 eval_time:482008ms
+total_eval_time:482.0s


### PR DESCRIPTION
## Summary

- **val_bpb: 1.06780** (3-seed mean, std 0.00037) | **~15.94 MB** | **8xH100 80GB SXM**
- Builds on **PR #1626**'s legal multi-phase TTT stack
- Replaces standard `sp8192` with a **lossless CaseOps tokenizer / dataset export** hosted publicly at `romeerp/parameter-golf-caseops-v1`
- Adds a **mild late Muon WD taper**: `WD_TAPER_START_FRAC=0.70`, `WD_TAPER_FINAL_MULT=0.50`
- Keeps phased TTT legal and score-first while improving pretrained, quantized, and post-TTT BPB

## Results

| Seed | Steps | Pre-Quant BPB | Quantized BPB | **Post-TTT BPB** | Artifact |
|------|------:|--------------:|--------------:|-----------------:|---------:|
| 0 | 4,921 | 1.07032992 | 1.08152131 | **1.06805820** | 15,932,307 |
| 42 | 4,866 | 1.07065549 | 1.08171495 | **1.06806595** | 15,935,802 |
| 1234 | 4,870 | 1.06971629 | 1.08036614 | **1.06727867** | 15,943,106 |
| **Mean** |  | **1.07023390** | **1.08120080** | **1.06780094** | **15,937,072** |

All 3 seeds are under the 600s train budget, under the 600s eval budget, and under the 16 MB artifact cap.

## Method

This submission combines two ideas:

1. **Lossless CaseOps tokenizer**
   - Uses the reversible `lossless_caps_caseops_v1` transform.
   - Factorizes text into a lowercase lexical stream plus a tiny capitalization side channel (`TITLE`, `ALLCAPS`, `CAPNEXT`, `ESC`).
   - Original text is reconstructed exactly by replaying those capitalization operators over the lowercase stream, so no information is discarded.
   - This reduces redundant case fragmentation in the main token stream while preserving exact recoverability.
   - Validation BPB is still charged against exact original UTF-8 bytes using exported validation byte sidecars.

2. **Mild tapered weight decay**
   - Keeps full Muon WD early in training when regularization/compressibility pressure matters most.
   - Tapers to half the base WD late in training, where weights are more settled and the optimization benefit appears to outweigh the regularization benefit.

The base architecture and legal phased-TTT evaluation flow come from PR #1626; this submission changes the tokenizer/data path and late WD schedule.

## Why the tokenizer is still metric-correct

The exporter writes:

- `fineweb_val_000000.bin`
- `fineweb_val_bytes_000000.bin`

The trainer loads the byte sidecar directly and logs:

- `val_bpb:byte_sidecar:enabled`

So BPB is computed against original raw-byte counts, not the transformed token stream length.

## Legality

- Attention remains causal.
- Scoring uses standard normalized cross-entropy.
- Phased TTT remains score-first in the PR #1626 sense.
- No validation token is used for adaptation before its score is counted.
- The tokenizer change is legality-preserving because it is a fully reversible preprocessing transform applied uniformly before tokenization.
- No information is discarded: the original text can be reconstructed exactly from the lowercase stream plus the capitalization operators.
- BPB is still charged against the original raw UTF-8 bytes through the exported validation byte sidecar, not against transformed text length.

## Reproducibility

Public artifacts:

- Dataset + tokenizer: `romeerp/parameter-golf-caseops-v1`

The record folder includes:

- `train_gpt.py`
- `README.md`
- `submission.json`
- `requirements.txt`
- `cached_challenge_fineweb.py`
- `download_hf_docs_and_tokenize.py`
- `lossless_caps.py`
- `tokenizer_specs_export_caseops_v1_reserved_only.json`
- all 3 seed logs

## Run instructions

From the record directory:

```bash
cd records/track_10min_16mb/2026-04-18_PR1626_CaseOps_Taper
```

Prepare the public HF tokenizer + dataset:

```bash
MATCHED_FINEWEB_REPO_ID=romeerp/parameter-golf-caseops-v1 \
MATCHED_FINEWEB_REMOTE_ROOT_PREFIX=datasets \
python3 cached_challenge_fineweb.py \
  --variant sp8192_lossless_caps_caseops_v1_reserved \
  --train-shards 80
```

Train + quantize + phased eval for one seed:

```bash
NCCL_NET=Socket \
SEED=0 \
TOKENIZER_PATH=./tokenizers/fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model \
DATASETS_DIR=./datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved \
torchrun --standalone --nproc_per_node=8 train_gpt.py \
  > train_seed0.log 2>&1
```





