### PR TITLE
Record: Alpha-Scaled LoRA + Warm-start A + WD 1.0 — val_bpb 1.07266 (3-seed mean)

### DIFF
--- a/records/track_10min_16mb/2026-04-21_AlphaLoRA_WarmStart_HighWD_1.07266/README.md
+++ b/records/track_10min_16mb/2026-04-21_AlphaLoRA_WarmStart_HighWD_1.07266/README.md
@@ -1,0 +1,125 @@
+# Alpha-Scaled LoRA + Warm-Start A + Higher Weight Decay — 1.07266 BPB
+
+**val_bpb: 1.07266105** (3-seed mean: seeds 1337, 42, 314)
+
+## Results
+
+| Seed | BPB | Steps | Eval time | Artifact |
+|------|-----|-------|-----------|----------|
+| 1337 | 1.07297641 | — | 449.2s | 15,934,599 B |
+| 42   | 1.07297575 | — | 448.3s | 15,933,292 B |
+| 314  | 1.07203098 | — | 458.8s | 15,935,775 B |
+| **Mean** | **1.07266105** | | | |
+
+All runs: train ≤600s, eval ≤600s, artifact ≤16MB.
+
+## Three novel changes on top of dexhunter's phased-TTT pipeline
+
+Prior phased-TTT submissions (PR #1530 @samacqua, PR #1610 @romeerp, @dexhunter 1.07193)
+use `BatchedLinearLoRA` with these defaults:
+
+- `forward(x) = (x @ A.T) @ B.T`   *(no rank scaling)*
+- `reset()`: re-randomize A uniform in [-1/√in, +1/√in], zero B
+- `TTT_WEIGHT_DECAY = 0.5`
+- `TTT_LORA_RANK = 96`
+
+This submission replaces the LoRA module with three composable changes
+(all env-controllable, all backward-compatible with the default flags off).
+
+### (1) Alpha/rank output scaling — enables safe higher rank
+
+```python
+class BatchedLinearLoRA(nn.Module):
+    _ALPHA = float(os.environ.get("TTT_LORA_ALPHA", "96"))
+
+    def __init__(self, bsz, in_features, out_features, rank):
+        ...
+        self._scale = self._ALPHA / rank    # <-- novel
+        ...
+
+    def forward(self, x):
+        return ((x @ self.A.T) @ self.B.T) * self._scale   # <-- novel
+```
+
+Without this, raw rank 128 **diverges** on seeds 314 and 1337 (TTT BPB collapses to ~1.133)
+while working on seed 42. With `alpha=96` rank 96 is numerically identical to the prior
+code, and `alpha=96, rank=128` reproduces that effective magnitude with 33% more A capacity.
+
+### (2) Warm-start A across batches
+
+```python
+_WARM_START_A = bool(int(os.environ.get("TTT_WARM_START_A", "1")))
+
+def reset(self):
+    with torch.no_grad():
+        if not self._WARM_START_A:
+            self.A.uniform_(-self._bound, self._bound)
+        self.B.zero_()
+```
+
+The phased-TTT loop processes ~780 batches of ~64 documents each. Previously A was
+re-randomized every batch, which throws away whatever feature directions the optimizer
+discovered on the earlier docs. Keeping A warm lets those directions accumulate while
+still starting each batch cleanly (B is still zeroed, so LoRA output at the start of
+a batch is zero).
+
+In isolation warm-start gives a good improvement on seeds 1337 and 42 but **regresses**
+on seed 314 (1.07200 → 1.07321) because A drifts into an overfit state for that seed's
+document ordering.
+
+### (3) Raised TTT weight decay 0.5 → 1.0 to stabilize (2)
+
+Doubling weight decay explicitly counteracts the across-batch overfit that warm-start
+enables. On seed 314 it restores parity with the alpha-only baseline (1.07200 → 1.07203,
+essentially noise); on seeds 1337 and 42 the bulk of the warm-start gain is preserved.
+
+### Combined result vs baselines
+
+| Seed | Baseline rank 96 | + alpha rank 128 | + warm A + WD=1.0 |
+|------|------------------|-------------------|---------------------|
+| 1337 | 1.07423 | 1.07379 (−0.00044) | **1.07298 (−0.00125)** |
+| 42   | 1.07341 | 1.07320 (−0.00021) | **1.07298 (−0.00043)** |
+| 314  | 1.07214 | 1.07200 (−0.00014) | **1.07203 (−0.00011)** |
+| Mean | 1.07326 | 1.07300 | **1.07266 (−0.00060)** |
+
+Every seed improves or stays flat vs the rank-96 baseline.
+
+## Legality (Issue #1017)
+
+- **Condition 1 (Causal)**: single left-to-right pass; LoRA state at position `t`
+  depends only on earlier tokens of the same document.
+- **Condition 2 (Normalized distribution)**: standard softmax over the 8192 SentencePiece
+  tokens, no hash bins / latent structures.
+- **Condition 3 (Score-before-update)**: chunk is scored through `forward_ttt_train`
+  *before* the optimizer step on that chunk.
+- **Condition 4 (Single pass)**: one left-to-right pass, no rescoring.
+
+## Attribution
+
+Everything outside of `BatchedLinearLoRA` + the optimizer's weight-decay default is
+unchanged from the existing pipeline:
+
+- `@bigbag` (PR #1493) — triple depth recurrence, parallel residuals, SP8192 baseline
+- `@EthanYangTW` (PR #1523) — parameter banking refinements
+- `@samacqua` (PR #1530) — VarLen attention, Fused Triton MLP, doc-independent LoRA TTT
+- `@romeerp` (PR #1610) — phased TTT (single-phase global SGD)
+- `@dexhunter` (1.07193 submission) — multi-phase global SGD, trimmed GPTQ, MATRIX_LR=0.026, per-layer clip sigmas, int7 embeddings
+- `@abaybektursun` (PR #549) — legal TTT framework
+
+## Reproduction
+
+```bash
+export DATA_DIR=/path/to/parameter-golf/data
+
+# Default seed 1337
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+
+# Other seeds
+SEED=42  torchrun --standalone --nproc_per_node=8 train_gpt.py
+SEED=314 torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+All hyperparameters are hardcoded as defaults in `train_gpt.py`:
+`TTT_LORA_RANK=128`, `TTT_LORA_ALPHA=96`, `TTT_WARM_START_A=1`,
+`TTT_WEIGHT_DECAY=1.0`, `PHASED_TTT_ENABLED=1`, `PHASED_TTT_NUM_PHASES=3`,
+`MATRIX_LR=0.026`, etc.

--- a/records/track_10min_16mb/2026-04-21_AlphaLoRA_WarmStart_HighWD_1.07266/requirements.txt
+++ b/records/track_10min_16mb/2026-04-21_AlphaLoRA_WarmStart_HighWD_1.07266/requirements.txt
@@ -1,0 +1,7 @@
+torch>=2.9
+flash-attn>=3.0
+triton>=3.5
+sentencepiece
+python-minifier
+brotli
+numpy

--- a/records/track_10min_16mb/2026-04-21_AlphaLoRA_WarmStart_HighWD_1.07266/submission.json
+++ b/records/track_10min_16mb/2026-04-21_AlphaLoRA_WarmStart_HighWD_1.07266/submission.json
@@ -1,0 +1,56 @@
+{
+  "authors": [
+    {
+      "name": "Renqian Luo",
+      "github_id": "renqianluo"
+    }
+  ],
+  "description": "Three composable novel TTT-LoRA improvements on top of dexhunter's phased TTT pipeline: (1) standard alpha/rank LoRA scaling so rank can be raised without instability, (2) warm-start of LoRA A across batches to let feature directions accumulate, (3) raised weight decay (0.5 -> 1.0) that regularizes the warmed A and prevents cross-batch overfit. 3-seed mean 1.07266 BPB.",
+  "val_bpb": 1.07266105,
+  "seed_results": {
+    "1337": 1.07297641,
+    "42": 1.07297575,
+    "314": 1.07203098
+  },
+  "eval_time_seconds": {
+    "1337": 449.2,
+    "42": 448.3,
+    "314": 458.8
+  },
+  "train_time_seconds": {
+    "1337": 596.1,
+    "42": 596.2,
+    "314": 596.1
+  },
+  "artifact_size_bytes": {
+    "1337": 15934599,
+    "42": 15933292,
+    "314": 15935775
+  },
+  "methods": [
+    "Novel (1): alpha/rank scaling on BatchedLinearLoRA output. Standard LoRA formulation, absent in prior phased-TTT submissions. Decouples rank from effective LR so higher-rank LoRA stays stable.",
+    "Novel (2): warm-start of LoRA A across batches (only B is reset to zero between batch boundaries). Lets the A matrix accumulate feature directions across the phased-TTT schedule instead of being re-randomized each batch.",
+    "Novel (3): raised TTT weight decay from 0.5 to 1.0, chosen specifically to counteract the across-batch overfit that full warm-start A alone caused on seed 314. Without this change warm-start is net zero; with it, all three seeds improve or tie.",
+    "LoRA rank 128 (vs prior 96), alpha=96, now safely higher capacity thanks to change (1)",
+    "Inherits dexhunter's phased TTT + multi-phase global SGD + trimmed GPTQ + MATRIX_LR=0.026; samacqua's VarLen + Fused Triton MLP; bigbag's triple depth recurrence + parallel residuals"
+  ],
+  "attribution": {
+    "alpha_scaled_lora__warm_start_A__higher_wd": "Renqian Luo (this work)",
+    "varlen_attention_fused_mlp_doc_ttt": "@samacqua (PR #1530)",
+    "phased_ttt_concept": "@romeerp (PR #1610)",
+    "multi_phase_global_sgd_trimmed_gptq": "@dexhunter",
+    "triple_recurrence_parallel_residuals": "@bigbag (PR #1493), @EthanYangTW (PR #1523)",
+    "legal_ttt_framework": "@abaybektursun (PR #549)"
+  },
+  "legal_ttt": true,
+  "compliance": {
+    "train_under_600s": true,
+    "eval_under_600s": true,
+    "artifact_under_16mb": true,
+    "no_slot": true,
+    "no_pre_quant_ttt": true,
+    "no_ngram_cache": true,
+    "score_first_ttt": true,
+    "three_seeds": true
+  }
+}

--- a/records/track_10min_16mb/2026-04-21_AlphaLoRA_WarmStart_HighWD_1.07266/train_gpt.py
+++ b/records/track_10min_16mb/2026-04-21_AlphaLoRA_WarmStart_HighWD_1.07266/train_gpt.py
@@ -1,0 +1,2985 @@
+import base64, collections, copy, fcntl, glob, io, json, lzma, math, os
+from pathlib import Path
+import random, re, subprocess, sys, time, uuid, numpy as np, sentencepiece as spm, torch, torch.distributed as dist, torch.nn.functional as F
+from torch import nn
+from flash_attn_interface import (
+    flash_attn_func as flash_attn_3_func,
+    flash_attn_varlen_func,
+)
+from concurrent.futures import ThreadPoolExecutor
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+class Hyperparameters:
+    data_dir = os.environ.get("DATA_DIR", "./data/")
+    seed = int(os.environ.get("SEED", 1337))
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.75))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 6e2))
+    val_batch_tokens = int(os.environ.get("VAL_BATCH_TOKENS", 524288))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    sliding_window_enabled = bool(int(os.environ.get("SLIDING_WINDOW_ENABLED", "0")))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 8192))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 4.0))
+    skip_gates_enabled = bool(int(os.environ.get("SKIP_GATES_ENABLED", "1")))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 3e1))
+    rope_base = float(os.environ.get("ROPE_BASE", 1e4))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    rope_train_seq_len = int(os.environ.get("ROPE_TRAIN_SEQ_LEN", 2048))
+    rope_yarn = bool(int(os.environ.get("ROPE_YARN", "0")))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 5.0))
+    num_loops = int(os.environ.get("NUM_LOOPS", 2))
+    loop_start = int(os.environ.get("LOOP_START", 3))
+    loop_end = int(os.environ.get("LOOP_END", 5))
+    enable_looping_at = float(os.environ.get("ENABLE_LOOPING_AT", 0.35))
+    parallel_start_layer = int(os.environ.get("PARALLEL_START_LAYER", 8))
+    parallel_final_lane = os.environ.get("PARALLEL_FINAL_LANE", "mean")
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.026))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.97))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-08))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.02))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_lora_rank = int(os.environ.get("TTT_LORA_RANK", 128))
+    ttt_lora_lr = float(os.environ.get("TTT_LORA_LR", 0.0001))
+    ttt_chunk_size = int(os.environ.get("TTT_CHUNK_SIZE", 48))
+    ttt_eval_seq_len = int(os.environ.get("TTT_EVAL_SEQ_LEN", 2048))
+    ttt_batch_size = int(os.environ.get("TTT_BATCH_SIZE", 64))
+    ttt_grad_steps = int(os.environ.get("TTT_GRAD_STEPS", 1))
+    ttt_weight_decay = float(os.environ.get("TTT_WEIGHT_DECAY", 1.0))
+    ttt_beta1 = float(os.environ.get("TTT_BETA1", 0))
+    ttt_beta2 = float(os.environ.get("TTT_BETA2", 0.999))
+    ttt_k_lora = bool(int(os.environ.get("TTT_K_LORA", "1")))
+    ttt_mlp_lora = bool(int(os.environ.get("TTT_MLP_LORA", "1")))
+    ttt_o_lora = bool(int(os.environ.get("TTT_O_LORA", "1")))
+    ttt_optimizer = os.environ.get("TTT_OPTIMIZER", "adam")
+    ttt_eval_batches = os.environ.get("TTT_EVAL_BATCHES", "")
+    val_doc_fraction = float(os.environ.get("VAL_DOC_FRACTION", 1.0))
+    compressor = os.environ.get("COMPRESSOR", "brotli")
+    gptq_calibration_batches = int(os.environ.get("GPTQ_CALIBRATION_BATCHES", 16))
+    gptq_reserve_seconds = float(os.environ.get("GPTQ_RESERVE_SECONDS", 4.0))
+    phased_ttt_enabled = bool(int(os.environ.get("PHASED_TTT_ENABLED", "1")))
+    phased_ttt_prefix_docs = int(os.environ.get("PHASED_TTT_PREFIX_DOCS", 2000))
+    phased_ttt_num_phases = int(os.environ.get("PHASED_TTT_NUM_PHASES", 3))
+    global_ttt_lr = float(os.environ.get("GLOBAL_TTT_LR", 0.001))
+    global_ttt_momentum = float(os.environ.get("GLOBAL_TTT_MOMENTUM", 0.9))
+    global_ttt_epochs = int(os.environ.get("GLOBAL_TTT_EPOCHS", 1))
+    global_ttt_chunk_tokens = int(os.environ.get("GLOBAL_TTT_CHUNK_TOKENS", 32768))
+    global_ttt_batch_seqs = int(os.environ.get("GLOBAL_TTT_BATCH_SEQS", 32))
+    global_ttt_warmup_start_lr = float(os.environ.get("GLOBAL_TTT_WARMUP_START_LR", 0.0))
+    global_ttt_warmup_chunks = int(os.environ.get("GLOBAL_TTT_WARMUP_CHUNKS", 0))
+    global_ttt_grad_clip = float(os.environ.get("GLOBAL_TTT_GRAD_CLIP", 1.0))
+    global_ttt_respect_doc_boundaries = bool(int(os.environ.get("GLOBAL_TTT_RESPECT_DOC_BOUNDARIES", "1")))
+    matrix_bits = int(os.environ.get("MATRIX_BITS", 6))
+    embed_bits = int(os.environ.get("EMBED_BITS", 7))
+    matrix_clip_sigmas = float(os.environ.get("MATRIX_CLIP_SIGMAS", 12.85))
+    embed_clip_sigmas = float(os.environ.get("EMBED_CLIP_SIGMAS", 15.0))
+    mlp_clip_sigmas = float(os.environ.get("MLP_CLIP_SIGMAS", 12.0))
+    attn_clip_sigmas = float(os.environ.get("ATTN_CLIP_SIGMAS", 13.0))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_main_process = rank == 0
+    grad_accum_steps = 8 // world_size
+    datasets_dir = os.path.join(data_dir, "datasets", f"fineweb10B_sp{vocab_size}")
+    train_files = os.path.join(datasets_dir, "fineweb_train_*.bin")
+    val_files = os.path.join(datasets_dir, "fineweb_val_*.bin")
+    tokenizer_path = os.path.join(
+        data_dir, "tokenizers", f"fineweb_{vocab_size}_bpe.model"
+    )
+    artifact_dir = os.environ.get("ARTIFACT_DIR", "")
+    logfile = (
+        os.path.join(artifact_dir, f"{run_id}.txt")
+        if artifact_dir
+        else f"logs/{run_id}.txt"
+    )
+    model_path = (
+        os.path.join(artifact_dir, "final_model.pt")
+        if artifact_dir
+        else "final_model.pt"
+    )
+    quantized_model_path = (
+        os.path.join(artifact_dir, "final_model.int6.ptz")
+        if artifact_dir
+        else "final_model.int6.ptz"
+    )
+
+
+_logger_hparams = None
+
+
+def set_logging_hparams(h):
+    global _logger_hparams
+    _logger_hparams = h
+
+
+def log(msg, console=True):
+    if _logger_hparams is None:
+        print(msg)
+        return
+    if _logger_hparams.is_main_process:
+        if console:
+            print(msg)
+        if _logger_hparams.logfile is not None:
+            with open(_logger_hparams.logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+
+class ValidationData:
+    def __init__(self, h, device):
+        self.sp = spm.SentencePieceProcessor(model_file=h.tokenizer_path)
+        if int(self.sp.vocab_size()) != h.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={h.vocab_size} does not match tokenizer vocab_size={int(self.sp.vocab_size())}"
+            )
+        self.val_tokens = load_validation_tokens(h.val_files, h.eval_seq_len)
+        (
+            self.base_bytes_lut,
+            self.has_leading_space_lut,
+            self.is_boundary_token_lut,
+        ) = build_sentencepiece_luts(self.sp, h.vocab_size, device)
+
+
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sp_vocab_size = int(sp.vocab_size())
+    assert (
+        sp.piece_to_id("▁") != sp.unk_id()
+    ), "Tokenizer must have '▁' (space) as its own token for correct BPB byte counting"
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = (tokens.numel() - 1) // seq_len * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def load_data_shard(file):
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE = {}
+_MMAP_CACHE = {}
+
+
+def _read_num_tokens(file):
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+
+def _get_shard_memmap(file):
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode="r", dtype="<u2", offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+BOS_ID = None
+
+
+def get_next_multiple_of_n(v, n):
+    return ((v + n - 1) // n) * n
+
+
+def _build_cu_seqlens(bos_pos, total_len, device, max_doc_len=0, bucket_size=64):
+    if not bos_pos or bos_pos[0] != 0:
+        bos_pos = [0] + bos_pos
+    seg_starts = []
+    starts_with_end = bos_pos + [total_len]
+    for i in range(len(starts_with_end) - 1):
+        start = starts_with_end[i]
+        end = starts_with_end[i + 1]
+        if max_doc_len > 0:
+            pos = start
+            while pos < end:
+                seg_starts.append(pos)
+                pos += max_doc_len
+        else:
+            seg_starts.append(start)
+    boundaries = seg_starts + [total_len]
+    padded_len = get_next_multiple_of_n(len(boundaries), bucket_size)
+    cu = torch.full((padded_len,), total_len, dtype=torch.int32, device=device)
+    cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+    seg_ends = seg_starts[1:] + [total_len]
+    max_seqlen = max(end - start for start, end in zip(seg_starts, seg_ends))
+    return cu, max_seqlen
+
+class DocumentPackingLoader:
+    _shard_pool = ThreadPoolExecutor(1)
+
+    def __init__(self, h, device, cu_bucket_size=64):
+        self.rank = h.rank
+        self.world_size = h.world_size
+        self.device = device
+        self.cu_bucket_size = cu_bucket_size
+        self.max_seq_len = h.train_seq_len
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files
+        self.file_iter = iter(self.files)
+        self._init_shard(load_data_shard(next(self.file_iter)))
+        self._next_shard = self._submit_next_shard()
+        self._batch_pool = ThreadPoolExecutor(1)
+        self._next_batch = None
+
+    def _init_shard(self, tokens):
+        global BOS_ID
+        self.tokens = tokens
+        self.shard_size = tokens.numel()
+        if BOS_ID is None:
+            BOS_ID = 1
+        self.bos_idx = (
+            (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        )
+        if self.bos_idx.size == 0:
+            self.bos_idx = np.array([0], dtype=np.int64)
+        self.cursor = int(self.bos_idx[0])
+
+    def _submit_next_shard(self):
+        try:
+            path = next(self.file_iter)
+            return self._shard_pool.submit(load_data_shard, path)
+        except StopIteration:
+            return None
+
+    def _advance_shard(self):
+        if self._next_shard is None:
+            self.file_iter = iter(self.files)
+            self._next_shard = self._shard_pool.submit(
+                load_data_shard, next(self.file_iter)
+            )
+        self._init_shard(self._next_shard.result())
+        self._next_shard = self._submit_next_shard()
+
+    def _local_doc_starts(self, local_start, total_len):
+        lo = np.searchsorted(self.bos_idx, local_start, side="left")
+        hi = np.searchsorted(self.bos_idx, local_start + total_len, side="left")
+        return (self.bos_idx[lo:hi] - local_start).tolist()
+
+    def _prepare_batch(self, num_tokens_local, max_seq_len):
+        per_rank_span = num_tokens_local + 1
+        global_span = per_rank_span * self.world_size
+        while self.cursor + global_span > self.shard_size:
+            self._advance_shard()
+        local_start = self.cursor + self.rank * per_rank_span
+        buf = self.tokens[local_start : local_start + per_rank_span]
+        inputs = buf[:-1].to(dtype=torch.int64).pin_memory()
+        targets = buf[1:].to(dtype=torch.int64).pin_memory()
+        starts = self._local_doc_starts(local_start, inputs.numel())
+        cu_seqlens, max_seqlen = _build_cu_seqlens(
+            starts, inputs.numel(), inputs.device, max_seq_len, self.cu_bucket_size
+        )
+        cu_seqlens = cu_seqlens.pin_memory()
+        self.cursor += global_span
+        return inputs, targets, cu_seqlens, max_seqlen
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        num_tokens_local = global_tokens // (self.world_size * grad_accum_steps)
+        if self._next_batch is not None:
+            inputs, targets, cu_seqlens, max_seqlen = self._next_batch.result()
+        else:
+            inputs, targets, cu_seqlens, max_seqlen = self._prepare_batch(
+                num_tokens_local, self.max_seq_len
+            )
+        self._next_batch = self._batch_pool.submit(
+            self._prepare_batch, num_tokens_local, self.max_seq_len
+        )
+        return (
+            inputs[None].to(self.device, non_blocking=True),
+            targets[None].to(self.device, non_blocking=True),
+            cu_seqlens.to(self.device, non_blocking=True),
+            max_seqlen,
+        )
+
+
+class ShuffledSequenceLoader:
+    def __init__(self, h, device):
+        self.world_size = h.world_size
+        self.seq_len = h.train_seq_len
+        self.device = device
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files[h.rank :: h.world_size]
+        self.rng = np.random.Generator(np.random.PCG64(h.rank))
+        self.num_tokens = [_read_num_tokens(f) for f in self.files]
+        self.start_inds = [[] for _ in self.files]
+        for si in range(len(self.files)):
+            self._reset_shard(si)
+
+    def _reset_shard(self, si):
+        max_phase = min(
+            self.seq_len - 1, max(0, self.num_tokens[si] - self.seq_len - 1)
+        )
+        phase = int(self.rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        num_sequences = (self.num_tokens[si] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[si] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for bi in range(device_batch_size):
+            total = remaining.sum()
+            if total <= 0:
+                for si in range(len(self.files)):
+                    self._reset_shard(si)
+                remaining = np.array(
+                    [len(s) for s in self.start_inds], dtype=np.float64
+                )
+                total = remaining.sum()
+            probs = remaining / total
+            si = int(self.rng.choice(len(self.files), p=probs))
+            start_ind = self.start_inds[si].pop()
+            remaining[si] -= 1
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[bi] = window[:-1]
+            y[bi] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x):
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+@triton.jit
+def linear_leaky_relu_square_kernel(
+    a_desc,
+    b_desc,
+    c_desc,
+    aux_desc,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    FORWARD: tl.constexpr,
+):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+    tile_id_c = start_pid - NUM_SMS
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+        tile_id_c += NUM_SMS
+        offs_am_c = offs_am
+        offs_bn_c = offs_bn
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+        c0 = acc0.to(dtype)
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            pre0 = aux_desc.load([offs_am_c, offs_bn_c])
+            pre1 = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c0 = c0 * tl.where(pre0 > 0, 2.0 * pre0, 0.5 * pre0)
+            c1 = c1 * tl.where(pre1 > 0, 2.0 * pre1, 0.5 * pre1)
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+        if FORWARD:
+            aux0 = tl.where(c0 > 0, c0, 0.5 * c0)
+            aux1 = tl.where(c1 > 0, c1, 0.5 * c1)
+            aux_desc.store([offs_am_c, offs_bn_c], aux0 * aux0)
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], aux1 * aux1)
+
+
+def linear_leaky_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K2 = b.shape
+    assert K == K2
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    forward = aux is None
+    if aux is None:
+        aux = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 256, 64
+    num_stages = 4 if forward else 3
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    grid = lambda _meta: (
+        min(num_sms, triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N)),
+    )
+    linear_leaky_relu_square_kernel[grid](
+        a_desc,
+        b_desc,
+        c_desc,
+        aux_desc,
+        M,
+        N,
+        K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        NUM_SMS=num_sms,
+        FORWARD=forward,
+        num_stages=num_stages,
+        num_warps=8,
+    )
+    if forward:
+        return c, aux
+    return c
+
+
+class FusedLinearLeakyReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, w1, w2):
+        x_flat = x.reshape(-1, x.shape[-1])
+        pre, post = linear_leaky_relu_square(x_flat, w1)
+        out = F.linear(post, w2)
+        ctx.save_for_backward(x, w1, w2, pre, post)
+        return out.view(*x.shape[:-1], out.shape[-1])
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, w1, w2, pre, post = ctx.saved_tensors
+        x_flat = x.reshape(-1, x.shape[-1])
+        grad_output_flat = grad_output.reshape(-1, grad_output.shape[-1])
+        dw2 = grad_output_flat.T @ post
+        dpre = linear_leaky_relu_square(grad_output_flat, w2.T.contiguous(), aux=pre)
+        dw1 = dpre.T @ x_flat
+        dx = dpre @ w1
+        return dx.view_as(x), dw1, dw2
+
+
+FusedLeakyReLUSquareMLP = FusedLinearLeakyReLUSquareFunction.apply
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=1e4, train_seq_len=1024, rope_dims=0, yarn=True):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.yarn = yarn
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / base ** (
+            torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+
+    def forward(self, seq_len, device, dtype):
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached < seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if self.yarn and seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * scale ** (rd / (rd - 2))
+                inv_freq = 1.0 / new_base ** (
+                    torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd
+                )
+            else:
+                inv_freq = self.inv_freq.float().to(device)
+            t = torch.arange(seq_len, device=device, dtype=torch.float32)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached[:, :seq_len].to(dtype=dtype), self._sin_cached[:, :seq_len].to(dtype=dtype)
+
+
+def apply_rotary_emb(x, cos, sin, rope_dims=0):
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=True
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len, yarn=yarn)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x, q_w, k_w, v_w, out_w, cu_seqlens=None, max_seqlen=0):
+        bsz, seqlen, dim = x.shape
+        q = F.linear(x, q_w.to(x.dtype)).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if cu_seqlens is not None:
+            y = flash_attn_varlen_func(
+                q[0],
+                k[0],
+                v[0],
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+                causal=True,
+                window_size=(-1, -1),
+            )[None]
+        else:
+            y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        self._last_proj_input = y.detach() if getattr(self, "_calib", False) else None
+        return F.linear(y, out_w.to(x.dtype))
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        self.use_fused = True
+
+    def forward(self, x, up_w, down_w):
+        if self.training and self.use_fused:
+            return FusedLeakyReLUSquareMLP(x, up_w.to(x.dtype), down_w.to(x.dtype))
+        hidden = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5).square()
+        self._last_down_input = hidden.detach() if getattr(self, "_calib", False) else None
+        return F.linear(hidden, down_w.to(x.dtype))
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        num_kv_heads,
+        mlp_mult,
+        rope_base,
+        qk_gain_init,
+        train_seq_len,
+        layer_idx=0,
+        ln_scale=False,
+        yarn=True,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=yarn
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(
+            torch.stack((torch.ones(dim), torch.zeros(dim))).float()
+        )
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+
+    def forward(self, x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=None, max_seqlen=0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(
+            self.attn_norm(x_in) * self.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[
+            None, None, :
+        ] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        return x_out
+
+class GPT(nn.Module):
+    def __init__(self, h):
+        super().__init__()
+        if h.logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {h.logit_softcap}")
+        self.tie_embeddings = h.tie_embeddings
+        self.tied_embed_init_std = h.tied_embed_init_std
+        self.logit_softcap = h.logit_softcap
+        self.tok_emb = nn.Embedding(h.vocab_size, h.model_dim)
+        self.num_layers = h.num_layers
+        head_dim = h.model_dim // h.num_heads
+        kv_dim = h.num_kv_heads * head_dim
+        hidden_dim = int(h.mlp_mult * h.model_dim)
+        self.qo_bank = nn.Parameter(torch.empty(2 * h.num_layers, h.model_dim, h.model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * h.num_layers, kv_dim, h.model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(h.num_layers, hidden_dim, h.model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(h.num_layers, h.model_dim, hidden_dim))
+        self.num_encoder_layers = h.num_layers // 2
+        self.num_decoder_layers = h.num_layers - self.num_encoder_layers
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    h.model_dim,
+                    h.num_heads,
+                    h.num_kv_heads,
+                    h.mlp_mult,
+                    h.rope_base,
+                    h.qk_gain_init,
+                    h.train_seq_len,
+                    layer_idx=i,
+                    ln_scale=h.ln_scale,
+                    yarn=h.rope_yarn,
+                )
+                for i in range(h.num_layers)
+            ]
+        )
+        if h.rope_dims > 0:
+            head_dim = h.model_dim // h.num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = h.rope_dims
+                block.attn.rotary = Rotary(
+                    head_dim,
+                    base=h.rope_base,
+                    train_seq_len=h.train_seq_len,
+                    rope_dims=h.rope_dims,
+                    yarn=h.rope_yarn,
+                )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None
+            if h.tie_embeddings
+            else CastedLinear(h.model_dim, h.vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if h.xsa_last_n > 0:
+            for i in range(max(0, h.num_layers - h.xsa_last_n), h.num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self.looping_active = False
+        if h.num_loops > 0:
+            loop_seg = list(range(h.loop_start, h.loop_end + 1))
+            all_indices = list(range(h.loop_start))
+            for _ in range(h.num_loops + 1):
+                all_indices.extend(loop_seg)
+            all_indices.extend(range(h.loop_end + 1, h.num_layers))
+            num_enc = len(all_indices) // 2
+            self.encoder_indices = all_indices[:num_enc]
+            self.decoder_indices = all_indices[num_enc:]
+        else:
+            self.encoder_indices = list(range(self.num_encoder_layers))
+            self.decoder_indices = list(range(self.num_encoder_layers, h.num_layers))
+        self.num_skip_weights = min(
+            len(self.encoder_indices), len(self.decoder_indices)
+        )
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+        )
+        self.skip_gates = (
+            nn.Parameter(
+                torch.zeros(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+            )
+            if h.skip_gates_enabled
+            else None
+        )
+        self.parallel_start_layer = h.parallel_start_layer
+        self.parallel_final_lane = h.parallel_final_lane.lower()
+        self.parallel_post_lambdas = nn.Parameter(
+            torch.ones(h.num_layers, 2, 2, dtype=torch.float32)
+        )
+        self.parallel_resid_lambdas = nn.Parameter(
+            torch.full((h.num_layers, 2), 1.1, dtype=torch.float32)
+        )
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.qo_bank.data[n + i])
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)
+        for i in range(n):
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.mlp_down_bank.data[i])
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _bank_weights(self, i):
+        n = self.num_layers
+        return (
+            self.qo_bank[i],
+            self.kv_bank[i],
+            self.kv_bank[n + i],
+            self.qo_bank[n + i],
+            self.mlp_up_bank[i],
+            self.mlp_down_bank[i],
+        )
+
+    def _parallel_block(
+        self, block_idx, lane0, lane1, x0,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+        cu_seqlens=None, max_seqlen=0,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        attn_out = block.attn(
+            block.attn_norm(attn_read) * block.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+        )
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * block.mlp(
+            block.mlp_norm(mlp_read) * block.ln_scale_factor, up_w, down_w
+        )
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+    def _final_parallel_hidden(self, lane0, lane1):
+        if self.parallel_final_lane == "mlp":
+            return lane1
+        if self.parallel_final_lane == "attn":
+            return lane0
+        return 0.5 * (lane0 + lane1)
+
+    def forward_logits(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else range(self.num_encoder_layers)
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else range(
+                self.num_encoder_layers,
+                self.num_encoder_layers + self.num_decoder_layers,
+            )
+        )
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block(
+                    i, lane0, lane1, x0, q_w, k_w, v_w, out_w, up_w, down_w,
+                    cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(self, input_ids, target_ids, cu_seqlens=None, max_seqlen=0):
+        logits = self.forward_logits(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        return F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            target_ids.reshape(-1),
+            reduction="mean",
+        )
+
+    def forward_ttt(self, input_ids, target_ids, lora):
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else list(range(self.num_encoder_layers))
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else list(
+                range(
+                    self.num_encoder_layers,
+                    self.num_encoder_layers + self.num_decoder_layers,
+                )
+            )
+        )
+        slot = 0
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block_with_lora(
+                    i, lane0, lane1, x0, lora, slot,
+                    q_w, k_w, v_w, out_w, up_w, down_w,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits = F.linear(x, self.tok_emb.weight)
+        else:
+            logits = self.lm_head(x)
+        logits = logits + lora.lm_head_lora(x)
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        bsz, sl, V = logits.shape
+        return F.cross_entropy(
+            logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none"
+        ).reshape(bsz, sl)
+
+    def _block_with_lora(self, block, x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w):
+        mix = block.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = block.attn_norm(x_in) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q = (F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_heads, attn.head_dim
+        )
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        x_out = x_in + block.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        mlp_n = block.mlp_norm(x_out) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        x_out = x_out + block.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * mlp_out
+        return x_out
+
+    def _parallel_block_with_lora(
+        self, block_idx, lane0, lane1, x0, lora, slot,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        n = block.attn_norm(attn_read) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q = (F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_heads, attn.head_dim
+        )
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_n = block.mlp_norm(mlp_read) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * mlp_out
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+
+class BatchedLinearLoRA(nn.Module):
+    # Novel: rank-scaled output (alpha/rank), like standard LoRA. Decouples
+    # effective magnitude from rank so changing rank does not change LR scale.
+    _ALPHA = float(os.environ.get("TTT_LORA_ALPHA", "96"))
+
+    def __init__(self, bsz, in_features, out_features, rank):
+        super().__init__()
+        self._bound = 1.0 / math.sqrt(in_features)
+        self._scale = self._ALPHA / rank
+        self.A = nn.Parameter(
+            torch.empty(bsz, rank, in_features).uniform_(-self._bound, self._bound)
+        )
+        self.B = nn.Parameter(torch.zeros(bsz, out_features, rank))
+
+    _WARM_START_A = bool(int(os.environ.get("TTT_WARM_START_A", "1")))
+
+    def reset(self):
+        with torch.no_grad():
+            # Novel: optionally keep A warm across batch resets (accumulates feature directions).
+            if not self._WARM_START_A:
+                self.A.uniform_(-self._bound, self._bound)
+            self.B.zero_()
+
+    def forward(self, x):
+        return ((x @ self.A.transpose(1, 2)) @ self.B.transpose(1, 2)) * self._scale
+
+
+class BatchedTTTLoRA(nn.Module):
+    def __init__(self, bsz, model, rank, k_lora=True, mlp_lora=True, o_lora=True):
+        super().__init__()
+        self.bsz = bsz
+        dim = model.qo_bank.shape[-1]
+        vocab = model.tok_emb.num_embeddings
+        if getattr(model, "looping_active", False):
+            num_slots = len(model.encoder_indices) + len(model.decoder_indices)
+        else:
+            num_slots = len(model.blocks)
+        kv_dim = model.blocks[0].attn.num_kv_heads * (
+            dim // model.blocks[0].attn.num_heads
+        )
+        embed_dim = model.tok_emb.embedding_dim
+        self.lm_head_lora = BatchedLinearLoRA(bsz, embed_dim, vocab, rank)
+        self.q_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+        )
+        self.v_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+        )
+        self.k_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+            )
+            if k_lora
+            else None
+        )
+        self.mlp_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if mlp_lora
+            else None
+        )
+        self.o_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if o_lora
+            else None
+        )
+
+    def reset(self):
+        with torch.no_grad():
+            self.lm_head_lora.reset()
+            for loras in [self.q_loras, self.v_loras, self.k_loras,
+                          self.mlp_loras, self.o_loras]:
+                if loras is not None:
+                    for lora in loras:
+                        lora.reset()
+
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps=10, eps=1e-07):
+    a, b, c = 3.4445, -4.775, 2.0315
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    for _ in range(steps):
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr,
+        momentum,
+        backend_steps,
+        nesterov=True,
+        weight_decay=0.0,
+        row_normalize=False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append({
+                    "p": p,
+                    "B": B,
+                    "padded_grad": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard_mom": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "full_update": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "scale": max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                })
+        self._bank_meta.sort(key=lambda m: -m["p"].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m["p"]
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m["padded_grad"]
+            pg[: m["B"]].copy_(p.grad.bfloat16())
+            if pg.shape[0] > m["B"]:
+                pg[m["B"] :].zero_()
+            fut = dist.reduce_scatter_tensor(
+                m["shard"], pg, op=dist.ReduceOp.AVG, async_op=True
+            )
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        if not self._built:
+            self._build()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+            row_normalize = group.get("row_normalize", False)
+            prev_ag_handle = None
+            prev_m = None
+            sharded = self._distributed and hasattr(self, "_rs_futures")
+            for idx, m in enumerate(self._bank_meta):
+                p = m["p"]
+                if p.grad is None:
+                    continue
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m["p"]
+                    upd = prev_m["full_update"][: prev_m["B"]]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+                if sharded and self._rs_futures[idx] is not None:
+                    self._rs_futures[idx].wait()
+                    g = m["shard"]
+                    buf = m["shard_mom"]
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+                if row_normalize:
+                    rn = update.float().norm(dim=-1, keepdim=True).clamp_min(1e-07)
+                    update = update / rn.to(update.dtype)
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m["full_update"], update, async_op=True
+                    )
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update.to(dtype=p.dtype), alpha=-lr * m["scale"])
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m["p"]
+                upd = prev_m["full_update"][: prev_m["B"]]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+            if hasattr(self, "_rs_futures"):
+                del self._rs_futures
+        return loss
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,parallel_post_lambdas,parallel_resid_lambdas",
+    ).split(",")
+    if pattern
+)
+
+
+PACKED_REPLICATED_GRAD_MAX_NUMEL = 1 << 15
+
+
+class Optimizers:
+    def __init__(self, h, base_model):
+        matrix_params = [
+            base_model.qo_bank,
+            base_model.kv_bank,
+            base_model.mlp_up_bank,
+            base_model.mlp_down_bank,
+        ]
+        block_named_params = list(base_model.blocks.named_parameters())
+        scalar_params = [
+            p
+            for (name, p) in block_named_params
+            if p.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        if base_model.skip_weights.numel() > 0:
+            scalar_params.append(base_model.skip_weights)
+        if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
+            scalar_params.append(base_model.skip_gates)
+        if base_model.parallel_post_lambdas is not None:
+            scalar_params.append(base_model.parallel_post_lambdas)
+        if base_model.parallel_resid_lambdas is not None:
+            scalar_params.append(base_model.parallel_resid_lambdas)
+        token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
+        tok_params = [
+            {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+        ]
+        self.optimizer_tok = torch.optim.AdamW(
+            tok_params,
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.embed_wd,
+            fused=True,
+        )
+        self.optimizer_muon = Muon(
+            matrix_params,
+            lr=h.matrix_lr,
+            momentum=h.muon_momentum,
+            backend_steps=h.muon_backend_steps,
+            weight_decay=h.muon_wd,
+            row_normalize=h.muon_row_normalize,
+        )
+        for group in self.optimizer_muon.param_groups:
+            group["base_lr"] = h.matrix_lr
+        self.optimizer_scalar = torch.optim.AdamW(
+            [{"params": scalar_params, "lr": h.scalar_lr, "base_lr": h.scalar_lr}],
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.adam_wd,
+            fused=True,
+        )
+        self.optimizers = [
+            self.optimizer_tok,
+            self.optimizer_muon,
+            self.optimizer_scalar,
+        ]
+        self.replicated_params = list(tok_params[0]["params"])
+        self.replicated_params.extend(scalar_params)
+        self.replicated_large_params = []
+        self.replicated_packed_params = []
+        for p in self.replicated_params:
+            if p.numel() <= PACKED_REPLICATED_GRAD_MAX_NUMEL:
+                self.replicated_packed_params.append(p)
+            else:
+                self.replicated_large_params.append(p)
+
+    def __iter__(self):
+        return iter(self.optimizers)
+
+    def zero_grad_all(self):
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    def _all_reduce_packed_grads(self):
+        grads_by_key = collections.defaultdict(list)
+        for p in self.replicated_packed_params:
+            if p.grad is not None:
+                grads_by_key[(p.grad.device, p.grad.dtype)].append(p.grad)
+        for grads in grads_by_key.values():
+            flat = torch.empty(
+                sum(g.numel() for g in grads),
+                device=grads[0].device,
+                dtype=grads[0].dtype,
+            )
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                flat[offset : offset + n].copy_(g.contiguous().view(-1))
+                offset += n
+            dist.all_reduce(flat, op=dist.ReduceOp.AVG)
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                g.copy_(flat[offset : offset + n].view_as(g))
+                offset += n
+
+    def step(self, distributed=False):
+        self.optimizer_muon.launch_reduce_scatters()
+        if distributed:
+            reduce_handles = [
+                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG, async_op=True)
+                for p in self.replicated_large_params
+                if p.grad is not None
+            ]
+            self._all_reduce_packed_grads()
+            for handle in reduce_handles:
+                handle.wait()
+        self.optimizer_tok.step()
+        self.optimizer_scalar.step()
+        self.optimizer_muon.step()
+        self.zero_grad_all()
+
+
+def restore_fp32_params(model):
+    for module in model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    for name, param in model.named_parameters():
+        if (
+            param.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ) and param.dtype != torch.float32:
+            param.data = param.data.float()
+    if hasattr(model, "qo_bank") and model.qo_bank is not None:
+        model.qo_bank.data = model.qo_bank.data.float()
+        model.kv_bank.data = model.kv_bank.data.float()
+    model.mlp_up_bank.data = model.mlp_up_bank.data.float()
+    model.mlp_down_bank.data = model.mlp_down_bank.data.float()
+
+
+def collect_hessians(model, train_loader, h, device, n_calibration_batches=64):
+    hessians = {}
+    hooks = []
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = True
+        block.mlp._calib = True
+        block.mlp.use_fused = False
+
+    def make_attn_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            for suffix in ["c_q", "c_k", "c_v"]:
+                name = f"blocks.{layer_idx}.attn.{suffix}.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            y = module._last_proj_input
+            if y is not None:
+                y = y.float()
+                if y.ndim == 3:
+                    y = y.reshape(-1, y.shape[-1])
+                name = f"blocks.{layer_idx}.attn.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        y.shape[1], y.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(y.T, y)
+        return hook_fn
+
+    def make_mlp_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            name = f"blocks.{layer_idx}.mlp.fc.weight"
+            if name not in hessians:
+                hessians[name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[name].addmm_(x.T, x)
+            h_act = module._last_down_input
+            if h_act is not None:
+                h_act = h_act.float()
+                if h_act.ndim == 3:
+                    h_act = h_act.reshape(-1, h_act.shape[-1])
+                name = f"blocks.{layer_idx}.mlp.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        h_act.shape[1], h_act.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(h_act.T, h_act)
+        return hook_fn
+
+    for i, block in enumerate(model.blocks):
+        hooks.append(block.attn.register_forward_hook(make_attn_hook(i)))
+        hooks.append(block.mlp.register_forward_hook(make_mlp_hook(i)))
+
+    # Hessian hooks for embedding factorization projection layers
+    def make_linear_input_hook(weight_name):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            if weight_name not in hessians:
+                hessians[weight_name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[weight_name].addmm_(x.T, x)
+        return hook_fn
+
+    if model.tie_embeddings:
+        hook_module = model.final_norm
+
+        def make_output_hook(name):
+            def hook_fn(module, inp, out):
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            return hook_fn
+
+        hooks.append(
+            hook_module.register_forward_hook(make_output_hook("tok_emb.weight"))
+        )
+    model.eval()
+    with torch.no_grad():
+        for _ in range(n_calibration_batches):
+            x, _ = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+            model.forward_logits(x)
+    for hook in hooks:
+        hook.remove()
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = False
+        block.mlp._calib = False
+        block.mlp.use_fused = True
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / n_calibration_batches
+    return hessians
+
+
+def gptq_quantize_weight(w, H, clip_sigmas=3.0, clip_range=63, block_size=128):
+    W_orig = w.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * H.diag().mean()
+    H.diagonal().add_(damp)
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+    Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    row_std = W_orig.std(dim=1)
+    s = (clip_sigmas * row_std / clip_range).clamp_min(1e-10).to(torch.float16)
+    sf = s.float()
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    W_work = W_perm.clone()
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W_work[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros(rows, i2 - i1)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            d = Hinv_block[j, j]
+            q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - q_col.float() * sf) / d
+            Err[:, j] = err
+            W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+        if i2 < cols:
+            W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+    return Q[:, invperm], s
+
+
+def gptq_mixed_quantize(state_dict, hessians, h):
+    result = {}
+    meta = {}
+    for (name, tensor) in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough (float16)"
+            continue
+        if "tok_emb" in name:
+            cs = h.embed_clip_sigmas
+        elif ".mlp." in name:
+            cs = h.mlp_clip_sigmas
+        elif ".attn." in name:
+            cs = h.attn_clip_sigmas
+        else:
+            cs = h.matrix_clip_sigmas
+        bits = h.embed_bits if "tok_emb" in name else h.matrix_bits
+        clip_range = 2 ** (bits - 1) - 1
+        ret = gptq_quantize_weight(
+            t, hessians[name], clip_sigmas=cs, clip_range=clip_range
+        )
+        q, s = ret
+        result[name + ".q"] = q
+        result[name + ".scale"] = s
+        meta[name] = f"gptq (int{bits})"
+    categories = collections.defaultdict(set)
+    for (name, cat) in meta.items():
+        short = re.sub("\\.\\d+$", "", re.sub("blocks\\.\\d+", "blocks", name))
+        categories[cat].add(short)
+    log("Quantized weights:")
+    for cat in sorted(categories):
+        log(f"  {cat}: {', '.join(sorted(categories[cat]))}")
+    return result, meta
+
+
+def dequantize_mixed(result, meta, template_sd):
+    out = {}
+    for (name, orig) in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if "passthrough" in info:
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (
+                q.float() * s.float().view(q.shape[0], *[1] * (q.ndim - 1))
+            ).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+_BSHF_MAGIC = b"BSHF"
+
+
+def _byte_shuffle(data, stride=2):
+    if stride <= 1 or len(data) < stride:
+        return data
+    src = np.frombuffer(data, dtype=np.uint8)
+    n = len(src)
+    out = np.empty(n, dtype=np.uint8)
+    dest_off = 0
+    for pos in range(stride):
+        chunk = src[pos::stride]
+        out[dest_off : dest_off + len(chunk)] = chunk
+        dest_off += len(chunk)
+    return _BSHF_MAGIC + bytes([stride]) + out.tobytes()
+
+
+def _byte_unshuffle(data):
+    if len(data) < 5 or data[:4] != _BSHF_MAGIC:
+        return data
+    stride = data[4]
+    if stride < 2:
+        return data[5:]
+    payload = np.frombuffer(data, dtype=np.uint8, offset=5)
+    n = len(payload)
+    out = np.empty(n, dtype=np.uint8)
+    src_off = 0
+    for pos in range(stride):
+        chunk_len = n // stride + (1 if pos < n % stride else 0)
+        out[pos::stride][:chunk_len] = payload[src_off : src_off + chunk_len]
+        src_off += chunk_len
+    return out.tobytes()
+
+
+def _compress(data, compressor):
+    data = _byte_shuffle(data)
+    if compressor == "lzma":
+        return lzma.compress(data, preset=6)
+    elif compressor == "brotli":
+        import brotli
+
+        return brotli.compress(data, quality=11)
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def _decompress(data, compressor):
+    if compressor == "lzma":
+        raw = lzma.decompress(data)
+    elif compressor == "brotli":
+        import brotli
+
+        raw = brotli.decompress(data)
+    else:
+        raise ValueError(f"Unknown compressor: {compressor!r}")
+    raw = _byte_unshuffle(raw)
+    return raw
+
+
+def _unbank_state_dict(state_dict, num_layers):
+    sd = {}
+    n = num_layers
+    for k, v in state_dict.items():
+        t = v.detach().cpu() if v is not None else None
+        if k == "qo_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_q.weight"] = t[i]
+                sd[f"blocks.{i}.attn.proj.weight"] = t[n + i]
+        elif k == "kv_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_k.weight"] = t[i]
+                sd[f"blocks.{i}.attn.c_v.weight"] = t[n + i]
+        elif k == "mlp_up_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.fc.weight"] = t[i]
+        elif k == "mlp_down_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.proj.weight"] = t[i]
+        else:
+            if t is not None:
+                sd[k] = t
+    return sd
+
+
+def _rebank_state_dict(flat_sd, num_layers, model_dim, kv_dim, hidden_dim):
+    sd = {}
+    n = num_layers
+    sd["qo_bank"] = torch.zeros(2 * n, model_dim, model_dim)
+    sd["kv_bank"] = torch.zeros(2 * n, kv_dim, model_dim)
+    for i in range(n):
+        sd["qo_bank"][i] = flat_sd[f"blocks.{i}.attn.c_q.weight"]
+        sd["qo_bank"][n + i] = flat_sd[f"blocks.{i}.attn.proj.weight"]
+        sd["kv_bank"][i] = flat_sd[f"blocks.{i}.attn.c_k.weight"]
+        sd["kv_bank"][n + i] = flat_sd[f"blocks.{i}.attn.c_v.weight"]
+    sd["mlp_up_bank"] = torch.zeros(n, hidden_dim, model_dim)
+    sd["mlp_down_bank"] = torch.zeros(n, model_dim, hidden_dim)
+    for i in range(n):
+        sd["mlp_up_bank"][i] = flat_sd[f"blocks.{i}.mlp.fc.weight"]
+        sd["mlp_down_bank"][i] = flat_sd[f"blocks.{i}.mlp.proj.weight"]
+    for k, v in flat_sd.items():
+        if not (
+            k.startswith("blocks.")
+            and any(
+                p in k
+                for p in [
+                    ".attn.c_q.", ".attn.c_k.", ".attn.c_v.",
+                    ".attn.proj.", ".mlp.fc.", ".mlp.proj.",
+                ]
+            )
+        ):
+            sd[k] = v
+    return sd
+
+
+
+def _compressed_code_size(code):
+    code_raw = code.encode("utf-8")
+    minified = subprocess.run(
+        ["pyminify", "--no-rename-locals", "--no-hoist-literals", "--remove-literal-statements", "-"],
+        input=code_raw, capture_output=True, check=True,
+    ).stdout
+    compressed = lzma.compress(minified)
+    encoded = base64.b85encode(compressed)
+    wrapper = b'import lzma as L,base64 as B\nexec(L.decompress(B.b85decode("' + encoded + b'")))\n'
+    return len(code_raw), len(wrapper)
+
+
+def serialize(h, base_model, code):
+    code_bytes_uncompressed, code_bytes = _compressed_code_size(code)
+    if h.is_main_process:
+        torch.save(base_model.state_dict(), h.model_path)
+        model_bytes = os.path.getsize(h.model_path)
+        log(f"Serialized model: {model_bytes} bytes")
+        log(f"Code size (uncompressed): {code_bytes_uncompressed} bytes")
+        log(f"Code size (compressed): {code_bytes} bytes")
+    sd_cpu = _unbank_state_dict(base_model.state_dict(), h.num_layers)
+    device = torch.device("cuda", h.local_rank)
+    log("GPTQ:collecting Hessians from calibration data...")
+    t0 = time.perf_counter()
+    calib_loader = ShuffledSequenceLoader(h, device)
+    hessians = collect_hessians(
+        base_model,
+        calib_loader,
+        h,
+        device,
+        n_calibration_batches=h.gptq_calibration_batches,
+    )
+    log(f"GPTQ:collected {len(hessians)} Hessians in {time.perf_counter()-t0:.1f}s")
+    quant_result, quant_meta = gptq_mixed_quantize(sd_cpu, hessians, h)
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = _compress(quant_raw, h.compressor)
+    quant_file_bytes = len(quant_blob)
+    bytes_total = quant_file_bytes + code_bytes
+    if h.is_main_process:
+        with open(h.quantized_model_path, "wb") as f:
+            f.write(quant_blob)
+        log(f"Serialized model quantized+{h.compressor}: {quant_file_bytes} bytes")
+        log(f"Total submission size quantized+{h.compressor}: {bytes_total} bytes")
+    return bytes_total, quant_file_bytes
+
+
+def deserialize(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    flat_template = _unbank_state_dict(eval_model.state_dict(), h.num_layers)
+    with open(h.quantized_model_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(_decompress(quant_blob_disk, h.compressor)), map_location="cpu"
+    )
+    deq_flat = dequantize_mixed(quant_state["w"], quant_state["m"], flat_template)
+    head_dim = h.model_dim // h.num_heads
+    kv_dim = h.num_kv_heads * head_dim
+    hidden_dim = int(h.mlp_mult * h.model_dim)
+    deq_state = _rebank_state_dict(deq_flat, h.num_layers, h.model_dim, kv_dim, hidden_dim)
+    eval_model.load_state_dict(deq_state, strict=True)
+    return eval_model
+
+
+def _loss_bpb(loss_sum, token_count, byte_count):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    return val_loss, val_bpb
+
+
+def eval_val(h, device, val_data, model, forward_logits_fn=None):
+    seq_len = h.eval_seq_len
+    local_batch_tokens = h.val_batch_tokens // (h.world_size * h.grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            f"VAL_BATCH_SIZE must provide at least one sequence per rank; got VAL_BATCH_SIZE={h.val_batch_tokens}, WORLD_SIZE={h.world_size}, GRAD_ACCUM_STEPS={h.grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = total_seqs * h.rank // h.world_size
+    seq_end = total_seqs * (h.rank + 1) // h.world_size
+
+    # TODO: Don't truncate this.
+    seq_end = seq_start + ((seq_end - seq_start) // local_batch_seqs) * local_batch_seqs
+
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    run_forward_logits = (
+        (model.module.forward_logits if hasattr(model, "module") else model.forward_logits)
+        if forward_logits_fn is None
+        else forward_logits_fn
+    )
+    model.eval()
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    with torch.no_grad():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_data.val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1]
+            y = local[1:]
+            bos_pos = (x == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                bos_pos, x.numel(), x.device, h.eval_seq_len, 64
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = run_forward_logits(
+                    x[None], cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                ).detach()
+            per_token_loss = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y.reshape(-1),
+                reduction="none",
+            )
+            val_loss_sum += per_token_loss.to(torch.float64).sum()
+            val_token_count += float(y.numel())
+            prev_ids = x
+            tgt_ids = y
+            token_bytes = val_data.base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (
+                val_data.has_leading_space_lut[tgt_ids]
+                & ~val_data.is_boundary_token_lut[prev_ids]
+            ).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    model.train()
+    return _loss_bpb(val_loss_sum, val_token_count, val_byte_count)
+
+
+def eval_val_sliding(h, device, val_data, base_model, forward_logits_fn=None, batch_seqs=32):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    run_forward_logits = base_model.forward_logits if forward_logits_fn is None else forward_logits_fn
+    seq_len = h.eval_seq_len
+    stride = h.eval_stride
+    total_tokens = val_data.val_tokens.numel() - 1
+    context_size = seq_len - stride
+    window_starts = [ws for ws in range(0, total_tokens, stride)
+                     if ws + context_size < total_tokens]
+    total_windows = len(window_starts)
+    my_s = (total_windows * h.rank) // h.world_size
+    my_e = (total_windows * (h.rank + 1)) // h.world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    total_batches = (len(my_windows) + batch_seqs - 1) // batch_seqs
+    is_master = h.rank == 0
+    cu_bucket = 64
+    t_sw_start = time.perf_counter()
+    with torch.no_grad():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_idx = bi // batch_seqs
+            if is_master and (batch_idx % 50 == 0 or batch_idx == total_batches - 1):
+                elapsed = time.perf_counter() - t_sw_start
+                rl = float(loss_sum.item() / token_count.item()) if token_count.item() > 0 else 0.0
+                rb = float((rl / math.log(2.0)) * token_count.item() / byte_count.item()) if byte_count.item() > 0 else 0.0
+                log(f"sliding_progress: batch {batch_idx+1}/{total_batches} "
+                    f"tokens:{int(token_count.item())} running_loss:{rl:.4f} running_bpb:{rb:.4f} "
+                    f"elapsed:{elapsed:.1f}s")
+            batch_ws = my_windows[bi:bi + batch_seqs]
+            x_parts = []
+            y_parts = []
+            cu_starts = []
+            score_ranges = []
+            offset = 0
+            for ws in batch_ws:
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                chunk_cpu = val_data.val_tokens[ws:end + 1]
+                bos_pos = (chunk_cpu[:-1] == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+                if not bos_pos or bos_pos[0] != 0:
+                    bos_pos = [0] + bos_pos
+                cu_starts.extend(offset + pos for pos in bos_pos)
+                chunk = chunk_cpu.to(dtype=torch.int64, device=device)
+                x_parts.append(chunk[:-1])
+                y_parts.append(chunk[1:])
+                score_ranges.append((offset, wlen, ws))
+                offset += wlen
+            x_cat = torch.cat(x_parts, dim=0)[None]
+            y_cat = torch.cat(y_parts, dim=0)
+            boundaries = cu_starts + [offset]
+            padded_len = get_next_multiple_of_n(len(boundaries), cu_bucket)
+            cu_seqlens = torch.full((padded_len,), offset, dtype=torch.int32, device=device)
+            cu_seqlens[:len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = run_forward_logits(x_cat, cu_seqlens=cu_seqlens, max_seqlen=seq_len)
+            flat_nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_cat,
+                reduction="none",
+            )
+            flat_x = x_cat.reshape(-1)
+            for off, wlen, ws in score_ranges:
+                s = 0 if ws == 0 else context_size
+                lo = off + s
+                hi = off + wlen
+                scored_nll = flat_nll[lo:hi].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(hi - lo)
+                tgt = y_cat[lo:hi]
+                prev = flat_x[lo:hi]
+                tb = val_data.base_bytes_lut[tgt].to(torch.float64)
+                tb += (val_data.has_leading_space_lut[tgt] & ~val_data.is_boundary_token_lut[prev]).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    base_model.train()
+    return _loss_bpb(loss_sum, token_count, byte_count)
+
+
+def _find_docs(all_tokens):
+    bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0].numpy()
+    docs = []
+    for i in range(len(bos_positions)):
+        start = int(bos_positions[i])
+        end = (
+            int(bos_positions[i + 1])
+            if i + 1 < len(bos_positions)
+            else all_tokens.numel()
+        )
+        if i + 1 < len(bos_positions):
+            end += 1
+        assert end - start >= 2
+        docs.append((start, end - start))
+    return docs
+
+
+def _build_ttt_global_batches(doc_entries, h, ascending=False):
+    batch_size = h.ttt_batch_size
+    global_doc_entries = sorted(doc_entries, key=lambda x: x[1][1])
+    global_batches = [
+        global_doc_entries[i : i + batch_size]
+        for i in range(0, len(global_doc_entries), batch_size)
+    ]
+    indexed = list(enumerate(global_batches))
+    if not ascending:
+        indexed.sort(key=lambda ib: -max(dl for _, (_, dl) in ib[1]))
+    return indexed
+
+
+def _init_batch_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(4, "little"))
+
+
+def _claim_next_batch(counter_path, queue_len):
+    try:
+        with open(counter_path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            idx = int.from_bytes(f.read(4), "little")
+            f.seek(0)
+            f.write((idx + 1).to_bytes(4, "little"))
+            f.flush()
+    except FileNotFoundError:
+        return queue_len
+    return idx
+
+
+def _compute_chunk_window(ci, pred_len, num_chunks, chunk_size, eval_seq_len):
+    chunk_end = pred_len if ci == num_chunks - 1 else (ci + 1) * chunk_size
+    win_start = max(0, chunk_end - eval_seq_len)
+    win_len = chunk_end - win_start
+    chunk_start = ci * chunk_size
+    chunk_offset = chunk_start - win_start
+    chunk_len = chunk_end - chunk_start
+    return win_start, win_len, chunk_offset, chunk_len
+
+
+def _accumulate_bpb(
+    ptl,
+    x,
+    y,
+    chunk_offsets,
+    chunk_lens,
+    pos_idx,
+    base_bytes_lut,
+    has_leading_space_lut,
+    is_boundary_token_lut,
+    loss_sum,
+    byte_sum,
+    token_count,
+):
+    pos = pos_idx[: x.size(1)].unsqueeze(0)
+    mask = (
+        (chunk_lens.unsqueeze(1) > 0)
+        & (pos >= chunk_offsets.unsqueeze(1))
+        & (pos < (chunk_offsets + chunk_lens).unsqueeze(1))
+    )
+    mask_f64 = mask.to(torch.float64)
+    tok_bytes = base_bytes_lut[y].to(torch.float64)
+    tok_bytes += (has_leading_space_lut[y] & ~is_boundary_token_lut[x]).to(
+        torch.float64
+    )
+    loss_sum += (ptl.to(torch.float64) * mask_f64).sum()
+    byte_sum += (tok_bytes * mask_f64).sum()
+    token_count += chunk_lens.to(torch.float64).sum()
+
+
+def _loss_bpb_from_sums(loss_sum, token_count, byte_sum):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_sum.item())
+    return val_loss, val_bpb
+
+
+def _split_doc_entries_for_phased(doc_entries, prefix_docs):
+    prefix_docs = max(0, min(len(doc_entries), int(prefix_docs)))
+    return doc_entries[:prefix_docs], doc_entries[prefix_docs:]
+
+
+def _add_to_counter(path, delta):
+    try:
+        with open(path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            cur = int.from_bytes(f.read(8), "little", signed=True)
+            cur += int(delta)
+            f.seek(0)
+            f.write(int(cur).to_bytes(8, "little", signed=True))
+            f.flush()
+            return cur
+    except FileNotFoundError:
+        return int(delta)
+
+
+def _init_int64_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(8, "little", signed=True))
+
+
+def _select_ttt_doc_entries(docs, h):
+    doc_entries = list(enumerate(docs))
+    if h.val_doc_fraction < 1.0:
+        sample_n = max(1, int(round(len(docs) * h.val_doc_fraction)))
+        sampled_indices = sorted(
+            random.Random(h.seed).sample(range(len(docs)), sample_n)
+        )
+        return [(i, docs[i]) for i in sampled_indices]
+    return doc_entries
+
+
+def train_val_ttt_global_sgd_distributed(h, device, val_data, base_model, val_tokens, batch_seqs=None):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    seq_len = h.eval_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = h.global_ttt_chunk_tokens
+    batch_seqs = h.global_ttt_batch_seqs if batch_seqs is None else batch_seqs
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    ttt_params = [p for p in base_model.parameters()]
+    for p in ttt_params:
+        p.requires_grad_(True)
+    optimizer = torch.optim.SGD(
+        ttt_params, lr=h.global_ttt_lr, momentum=h.global_ttt_momentum
+    )
+    t_start = time.perf_counter()
+    for ci in range(num_chunks):
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+        is_last_chunk = ci == num_chunks - 1
+        if is_last_chunk or h.global_ttt_epochs <= 0:
+            continue
+        base_model.train()
+        chunk_seqs = (chunk_end - chunk_start) // seq_len
+        if chunk_seqs <= 0:
+            continue
+        warmup_chunks = max(0, min(h.global_ttt_warmup_chunks, num_chunks - 1))
+        if warmup_chunks > 0 and ci < warmup_chunks:
+            warmup_denom = max(warmup_chunks - 1, 1)
+            warmup_t = ci / warmup_denom
+            lr_now = (
+                h.global_ttt_warmup_start_lr
+                + (h.global_ttt_lr - h.global_ttt_warmup_start_lr) * warmup_t
+            )
+        else:
+            decay_steps = max(num_chunks - 1 - warmup_chunks, 1)
+            decay_ci = max(ci - warmup_chunks, 0)
+            lr_now = h.global_ttt_lr * 0.5 * (
+                1.0 + math.cos(math.pi * decay_ci / decay_steps)
+            )
+        for pg in optimizer.param_groups:
+            pg["lr"] = lr_now
+        my_seq_s = chunk_seqs * h.rank // h.world_size
+        my_seq_e = chunk_seqs * (h.rank + 1) // h.world_size
+        my_chunk_seqs = my_seq_e - my_seq_s
+        for _ in range(h.global_ttt_epochs):
+            for bs in range(0, my_chunk_seqs, batch_seqs):
+                be = min(bs + batch_seqs, my_chunk_seqs)
+                actual_bs = my_seq_s + bs
+                start_tok = chunk_start + actual_bs * seq_len
+                end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                if end_tok > val_tokens.numel():
+                    continue
+                local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                x_flat = local[:-1]
+                y_flat = local[1:]
+                optimizer.zero_grad(set_to_none=True)
+                with torch.enable_grad():
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        if h.global_ttt_respect_doc_boundaries:
+                            bos_pos = (x_flat == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+                            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                                bos_pos, x_flat.numel(), x_flat.device, h.eval_seq_len, 64
+                            )
+                            loss = base_model(
+                                x_flat[None],
+                                y_flat[None],
+                                cu_seqlens=cu_seqlens,
+                                max_seqlen=max_seqlen,
+                            )
+                        else:
+                            x = x_flat.reshape(-1, seq_len)
+                            y = y_flat.reshape(-1, seq_len)
+                            loss = base_model(x, y)
+                loss.backward()
+                if dist.is_available() and dist.is_initialized():
+                    for p in ttt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+                            p.grad.mul_(1.0 / h.world_size)
+                if h.global_ttt_grad_clip > 0:
+                    torch.nn.utils.clip_grad_norm_(ttt_params, h.global_ttt_grad_clip)
+                optimizer.step()
+        base_model.eval()
+        if h.rank == 0:
+            elapsed = time.perf_counter() - t_start
+            log(
+                f"tttg: c{ci+1}/{num_chunks} lr:{lr_now:.6f} t:{elapsed:.1f}s"
+            )
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+
+def eval_val_ttt_phased(h, base_model, device, val_data, forward_ttt_train):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+    all_tokens = val_data.val_tokens
+    all_tokens_idx = all_tokens.to(torch.int32)
+    docs = _find_docs(all_tokens)
+    doc_entries = _select_ttt_doc_entries(docs, h)
+    prefix_doc_limit = max(0, min(len(doc_entries), int(h.phased_ttt_prefix_docs)))
+    num_phases = max(1, int(h.phased_ttt_num_phases))
+    phase_boundaries = []
+    for pi in range(num_phases):
+        boundary = prefix_doc_limit * (pi + 1) // num_phases
+        phase_boundaries.append(boundary)
+    current_phase = 0
+    current_phase_boundary = phase_boundaries[0]
+    log(
+        "ttt_phased:"
+        f" total_docs:{len(doc_entries)} prefix_docs:{prefix_doc_limit} "
+        f"suffix_docs:{len(doc_entries) - prefix_doc_limit}"
+        f" num_phases:{num_phases} boundaries:{phase_boundaries}"
+    )
+    chunk_size, eval_seq_len = h.ttt_chunk_size, h.ttt_eval_seq_len
+    eval_batch_set = None
+    if h.ttt_eval_batches:
+        eval_batch_set = set(int(x) for x in h.ttt_eval_batches.split(",") if x.strip())
+    use_ascending = eval_batch_set is not None
+    global_batches_sorted = _build_ttt_global_batches(
+        doc_entries, h, ascending=use_ascending
+    )
+    queue_len = len(global_batches_sorted)
+    counter_path = f"/tmp/ttt_counter_{h.run_id}"
+    prefix_counter_path = f"/tmp/ttt_prefix_counter_{h.run_id}"
+    pause_flag_path = f"/tmp/ttt_pause_flag_{h.run_id}"
+    if h.rank == 0:
+        _init_batch_counter(counter_path)
+        _init_int64_counter(prefix_counter_path)
+        try:
+            os.remove(pause_flag_path)
+        except FileNotFoundError:
+            pass
+    if dist.is_available() and dist.is_initialized():
+        path_list = [counter_path, prefix_counter_path, pause_flag_path]
+        dist.broadcast_object_list(path_list, src=0)
+        counter_path, prefix_counter_path, pause_flag_path = path_list
+        dist.barrier()
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    t_start = time.perf_counter()
+    reusable_lora = BatchedTTTLoRA(
+        h.ttt_batch_size, base_model, h.ttt_lora_rank,
+        k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+    ).to(device)
+
+    def _build_opt(lora):
+        if h.ttt_optimizer == "sgd":
+            return torch.optim.SGD(
+                lora.parameters(), lr=h.ttt_lora_lr,
+                momentum=h.ttt_beta1, weight_decay=h.ttt_weight_decay,
+            )
+        return torch.optim.AdamW(
+            lora.parameters(), lr=h.ttt_lora_lr,
+            betas=(h.ttt_beta1, h.ttt_beta2),
+            eps=1e-10, weight_decay=h.ttt_weight_decay, fused=True,
+        )
+
+    reusable_opt = _build_opt(reusable_lora)
+    local_scored_docs = []
+    global_ttt_done = prefix_doc_limit == 0
+    try:
+      while True:
+        queue_idx = _claim_next_batch(counter_path, queue_len)
+        if queue_idx >= queue_len:
+            break
+        orig_batch_idx, batch_entries = global_batches_sorted[queue_idx]
+        batch = [doc for _, doc in batch_entries]
+        bsz = len(batch)
+        prev_loss = loss_sum.item()
+        prev_bytes = byte_sum.item()
+        prev_tokens = token_count.item()
+        if bsz == reusable_lora.bsz:
+            reusable_lora.reset()
+            for s in reusable_opt.state.values():
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor):
+                        v.zero_()
+                    elif k == "step":
+                        s[k] = 0
+            cur_lora = reusable_lora
+            cur_opt = reusable_opt
+        else:
+            cur_lora = BatchedTTTLoRA(
+                bsz, base_model, h.ttt_lora_rank,
+                k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+            ).to(device)
+            cur_opt = _build_opt(cur_lora)
+        pred_lens = [doc_len - 1 for _, doc_len in batch]
+        num_chunks = [(pl + chunk_size - 1) // chunk_size for pl in pred_lens]
+        max_nc = max(num_chunks)
+        num_chunks_t = torch.tensor(num_chunks, dtype=torch.int64, device=device)
+        for ci in range(max_nc):
+            active = [ci < nc for nc in num_chunks]
+            needs_train = any(ci < nc - 1 for nc in num_chunks)
+            tok_starts = torch.zeros(bsz, dtype=torch.int64)
+            tok_wls = torch.zeros(bsz, dtype=torch.int64)
+            chunk_offsets_cpu = torch.zeros(bsz, dtype=torch.int64)
+            chunk_lens_cpu = torch.zeros(bsz, dtype=torch.int64)
+            for b in range(bsz):
+                if not active[b]:
+                    continue
+                doc_start, doc_len = batch[b]
+                win_start, win_len, chunk_offset, chunk_len = _compute_chunk_window(
+                    ci, pred_lens[b], num_chunks[b], chunk_size, eval_seq_len
+                )
+                tok_starts[b] = doc_start + win_start
+                tok_wls[b] = win_len
+                chunk_offsets_cpu[b] = chunk_offset
+                chunk_lens_cpu[b] = chunk_len
+            _, context_size, chunk_offset, _ = _compute_chunk_window(
+                ci, (ci + 1) * chunk_size, ci + 1, chunk_size, eval_seq_len
+            )
+            col_idx = torch.arange(context_size + 1)
+            idx = tok_starts.unsqueeze(1) + col_idx.unsqueeze(0)
+            idx.clamp_(max=all_tokens.numel() - 1)
+            gathered_gpu = all_tokens_idx[idx].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            valid = (col_idx[:context_size].unsqueeze(0) < tok_wls.unsqueeze(1)).to(
+                device, non_blocking=True
+            )
+            chunk_offsets = chunk_offsets_cpu.to(device, non_blocking=True)
+            chunk_lens = chunk_lens_cpu.to(device, non_blocking=True)
+            x = torch.where(valid, gathered_gpu[:, :context_size], 0)
+            y = torch.where(valid, gathered_gpu[:, 1 : context_size + 1], 0)
+            ctx_pos = torch.arange(context_size, device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+            with torch.no_grad():
+                _accumulate_bpb(
+                    per_tok_loss,
+                    x,
+                    y,
+                    chunk_offsets,
+                    chunk_lens,
+                    ctx_pos,
+                    val_data.base_bytes_lut,
+                    val_data.has_leading_space_lut,
+                    val_data.is_boundary_token_lut,
+                    loss_sum,
+                    byte_sum,
+                    token_count,
+                )
+            if needs_train:
+                activate_chunk_mask = (num_chunks_t - 1 > ci).float()
+                for gi in range(h.ttt_grad_steps):
+                    if gi > 0:
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+                    per_doc = per_tok_loss[
+                        :, chunk_offset : chunk_offset + chunk_size
+                    ].mean(dim=-1)
+                    cur_opt.zero_grad(set_to_none=True)
+                    (per_doc * activate_chunk_mask).sum().backward()
+                    cur_opt.step()
+            else:
+                del per_tok_loss
+        batch_num = orig_batch_idx + 1
+        doc_lens = [dl for _, dl in batch]
+        should_report = batch_num in eval_batch_set if eval_batch_set is not None else True
+        if should_report:
+            cur_tokens = token_count.item()
+            cur_loss_val = loss_sum.item()
+            cur_bytes_val = byte_sum.item()
+            dt = cur_tokens - prev_tokens
+            db = cur_bytes_val - prev_bytes
+            if dt > 0 and db > 0:
+                b_loss = (cur_loss_val - prev_loss) / dt
+                b_bpb = b_loss / math.log(2.0) * (dt / db)
+            else:
+                b_loss = b_bpb = 0.0
+            r_loss = cur_loss_val / max(cur_tokens, 1)
+            r_bpb = r_loss / math.log(2.0) * (cur_tokens / max(cur_bytes_val, 1))
+            elapsed = time.perf_counter() - t_start
+            log(
+                f"ttp: b{batch_num}/{queue_len} bl:{b_loss:.4f} bb:{b_bpb:.4f} "
+                f"rl:{r_loss:.4f} rb:{r_bpb:.4f} dl:{min(doc_lens)}-{max(doc_lens)} "
+                f"gd:{int(global_ttt_done)}"
+            )
+        if not global_ttt_done:
+            local_scored_docs.extend(
+                (orig_batch_idx, pos, doc_start, doc_len)
+                for pos, (doc_start, doc_len) in enumerate(batch)
+            )
+            prefix_done = _add_to_counter(prefix_counter_path, len(batch_entries))
+            if prefix_done >= current_phase_boundary:
+                try:
+                    with open(pause_flag_path, "x"):
+                        pass
+                except FileExistsError:
+                    pass
+            should_pause = os.path.exists(pause_flag_path)
+            if should_pause:
+                if dist.is_available() and dist.is_initialized():
+                    dist.barrier()
+                gathered_scored_docs = [None] * h.world_size
+                if dist.is_available() and dist.is_initialized():
+                    dist.all_gather_object(gathered_scored_docs, local_scored_docs)
+                else:
+                    gathered_scored_docs = [local_scored_docs]
+                scored_docs_for_global = []
+                for rank_docs in gathered_scored_docs:
+                    if rank_docs:
+                        scored_docs_for_global.extend(rank_docs)
+                scored_docs_for_global.sort(key=lambda x: (x[0], x[1]))
+                scored_docs_for_global = scored_docs_for_global[:current_phase_boundary]
+                scored_token_chunks = [
+                    val_data.val_tokens[doc_start : doc_start + doc_len]
+                    for _, _, doc_start, doc_len in scored_docs_for_global
+                ]
+                if scored_token_chunks:
+                    global_ttt_tokens = torch.cat(scored_token_chunks)
+                else:
+                    global_ttt_tokens = val_data.val_tokens[:0]
+                if h.rank == 0:
+                    prefix_done = 0
+                    try:
+                        with open(prefix_counter_path, "rb") as f:
+                            prefix_done = int.from_bytes(
+                                f.read(8), "little", signed=True
+                            )
+                    except FileNotFoundError:
+                        pass
+                    log(
+                        f"ttpp: phase:{current_phase + 1}/{num_phases} pd:{prefix_done} "
+                        f"gd:{len(scored_docs_for_global)} "
+                        f"t:{time.perf_counter() - t_start:.1f}s"
+                    )
+                train_val_ttt_global_sgd_distributed(
+                    h, device, val_data, base_model, global_ttt_tokens
+                )
+                for p in base_model.parameters():
+                    p.requires_grad_(False)
+                reusable_lora = BatchedTTTLoRA(
+                    h.ttt_batch_size, base_model, h.ttt_lora_rank,
+                    k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+                ).to(device)
+                reusable_opt = _build_opt(reusable_lora)
+                current_phase += 1
+                if current_phase >= num_phases:
+                    global_ttt_done = True
+                else:
+                    current_phase_boundary = phase_boundaries[current_phase]
+                    if h.rank == 0:
+                        try:
+                            os.remove(pause_flag_path)
+                        except FileNotFoundError:
+                            pass
+                if dist.is_available() and dist.is_initialized():
+                    dist.barrier()
+                if h.rank == 0:
+                    log(f"ttpr: phase:{current_phase}/{num_phases} t:{time.perf_counter() - t_start:.1f}s")
+        del cur_lora, cur_opt
+    finally:
+        pass
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.train()
+    return _loss_bpb_from_sums(loss_sum, token_count, byte_sum)
+
+
+def timed_eval(label, fn, *args, **kwargs):
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    val_loss, val_bpb = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    elapsed_ms = 1e3 * (time.perf_counter() - t0)
+    log(
+        f"{label} val_loss:{val_loss:.8f} val_bpb:{val_bpb:.8f} eval_time:{elapsed_ms:.0f}ms"
+    )
+    return val_loss, val_bpb
+
+
+def train_model(h, device, val_data):
+    base_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        base_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    model = compiled_model
+    log(f"model_params:{sum(p.numel()for p in base_model.parameters())}")
+    optimizers = Optimizers(h, base_model)
+    train_loader = DocumentPackingLoader(h, device)
+    max_wallclock_ms = (
+        1e3 * h.max_wallclock_seconds if h.max_wallclock_seconds > 0 else None
+    )
+    if max_wallclock_ms is not None:
+        max_wallclock_ms -= h.gptq_reserve_seconds * 1e3
+        log(
+            f"gptq:reserving {h.gptq_reserve_seconds:.0f}s, effective={max_wallclock_ms:.0f}ms"
+        )
+
+    def training_frac(step, elapsed_ms):
+        if max_wallclock_ms is None:
+            return step / max(h.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-09)
+
+    def lr_mul(frac):
+        if h.warmdown_frac <= 0:
+            return 1.0
+        if frac >= 1.0 - h.warmdown_frac:
+            return max((1.0 - frac) / h.warmdown_frac, h.min_lr)
+        return 1.0
+
+    def step_fn(step, lr_scale):
+        optimizers.zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(h.grad_accum_steps):
+            x, y, cu_seqlens, _max_seqlen = train_loader.next_batch(
+                h.train_batch_tokens, h.grad_accum_steps
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y, cu_seqlens=cu_seqlens, max_seqlen=h.train_seq_len)
+            train_loss += loss.detach()
+            (loss / h.grad_accum_steps).backward()
+        train_loss /= h.grad_accum_steps
+        frac = (
+            min(step / h.muon_momentum_warmup_steps, 1.0)
+            if h.muon_momentum_warmup_steps > 0
+            else 1.0
+        )
+        muon_momentum = (
+            1 - frac
+        ) * h.muon_momentum_warmup_start + frac * h.muon_momentum
+        for group in optimizers.optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * lr_scale
+        if h.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), h.grad_clip_norm)
+        optimizers.step(distributed=h.distributed)
+        return train_loss
+
+    if h.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for (name, tensor) in base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in optimizers
+        ]
+        model.train()
+        num_tokens_local = h.train_batch_tokens // h.world_size
+        for blk in base_model.blocks:
+            blk.attn.rotary(num_tokens_local, device, torch.bfloat16)
+        cu_bucket_size = train_loader.cu_bucket_size
+        warmup_cu_buckets = tuple(cu_bucket_size * i for i in range(1, 5))
+        warmup_cu_iters = 3
+        x, y, cu_seqlens, _ = train_loader.next_batch(
+            h.train_batch_tokens, h.grad_accum_steps
+        )
+        log(f"warmup_cu_buckets:{','.join(str(b) for b in warmup_cu_buckets)} iters_each:{warmup_cu_iters}")
+        def _run_cu_bucket_warmup():
+            for bucket_len in warmup_cu_buckets:
+                boundaries = list(range(0, x.size(1), max(h.train_seq_len, 1)))
+                if boundaries[-1] != x.size(1):
+                    boundaries.append(x.size(1))
+                cu = torch.full((bucket_len,), x.size(1), dtype=torch.int32, device=device)
+                cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+                for _ in range(warmup_cu_iters):
+                    optimizers.zero_grad_all()
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                        wloss = model(x, y, cu_seqlens=cu, max_seqlen=h.train_seq_len)
+                    (wloss / h.grad_accum_steps).backward()
+            optimizers.zero_grad_all()
+        _run_cu_bucket_warmup()
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            _run_cu_bucket_warmup()
+            base_model.looping_active = False
+        for warmup_step in range(h.warmup_steps):
+            step_fn(warmup_step, 1.0)
+            if (
+                warmup_step <= 5
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == h.warmup_steps
+            ):
+                log(f"warmup_step: {warmup_step+1}/{h.warmup_steps}")
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            log(
+                f"loop_warmup:enabled encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            for warmup_step in range(h.warmup_steps):
+                step_fn(warmup_step, 1.0)
+                if (
+                    warmup_step <= 5
+                    or (warmup_step + 1) % 10 == 0
+                    or warmup_step + 1 == h.warmup_steps
+                ):
+                    log(f"loop_warmup_step: {warmup_step+1}/{h.warmup_steps}")
+            base_model.looping_active = False
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for (opt, state) in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        optimizers.zero_grad_all()
+        train_loader = DocumentPackingLoader(h, device)
+    ema_state = {
+        name: t.detach().float().clone()
+        for (name, t) in base_model.state_dict().items()
+    }
+    ema_decay = h.ema_decay
+    training_time_ms = 0.0
+    stop_after_step = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = (
+            step == h.iterations
+            or stop_after_step is not None
+            and step >= stop_after_step
+        )
+        should_validate = (
+            last_step or h.val_loss_every > 0 and step % h.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1e3 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                h, device, val_data, model, compiled_forward_logits
+            )
+            log(
+                f"{step}/{h.iterations} val_loss: {val_loss:.4f} val_bpb: {val_bpb:.4f}"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < h.iterations:
+                log(
+                    f"stopping_early: wallclock_cap train_time: {training_time_ms:.0f}ms step: {step}/{h.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        frac = training_frac(step, elapsed_ms)
+        scale = lr_mul(frac)
+        if (
+            h.num_loops > 0
+            and not base_model.looping_active
+            and frac >= h.enable_looping_at
+        ):
+            base_model.looping_active = True
+            log(
+                f"layer_loop:enabled step:{step} frac:{frac:.3f} encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+        train_loss = step_fn(step, scale)
+        with torch.no_grad():
+            for (name, t) in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(
+                    t.detach().float(), alpha=1.0 - ema_decay
+                )
+        step += 1
+        approx_training_time_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        should_log_train = h.train_log_every > 0 and (
+            step <= 5 or step % h.train_log_every == 0 or stop_after_step is not None
+        )
+        if should_log_train:
+            tok_per_sec = step * h.train_batch_tokens / (approx_training_time_ms / 1e3)
+            log(
+                f"{step}/{h.iterations} train_loss: {train_loss.item():.4f} train_time: {approx_training_time_ms/60000:.1f}m tok/s: {tok_per_sec:.0f}"
+            )
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if h.distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated()//1024//1024} MiB reserved: {torch.cuda.max_memory_reserved()//1024//1024} MiB"
+    )
+    log("ema:applying EMA weights")
+    current_state = base_model.state_dict()
+    avg_state = {
+        name: t.to(dtype=current_state[name].dtype) for (name, t) in ema_state.items()
+    }
+    base_model.load_state_dict(avg_state, strict=True)
+    return base_model, compiled_model, compiled_forward_logits
+
+
+def train_and_eval(h, device):
+    random.seed(h.seed)
+    np.random.seed(h.seed)
+    torch.manual_seed(h.seed)
+    torch.cuda.manual_seed_all(h.seed)
+    if h.artifact_dir and h.is_main_process:
+        os.makedirs(h.artifact_dir, exist_ok=True)
+    val_data = ValidationData(h, device)
+    log(
+        f"train_shards: {len(list(Path(h.datasets_dir).resolve().glob('fineweb_train_*.bin')))}"
+    )
+    log(f"val_tokens: {val_data.val_tokens.numel()-1}")
+    base_model, compiled_model, compiled_forward_logits = train_model(
+        h, device, val_data
+    )
+    torch._dynamo.reset()
+    timed_eval(
+        "diagnostic pre-quantization post-ema",
+        eval_val,
+        h,
+        device,
+        val_data,
+        compiled_model,
+        compiled_forward_logits,
+    )
+    serialize(h, base_model, Path(__file__).read_text(encoding="utf-8"))
+    if h.distributed:
+        dist.barrier()
+    eval_model = deserialize(h, device)
+    if h.num_loops > 0:
+        eval_model.looping_active = True
+    compiled_model = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        eval_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    timed_eval(
+        "diagnostic quantized",
+        eval_val,
+        h,
+        device,
+        val_data,
+        compiled_model,
+        compiled_forward_logits,
+    )
+    if h.sliding_window_enabled:
+        timed_eval(
+            "diagnostic quantized_sliding_window",
+            eval_val_sliding,
+            h,
+            device,
+            val_data,
+            eval_model,
+            forward_logits_fn=compiled_forward_logits,
+        )
+    if h.ttt_enabled:
+        del eval_model, compiled_model
+        torch._dynamo.reset()
+        torch.cuda.empty_cache()
+        ttt_model = deserialize(h, device)
+        if h.num_loops > 0:
+            ttt_model.looping_active = True
+        for p in ttt_model.parameters():
+            p.requires_grad_(False)
+
+        if h.rope_yarn:
+            _yarn_seqlen = h.train_batch_tokens // h.grad_accum_steps
+            for block in ttt_model.blocks:
+                block.attn.rotary(_yarn_seqlen, device, torch.bfloat16)
+        else:
+            for block in ttt_model.blocks:
+                block.attn.rotary._cos_cached = None
+                block.attn.rotary._sin_cached = None
+                block.attn.rotary._seq_len_cached = 0
+                block.attn.rotary(h.ttt_eval_seq_len, device, torch.bfloat16)
+
+        def _fwd_ttt_inner(input_ids, target_ids, lora):
+            return ttt_model.forward_ttt(input_ids, target_ids, lora=lora)
+
+        _fwd_ttt_compiled_inner = None
+
+        def _fwd_ttt(input_ids, target_ids, lora):
+            nonlocal _fwd_ttt_compiled_inner
+            if _fwd_ttt_compiled_inner is None:
+                _fwd_ttt_compiled_inner = torch.compile(_fwd_ttt_inner, dynamic=True)
+            return _fwd_ttt_compiled_inner(input_ids, target_ids, lora=lora)
+
+        fwd_ttt_compiled = _fwd_ttt
+        log(f"ttt_lora:warming up compile (random tokens, no val data)")
+        global BOS_ID
+        if BOS_ID is None:
+            BOS_ID = 1
+        t_warmup = time.perf_counter()
+        warmup_bszes = [h.ttt_batch_size]
+        for bsz in warmup_bszes:
+            wl = BatchedTTTLoRA(
+                bsz, ttt_model, h.ttt_lora_rank,
+                k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+            ).to(device)
+            wo = torch.optim.AdamW(
+                wl.parameters(),
+                lr=h.ttt_lora_lr,
+                betas=(h.ttt_beta1, h.ttt_beta2),
+                eps=1e-10,
+                weight_decay=h.ttt_weight_decay,
+                fused=True,
+            )
+            for ctx_len in (h.ttt_chunk_size, h.ttt_eval_seq_len):
+                xw = torch.randint(0, h.vocab_size, (bsz, ctx_len), device=device, dtype=torch.int64)
+                yw = torch.randint(0, h.vocab_size, (bsz, ctx_len), device=device, dtype=torch.int64)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    ptl = fwd_ttt_compiled(xw, yw, lora=wl)
+                ptl[:, : min(h.ttt_chunk_size, ctx_len)].mean(dim=-1).sum().backward()
+                wo.step()
+                wo.zero_grad(set_to_none=True)
+            del wl, wo
+        torch.cuda.empty_cache()
+        compile_elapsed = time.perf_counter() - t_warmup
+        log(f"ttt_lora:compile warmup done ({compile_elapsed:.1f}s)")
+        log("\nbeginning TTT eval timer")
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_val_loss, ttt_val_bpb = eval_val_ttt_phased(
+            h, ttt_model, device, val_data, forward_ttt_train=fwd_ttt_compiled
+        )
+        torch.cuda.synchronize()
+        ttt_eval_elapsed = time.perf_counter() - t_ttt
+        log(
+            "quantized_ttt_phased "
+            f"val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f} "
+            f"eval_time:{1e3*ttt_eval_elapsed:.0f}ms"
+        )
+        log(f"total_eval_time:{ttt_eval_elapsed:.1f}s")
+        del ttt_model
+
+
+def main():
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    torch._dynamo.config.optimize_ddp = False
+    torch._dynamo.config.cache_size_limit = 16
+    h = Hyperparameters()
+    set_logging_hparams(h)
+    if h.is_main_process:
+        os.makedirs(h.artifact_dir if h.artifact_dir else "logs", exist_ok=True)
+        log(100 * "=", console=False)
+        log("Hyperparameters:", console=True)
+        for (k, v) in sorted(vars(type(h)).items()):
+            if not k.startswith("_"):
+                log(f"  {k}: {v}", console=True)
+        log("=" * 100, console=False)
+        log("Source code:", console=False)
+        log("=" * 100, console=False)
+        with open(__file__, "r", encoding="utf-8") as _src:
+            log(_src.read(), console=False)
+        log("=" * 100, console=False)
+        log(f"Running Python {sys.version}", console=False)
+        log(f"Running PyTorch {torch.__version__}", console=False)
+        log("=" * 100, console=False)
+    train_and_eval(h, device)
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-04-21_AlphaLoRA_WarmStart_HighWD_1.07266/train_seed1337.log
+++ b/records/track_10min_16mb/2026-04-21_AlphaLoRA_WarmStart_HighWD_1.07266/train_seed1337.log
@@ -1,0 +1,758 @@
+[Tue Apr 21 21:38:32 UTC 2026] Starting SP8192 dexhunter experiment: pure_ttt_sp8192_dxwarmwd_seed1337_8gpu
+Extra args: SEED=1337 PHASED_TTT_ENABLED=1 PHASED_TTT_PREFIX_DOCS=2000 PHASED_TTT_NUM_PHASES=3 MLP_CLIP_SIGMAS=12.0 ATTN_CLIP_SIGMAS=13.0 EMBED_BITS=7 EMBED_CLIP_SIGMAS=15.0 MATRIX_LR=0.026 GPTQ_RESERVE_SECONDS=4 GPTQ_CALIBRATION_BATCHES=16 TTT_LORA_RANK=128 TTT_LORA_ALPHA=96 TTT_WARM_START_A=1 TTT_WEIGHT_DECAY=1.0
+torch: 2.9.1+cu128
+FA3 interface: OK
+[Tue Apr 21 21:38:36 UTC 2026] GPU check:
+0, 1 MiB, 0 %
+1, 1 MiB, 0 %
+2, 1 MiB, 0 %
+3, 1 MiB, 0 %
+4, 1 MiB, 0 %
+5, 1 MiB, 0 %
+6, 1 MiB, 0 %
+7, 1 MiB, 0 %
+W0421 21:38:37.925000 112 torch/distributed/run.py:803] 
+W0421 21:38:37.925000 112 torch/distributed/run.py:803] *****************************************
+W0421 21:38:37.925000 112 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0421 21:38:37.925000 112 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  artifact_dir: 
+  attn_clip_sigmas: 13.0
+  beta1: 0.9
+  beta2: 0.95
+  compressor: brotli
+  data_dir: DATA_DIR
+  datasets_dir: DATA_DIR/datasets/fineweb10B_sp8192
+  distributed: True
+  ema_decay: 0.9965
+  embed_bits: 7
+  embed_clip_sigmas: 15.0
+  embed_lr: 0.6
+  embed_wd: 0.085
+  enable_looping_at: 0.35
+  eval_seq_len: 2048
+  eval_stride: 64
+  global_ttt_batch_seqs: 32
+  global_ttt_chunk_tokens: 32768
+  global_ttt_epochs: 1
+  global_ttt_grad_clip: 1.0
+  global_ttt_lr: 0.001
+  global_ttt_momentum: 0.9
+  global_ttt_respect_doc_boundaries: True
+  global_ttt_warmup_chunks: 0
+  global_ttt_warmup_start_lr: 0.0
+  gptq_calibration_batches: 16
+  gptq_reserve_seconds: 4.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  is_main_process: True
+  iterations: 20000
+  ln_scale: True
+  local_rank: 0
+  logfile: logs/e0b9ca8b-c72d-4d1a-a735-c94eab13e028.txt
+  logit_softcap: 30.0
+  loop_end: 5
+  loop_start: 3
+  matrix_bits: 6
+  matrix_clip_sigmas: 12.85
+  matrix_lr: 0.026
+  max_wallclock_seconds: 600.0
+  min_lr: 0.0
+  mlp_clip_sigmas: 12.0
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: final_model.pt
+  muon_backend_steps: 5
+  muon_momentum: 0.97
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_row_normalize: True
+  muon_wd: 0.095
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  num_loops: 2
+  parallel_final_lane: mean
+  parallel_start_layer: 8
+  phased_ttt_enabled: True
+  phased_ttt_num_phases: 3
+  phased_ttt_prefix_docs: 2000
+  qk_gain_init: 5.0
+  quantized_model_path: final_model.int6.ptz
+  rank: 0
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  rope_yarn: False
+  run_id: e0b9ca8b-c72d-4d1a-a735-c94eab13e028
+  scalar_lr: 0.02
+  seed: 1337
+  skip_gates_enabled: True
+  sliding_window_enabled: False
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  tokenizer_path: DATA_DIR/tokenizers/fineweb_8192_bpe.model
+  train_batch_tokens: 786432
+  train_files: DATA_DIR/datasets/fineweb10B_sp8192/fineweb_train_*.bin
+  train_log_every: 500
+  train_seq_len: 2048
+  ttt_batch_size: 64
+  ttt_beta1: 0.0
+  ttt_beta2: 0.999
+  ttt_chunk_size: 48
+  ttt_enabled: True
+  ttt_eval_batches: 
+  ttt_eval_seq_len: 2048
+  ttt_grad_steps: 1
+  ttt_k_lora: True
+  ttt_lora_lr: 0.0001
+  ttt_lora_rank: 128
+  ttt_mlp_lora: True
+  ttt_o_lora: True
+  ttt_optimizer: adam
+  ttt_weight_decay: 1.0
+  val_batch_tokens: 524288
+  val_doc_fraction: 1.0
+  val_files: DATA_DIR/datasets/fineweb10B_sp8192/fineweb_val_*.bin
+  val_loss_every: 4000
+  vocab_size: 8192
+  warmdown_frac: 0.75
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+train_shards: 80
+val_tokens: 40540160
+model_params:35944602
+gptq:reserving 4s, effective=596000ms
+warmup_cu_buckets:64,128,192,256 iters_each:3
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup:enabled encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+loop_warmup_step: 1/20
+loop_warmup_step: 2/20
+loop_warmup_step: 3/20
+loop_warmup_step: 4/20
+loop_warmup_step: 5/20
+loop_warmup_step: 6/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+0/20000 val_loss: 9.0095 val_bpb: 3.4877
+1/20000 train_loss: 9.0094 train_time: 0.0m tok/s: 16667926
+2/20000 train_loss: 12.2097 train_time: 0.0m tok/s: 11819342
+3/20000 train_loss: 11.2270 train_time: 0.0m tok/s: 10441649
+4/20000 train_loss: 9.5990 train_time: 0.0m tok/s: 9816606
+5/20000 train_loss: 8.2075 train_time: 0.0m tok/s: 9486337
+500/20000 train_loss: 3.2673 train_time: 0.8m tok/s: 8276967
+1000/20000 train_loss: 3.0298 train_time: 1.6m tok/s: 8244582
+1500/20000 train_loss: 3.0379 train_time: 2.4m tok/s: 8241815
+2000/20000 train_loss: 2.9941 train_time: 3.2m tok/s: 8240395
+layer_loop:enabled step:2185 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2500/20000 train_loss: 3.0797 train_time: 4.2m tok/s: 7788851
+3000/20000 train_loss: 2.9209 train_time: 5.4m tok/s: 7331292
+3500/20000 train_loss: 2.9852 train_time: 6.5m tok/s: 7036266
+4000/20000 train_loss: 2.9136 train_time: 7.7m tok/s: 6828516
+4000/20000 val_loss: 2.8930 val_bpb: 1.1199
+4500/20000 train_loss: 2.8726 train_time: 8.8m tok/s: 6676229
+4952/20000 val_loss: 2.7741 val_bpb: 1.0739
+stopping_early: wallclock_cap train_time: 596128ms step: 4952/20000
+peak memory allocated: 40029 MiB reserved: 44036 MiB
+ema:applying EMA weights
+diagnostic pre-quantization post-ema val_loss:2.77263281 val_bpb:1.07333797 eval_time:8457ms
+Serialized model: 135409136 bytes
+Code size (uncompressed): 122655 bytes
+Code size (compressed): 27680 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 3.6s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int7): tok_emb.weight
+  passthrough (float16): blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, skip_gates, skip_weights
+Serialized model quantized+brotli: 15906919 bytes
+Total submission size quantized+brotli: 15934599 bytes
+diagnostic quantized val_loss:2.80359225 val_bpb:1.08532295 eval_time:57996ms
+ttt_lora:warming up compile (random tokens, no val data)
+ttt_lora:compile warmup done (159.4s)
+
+beginning TTT eval timer
+ttt_phased: total_docs:50000 prefix_docs:2000 suffix_docs:48000 num_phases:3 boundaries:[666, 1333, 2000]
+ttp: b777/782 bl:2.7305 bb:1.0921 rl:2.7305 rb:1.0921 dl:7190-7938 gd:0
+ttp: b772/782 bl:2.7707 bb:1.1082 rl:2.7467 rb:1.0986 dl:4937-5193 gd:0
+ttp: b767/782 bl:2.7578 bb:1.1011 rl:2.7494 rb:1.0992 dl:3963-4123 gd:0
+ttpp: phase:1/3 pd:1104 gd:666 t:199.8s
+tttg: c1/95 lr:0.001000 t:1.7s
+tttg: c2/95 lr:0.001000 t:1.7s
+tttg: c3/95 lr:0.000999 t:1.8s
+tttg: c4/95 lr:0.000997 t:1.9s
+tttg: c5/95 lr:0.000996 t:1.9s
+tttg: c6/95 lr:0.000993 t:2.0s
+tttg: c7/95 lr:0.000990 t:2.1s
+tttg: c8/95 lr:0.000986 t:2.2s
+tttg: c9/95 lr:0.000982 t:2.2s
+tttg: c10/95 lr:0.000978 t:2.3s
+tttg: c11/95 lr:0.000972 t:2.4s
+tttg: c12/95 lr:0.000967 t:2.5s
+tttg: c13/95 lr:0.000960 t:2.5s
+tttg: c14/95 lr:0.000954 t:2.6s
+tttg: c15/95 lr:0.000946 t:2.7s
+tttg: c16/95 lr:0.000938 t:2.7s
+tttg: c17/95 lr:0.000930 t:2.8s
+tttg: c18/95 lr:0.000921 t:2.9s
+tttg: c19/95 lr:0.000912 t:3.0s
+tttg: c20/95 lr:0.000903 t:3.1s
+tttg: c21/95 lr:0.000892 t:3.1s
+tttg: c22/95 lr:0.000882 t:3.2s
+tttg: c23/95 lr:0.000871 t:3.3s
+tttg: c24/95 lr:0.000859 t:3.3s
+tttg: c25/95 lr:0.000848 t:3.4s
+tttg: c26/95 lr:0.000835 t:3.5s
+tttg: c27/95 lr:0.000823 t:3.6s
+tttg: c28/95 lr:0.000810 t:3.6s
+tttg: c29/95 lr:0.000797 t:3.7s
+tttg: c30/95 lr:0.000783 t:3.8s
+tttg: c31/95 lr:0.000769 t:3.8s
+tttg: c32/95 lr:0.000755 t:3.9s
+tttg: c33/95 lr:0.000740 t:4.0s
+tttg: c34/95 lr:0.000726 t:4.1s
+tttg: c35/95 lr:0.000710 t:4.1s
+tttg: c36/95 lr:0.000695 t:4.2s
+tttg: c37/95 lr:0.000680 t:4.3s
+tttg: c38/95 lr:0.000664 t:4.4s
+tttg: c39/95 lr:0.000648 t:4.4s
+tttg: c40/95 lr:0.000632 t:4.5s
+tttg: c41/95 lr:0.000616 t:4.6s
+tttg: c42/95 lr:0.000600 t:4.6s
+tttg: c43/95 lr:0.000583 t:4.7s
+tttg: c44/95 lr:0.000567 t:4.8s
+tttg: c45/95 lr:0.000550 t:4.8s
+tttg: c46/95 lr:0.000533 t:4.9s
+tttg: c47/95 lr:0.000517 t:5.0s
+tttg: c48/95 lr:0.000500 t:5.1s
+tttg: c49/95 lr:0.000483 t:5.1s
+tttg: c50/95 lr:0.000467 t:5.2s
+tttg: c51/95 lr:0.000450 t:5.3s
+tttg: c52/95 lr:0.000433 t:5.3s
+tttg: c53/95 lr:0.000417 t:5.4s
+tttg: c54/95 lr:0.000400 t:5.5s
+tttg: c55/95 lr:0.000384 t:5.6s
+tttg: c56/95 lr:0.000368 t:5.6s
+tttg: c57/95 lr:0.000352 t:5.7s
+tttg: c58/95 lr:0.000336 t:5.8s
+tttg: c59/95 lr:0.000320 t:5.8s
+tttg: c60/95 lr:0.000305 t:5.9s
+tttg: c61/95 lr:0.000290 t:6.0s
+tttg: c62/95 lr:0.000274 t:6.0s
+tttg: c63/95 lr:0.000260 t:6.1s
+tttg: c64/95 lr:0.000245 t:6.2s
+tttg: c65/95 lr:0.000231 t:6.3s
+tttg: c66/95 lr:0.000217 t:6.3s
+tttg: c67/95 lr:0.000203 t:6.4s
+tttg: c68/95 lr:0.000190 t:6.5s
+tttg: c69/95 lr:0.000177 t:6.5s
+tttg: c70/95 lr:0.000165 t:6.6s
+tttg: c71/95 lr:0.000152 t:6.7s
+tttg: c72/95 lr:0.000141 t:6.7s
+tttg: c73/95 lr:0.000129 t:6.8s
+tttg: c74/95 lr:0.000118 t:6.9s
+tttg: c75/95 lr:0.000108 t:7.0s
+tttg: c76/95 lr:0.000097 t:7.0s
+tttg: c77/95 lr:0.000088 t:7.1s
+tttg: c78/95 lr:0.000079 t:7.2s
+tttg: c79/95 lr:0.000070 t:7.2s
+tttg: c80/95 lr:0.000062 t:7.3s
+tttg: c81/95 lr:0.000054 t:7.4s
+tttg: c82/95 lr:0.000046 t:7.5s
+tttg: c83/95 lr:0.000040 t:7.5s
+tttg: c84/95 lr:0.000033 t:7.6s
+tttg: c85/95 lr:0.000028 t:7.7s
+tttg: c86/95 lr:0.000022 t:7.8s
+tttg: c87/95 lr:0.000018 t:7.8s
+tttg: c88/95 lr:0.000014 t:7.9s
+tttg: c89/95 lr:0.000010 t:8.0s
+tttg: c90/95 lr:0.000007 t:8.0s
+tttg: c91/95 lr:0.000004 t:8.1s
+tttg: c92/95 lr:0.000003 t:8.2s
+tttg: c93/95 lr:0.000001 t:8.2s
+tttg: c94/95 lr:0.000000 t:8.3s
+ttpr: phase:1/3 t:210.6s
+ttp: b757/782 bl:2.6380 bb:1.0195 rl:2.7320 rb:1.0864 dl:3033-3108 gd:0
+ttp: b756/782 bl:2.7826 bb:1.0785 rl:2.7387 rb:1.0854 dl:2973-3032 gd:0
+ttpp: phase:2/3 pd:1808 gd:1333 t:319.4s
+tttg: c1/158 lr:0.001000 t:0.1s
+tttg: c2/158 lr:0.001000 t:0.1s
+tttg: c3/158 lr:0.001000 t:0.2s
+tttg: c4/158 lr:0.000999 t:0.3s
+tttg: c5/158 lr:0.000998 t:0.4s
+tttg: c6/158 lr:0.000997 t:0.4s
+tttg: c7/158 lr:0.000996 t:0.5s
+tttg: c8/158 lr:0.000995 t:0.6s
+tttg: c9/158 lr:0.000994 t:0.6s
+tttg: c10/158 lr:0.000992 t:0.7s
+tttg: c11/158 lr:0.000990 t:0.8s
+tttg: c12/158 lr:0.000988 t:0.9s
+tttg: c13/158 lr:0.000986 t:0.9s
+tttg: c14/158 lr:0.000983 t:1.0s
+tttg: c15/158 lr:0.000981 t:1.1s
+tttg: c16/158 lr:0.000978 t:1.1s
+tttg: c17/158 lr:0.000975 t:1.2s
+tttg: c18/158 lr:0.000971 t:1.3s
+tttg: c19/158 lr:0.000968 t:1.4s
+tttg: c20/158 lr:0.000964 t:1.4s
+tttg: c21/158 lr:0.000960 t:1.5s
+tttg: c22/158 lr:0.000957 t:1.6s
+tttg: c23/158 lr:0.000952 t:1.6s
+tttg: c24/158 lr:0.000948 t:1.7s
+tttg: c25/158 lr:0.000943 t:1.8s
+tttg: c26/158 lr:0.000939 t:1.9s
+tttg: c27/158 lr:0.000934 t:1.9s
+tttg: c28/158 lr:0.000929 t:2.0s
+tttg: c29/158 lr:0.000924 t:2.1s
+tttg: c30/158 lr:0.000918 t:2.1s
+tttg: c31/158 lr:0.000913 t:2.2s
+tttg: c32/158 lr:0.000907 t:2.3s
+tttg: c33/158 lr:0.000901 t:2.3s
+tttg: c34/158 lr:0.000895 t:2.4s
+tttg: c35/158 lr:0.000889 t:2.5s
+tttg: c36/158 lr:0.000882 t:2.5s
+tttg: c37/158 lr:0.000876 t:2.6s
+tttg: c38/158 lr:0.000869 t:2.7s
+tttg: c39/158 lr:0.000862 t:2.8s
+tttg: c40/158 lr:0.000855 t:2.8s
+tttg: c41/158 lr:0.000848 t:2.9s
+tttg: c42/158 lr:0.000841 t:3.0s
+tttg: c43/158 lr:0.000834 t:3.1s
+tttg: c44/158 lr:0.000826 t:3.1s
+tttg: c45/158 lr:0.000818 t:3.2s
+tttg: c46/158 lr:0.000811 t:3.3s
+tttg: c47/158 lr:0.000803 t:3.3s
+tttg: c48/158 lr:0.000795 t:3.4s
+tttg: c49/158 lr:0.000787 t:3.5s
+tttg: c50/158 lr:0.000778 t:3.5s
+tttg: c51/158 lr:0.000770 t:3.6s
+tttg: c52/158 lr:0.000761 t:3.7s
+tttg: c53/158 lr:0.000753 t:3.8s
+tttg: c54/158 lr:0.000744 t:3.8s
+tttg: c55/158 lr:0.000735 t:3.9s
+tttg: c56/158 lr:0.000727 t:4.0s
+tttg: c57/158 lr:0.000718 t:4.0s
+tttg: c58/158 lr:0.000709 t:4.1s
+tttg: c59/158 lr:0.000699 t:4.2s
+tttg: c60/158 lr:0.000690 t:4.3s
+tttg: c61/158 lr:0.000681 t:4.3s
+tttg: c62/158 lr:0.000672 t:4.4s
+tttg: c63/158 lr:0.000662 t:4.5s
+tttg: c64/158 lr:0.000653 t:4.5s
+tttg: c65/158 lr:0.000643 t:4.6s
+tttg: c66/158 lr:0.000633 t:4.7s
+tttg: c67/158 lr:0.000624 t:4.8s
+tttg: c68/158 lr:0.000614 t:4.8s
+tttg: c69/158 lr:0.000604 t:4.9s
+tttg: c70/158 lr:0.000594 t:5.0s
+tttg: c71/158 lr:0.000585 t:5.0s
+tttg: c72/158 lr:0.000575 t:5.1s
+tttg: c73/158 lr:0.000565 t:5.2s
+tttg: c74/158 lr:0.000555 t:5.2s
+tttg: c75/158 lr:0.000545 t:5.3s
+tttg: c76/158 lr:0.000535 t:5.4s
+tttg: c77/158 lr:0.000525 t:5.5s
+tttg: c78/158 lr:0.000515 t:5.5s
+tttg: c79/158 lr:0.000505 t:5.6s
+tttg: c80/158 lr:0.000495 t:5.7s
+tttg: c81/158 lr:0.000485 t:5.8s
+tttg: c82/158 lr:0.000475 t:5.8s
+tttg: c83/158 lr:0.000465 t:5.9s
+tttg: c84/158 lr:0.000455 t:6.0s
+tttg: c85/158 lr:0.000445 t:6.0s
+tttg: c86/158 lr:0.000435 t:6.1s
+tttg: c87/158 lr:0.000425 t:6.2s
+tttg: c88/158 lr:0.000415 t:6.3s
+tttg: c89/158 lr:0.000406 t:6.3s
+tttg: c90/158 lr:0.000396 t:6.4s
+tttg: c91/158 lr:0.000386 t:6.5s
+tttg: c92/158 lr:0.000376 t:6.6s
+tttg: c93/158 lr:0.000367 t:6.6s
+tttg: c94/158 lr:0.000357 t:6.7s
+tttg: c95/158 lr:0.000347 t:6.8s
+tttg: c96/158 lr:0.000338 t:6.9s
+tttg: c97/158 lr:0.000328 t:6.9s
+tttg: c98/158 lr:0.000319 t:7.0s
+tttg: c99/158 lr:0.000310 t:7.1s
+tttg: c100/158 lr:0.000301 t:7.1s
+tttg: c101/158 lr:0.000291 t:7.2s
+tttg: c102/158 lr:0.000282 t:7.3s
+tttg: c103/158 lr:0.000273 t:7.3s
+tttg: c104/158 lr:0.000265 t:7.4s
+tttg: c105/158 lr:0.000256 t:7.5s
+tttg: c106/158 lr:0.000247 t:7.6s
+tttg: c107/158 lr:0.000239 t:7.6s
+tttg: c108/158 lr:0.000230 t:7.7s
+tttg: c109/158 lr:0.000222 t:7.8s
+tttg: c110/158 lr:0.000213 t:7.9s
+tttg: c111/158 lr:0.000205 t:8.0s
+tttg: c112/158 lr:0.000197 t:8.0s
+tttg: c113/158 lr:0.000189 t:8.1s
+tttg: c114/158 lr:0.000182 t:8.2s
+tttg: c115/158 lr:0.000174 t:8.3s
+tttg: c116/158 lr:0.000166 t:8.3s
+tttg: c117/158 lr:0.000159 t:8.4s
+tttg: c118/158 lr:0.000152 t:8.5s
+tttg: c119/158 lr:0.000145 t:8.6s
+tttg: c120/158 lr:0.000138 t:8.7s
+tttg: c121/158 lr:0.000131 t:8.8s
+tttg: c122/158 lr:0.000124 t:8.9s
+tttg: c123/158 lr:0.000118 t:8.9s
+tttg: c124/158 lr:0.000111 t:9.0s
+tttg: c125/158 lr:0.000105 t:9.1s
+tttg: c126/158 lr:0.000099 t:9.1s
+tttg: c127/158 lr:0.000093 t:9.2s
+tttg: c128/158 lr:0.000087 t:9.3s
+tttg: c129/158 lr:0.000082 t:9.4s
+tttg: c130/158 lr:0.000076 t:9.4s
+tttg: c131/158 lr:0.000071 t:9.5s
+tttg: c132/158 lr:0.000066 t:9.6s
+tttg: c133/158 lr:0.000061 t:9.6s
+tttg: c134/158 lr:0.000057 t:9.7s
+tttg: c135/158 lr:0.000052 t:9.8s
+tttg: c136/158 lr:0.000048 t:9.9s
+tttg: c137/158 lr:0.000043 t:9.9s
+tttg: c138/158 lr:0.000040 t:10.0s
+tttg: c139/158 lr:0.000036 t:10.1s
+tttg: c140/158 lr:0.000032 t:10.1s
+tttg: c141/158 lr:0.000029 t:10.2s
+tttg: c142/158 lr:0.000025 t:10.3s
+tttg: c143/158 lr:0.000022 t:10.3s
+tttg: c144/158 lr:0.000019 t:10.4s
+tttg: c145/158 lr:0.000017 t:10.5s
+tttg: c146/158 lr:0.000014 t:10.5s
+tttg: c147/158 lr:0.000012 t:10.6s
+tttg: c148/158 lr:0.000010 t:10.7s
+tttg: c149/158 lr:0.000008 t:10.8s
+tttg: c150/158 lr:0.000006 t:10.9s
+tttg: c151/158 lr:0.000005 t:10.9s
+tttg: c152/158 lr:0.000004 t:11.0s
+tttg: c153/158 lr:0.000003 t:11.1s
+tttg: c154/158 lr:0.000002 t:11.1s
+tttg: c155/158 lr:0.000001 t:11.2s
+tttg: c156/158 lr:0.000000 t:11.3s
+tttg: c157/158 lr:0.000000 t:11.3s
+ttpr: phase:2/3 t:333.3s
+ttp: b746/782 bl:2.6779 bb:1.0544 rl:2.7327 rb:1.0823 dl:2459-2501 gd:0
+ttp: b744/782 bl:2.6549 bb:1.0577 rl:2.7259 rb:1.0802 dl:2388-2419 gd:0
+ttpp: phase:3/3 pd:2448 gd:2000 t:347.2s
+tttg: c1/213 lr:0.001000 t:0.1s
+tttg: c2/213 lr:0.001000 t:0.2s
+tttg: c3/213 lr:0.001000 t:0.2s
+tttg: c4/213 lr:0.001000 t:0.3s
+tttg: c5/213 lr:0.000999 t:0.4s
+tttg: c6/213 lr:0.000999 t:0.5s
+tttg: c7/213 lr:0.000998 t:0.5s
+tttg: c8/213 lr:0.000997 t:0.6s
+tttg: c9/213 lr:0.000996 t:0.7s
+tttg: c10/213 lr:0.000996 t:0.7s
+tttg: c11/213 lr:0.000995 t:0.8s
+tttg: c12/213 lr:0.000993 t:0.9s
+tttg: c13/213 lr:0.000992 t:1.0s
+tttg: c14/213 lr:0.000991 t:1.0s
+tttg: c15/213 lr:0.000989 t:1.1s
+tttg: c16/213 lr:0.000988 t:1.2s
+tttg: c17/213 lr:0.000986 t:1.2s
+tttg: c18/213 lr:0.000984 t:1.3s
+tttg: c19/213 lr:0.000982 t:1.4s
+tttg: c20/213 lr:0.000980 t:1.5s
+tttg: c21/213 lr:0.000978 t:1.5s
+tttg: c22/213 lr:0.000976 t:1.6s
+tttg: c23/213 lr:0.000974 t:1.7s
+tttg: c24/213 lr:0.000971 t:1.8s
+tttg: c25/213 lr:0.000969 t:1.8s
+tttg: c26/213 lr:0.000966 t:1.9s
+tttg: c27/213 lr:0.000963 t:2.0s
+tttg: c28/213 lr:0.000961 t:2.0s
+tttg: c29/213 lr:0.000958 t:2.1s
+tttg: c30/213 lr:0.000955 t:2.2s
+tttg: c31/213 lr:0.000951 t:2.2s
+tttg: c32/213 lr:0.000948 t:2.3s
+tttg: c33/213 lr:0.000945 t:2.4s
+tttg: c34/213 lr:0.000941 t:2.5s
+tttg: c35/213 lr:0.000938 t:2.5s
+tttg: c36/213 lr:0.000934 t:2.6s
+tttg: c37/213 lr:0.000931 t:2.7s
+tttg: c38/213 lr:0.000927 t:2.7s
+tttg: c39/213 lr:0.000923 t:2.8s
+tttg: c40/213 lr:0.000919 t:2.9s
+tttg: c41/213 lr:0.000915 t:2.9s
+tttg: c42/213 lr:0.000911 t:3.0s
+tttg: c43/213 lr:0.000906 t:3.1s
+tttg: c44/213 lr:0.000902 t:3.2s
+tttg: c45/213 lr:0.000897 t:3.2s
+tttg: c46/213 lr:0.000893 t:3.3s
+tttg: c47/213 lr:0.000888 t:3.4s
+tttg: c48/213 lr:0.000884 t:3.4s
+tttg: c49/213 lr:0.000879 t:3.5s
+tttg: c50/213 lr:0.000874 t:3.6s
+tttg: c51/213 lr:0.000869 t:3.7s
+tttg: c52/213 lr:0.000864 t:3.7s
+tttg: c53/213 lr:0.000859 t:3.8s
+tttg: c54/213 lr:0.000854 t:3.9s
+tttg: c55/213 lr:0.000848 t:3.9s
+tttg: c56/213 lr:0.000843 t:4.0s
+tttg: c57/213 lr:0.000837 t:4.1s
+tttg: c58/213 lr:0.000832 t:4.1s
+tttg: c59/213 lr:0.000826 t:4.2s
+tttg: c60/213 lr:0.000821 t:4.3s
+tttg: c61/213 lr:0.000815 t:4.4s
+tttg: c62/213 lr:0.000809 t:4.4s
+tttg: c63/213 lr:0.000803 t:4.5s
+tttg: c64/213 lr:0.000797 t:4.6s
+tttg: c65/213 lr:0.000791 t:4.6s
+tttg: c66/213 lr:0.000785 t:4.7s
+tttg: c67/213 lr:0.000779 t:4.8s
+tttg: c68/213 lr:0.000773 t:4.9s
+tttg: c69/213 lr:0.000767 t:4.9s
+tttg: c70/213 lr:0.000761 t:5.0s
+tttg: c71/213 lr:0.000754 t:5.1s
+tttg: c72/213 lr:0.000748 t:5.1s
+tttg: c73/213 lr:0.000741 t:5.2s
+tttg: c74/213 lr:0.000735 t:5.3s
+tttg: c75/213 lr:0.000728 t:5.3s
+tttg: c76/213 lr:0.000722 t:5.4s
+tttg: c77/213 lr:0.000715 t:5.5s
+tttg: c78/213 lr:0.000708 t:5.6s
+tttg: c79/213 lr:0.000702 t:5.6s
+tttg: c80/213 lr:0.000695 t:5.7s
+tttg: c81/213 lr:0.000688 t:5.8s
+tttg: c82/213 lr:0.000681 t:5.8s
+tttg: c83/213 lr:0.000674 t:5.9s
+tttg: c84/213 lr:0.000667 t:6.0s
+tttg: c85/213 lr:0.000660 t:6.0s
+tttg: c86/213 lr:0.000653 t:6.1s
+tttg: c87/213 lr:0.000646 t:6.2s
+tttg: c88/213 lr:0.000639 t:6.2s
+tttg: c89/213 lr:0.000632 t:6.3s
+tttg: c90/213 lr:0.000625 t:6.4s
+tttg: c91/213 lr:0.000617 t:6.5s
+tttg: c92/213 lr:0.000610 t:6.5s
+tttg: c93/213 lr:0.000603 t:6.6s
+tttg: c94/213 lr:0.000596 t:6.7s
+tttg: c95/213 lr:0.000588 t:6.7s
+tttg: c96/213 lr:0.000581 t:6.8s
+tttg: c97/213 lr:0.000574 t:6.9s
+tttg: c98/213 lr:0.000566 t:7.0s
+tttg: c99/213 lr:0.000559 t:7.0s
+tttg: c100/213 lr:0.000552 t:7.1s
+tttg: c101/213 lr:0.000544 t:7.2s
+tttg: c102/213 lr:0.000537 t:7.2s
+tttg: c103/213 lr:0.000530 t:7.3s
+tttg: c104/213 lr:0.000522 t:7.4s
+tttg: c105/213 lr:0.000515 t:7.4s
+tttg: c106/213 lr:0.000507 t:7.5s
+tttg: c107/213 lr:0.000500 t:7.6s
+tttg: c108/213 lr:0.000493 t:7.7s
+tttg: c109/213 lr:0.000485 t:7.7s
+tttg: c110/213 lr:0.000478 t:7.8s
+tttg: c111/213 lr:0.000470 t:7.9s
+tttg: c112/213 lr:0.000463 t:7.9s
+tttg: c113/213 lr:0.000456 t:8.0s
+tttg: c114/213 lr:0.000448 t:8.1s
+tttg: c115/213 lr:0.000441 t:8.1s
+tttg: c116/213 lr:0.000434 t:8.2s
+tttg: c117/213 lr:0.000426 t:8.3s
+tttg: c118/213 lr:0.000419 t:8.3s
+tttg: c119/213 lr:0.000412 t:8.4s
+tttg: c120/213 lr:0.000404 t:8.5s
+tttg: c121/213 lr:0.000397 t:8.6s
+tttg: c122/213 lr:0.000390 t:8.6s
+tttg: c123/213 lr:0.000383 t:8.7s
+tttg: c124/213 lr:0.000375 t:8.8s
+tttg: c125/213 lr:0.000368 t:8.8s
+tttg: c126/213 lr:0.000361 t:8.9s
+tttg: c127/213 lr:0.000354 t:9.0s
+tttg: c128/213 lr:0.000347 t:9.1s
+tttg: c129/213 lr:0.000340 t:9.1s
+tttg: c130/213 lr:0.000333 t:9.2s
+tttg: c131/213 lr:0.000326 t:9.3s
+tttg: c132/213 lr:0.000319 t:9.3s
+tttg: c133/213 lr:0.000312 t:9.4s
+tttg: c134/213 lr:0.000305 t:9.5s
+tttg: c135/213 lr:0.000298 t:9.5s
+tttg: c136/213 lr:0.000292 t:9.6s
+tttg: c137/213 lr:0.000285 t:9.7s
+tttg: c138/213 lr:0.000278 t:9.7s
+tttg: c139/213 lr:0.000272 t:9.8s
+tttg: c140/213 lr:0.000265 t:9.9s
+tttg: c141/213 lr:0.000259 t:10.0s
+tttg: c142/213 lr:0.000252 t:10.0s
+tttg: c143/213 lr:0.000246 t:10.1s
+tttg: c144/213 lr:0.000239 t:10.2s
+tttg: c145/213 lr:0.000233 t:10.2s
+tttg: c146/213 lr:0.000227 t:10.3s
+tttg: c147/213 lr:0.000221 t:10.4s
+tttg: c148/213 lr:0.000215 t:10.4s
+tttg: c149/213 lr:0.000209 t:10.5s
+tttg: c150/213 lr:0.000203 t:10.6s
+tttg: c151/213 lr:0.000197 t:10.6s
+tttg: c152/213 lr:0.000191 t:10.7s
+tttg: c153/213 lr:0.000185 t:10.8s
+tttg: c154/213 lr:0.000179 t:10.9s
+tttg: c155/213 lr:0.000174 t:10.9s
+tttg: c156/213 lr:0.000168 t:11.0s
+tttg: c157/213 lr:0.000163 t:11.1s
+tttg: c158/213 lr:0.000157 t:11.1s
+tttg: c159/213 lr:0.000152 t:11.2s
+tttg: c160/213 lr:0.000146 t:11.3s
+tttg: c161/213 lr:0.000141 t:11.3s
+tttg: c162/213 lr:0.000136 t:11.4s
+tttg: c163/213 lr:0.000131 t:11.5s
+tttg: c164/213 lr:0.000126 t:11.6s
+tttg: c165/213 lr:0.000121 t:11.6s
+tttg: c166/213 lr:0.000116 t:11.7s
+tttg: c167/213 lr:0.000112 t:11.8s
+tttg: c168/213 lr:0.000107 t:11.8s
+tttg: c169/213 lr:0.000103 t:11.9s
+tttg: c170/213 lr:0.000098 t:12.0s
+tttg: c171/213 lr:0.000094 t:12.1s
+tttg: c172/213 lr:0.000089 t:12.1s
+tttg: c173/213 lr:0.000085 t:12.2s
+tttg: c174/213 lr:0.000081 t:12.3s
+tttg: c175/213 lr:0.000077 t:12.3s
+tttg: c176/213 lr:0.000073 t:12.4s
+tttg: c177/213 lr:0.000069 t:12.5s
+tttg: c178/213 lr:0.000066 t:12.5s
+tttg: c179/213 lr:0.000062 t:12.6s
+tttg: c180/213 lr:0.000059 t:12.7s
+tttg: c181/213 lr:0.000055 t:12.8s
+tttg: c182/213 lr:0.000052 t:12.8s
+tttg: c183/213 lr:0.000049 t:12.9s
+tttg: c184/213 lr:0.000045 t:13.0s
+tttg: c185/213 lr:0.000042 t:13.0s
+tttg: c186/213 lr:0.000039 t:13.1s
+tttg: c187/213 lr:0.000037 t:13.2s
+tttg: c188/213 lr:0.000034 t:13.2s
+tttg: c189/213 lr:0.000031 t:13.3s
+tttg: c190/213 lr:0.000029 t:13.4s
+tttg: c191/213 lr:0.000026 t:13.5s
+tttg: c192/213 lr:0.000024 t:13.5s
+tttg: c193/213 lr:0.000022 t:13.6s
+tttg: c194/213 lr:0.000020 t:13.7s
+tttg: c195/213 lr:0.000018 t:13.7s
+tttg: c196/213 lr:0.000016 t:13.8s
+tttg: c197/213 lr:0.000014 t:13.9s
+tttg: c198/213 lr:0.000012 t:14.0s
+tttg: c199/213 lr:0.000011 t:14.0s
+tttg: c200/213 lr:0.000009 t:14.1s
+tttg: c201/213 lr:0.000008 t:14.2s
+tttg: c202/213 lr:0.000007 t:14.2s
+tttg: c203/213 lr:0.000005 t:14.3s
+tttg: c204/213 lr:0.000004 t:14.4s
+tttg: c205/213 lr:0.000004 t:14.4s
+tttg: c206/213 lr:0.000003 t:14.5s
+tttg: c207/213 lr:0.000002 t:14.6s
+tttg: c208/213 lr:0.000001 t:14.7s
+tttg: c209/213 lr:0.000001 t:14.7s
+tttg: c210/213 lr:0.000000 t:14.8s
+tttg: c211/213 lr:0.000000 t:14.9s
+tttg: c212/213 lr:0.000000 t:14.9s
+ttpr: phase:3/3 t:364.5s
+ttp: b736/782 bl:2.6718 bb:1.0414 rl:2.7220 rb:1.0773 dl:2140-2165 gd:1
+ttp: b734/782 bl:2.7676 bb:1.0554 rl:2.7250 rb:1.0758 dl:2091-2115 gd:1
+ttp: b722/782 bl:2.7680 bb:1.0583 rl:2.7274 rb:1.0748 dl:1846-1861 gd:1
+ttp: b720/782 bl:2.8216 bb:1.0777 rl:2.7322 rb:1.0750 dl:1816-1832 gd:1
+ttp: b706/782 bl:2.7142 bb:1.0434 rl:2.7314 rb:1.0736 dl:1617-1627 gd:1
+ttp: b703/782 bl:2.9101 bb:1.1008 rl:2.7388 rb:1.0747 dl:1582-1594 gd:1
+ttp: b690/782 bl:2.8374 bb:1.0632 rl:2.7423 rb:1.0743 dl:1458-1467 gd:1
+ttp: b686/782 bl:2.8034 bb:1.0532 rl:2.7444 rb:1.0735 dl:1422-1432 gd:1
+ttp: b679/782 bl:2.8462 bb:1.0843 rl:2.7477 rb:1.0739 dl:1368-1374 gd:1
+ttp: b670/782 bl:2.8228 bb:1.0554 rl:2.7499 rb:1.0733 dl:1308-1315 gd:1
+ttp: b660/782 bl:2.8479 bb:1.0897 rl:2.7526 rb:1.0738 dl:1245-1250 gd:1
+ttp: b650/782 bl:2.7867 bb:1.0730 rl:2.7535 rb:1.0738 dl:1188-1193 gd:1
+ttp: b647/782 bl:2.7483 bb:1.0463 rl:2.7533 rb:1.0731 dl:1171-1177 gd:1
+ttp: b639/782 bl:2.8511 bb:1.0800 rl:2.7556 rb:1.0732 dl:1129-1134 gd:1
+ttp: b632/782 bl:2.7325 bb:1.0263 rl:2.7551 rb:1.0722 dl:1096-1101 gd:1
+ttp: b627/782 bl:2.7377 bb:1.0363 rl:2.7547 rb:1.0714 dl:1073-1077 gd:1
+ttp: b621/782 bl:2.8309 bb:1.0842 rl:2.7562 rb:1.0717 dl:1046-1050 gd:1
+ttp: b613/782 bl:2.8199 bb:1.0613 rl:2.7574 rb:1.0715 dl:1012-1016 gd:1
+ttp: b602/782 bl:2.7806 bb:1.0400 rl:2.7579 rb:1.0709 dl:966-971 gd:1
+ttp: b595/782 bl:2.7294 bb:1.0553 rl:2.7574 rb:1.0706 dl:940-943 gd:1
+ttp: b587/782 bl:2.7840 bb:1.0631 rl:2.7578 rb:1.0705 dl:914-917 gd:1
+ttp: b578/782 bl:2.7985 bb:1.0662 rl:2.7584 rb:1.0704 dl:884-887 gd:1
+ttp: b570/782 bl:2.7759 bb:1.0803 rl:2.7587 rb:1.0706 dl:858-862 gd:1
+ttp: b566/782 bl:2.7166 bb:1.0324 rl:2.7581 rb:1.0700 dl:846-849 gd:1
+ttp: b558/782 bl:2.6926 bb:1.0198 rl:2.7572 rb:1.0693 dl:821-824 gd:1
+ttp: b547/782 bl:2.7281 bb:1.0303 rl:2.7568 rb:1.0688 dl:790-793 gd:1
+ttp: b493/782 bl:2.8427 bb:1.1148 rl:2.7577 rb:1.0693 dl:659-661 gd:1
+ttp: b485/782 bl:2.7934 bb:1.0513 rl:2.7581 rb:1.0691 dl:643-645 gd:1
+ttp: b477/782 bl:2.7769 bb:1.0550 rl:2.7583 rb:1.0689 dl:626-628 gd:1
+ttp: b468/782 bl:2.7850 bb:1.0572 rl:2.7586 rb:1.0688 dl:608-610 gd:1
+ttp: b460/782 bl:2.7949 bb:1.0601 rl:2.7589 rb:1.0687 dl:593-595 gd:1
+ttp: b453/782 bl:2.7582 bb:1.0584 rl:2.7589 rb:1.0686 dl:580-582 gd:1
+ttp: b442/782 bl:2.8019 bb:1.0523 rl:2.7593 rb:1.0685 dl:560-562 gd:1
+ttp: b434/782 bl:2.7228 bb:1.0404 rl:2.7590 rb:1.0682 dl:545-547 gd:1
+ttp: b426/782 bl:2.7269 bb:1.0671 rl:2.7587 rb:1.0682 dl:532-533 gd:1
+ttp: b418/782 bl:2.8048 bb:1.0699 rl:2.7591 rb:1.0682 dl:517-519 gd:1
+ttp: b410/782 bl:2.7763 bb:1.0542 rl:2.7592 rb:1.0681 dl:505-507 gd:1
+ttp: b403/782 bl:2.8131 bb:1.0512 rl:2.7596 rb:1.0680 dl:493-495 gd:1
+ttp: b395/782 bl:2.7341 bb:1.0440 rl:2.7594 rb:1.0678 dl:481-482 gd:1
+ttp: b385/782 bl:2.8812 bb:1.0979 rl:2.7602 rb:1.0680 dl:466-467 gd:1
+ttp: b378/782 bl:2.8163 bb:1.0958 rl:2.7606 rb:1.0682 dl:456-457 gd:1
+ttp: b371/782 bl:2.7917 bb:1.0671 rl:2.7608 rb:1.0682 dl:446-447 gd:1
+ttp: b364/782 bl:2.7339 bb:1.0664 rl:2.7606 rb:1.0682 dl:436-437 gd:1
+ttp: b357/782 bl:2.8558 bb:1.0806 rl:2.7612 rb:1.0683 dl:426-427 gd:1
+ttp: b350/782 bl:2.7333 bb:1.0602 rl:2.7611 rb:1.0682 dl:417-418 gd:1
+ttp: b343/782 bl:2.7959 bb:1.0668 rl:2.7613 rb:1.0682 dl:407-408 gd:1
+ttp: b336/782 bl:2.9516 bb:1.1664 rl:2.7623 rb:1.0688 dl:398-399 gd:1
+ttp: b329/782 bl:2.8296 bb:1.1037 rl:2.7627 rb:1.0690 dl:389-390 gd:1
+ttp: b322/782 bl:2.7601 bb:1.0785 rl:2.7627 rb:1.0690 dl:380-381 gd:1
+ttp: b315/782 bl:2.7277 bb:1.0725 rl:2.7625 rb:1.0690 dl:370-371 gd:1
+ttp: b308/782 bl:2.7898 bb:1.0838 rl:2.7626 rb:1.0691 dl:362-363 gd:1
+ttp: b301/782 bl:2.7935 bb:1.0863 rl:2.7628 rb:1.0692 dl:353-354 gd:1
+ttp: b293/782 bl:2.7603 bb:1.0664 rl:2.7628 rb:1.0692 dl:343-345 gd:1
+ttp: b287/782 bl:2.8590 bb:1.1153 rl:2.7632 rb:1.0694 dl:336-337 gd:1
+ttp: b283/782 bl:2.7917 bb:1.0709 rl:2.7633 rb:1.0694 dl:332-333 gd:1
+ttp: b275/782 bl:2.7511 bb:1.0640 rl:2.7633 rb:1.0694 dl:323-324 gd:1
+ttp: b267/782 bl:2.8640 bb:1.0982 rl:2.7637 rb:1.0695 dl:314-315 gd:1
+ttp: b261/782 bl:2.8682 bb:1.1219 rl:2.7641 rb:1.0697 dl:308-309 gd:1
+ttp: b253/782 bl:2.7555 bb:1.0821 rl:2.7641 rb:1.0697 dl:298-299 gd:1
+ttp: b245/782 bl:2.8688 bb:1.1016 rl:2.7645 rb:1.0699 dl:290-291 gd:1
+ttp: b233/782 bl:2.8500 bb:1.1198 rl:2.7648 rb:1.0700 dl:278-279 gd:1
+ttp: b224/782 bl:2.8151 bb:1.1058 rl:2.7650 rb:1.0702 dl:269-270 gd:1
+ttp: b216/782 bl:2.9309 bb:1.1153 rl:2.7656 rb:1.0703 dl:261-262 gd:1
+ttp: b207/782 bl:2.8355 bb:1.1154 rl:2.7658 rb:1.0705 dl:253-254 gd:1
+ttp: b199/782 bl:2.9431 bb:1.1280 rl:2.7664 rb:1.0707 dl:246-247 gd:1
+ttp: b192/782 bl:2.9059 bb:1.1454 rl:2.7668 rb:1.0709 dl:239-240 gd:1
+ttp: b189/782 bl:2.9609 bb:1.2017 rl:2.7674 rb:1.0713 dl:237-237 gd:1
+ttp: b181/782 bl:2.8788 bb:1.1568 rl:2.7677 rb:1.0715 dl:230-230 gd:1
+ttp: b172/782 bl:3.0113 bb:1.1843 rl:2.7684 rb:1.0718 dl:222-223 gd:1
+ttp: b164/782 bl:2.9660 bb:1.1470 rl:2.7689 rb:1.0720 dl:215-216 gd:1
+ttp: b156/782 bl:2.8938 bb:1.1096 rl:2.7693 rb:1.0721 dl:208-209 gd:1
+ttp: b148/782 bl:2.9742 bb:1.1560 rl:2.7698 rb:1.0724 dl:202-203 gd:1
+ttp: b140/782 bl:2.9702 bb:1.1728 rl:2.7703 rb:1.0726 dl:195-196 gd:1
+ttp: b130/782 bl:3.1291 bb:1.2300 rl:2.7712 rb:1.0730 dl:187-188 gd:1
+ttp: b122/782 bl:2.9004 bb:1.1604 rl:2.7715 rb:1.0732 dl:181-182 gd:1
+ttp: b115/782 bl:2.8662 bb:1.1566 rl:2.7717 rb:1.0733 dl:176-177 gd:1
+ttp: b106/782 bl:2.9658 bb:1.1979 rl:2.7721 rb:1.0736 dl:170-171 gd:1
+ttp: b95/782 bl:3.0115 bb:1.2263 rl:2.7726 rb:1.0739 dl:161-162 gd:1
+ttp: b86/782 bl:3.0350 bb:1.2632 rl:2.7731 rb:1.0742 dl:154-155 gd:1
+ttp: b78/782 bl:2.9178 bb:1.1321 rl:2.7733 rb:1.0743 dl:148-149 gd:1
+ttp: b70/782 bl:3.0665 bb:1.1653 rl:2.7739 rb:1.0745 dl:142-143 gd:1
+ttp: b62/782 bl:2.9853 bb:1.2076 rl:2.7742 rb:1.0747 dl:136-137 gd:1
+ttp: b53/782 bl:3.1320 bb:1.2348 rl:2.7748 rb:1.0750 dl:129-130 gd:1
+ttp: b46/782 bl:3.1354 bb:1.2260 rl:2.7753 rb:1.0752 dl:123-124 gd:1
+ttp: b38/782 bl:3.0444 bb:1.2151 rl:2.7757 rb:1.0754 dl:117-118 gd:1
+ttp: b30/782 bl:3.1255 bb:1.2520 rl:2.7762 rb:1.0756 dl:110-111 gd:1
+ttp: b22/782 bl:3.1623 bb:1.2327 rl:2.7767 rb:1.0758 dl:103-104 gd:1
+ttp: b14/782 bl:3.1346 bb:1.2328 rl:2.7771 rb:1.0760 dl:94-95 gd:1
+ttp: b10/782 bl:3.1344 bb:1.2385 rl:2.7775 rb:1.0762 dl:89-90 gd:1
+ttp: b2/782 bl:3.1527 bb:1.1693 rl:2.7778 rb:1.0763 dl:70-75 gd:1
+quantized_ttt_phased val_loss:2.77160951 val_bpb:1.07297641 eval_time:449182ms
+total_eval_time:449.2s
+[Tue Apr 21 22:08:47 UTC 2026] Experiment pure_ttt_sp8192_dxwarmwd_seed1337_8gpu complete
+Final BPB: diagnostic pre-quantization post-ema val_loss:2.77263281 val_bpb:1.07333797 eval_time:8457ms
+diagnostic quantized val_loss:2.80359225 val_bpb:1.08532295 eval_time:57996ms
+quantized_ttt_phased val_loss:2.77160951 val_bpb:1.07297641 eval_time:449182ms

--- a/records/track_10min_16mb/2026-04-21_AlphaLoRA_WarmStart_HighWD_1.07266/train_seed314.log
+++ b/records/track_10min_16mb/2026-04-21_AlphaLoRA_WarmStart_HighWD_1.07266/train_seed314.log
@@ -1,0 +1,760 @@
+[Tue Apr 21 20:50:24 UTC 2026] Starting SP8192 dexhunter experiment: pure_ttt_sp8192_dxwarmwd_seed314_8gpu
+Extra args: SEED=314 PHASED_TTT_ENABLED=1 PHASED_TTT_PREFIX_DOCS=2000 PHASED_TTT_NUM_PHASES=3 MLP_CLIP_SIGMAS=12.0 ATTN_CLIP_SIGMAS=13.0 EMBED_BITS=7 EMBED_CLIP_SIGMAS=15.0 MATRIX_LR=0.026 GPTQ_RESERVE_SECONDS=4 GPTQ_CALIBRATION_BATCHES=16 TTT_LORA_RANK=128 TTT_LORA_ALPHA=96 TTT_WARM_START_A=1 TTT_WEIGHT_DECAY=1.0
+torch: 2.9.1+cu128
+FA3 interface: OK
+[Tue Apr 21 20:50:30 UTC 2026] GPU check:
+0, 1 MiB, 0 %
+1, 1 MiB, 0 %
+2, 1 MiB, 0 %
+3, 1 MiB, 0 %
+4, 1 MiB, 0 %
+5, 1 MiB, 0 %
+6, 1 MiB, 0 %
+7, 1 MiB, 0 %
+W0421 20:50:31.417000 112 torch/distributed/run.py:803] 
+W0421 20:50:31.417000 112 torch/distributed/run.py:803] *****************************************
+W0421 20:50:31.417000 112 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0421 20:50:31.417000 112 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  artifact_dir: 
+  attn_clip_sigmas: 13.0
+  beta1: 0.9
+  beta2: 0.95
+  compressor: brotli
+  data_dir: DATA_DIR
+  datasets_dir: DATA_DIR/datasets/fineweb10B_sp8192
+  distributed: True
+  ema_decay: 0.9965
+  embed_bits: 7
+  embed_clip_sigmas: 15.0
+  embed_lr: 0.6
+  embed_wd: 0.085
+  enable_looping_at: 0.35
+  eval_seq_len: 2048
+  eval_stride: 64
+  global_ttt_batch_seqs: 32
+  global_ttt_chunk_tokens: 32768
+  global_ttt_epochs: 1
+  global_ttt_grad_clip: 1.0
+  global_ttt_lr: 0.001
+  global_ttt_momentum: 0.9
+  global_ttt_respect_doc_boundaries: True
+  global_ttt_warmup_chunks: 0
+  global_ttt_warmup_start_lr: 0.0
+  gptq_calibration_batches: 16
+  gptq_reserve_seconds: 4.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  is_main_process: True
+  iterations: 20000
+  ln_scale: True
+  local_rank: 0
+  logfile: logs/ec4c6b00-a039-4cb8-8f15-5474f8e015e7.txt
+  logit_softcap: 30.0
+  loop_end: 5
+  loop_start: 3
+  matrix_bits: 6
+  matrix_clip_sigmas: 12.85
+  matrix_lr: 0.026
+  max_wallclock_seconds: 600.0
+  min_lr: 0.0
+  mlp_clip_sigmas: 12.0
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: final_model.pt
+  muon_backend_steps: 5
+  muon_momentum: 0.97
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_row_normalize: True
+  muon_wd: 0.095
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  num_loops: 2
+  parallel_final_lane: mean
+  parallel_start_layer: 8
+  phased_ttt_enabled: True
+  phased_ttt_num_phases: 3
+  phased_ttt_prefix_docs: 2000
+  qk_gain_init: 5.0
+  quantized_model_path: final_model.int6.ptz
+  rank: 0
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  rope_yarn: False
+  run_id: ec4c6b00-a039-4cb8-8f15-5474f8e015e7
+  scalar_lr: 0.02
+  seed: 314
+  skip_gates_enabled: True
+  sliding_window_enabled: False
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  tokenizer_path: DATA_DIR/tokenizers/fineweb_8192_bpe.model
+  train_batch_tokens: 786432
+  train_files: DATA_DIR/datasets/fineweb10B_sp8192/fineweb_train_*.bin
+  train_log_every: 500
+  train_seq_len: 2048
+  ttt_batch_size: 64
+  ttt_beta1: 0.0
+  ttt_beta2: 0.999
+  ttt_chunk_size: 48
+  ttt_enabled: True
+  ttt_eval_batches: 
+  ttt_eval_seq_len: 2048
+  ttt_grad_steps: 1
+  ttt_k_lora: True
+  ttt_lora_lr: 0.0001
+  ttt_lora_rank: 128
+  ttt_mlp_lora: True
+  ttt_o_lora: True
+  ttt_optimizer: adam
+  ttt_weight_decay: 1.0
+  val_batch_tokens: 524288
+  val_doc_fraction: 1.0
+  val_files: DATA_DIR/datasets/fineweb10B_sp8192/fineweb_val_*.bin
+  val_loss_every: 4000
+  vocab_size: 8192
+  warmdown_frac: 0.75
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+train_shards: 80
+val_tokens: 40540160
+model_params:35944602
+gptq:reserving 4s, effective=596000ms
+warmup_cu_buckets:64,128,192,256 iters_each:3
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup:enabled encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+loop_warmup_step: 1/20
+loop_warmup_step: 2/20
+loop_warmup_step: 3/20
+loop_warmup_step: 4/20
+loop_warmup_step: 5/20
+loop_warmup_step: 6/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+0/20000 val_loss: 9.0092 val_bpb: 3.4876
+1/20000 train_loss: 9.0084 train_time: 0.0m tok/s: 16277093
+2/20000 train_loss: 12.3027 train_time: 0.0m tok/s: 12406459
+3/20000 train_loss: 11.2467 train_time: 0.0m tok/s: 10355115
+4/20000 train_loss: 9.6668 train_time: 0.0m tok/s: 9378673
+5/20000 train_loss: 8.2459 train_time: 0.0m tok/s: 9085774
+500/20000 train_loss: 3.2637 train_time: 0.8m tok/s: 8260416
+1000/20000 train_loss: 3.0250 train_time: 1.6m tok/s: 8219214
+1500/20000 train_loss: 3.0305 train_time: 2.4m tok/s: 8218915
+2000/20000 train_loss: 2.9830 train_time: 3.2m tok/s: 8221390
+layer_loop:enabled step:2180 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2500/20000 train_loss: 3.0748 train_time: 4.2m tok/s: 7765391
+3000/20000 train_loss: 2.9112 train_time: 5.4m tok/s: 7308928
+3500/20000 train_loss: 2.9816 train_time: 6.5m tok/s: 7014857
+4000/20000 train_loss: 2.9126 train_time: 7.8m tok/s: 6756993
+4000/20000 val_loss: 2.8862 val_bpb: 1.1173
+4500/20000 train_loss: 2.8670 train_time: 8.9m tok/s: 6612662
+4913/20000 val_loss: 2.7715 val_bpb: 1.0729
+stopping_early: wallclock_cap train_time: 596057ms step: 4913/20000
+peak memory allocated: 40029 MiB reserved: 44036 MiB
+ema:applying EMA weights
+diagnostic pre-quantization post-ema val_loss:2.77043120 val_bpb:1.07248569 eval_time:6581ms
+Serialized model: 135409136 bytes
+Code size (uncompressed): 122655 bytes
+Code size (compressed): 27680 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 4.4s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int7): tok_emb.weight
+  passthrough (float16): blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, skip_gates, skip_weights
+Serialized model quantized+brotli: 15908095 bytes
+Total submission size quantized+brotli: 15935775 bytes
+diagnostic quantized val_loss:2.80111149 val_bpb:1.08436260 eval_time:57830ms
+ttt_lora:warming up compile (random tokens, no val data)
+ttt_lora:compile warmup done (151.2s)
+
+beginning TTT eval timer
+ttt_phased: total_docs:50000 prefix_docs:2000 suffix_docs:48000 num_phases:3 boundaries:[666, 1333, 2000]
+ttp: b775/782 bl:2.6900 bb:1.0649 rl:2.6900 rb:1.0649 dl:5853-6355 gd:0
+ttp: b774/782 bl:2.7297 bb:1.0780 rl:2.7092 rb:1.0712 dl:5552-5852 gd:0
+ttp: b769/782 bl:2.7706 bb:1.0964 rl:2.7258 rb:1.0781 dl:4307-4479 gd:0
+ttpp: phase:1/3 pd:1104 gd:666 t:199.9s
+tttg: c1/95 lr:0.001000 t:1.7s
+tttg: c2/95 lr:0.001000 t:1.7s
+tttg: c3/95 lr:0.000999 t:1.8s
+tttg: c4/95 lr:0.000997 t:1.9s
+tttg: c5/95 lr:0.000996 t:2.0s
+tttg: c6/95 lr:0.000993 t:2.1s
+tttg: c7/95 lr:0.000990 t:2.2s
+tttg: c8/95 lr:0.000986 t:2.2s
+tttg: c9/95 lr:0.000982 t:2.3s
+tttg: c10/95 lr:0.000978 t:2.4s
+tttg: c11/95 lr:0.000972 t:2.5s
+tttg: c12/95 lr:0.000967 t:2.6s
+tttg: c13/95 lr:0.000960 t:2.6s
+tttg: c14/95 lr:0.000954 t:2.7s
+tttg: c15/95 lr:0.000946 t:2.8s
+tttg: c16/95 lr:0.000938 t:2.9s
+tttg: c17/95 lr:0.000930 t:2.9s
+tttg: c18/95 lr:0.000921 t:3.0s
+tttg: c19/95 lr:0.000912 t:3.1s
+tttg: c20/95 lr:0.000903 t:3.2s
+tttg: c21/95 lr:0.000892 t:3.3s
+tttg: c22/95 lr:0.000882 t:3.3s
+tttg: c23/95 lr:0.000871 t:3.4s
+tttg: c24/95 lr:0.000859 t:3.5s
+tttg: c25/95 lr:0.000848 t:3.6s
+tttg: c26/95 lr:0.000835 t:3.7s
+tttg: c27/95 lr:0.000823 t:3.7s
+tttg: c28/95 lr:0.000810 t:3.8s
+tttg: c29/95 lr:0.000797 t:3.9s
+tttg: c30/95 lr:0.000783 t:4.0s
+tttg: c31/95 lr:0.000769 t:4.1s
+tttg: c32/95 lr:0.000755 t:4.1s
+tttg: c33/95 lr:0.000740 t:4.2s
+tttg: c34/95 lr:0.000726 t:4.3s
+tttg: c35/95 lr:0.000710 t:4.4s
+tttg: c36/95 lr:0.000695 t:4.5s
+tttg: c37/95 lr:0.000680 t:4.5s
+tttg: c38/95 lr:0.000664 t:4.6s
+tttg: c39/95 lr:0.000648 t:4.7s
+tttg: c40/95 lr:0.000632 t:4.8s
+tttg: c41/95 lr:0.000616 t:4.8s
+tttg: c42/95 lr:0.000600 t:4.9s
+tttg: c43/95 lr:0.000583 t:5.0s
+tttg: c44/95 lr:0.000567 t:5.1s
+tttg: c45/95 lr:0.000550 t:5.1s
+tttg: c46/95 lr:0.000533 t:5.2s
+tttg: c47/95 lr:0.000517 t:5.3s
+tttg: c48/95 lr:0.000500 t:5.4s
+tttg: c49/95 lr:0.000483 t:5.5s
+tttg: c50/95 lr:0.000467 t:5.5s
+tttg: c51/95 lr:0.000450 t:5.6s
+tttg: c52/95 lr:0.000433 t:5.7s
+tttg: c53/95 lr:0.000417 t:5.8s
+tttg: c54/95 lr:0.000400 t:5.9s
+tttg: c55/95 lr:0.000384 t:5.9s
+tttg: c56/95 lr:0.000368 t:6.0s
+tttg: c57/95 lr:0.000352 t:6.1s
+tttg: c58/95 lr:0.000336 t:6.2s
+tttg: c59/95 lr:0.000320 t:6.2s
+tttg: c60/95 lr:0.000305 t:6.3s
+tttg: c61/95 lr:0.000290 t:6.4s
+tttg: c62/95 lr:0.000274 t:6.5s
+tttg: c63/95 lr:0.000260 t:6.6s
+tttg: c64/95 lr:0.000245 t:6.6s
+tttg: c65/95 lr:0.000231 t:6.7s
+tttg: c66/95 lr:0.000217 t:6.8s
+tttg: c67/95 lr:0.000203 t:6.9s
+tttg: c68/95 lr:0.000190 t:7.0s
+tttg: c69/95 lr:0.000177 t:7.0s
+tttg: c70/95 lr:0.000165 t:7.1s
+tttg: c71/95 lr:0.000152 t:7.2s
+tttg: c72/95 lr:0.000141 t:7.3s
+tttg: c73/95 lr:0.000129 t:7.3s
+tttg: c74/95 lr:0.000118 t:7.4s
+tttg: c75/95 lr:0.000108 t:7.5s
+tttg: c76/95 lr:0.000097 t:7.6s
+tttg: c77/95 lr:0.000088 t:7.7s
+tttg: c78/95 lr:0.000079 t:7.8s
+tttg: c79/95 lr:0.000070 t:7.8s
+tttg: c80/95 lr:0.000062 t:7.9s
+tttg: c81/95 lr:0.000054 t:8.0s
+tttg: c82/95 lr:0.000046 t:8.1s
+tttg: c83/95 lr:0.000040 t:8.2s
+tttg: c84/95 lr:0.000033 t:8.2s
+tttg: c85/95 lr:0.000028 t:8.3s
+tttg: c86/95 lr:0.000022 t:8.4s
+tttg: c87/95 lr:0.000018 t:8.5s
+tttg: c88/95 lr:0.000014 t:8.5s
+tttg: c89/95 lr:0.000010 t:8.6s
+tttg: c90/95 lr:0.000007 t:8.7s
+tttg: c91/95 lr:0.000004 t:8.8s
+tttg: c92/95 lr:0.000003 t:8.8s
+tttg: c93/95 lr:0.000001 t:8.9s
+tttg: c94/95 lr:0.000000 t:9.0s
+ttpr: phase:1/3 t:211.4s
+ttp: b757/782 bl:2.6380 bb:1.0195 rl:2.7118 rb:1.0686 dl:3033-3108 gd:0
+ttp: b756/782 bl:2.7790 bb:1.0771 rl:2.7209 rb:1.0697 dl:2973-3032 gd:0
+ttpp: phase:2/3 pd:1808 gd:1333 t:320.2s
+tttg: c1/158 lr:0.001000 t:0.1s
+tttg: c2/158 lr:0.001000 t:0.1s
+tttg: c3/158 lr:0.001000 t:0.2s
+tttg: c4/158 lr:0.000999 t:0.3s
+tttg: c5/158 lr:0.000998 t:0.4s
+tttg: c6/158 lr:0.000997 t:0.5s
+tttg: c7/158 lr:0.000996 t:0.5s
+tttg: c8/158 lr:0.000995 t:0.6s
+tttg: c9/158 lr:0.000994 t:0.7s
+tttg: c10/158 lr:0.000992 t:0.8s
+tttg: c11/158 lr:0.000990 t:0.8s
+tttg: c12/158 lr:0.000988 t:0.9s
+tttg: c13/158 lr:0.000986 t:1.0s
+tttg: c14/158 lr:0.000983 t:1.1s
+tttg: c15/158 lr:0.000981 t:1.1s
+tttg: c16/158 lr:0.000978 t:1.2s
+tttg: c17/158 lr:0.000975 t:1.3s
+tttg: c18/158 lr:0.000971 t:1.4s
+tttg: c19/158 lr:0.000968 t:1.5s
+tttg: c20/158 lr:0.000964 t:1.5s
+tttg: c21/158 lr:0.000960 t:1.6s
+tttg: c22/158 lr:0.000957 t:1.7s
+tttg: c23/158 lr:0.000952 t:1.7s
+tttg: c24/158 lr:0.000948 t:1.8s
+tttg: c25/158 lr:0.000943 t:1.9s
+tttg: c26/158 lr:0.000939 t:2.0s
+tttg: c27/158 lr:0.000934 t:2.1s
+tttg: c28/158 lr:0.000929 t:2.2s
+tttg: c29/158 lr:0.000924 t:2.2s
+tttg: c30/158 lr:0.000918 t:2.3s
+tttg: c31/158 lr:0.000913 t:2.4s
+tttg: c32/158 lr:0.000907 t:2.5s
+tttg: c33/158 lr:0.000901 t:2.5s
+tttg: c34/158 lr:0.000895 t:2.6s
+tttg: c35/158 lr:0.000889 t:2.7s
+tttg: c36/158 lr:0.000882 t:2.8s
+tttg: c37/158 lr:0.000876 t:2.8s
+tttg: c38/158 lr:0.000869 t:2.9s
+tttg: c39/158 lr:0.000862 t:3.0s
+tttg: c40/158 lr:0.000855 t:3.1s
+tttg: c41/158 lr:0.000848 t:3.2s
+tttg: c42/158 lr:0.000841 t:3.2s
+tttg: c43/158 lr:0.000834 t:3.3s
+tttg: c44/158 lr:0.000826 t:3.4s
+tttg: c45/158 lr:0.000818 t:3.5s
+tttg: c46/158 lr:0.000811 t:3.5s
+tttg: c47/158 lr:0.000803 t:3.6s
+tttg: c48/158 lr:0.000795 t:3.7s
+tttg: c49/158 lr:0.000787 t:3.8s
+tttg: c50/158 lr:0.000778 t:3.8s
+tttg: c51/158 lr:0.000770 t:3.9s
+tttg: c52/158 lr:0.000761 t:4.0s
+tttg: c53/158 lr:0.000753 t:4.1s
+tttg: c54/158 lr:0.000744 t:4.2s
+tttg: c55/158 lr:0.000735 t:4.2s
+tttg: c56/158 lr:0.000727 t:4.3s
+tttg: c57/158 lr:0.000718 t:4.4s
+tttg: c58/158 lr:0.000709 t:4.5s
+tttg: c59/158 lr:0.000699 t:4.6s
+tttg: c60/158 lr:0.000690 t:4.7s
+tttg: c61/158 lr:0.000681 t:4.7s
+tttg: c62/158 lr:0.000672 t:4.8s
+tttg: c63/158 lr:0.000662 t:4.9s
+tttg: c64/158 lr:0.000653 t:5.0s
+tttg: c65/158 lr:0.000643 t:5.0s
+tttg: c66/158 lr:0.000633 t:5.1s
+tttg: c67/158 lr:0.000624 t:5.2s
+tttg: c68/158 lr:0.000614 t:5.3s
+tttg: c69/158 lr:0.000604 t:5.3s
+tttg: c70/158 lr:0.000594 t:5.4s
+tttg: c71/158 lr:0.000585 t:5.5s
+tttg: c72/158 lr:0.000575 t:5.6s
+tttg: c73/158 lr:0.000565 t:5.7s
+tttg: c74/158 lr:0.000555 t:5.7s
+tttg: c75/158 lr:0.000545 t:5.8s
+tttg: c76/158 lr:0.000535 t:5.9s
+tttg: c77/158 lr:0.000525 t:6.0s
+tttg: c78/158 lr:0.000515 t:6.1s
+tttg: c79/158 lr:0.000505 t:6.1s
+tttg: c80/158 lr:0.000495 t:6.2s
+tttg: c81/158 lr:0.000485 t:6.3s
+tttg: c82/158 lr:0.000475 t:6.4s
+tttg: c83/158 lr:0.000465 t:6.5s
+tttg: c84/158 lr:0.000455 t:6.5s
+tttg: c85/158 lr:0.000445 t:6.6s
+tttg: c86/158 lr:0.000435 t:6.7s
+tttg: c87/158 lr:0.000425 t:6.8s
+tttg: c88/158 lr:0.000415 t:6.8s
+tttg: c89/158 lr:0.000406 t:6.9s
+tttg: c90/158 lr:0.000396 t:7.0s
+tttg: c91/158 lr:0.000386 t:7.1s
+tttg: c92/158 lr:0.000376 t:7.1s
+tttg: c93/158 lr:0.000367 t:7.2s
+tttg: c94/158 lr:0.000357 t:7.3s
+tttg: c95/158 lr:0.000347 t:7.4s
+tttg: c96/158 lr:0.000338 t:7.5s
+tttg: c97/158 lr:0.000328 t:7.5s
+tttg: c98/158 lr:0.000319 t:7.6s
+tttg: c99/158 lr:0.000310 t:7.7s
+tttg: c100/158 lr:0.000301 t:7.8s
+tttg: c101/158 lr:0.000291 t:7.9s
+tttg: c102/158 lr:0.000282 t:7.9s
+tttg: c103/158 lr:0.000273 t:8.0s
+tttg: c104/158 lr:0.000265 t:8.1s
+tttg: c105/158 lr:0.000256 t:8.2s
+tttg: c106/158 lr:0.000247 t:8.3s
+tttg: c107/158 lr:0.000239 t:8.3s
+tttg: c108/158 lr:0.000230 t:8.4s
+tttg: c109/158 lr:0.000222 t:8.5s
+tttg: c110/158 lr:0.000213 t:8.6s
+tttg: c111/158 lr:0.000205 t:8.6s
+tttg: c112/158 lr:0.000197 t:8.7s
+tttg: c113/158 lr:0.000189 t:8.8s
+tttg: c114/158 lr:0.000182 t:8.9s
+tttg: c115/158 lr:0.000174 t:8.9s
+tttg: c116/158 lr:0.000166 t:9.0s
+tttg: c117/158 lr:0.000159 t:9.1s
+tttg: c118/158 lr:0.000152 t:9.2s
+tttg: c119/158 lr:0.000145 t:9.2s
+tttg: c120/158 lr:0.000138 t:9.3s
+tttg: c121/158 lr:0.000131 t:9.4s
+tttg: c122/158 lr:0.000124 t:9.5s
+tttg: c123/158 lr:0.000118 t:9.6s
+tttg: c124/158 lr:0.000111 t:9.7s
+tttg: c125/158 lr:0.000105 t:9.7s
+tttg: c126/158 lr:0.000099 t:9.8s
+tttg: c127/158 lr:0.000093 t:9.9s
+tttg: c128/158 lr:0.000087 t:10.0s
+tttg: c129/158 lr:0.000082 t:10.0s
+tttg: c130/158 lr:0.000076 t:10.1s
+tttg: c131/158 lr:0.000071 t:10.2s
+tttg: c132/158 lr:0.000066 t:10.3s
+tttg: c133/158 lr:0.000061 t:10.4s
+tttg: c134/158 lr:0.000057 t:10.4s
+tttg: c135/158 lr:0.000052 t:10.5s
+tttg: c136/158 lr:0.000048 t:10.6s
+tttg: c137/158 lr:0.000043 t:10.7s
+tttg: c138/158 lr:0.000040 t:10.7s
+tttg: c139/158 lr:0.000036 t:10.8s
+tttg: c140/158 lr:0.000032 t:10.9s
+tttg: c141/158 lr:0.000029 t:11.0s
+tttg: c142/158 lr:0.000025 t:11.1s
+tttg: c143/158 lr:0.000022 t:11.1s
+tttg: c144/158 lr:0.000019 t:11.2s
+tttg: c145/158 lr:0.000017 t:11.3s
+tttg: c146/158 lr:0.000014 t:11.4s
+tttg: c147/158 lr:0.000012 t:11.4s
+tttg: c148/158 lr:0.000010 t:11.5s
+tttg: c149/158 lr:0.000008 t:11.6s
+tttg: c150/158 lr:0.000006 t:11.7s
+tttg: c151/158 lr:0.000005 t:11.8s
+tttg: c152/158 lr:0.000004 t:11.8s
+tttg: c153/158 lr:0.000003 t:11.9s
+tttg: c154/158 lr:0.000002 t:12.0s
+tttg: c155/158 lr:0.000001 t:12.1s
+tttg: c156/158 lr:0.000000 t:12.1s
+tttg: c157/158 lr:0.000000 t:12.2s
+ttpr: phase:2/3 t:334.9s
+ttp: b746/782 bl:2.6738 bb:1.0528 rl:2.7162 rb:1.0680 dl:2459-2501 gd:0
+ttpp: phase:3/3 pd:2448 gd:2000 t:348.8s
+tttg: c1/213 lr:0.001000 t:0.1s
+tttg: c2/213 lr:0.001000 t:0.2s
+tttg: c3/213 lr:0.001000 t:0.2s
+tttg: c4/213 lr:0.001000 t:0.3s
+tttg: c5/213 lr:0.000999 t:0.4s
+tttg: c6/213 lr:0.000999 t:0.5s
+tttg: c7/213 lr:0.000998 t:0.6s
+tttg: c8/213 lr:0.000997 t:0.6s
+tttg: c9/213 lr:0.000996 t:0.7s
+tttg: c10/213 lr:0.000996 t:0.8s
+tttg: c11/213 lr:0.000995 t:0.9s
+tttg: c12/213 lr:0.000993 t:0.9s
+tttg: c13/213 lr:0.000992 t:1.0s
+tttg: c14/213 lr:0.000991 t:1.1s
+tttg: c15/213 lr:0.000989 t:1.2s
+tttg: c16/213 lr:0.000988 t:1.2s
+tttg: c17/213 lr:0.000986 t:1.3s
+tttg: c18/213 lr:0.000984 t:1.4s
+tttg: c19/213 lr:0.000982 t:1.5s
+tttg: c20/213 lr:0.000980 t:1.6s
+tttg: c21/213 lr:0.000978 t:1.6s
+tttg: c22/213 lr:0.000976 t:1.7s
+tttg: c23/213 lr:0.000974 t:1.8s
+tttg: c24/213 lr:0.000971 t:1.9s
+tttg: c25/213 lr:0.000969 t:1.9s
+tttg: c26/213 lr:0.000966 t:2.0s
+tttg: c27/213 lr:0.000963 t:2.1s
+tttg: c28/213 lr:0.000961 t:2.2s
+tttg: c29/213 lr:0.000958 t:2.3s
+tttg: c30/213 lr:0.000955 t:2.3s
+tttg: c31/213 lr:0.000951 t:2.4s
+tttg: c32/213 lr:0.000948 t:2.5s
+tttg: c33/213 lr:0.000945 t:2.6s
+tttg: c34/213 lr:0.000941 t:2.6s
+tttg: c35/213 lr:0.000938 t:2.7s
+tttg: c36/213 lr:0.000934 t:2.8s
+tttg: c37/213 lr:0.000931 t:2.9s
+tttg: c38/213 lr:0.000927 t:2.9s
+tttg: c39/213 lr:0.000923 t:3.0s
+tttg: c40/213 lr:0.000919 t:3.1s
+tttg: c41/213 lr:0.000915 t:3.2s
+tttg: c42/213 lr:0.000911 t:3.2s
+tttg: c43/213 lr:0.000906 t:3.3s
+tttg: c44/213 lr:0.000902 t:3.4s
+tttg: c45/213 lr:0.000897 t:3.5s
+tttg: c46/213 lr:0.000893 t:3.5s
+tttg: c47/213 lr:0.000888 t:3.6s
+tttg: c48/213 lr:0.000884 t:3.7s
+tttg: c49/213 lr:0.000879 t:3.8s
+tttg: c50/213 lr:0.000874 t:3.8s
+tttg: c51/213 lr:0.000869 t:3.9s
+tttg: c52/213 lr:0.000864 t:4.0s
+tttg: c53/213 lr:0.000859 t:4.1s
+tttg: c54/213 lr:0.000854 t:4.1s
+tttg: c55/213 lr:0.000848 t:4.2s
+tttg: c56/213 lr:0.000843 t:4.3s
+tttg: c57/213 lr:0.000837 t:4.4s
+tttg: c58/213 lr:0.000832 t:4.4s
+tttg: c59/213 lr:0.000826 t:4.5s
+tttg: c60/213 lr:0.000821 t:4.6s
+tttg: c61/213 lr:0.000815 t:4.7s
+tttg: c62/213 lr:0.000809 t:4.7s
+tttg: c63/213 lr:0.000803 t:4.8s
+tttg: c64/213 lr:0.000797 t:4.9s
+tttg: c65/213 lr:0.000791 t:5.0s
+tttg: c66/213 lr:0.000785 t:5.0s
+tttg: c67/213 lr:0.000779 t:5.1s
+tttg: c68/213 lr:0.000773 t:5.2s
+tttg: c69/213 lr:0.000767 t:5.3s
+tttg: c70/213 lr:0.000761 t:5.3s
+tttg: c71/213 lr:0.000754 t:5.4s
+tttg: c72/213 lr:0.000748 t:5.5s
+tttg: c73/213 lr:0.000741 t:5.6s
+tttg: c74/213 lr:0.000735 t:5.7s
+tttg: c75/213 lr:0.000728 t:5.7s
+tttg: c76/213 lr:0.000722 t:5.8s
+tttg: c77/213 lr:0.000715 t:5.9s
+tttg: c78/213 lr:0.000708 t:6.0s
+tttg: c79/213 lr:0.000702 t:6.0s
+tttg: c80/213 lr:0.000695 t:6.1s
+tttg: c81/213 lr:0.000688 t:6.2s
+tttg: c82/213 lr:0.000681 t:6.3s
+tttg: c83/213 lr:0.000674 t:6.3s
+tttg: c84/213 lr:0.000667 t:6.4s
+tttg: c85/213 lr:0.000660 t:6.5s
+tttg: c86/213 lr:0.000653 t:6.6s
+tttg: c87/213 lr:0.000646 t:6.6s
+tttg: c88/213 lr:0.000639 t:6.7s
+tttg: c89/213 lr:0.000632 t:6.8s
+tttg: c90/213 lr:0.000625 t:6.9s
+tttg: c91/213 lr:0.000617 t:6.9s
+tttg: c92/213 lr:0.000610 t:7.0s
+tttg: c93/213 lr:0.000603 t:7.1s
+tttg: c94/213 lr:0.000596 t:7.2s
+tttg: c95/213 lr:0.000588 t:7.2s
+tttg: c96/213 lr:0.000581 t:7.3s
+tttg: c97/213 lr:0.000574 t:7.4s
+tttg: c98/213 lr:0.000566 t:7.5s
+tttg: c99/213 lr:0.000559 t:7.5s
+tttg: c100/213 lr:0.000552 t:7.6s
+tttg: c101/213 lr:0.000544 t:7.7s
+tttg: c102/213 lr:0.000537 t:7.8s
+tttg: c103/213 lr:0.000530 t:7.9s
+tttg: c104/213 lr:0.000522 t:7.9s
+tttg: c105/213 lr:0.000515 t:8.0s
+tttg: c106/213 lr:0.000507 t:8.1s
+tttg: c107/213 lr:0.000500 t:8.2s
+tttg: c108/213 lr:0.000493 t:8.3s
+tttg: c109/213 lr:0.000485 t:8.3s
+tttg: c110/213 lr:0.000478 t:8.4s
+tttg: c111/213 lr:0.000470 t:8.5s
+tttg: c112/213 lr:0.000463 t:8.6s
+tttg: c113/213 lr:0.000456 t:8.7s
+tttg: c114/213 lr:0.000448 t:8.7s
+tttg: c115/213 lr:0.000441 t:8.8s
+tttg: c116/213 lr:0.000434 t:8.9s
+tttg: c117/213 lr:0.000426 t:9.0s
+tttg: c118/213 lr:0.000419 t:9.0s
+tttg: c119/213 lr:0.000412 t:9.1s
+tttg: c120/213 lr:0.000404 t:9.2s
+tttg: c121/213 lr:0.000397 t:9.3s
+tttg: c122/213 lr:0.000390 t:9.3s
+tttg: c123/213 lr:0.000383 t:9.4s
+tttg: c124/213 lr:0.000375 t:9.5s
+tttg: c125/213 lr:0.000368 t:9.6s
+tttg: c126/213 lr:0.000361 t:9.7s
+tttg: c127/213 lr:0.000354 t:9.7s
+tttg: c128/213 lr:0.000347 t:9.8s
+tttg: c129/213 lr:0.000340 t:9.9s
+tttg: c130/213 lr:0.000333 t:10.0s
+tttg: c131/213 lr:0.000326 t:10.0s
+tttg: c132/213 lr:0.000319 t:10.1s
+tttg: c133/213 lr:0.000312 t:10.2s
+tttg: c134/213 lr:0.000305 t:10.3s
+tttg: c135/213 lr:0.000298 t:10.3s
+tttg: c136/213 lr:0.000292 t:10.4s
+tttg: c137/213 lr:0.000285 t:10.5s
+tttg: c138/213 lr:0.000278 t:10.6s
+tttg: c139/213 lr:0.000272 t:10.6s
+tttg: c140/213 lr:0.000265 t:10.7s
+tttg: c141/213 lr:0.000259 t:10.8s
+tttg: c142/213 lr:0.000252 t:10.9s
+tttg: c143/213 lr:0.000246 t:11.0s
+tttg: c144/213 lr:0.000239 t:11.0s
+tttg: c145/213 lr:0.000233 t:11.1s
+tttg: c146/213 lr:0.000227 t:11.2s
+tttg: c147/213 lr:0.000221 t:11.3s
+tttg: c148/213 lr:0.000215 t:11.3s
+tttg: c149/213 lr:0.000209 t:11.4s
+tttg: c150/213 lr:0.000203 t:11.5s
+tttg: c151/213 lr:0.000197 t:11.6s
+tttg: c152/213 lr:0.000191 t:11.6s
+tttg: c153/213 lr:0.000185 t:11.7s
+tttg: c154/213 lr:0.000179 t:11.8s
+tttg: c155/213 lr:0.000174 t:11.9s
+tttg: c156/213 lr:0.000168 t:12.0s
+tttg: c157/213 lr:0.000163 t:12.0s
+tttg: c158/213 lr:0.000157 t:12.1s
+tttg: c159/213 lr:0.000152 t:12.2s
+tttg: c160/213 lr:0.000146 t:12.3s
+tttg: c161/213 lr:0.000141 t:12.4s
+tttg: c162/213 lr:0.000136 t:12.4s
+tttg: c163/213 lr:0.000131 t:12.5s
+tttg: c164/213 lr:0.000126 t:12.6s
+tttg: c165/213 lr:0.000121 t:12.7s
+tttg: c166/213 lr:0.000116 t:12.8s
+tttg: c167/213 lr:0.000112 t:12.8s
+tttg: c168/213 lr:0.000107 t:12.9s
+tttg: c169/213 lr:0.000103 t:13.0s
+tttg: c170/213 lr:0.000098 t:13.1s
+tttg: c171/213 lr:0.000094 t:13.1s
+tttg: c172/213 lr:0.000089 t:13.2s
+tttg: c173/213 lr:0.000085 t:13.3s
+tttg: c174/213 lr:0.000081 t:13.4s
+tttg: c175/213 lr:0.000077 t:13.4s
+tttg: c176/213 lr:0.000073 t:13.5s
+tttg: c177/213 lr:0.000069 t:13.6s
+tttg: c178/213 lr:0.000066 t:13.7s
+tttg: c179/213 lr:0.000062 t:13.7s
+tttg: c180/213 lr:0.000059 t:13.8s
+tttg: c181/213 lr:0.000055 t:13.9s
+tttg: c182/213 lr:0.000052 t:14.0s
+tttg: c183/213 lr:0.000049 t:14.1s
+tttg: c184/213 lr:0.000045 t:14.1s
+tttg: c185/213 lr:0.000042 t:14.2s
+tttg: c186/213 lr:0.000039 t:14.3s
+tttg: c187/213 lr:0.000037 t:14.4s
+tttg: c188/213 lr:0.000034 t:14.4s
+tttg: c189/213 lr:0.000031 t:14.5s
+tttg: c190/213 lr:0.000029 t:14.6s
+tttg: c191/213 lr:0.000026 t:14.7s
+tttg: c192/213 lr:0.000024 t:14.7s
+tttg: c193/213 lr:0.000022 t:14.8s
+tttg: c194/213 lr:0.000020 t:14.9s
+tttg: c195/213 lr:0.000018 t:15.0s
+tttg: c196/213 lr:0.000016 t:15.1s
+tttg: c197/213 lr:0.000014 t:15.1s
+tttg: c198/213 lr:0.000012 t:15.2s
+tttg: c199/213 lr:0.000011 t:15.3s
+tttg: c200/213 lr:0.000009 t:15.4s
+tttg: c201/213 lr:0.000008 t:15.4s
+tttg: c202/213 lr:0.000007 t:15.5s
+tttg: c203/213 lr:0.000005 t:15.6s
+tttg: c204/213 lr:0.000004 t:15.7s
+tttg: c205/213 lr:0.000004 t:15.7s
+tttg: c206/213 lr:0.000003 t:15.8s
+tttg: c207/213 lr:0.000002 t:15.9s
+tttg: c208/213 lr:0.000001 t:16.0s
+tttg: c209/213 lr:0.000001 t:16.1s
+tttg: c210/213 lr:0.000000 t:16.1s
+tttg: c211/213 lr:0.000000 t:16.2s
+tttg: c212/213 lr:0.000000 t:16.3s
+ttpr: phase:3/3 t:367.6s
+ttp: b736/782 bl:2.6707 bb:1.0410 rl:2.7125 rb:1.0659 dl:2140-2165 gd:1
+ttp: b734/782 bl:2.7686 bb:1.0557 rl:2.7166 rb:1.0651 dl:2091-2115 gd:1
+ttp: b722/782 bl:2.7667 bb:1.0578 rl:2.7196 rb:1.0647 dl:1846-1861 gd:1
+ttp: b720/782 bl:2.8176 bb:1.0762 rl:2.7251 rb:1.0653 dl:1816-1832 gd:1
+ttp: b706/782 bl:2.7141 bb:1.0434 rl:2.7246 rb:1.0643 dl:1617-1627 gd:1
+ttp: b704/782 bl:2.7402 bb:1.0220 rl:2.7253 rb:1.0623 dl:1595-1606 gd:1
+ttp: b692/782 bl:2.7626 bb:1.0482 rl:2.7267 rb:1.0617 dl:1477-1484 gd:1
+ttp: b687/782 bl:2.7108 bb:1.0468 rl:2.7261 rb:1.0612 dl:1432-1441 gd:1
+ttp: b682/782 bl:2.7980 bb:1.0688 rl:2.7286 rb:1.0614 dl:1393-1400 gd:1
+ttp: b669/782 bl:2.7739 bb:1.0519 rl:2.7301 rb:1.0611 dl:1301-1308 gd:1
+ttp: b662/782 bl:2.8068 bb:1.0710 rl:2.7323 rb:1.0614 dl:1258-1263 gd:1
+ttp: b655/782 bl:2.6729 bb:1.0167 rl:2.7307 rb:1.0602 dl:1215-1220 gd:1
+ttp: b648/782 bl:2.7444 bb:1.0403 rl:2.7310 rb:1.0596 dl:1177-1182 gd:1
+ttp: b641/782 bl:2.7628 bb:1.0402 rl:2.7318 rb:1.0591 dl:1140-1144 gd:1
+ttp: b632/782 bl:2.7283 bb:1.0248 rl:2.7317 rb:1.0583 dl:1096-1101 gd:1
+ttp: b627/782 bl:2.7312 bb:1.0338 rl:2.7317 rb:1.0578 dl:1073-1077 gd:1
+ttp: b617/782 bl:2.7380 bb:1.0363 rl:2.7319 rb:1.0573 dl:1027-1031 gd:1
+ttp: b609/782 bl:2.7836 bb:1.0567 rl:2.7329 rb:1.0573 dl:994-999 gd:1
+ttp: b603/782 bl:2.8273 bb:1.0830 rl:2.7347 rb:1.0578 dl:971-974 gd:1
+ttp: b592/782 bl:2.7748 bb:1.0447 rl:2.7354 rb:1.0575 dl:930-933 gd:1
+ttp: b584/782 bl:2.7594 bb:1.0367 rl:2.7358 rb:1.0572 dl:904-907 gd:1
+ttp: b579/782 bl:2.6312 bb:1.0028 rl:2.7341 rb:1.0563 dl:888-891 gd:1
+ttp: b571/782 bl:2.7061 bb:1.0322 rl:2.7336 rb:1.0559 dl:862-865 gd:1
+ttp: b565/782 bl:2.7663 bb:1.0600 rl:2.7341 rb:1.0560 dl:843-846 gd:1
+ttp: b555/782 bl:2.7596 bb:1.0532 rl:2.7345 rb:1.0559 dl:812-815 gd:1
+ttp: b550/782 bl:2.8039 bb:1.0758 rl:2.7354 rb:1.0562 dl:798-801 gd:1
+ttp: b542/782 bl:2.8276 bb:1.0711 rl:2.7367 rb:1.0564 dl:777-779 gd:1
+ttp: b533/782 bl:2.7626 bb:1.0319 rl:2.7370 rb:1.0561 dl:754-757 gd:1
+ttp: b525/782 bl:2.7737 bb:1.0671 rl:2.7375 rb:1.0562 dl:735-737 gd:1
+ttp: b518/782 bl:2.7293 bb:1.0512 rl:2.7374 rb:1.0562 dl:717-720 gd:1
+ttp: b515/782 bl:2.7812 bb:1.0720 rl:2.7379 rb:1.0563 dl:710-713 gd:1
+ttp: b507/782 bl:2.7548 bb:1.0399 rl:2.7381 rb:1.0562 dl:690-693 gd:1
+ttp: b498/782 bl:2.6709 bb:1.0340 rl:2.7373 rb:1.0559 dl:671-673 gd:1
+ttp: b489/782 bl:2.7929 bb:1.0799 rl:2.7379 rb:1.0562 dl:651-653 gd:1
+ttp: b481/782 bl:2.7914 bb:1.0975 rl:2.7384 rb:1.0566 dl:635-637 gd:1
+ttp: b473/782 bl:2.8254 bb:1.0750 rl:2.7393 rb:1.0567 dl:618-620 gd:1
+ttp: b463/782 bl:2.7950 bb:1.0729 rl:2.7398 rb:1.0569 dl:599-600 gd:1
+ttp: b455/782 bl:2.7948 bb:1.0718 rl:2.7403 rb:1.0570 dl:584-586 gd:1
+ttp: b447/782 bl:2.8277 bb:1.0874 rl:2.7410 rb:1.0573 dl:569-571 gd:1
+ttp: b439/782 bl:2.7490 bb:1.0419 rl:2.7411 rb:1.0572 dl:555-556 gd:1
+ttp: b429/782 bl:2.7489 bb:1.0788 rl:2.7412 rb:1.0573 dl:537-539 gd:1
+ttp: b421/782 bl:2.7854 bb:1.0507 rl:2.7415 rb:1.0573 dl:523-524 gd:1
+ttp: b416/782 bl:2.7559 bb:1.0344 rl:2.7416 rb:1.0571 dl:514-516 gd:1
+ttp: b408/782 bl:2.8283 bb:1.0818 rl:2.7422 rb:1.0573 dl:501-503 gd:1
+ttp: b398/782 bl:2.8770 bb:1.0927 rl:2.7432 rb:1.0575 dl:486-487 gd:1
+ttp: b389/782 bl:2.7808 bb:1.0592 rl:2.7434 rb:1.0575 dl:471-473 gd:1
+ttp: b381/782 bl:2.8974 bb:1.0880 rl:2.7444 rb:1.0577 dl:460-461 gd:1
+ttp: b373/782 bl:2.7597 bb:1.0772 rl:2.7445 rb:1.0579 dl:449-450 gd:1
+ttp: b365/782 bl:2.7724 bb:1.0805 rl:2.7447 rb:1.0580 dl:437-439 gd:1
+ttp: b357/782 bl:2.8568 bb:1.0809 rl:2.7454 rb:1.0581 dl:426-427 gd:1
+ttp: b349/782 bl:2.9168 bb:1.1083 rl:2.7464 rb:1.0584 dl:415-417 gd:1
+ttp: b341/782 bl:2.8627 bb:1.0959 rl:2.7470 rb:1.0586 dl:404-406 gd:1
+ttp: b333/782 bl:2.9047 bb:1.1313 rl:2.7479 rb:1.0590 dl:394-395 gd:1
+ttp: b324/782 bl:2.7673 bb:1.0555 rl:2.7480 rb:1.0590 dl:382-384 gd:1
+ttp: b317/782 bl:2.8636 bb:1.1070 rl:2.7485 rb:1.0593 dl:373-374 gd:1
+ttp: b309/782 bl:2.8298 bb:1.1040 rl:2.7489 rb:1.0595 dl:363-364 gd:1
+ttp: b301/782 bl:2.7817 bb:1.0817 rl:2.7491 rb:1.0596 dl:353-354 gd:1
+ttp: b292/782 bl:2.7837 bb:1.0786 rl:2.7493 rb:1.0597 dl:342-343 gd:1
+ttp: b284/782 bl:2.8836 bb:1.0871 rl:2.7499 rb:1.0598 dl:333-334 gd:1
+ttp: b276/782 bl:2.8300 bb:1.0969 rl:2.7502 rb:1.0600 dl:324-325 gd:1
+ttp: b268/782 bl:2.8525 bb:1.0967 rl:2.7506 rb:1.0601 dl:315-316 gd:1
+ttp: b260/782 bl:2.8174 bb:1.0990 rl:2.7509 rb:1.0603 dl:306-307 gd:1
+ttp: b252/782 bl:2.8898 bb:1.1260 rl:2.7514 rb:1.0605 dl:297-298 gd:1
+ttp: b244/782 bl:2.9379 bb:1.1523 rl:2.7521 rb:1.0609 dl:289-290 gd:1
+ttp: b236/782 bl:2.8402 bb:1.1039 rl:2.7525 rb:1.0610 dl:281-282 gd:1
+ttp: b228/782 bl:2.8631 bb:1.1330 rl:2.7529 rb:1.0613 dl:273-274 gd:1
+ttp: b220/782 bl:2.8556 bb:1.1051 rl:2.7532 rb:1.0614 dl:265-266 gd:1
+ttp: b212/782 bl:2.9229 bb:1.1440 rl:2.7538 rb:1.0617 dl:257-258 gd:1
+ttp: b204/782 bl:2.9059 bb:1.1304 rl:2.7543 rb:1.0619 dl:250-251 gd:1
+ttp: b196/782 bl:2.9016 bb:1.1626 rl:2.7547 rb:1.0622 dl:243-244 gd:1
+ttp: b187/782 bl:2.9094 bb:1.1218 rl:2.7552 rb:1.0624 dl:235-236 gd:1
+ttp: b178/782 bl:2.8657 bb:1.1429 rl:2.7555 rb:1.0626 dl:227-228 gd:1
+ttp: b169/782 bl:2.9050 bb:1.1607 rl:2.7559 rb:1.0629 dl:219-220 gd:1
+ttp: b159/782 bl:2.9886 bb:1.1774 rl:2.7565 rb:1.0632 dl:211-212 gd:1
+ttp: b151/782 bl:2.8034 bb:1.1048 rl:2.7566 rb:1.0633 dl:204-205 gd:1
+ttp: b142/782 bl:2.9640 bb:1.1620 rl:2.7572 rb:1.0635 dl:197-198 gd:1
+ttp: b134/782 bl:3.0215 bb:1.2085 rl:2.7578 rb:1.0638 dl:190-191 gd:1
+ttp: b125/782 bl:3.0089 bb:1.1924 rl:2.7584 rb:1.0641 dl:184-185 gd:1
+ttp: b116/782 bl:3.0081 bb:1.1895 rl:2.7589 rb:1.0644 dl:177-178 gd:1
+ttp: b110/782 bl:3.0164 bb:1.1712 rl:2.7595 rb:1.0646 dl:173-173 gd:1
+ttp: b101/782 bl:2.9721 bb:1.1665 rl:2.7599 rb:1.0648 dl:166-167 gd:1
+ttp: b92/782 bl:2.8899 bb:1.1688 rl:2.7602 rb:1.0650 dl:159-160 gd:1
+ttp: b84/782 bl:3.0230 bb:1.2180 rl:2.7607 rb:1.0653 dl:153-154 gd:1
+ttp: b76/782 bl:3.0473 bb:1.2226 rl:2.7612 rb:1.0656 dl:147-148 gd:1
+ttp: b68/782 bl:3.0985 bb:1.2038 rl:2.7618 rb:1.0658 dl:141-142 gd:1
+ttp: b61/782 bl:2.9206 bb:1.1418 rl:2.7620 rb:1.0659 dl:135-136 gd:1
+ttp: b52/782 bl:3.0510 bb:1.1938 rl:2.7625 rb:1.0661 dl:128-129 gd:1
+ttp: b44/782 bl:3.1272 bb:1.2186 rl:2.7630 rb:1.0664 dl:122-122 gd:1
+ttp: b34/782 bl:3.0783 bb:1.2462 rl:2.7635 rb:1.0666 dl:114-115 gd:1
+ttp: b27/782 bl:3.0947 bb:1.2354 rl:2.7639 rb:1.0668 dl:107-108 gd:1
+ttp: b14/782 bl:3.1388 bb:1.2345 rl:2.7643 rb:1.0670 dl:94-95 gd:1
+ttp: b10/782 bl:3.1366 bb:1.2394 rl:2.7647 rb:1.0672 dl:89-90 gd:1
+ttp: b2/782 bl:3.1516 bb:1.1689 rl:2.7651 rb:1.0673 dl:70-75 gd:1
+quantized_ttt_phased val_loss:2.76916735 val_bpb:1.07203098 eval_time:458760ms
+total_eval_time:458.8s
+[Tue Apr 21 21:20:47 UTC 2026] Experiment pure_ttt_sp8192_dxwarmwd_seed314_8gpu complete
+Final BPB: diagnostic pre-quantization post-ema val_loss:2.77043120 val_bpb:1.07248569 eval_time:6581ms
+diagnostic quantized val_loss:2.80111149 val_bpb:1.08436260 eval_time:57830ms
+quantized_ttt_phased val_loss:2.76916735 val_bpb:1.07203098 eval_time:458760ms

--- a/records/track_10min_16mb/2026-04-21_AlphaLoRA_WarmStart_HighWD_1.07266/train_seed42.log
+++ b/records/track_10min_16mb/2026-04-21_AlphaLoRA_WarmStart_HighWD_1.07266/train_seed42.log
@@ -1,0 +1,757 @@
+[Tue Apr 21 21:38:14 UTC 2026] Starting SP8192 dexhunter experiment: pure_ttt_sp8192_dxwarmwd_seed42_8gpu
+Extra args: SEED=42 PHASED_TTT_ENABLED=1 PHASED_TTT_PREFIX_DOCS=2000 PHASED_TTT_NUM_PHASES=3 MLP_CLIP_SIGMAS=12.0 ATTN_CLIP_SIGMAS=13.0 EMBED_BITS=7 EMBED_CLIP_SIGMAS=15.0 MATRIX_LR=0.026 GPTQ_RESERVE_SECONDS=4 GPTQ_CALIBRATION_BATCHES=16 TTT_LORA_RANK=128 TTT_LORA_ALPHA=96 TTT_WARM_START_A=1 TTT_WEIGHT_DECAY=1.0
+torch: 2.9.1+cu128
+FA3 interface: OK
+[Tue Apr 21 21:38:18 UTC 2026] GPU check:
+0, 1 MiB, 0 %
+1, 1 MiB, 0 %
+2, 1 MiB, 0 %
+3, 1 MiB, 0 %
+4, 1 MiB, 0 %
+5, 1 MiB, 0 %
+6, 1 MiB, 0 %
+7, 1 MiB, 0 %
+W0421 21:38:20.054000 112 torch/distributed/run.py:803] 
+W0421 21:38:20.054000 112 torch/distributed/run.py:803] *****************************************
+W0421 21:38:20.054000 112 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0421 21:38:20.054000 112 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  artifact_dir: 
+  attn_clip_sigmas: 13.0
+  beta1: 0.9
+  beta2: 0.95
+  compressor: brotli
+  data_dir: DATA_DIR
+  datasets_dir: DATA_DIR/datasets/fineweb10B_sp8192
+  distributed: True
+  ema_decay: 0.9965
+  embed_bits: 7
+  embed_clip_sigmas: 15.0
+  embed_lr: 0.6
+  embed_wd: 0.085
+  enable_looping_at: 0.35
+  eval_seq_len: 2048
+  eval_stride: 64
+  global_ttt_batch_seqs: 32
+  global_ttt_chunk_tokens: 32768
+  global_ttt_epochs: 1
+  global_ttt_grad_clip: 1.0
+  global_ttt_lr: 0.001
+  global_ttt_momentum: 0.9
+  global_ttt_respect_doc_boundaries: True
+  global_ttt_warmup_chunks: 0
+  global_ttt_warmup_start_lr: 0.0
+  gptq_calibration_batches: 16
+  gptq_reserve_seconds: 4.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  is_main_process: True
+  iterations: 20000
+  ln_scale: True
+  local_rank: 0
+  logfile: logs/3c4cb48a-46cc-41ff-a10e-50a50f2924f5.txt
+  logit_softcap: 30.0
+  loop_end: 5
+  loop_start: 3
+  matrix_bits: 6
+  matrix_clip_sigmas: 12.85
+  matrix_lr: 0.026
+  max_wallclock_seconds: 600.0
+  min_lr: 0.0
+  mlp_clip_sigmas: 12.0
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: final_model.pt
+  muon_backend_steps: 5
+  muon_momentum: 0.97
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_row_normalize: True
+  muon_wd: 0.095
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  num_loops: 2
+  parallel_final_lane: mean
+  parallel_start_layer: 8
+  phased_ttt_enabled: True
+  phased_ttt_num_phases: 3
+  phased_ttt_prefix_docs: 2000
+  qk_gain_init: 5.0
+  quantized_model_path: final_model.int6.ptz
+  rank: 0
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  rope_yarn: False
+  run_id: 3c4cb48a-46cc-41ff-a10e-50a50f2924f5
+  scalar_lr: 0.02
+  seed: 42
+  skip_gates_enabled: True
+  sliding_window_enabled: False
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  tokenizer_path: DATA_DIR/tokenizers/fineweb_8192_bpe.model
+  train_batch_tokens: 786432
+  train_files: DATA_DIR/datasets/fineweb10B_sp8192/fineweb_train_*.bin
+  train_log_every: 500
+  train_seq_len: 2048
+  ttt_batch_size: 64
+  ttt_beta1: 0.0
+  ttt_beta2: 0.999
+  ttt_chunk_size: 48
+  ttt_enabled: True
+  ttt_eval_batches: 
+  ttt_eval_seq_len: 2048
+  ttt_grad_steps: 1
+  ttt_k_lora: True
+  ttt_lora_lr: 0.0001
+  ttt_lora_rank: 128
+  ttt_mlp_lora: True
+  ttt_o_lora: True
+  ttt_optimizer: adam
+  ttt_weight_decay: 1.0
+  val_batch_tokens: 524288
+  val_doc_fraction: 1.0
+  val_files: DATA_DIR/datasets/fineweb10B_sp8192/fineweb_val_*.bin
+  val_loss_every: 4000
+  vocab_size: 8192
+  warmdown_frac: 0.75
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+train_shards: 80
+val_tokens: 40540160
+model_params:35944602
+gptq:reserving 4s, effective=596000ms
+warmup_cu_buckets:64,128,192,256 iters_each:3
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup:enabled encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+loop_warmup_step: 1/20
+loop_warmup_step: 2/20
+loop_warmup_step: 3/20
+loop_warmup_step: 4/20
+loop_warmup_step: 5/20
+loop_warmup_step: 6/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+0/20000 val_loss: 9.0078 val_bpb: 3.4871
+1/20000 train_loss: 9.0072 train_time: 0.0m tok/s: 16194716
+2/20000 train_loss: 12.3312 train_time: 0.0m tok/s: 12627845
+3/20000 train_loss: 11.2822 train_time: 0.0m tok/s: 10861972
+4/20000 train_loss: 9.6150 train_time: 0.0m tok/s: 10018959
+5/20000 train_loss: 8.2173 train_time: 0.0m tok/s: 9633184
+500/20000 train_loss: 3.2696 train_time: 0.8m tok/s: 8289973
+1000/20000 train_loss: 3.0293 train_time: 1.6m tok/s: 8261095
+1500/20000 train_loss: 3.0366 train_time: 2.4m tok/s: 8260808
+2000/20000 train_loss: 2.9900 train_time: 3.2m tok/s: 8265540
+layer_loop:enabled step:2191 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2500/20000 train_loss: 3.0790 train_time: 4.2m tok/s: 7815259
+3000/20000 train_loss: 2.9118 train_time: 5.4m tok/s: 7348003
+3500/20000 train_loss: 2.9879 train_time: 6.5m tok/s: 7048284
+4000/20000 train_loss: 2.9175 train_time: 7.7m tok/s: 6841405
+4000/20000 val_loss: 2.8917 val_bpb: 1.1194
+4500/20000 train_loss: 2.8689 train_time: 8.8m tok/s: 6691223
+4960/20000 val_loss: 2.7726 val_bpb: 1.0733
+stopping_early: wallclock_cap train_time: 596188ms step: 4960/20000
+peak memory allocated: 40029 MiB reserved: 44036 MiB
+ema:applying EMA weights
+diagnostic pre-quantization post-ema val_loss:2.77133954 val_bpb:1.07283732 eval_time:8726ms
+Serialized model: 135409136 bytes
+Code size (uncompressed): 122655 bytes
+Code size (compressed): 27680 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 3.5s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int7): tok_emb.weight
+  passthrough (float16): blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, skip_gates, skip_weights
+Serialized model quantized+brotli: 15905612 bytes
+Total submission size quantized+brotli: 15933292 bytes
+diagnostic quantized val_loss:2.80171217 val_bpb:1.08459514 eval_time:58133ms
+ttt_lora:warming up compile (random tokens, no val data)
+ttt_lora:compile warmup done (159.3s)
+
+beginning TTT eval timer
+ttt_phased: total_docs:50000 prefix_docs:2000 suffix_docs:48000 num_phases:3 boundaries:[666, 1333, 2000]
+ttp: b779/782 bl:2.6519 bb:1.0802 rl:2.6519 rb:1.0802 dl:9037-11049 gd:0
+ttp: b770/782 bl:2.6618 bb:1.0533 rl:2.6551 rb:1.0715 dl:4479-4698 gd:0
+ttpp: phase:1/3 pd:1104 gd:666 t:197.7s
+tttg: c1/95 lr:0.001000 t:1.7s
+tttg: c2/95 lr:0.001000 t:1.8s
+tttg: c3/95 lr:0.000999 t:1.9s
+tttg: c4/95 lr:0.000997 t:1.9s
+tttg: c5/95 lr:0.000996 t:2.0s
+tttg: c6/95 lr:0.000993 t:2.1s
+tttg: c7/95 lr:0.000990 t:2.1s
+tttg: c8/95 lr:0.000986 t:2.2s
+tttg: c9/95 lr:0.000982 t:2.3s
+tttg: c10/95 lr:0.000978 t:2.4s
+tttg: c11/95 lr:0.000972 t:2.4s
+tttg: c12/95 lr:0.000967 t:2.5s
+tttg: c13/95 lr:0.000960 t:2.6s
+tttg: c14/95 lr:0.000954 t:2.6s
+tttg: c15/95 lr:0.000946 t:2.7s
+tttg: c16/95 lr:0.000938 t:2.8s
+tttg: c17/95 lr:0.000930 t:2.8s
+tttg: c18/95 lr:0.000921 t:2.9s
+tttg: c19/95 lr:0.000912 t:3.0s
+tttg: c20/95 lr:0.000903 t:3.1s
+tttg: c21/95 lr:0.000892 t:3.1s
+tttg: c22/95 lr:0.000882 t:3.2s
+tttg: c23/95 lr:0.000871 t:3.3s
+tttg: c24/95 lr:0.000859 t:3.3s
+tttg: c25/95 lr:0.000848 t:3.4s
+tttg: c26/95 lr:0.000835 t:3.5s
+tttg: c27/95 lr:0.000823 t:3.6s
+tttg: c28/95 lr:0.000810 t:3.6s
+tttg: c29/95 lr:0.000797 t:3.7s
+tttg: c30/95 lr:0.000783 t:3.8s
+tttg: c31/95 lr:0.000769 t:3.9s
+tttg: c32/95 lr:0.000755 t:3.9s
+tttg: c33/95 lr:0.000740 t:4.0s
+tttg: c34/95 lr:0.000726 t:4.1s
+tttg: c35/95 lr:0.000710 t:4.1s
+tttg: c36/95 lr:0.000695 t:4.2s
+tttg: c37/95 lr:0.000680 t:4.3s
+tttg: c38/95 lr:0.000664 t:4.3s
+tttg: c39/95 lr:0.000648 t:4.4s
+tttg: c40/95 lr:0.000632 t:4.5s
+tttg: c41/95 lr:0.000616 t:4.6s
+tttg: c42/95 lr:0.000600 t:4.6s
+tttg: c43/95 lr:0.000583 t:4.7s
+tttg: c44/95 lr:0.000567 t:4.8s
+tttg: c45/95 lr:0.000550 t:4.8s
+tttg: c46/95 lr:0.000533 t:4.9s
+tttg: c47/95 lr:0.000517 t:5.0s
+tttg: c48/95 lr:0.000500 t:5.1s
+tttg: c49/95 lr:0.000483 t:5.1s
+tttg: c50/95 lr:0.000467 t:5.2s
+tttg: c51/95 lr:0.000450 t:5.3s
+tttg: c52/95 lr:0.000433 t:5.3s
+tttg: c53/95 lr:0.000417 t:5.4s
+tttg: c54/95 lr:0.000400 t:5.5s
+tttg: c55/95 lr:0.000384 t:5.6s
+tttg: c56/95 lr:0.000368 t:5.6s
+tttg: c57/95 lr:0.000352 t:5.7s
+tttg: c58/95 lr:0.000336 t:5.8s
+tttg: c59/95 lr:0.000320 t:5.9s
+tttg: c60/95 lr:0.000305 t:5.9s
+tttg: c61/95 lr:0.000290 t:6.0s
+tttg: c62/95 lr:0.000274 t:6.1s
+tttg: c63/95 lr:0.000260 t:6.1s
+tttg: c64/95 lr:0.000245 t:6.2s
+tttg: c65/95 lr:0.000231 t:6.3s
+tttg: c66/95 lr:0.000217 t:6.3s
+tttg: c67/95 lr:0.000203 t:6.4s
+tttg: c68/95 lr:0.000190 t:6.5s
+tttg: c69/95 lr:0.000177 t:6.5s
+tttg: c70/95 lr:0.000165 t:6.6s
+tttg: c71/95 lr:0.000152 t:6.7s
+tttg: c72/95 lr:0.000141 t:6.8s
+tttg: c73/95 lr:0.000129 t:6.9s
+tttg: c74/95 lr:0.000118 t:6.9s
+tttg: c75/95 lr:0.000108 t:7.0s
+tttg: c76/95 lr:0.000097 t:7.1s
+tttg: c77/95 lr:0.000088 t:7.1s
+tttg: c78/95 lr:0.000079 t:7.2s
+tttg: c79/95 lr:0.000070 t:7.3s
+tttg: c80/95 lr:0.000062 t:7.4s
+tttg: c81/95 lr:0.000054 t:7.4s
+tttg: c82/95 lr:0.000046 t:7.5s
+tttg: c83/95 lr:0.000040 t:7.6s
+tttg: c84/95 lr:0.000033 t:7.6s
+tttg: c85/95 lr:0.000028 t:7.7s
+tttg: c86/95 lr:0.000022 t:7.8s
+tttg: c87/95 lr:0.000018 t:7.9s
+tttg: c88/95 lr:0.000014 t:7.9s
+tttg: c89/95 lr:0.000010 t:8.0s
+tttg: c90/95 lr:0.000007 t:8.1s
+tttg: c91/95 lr:0.000004 t:8.1s
+tttg: c92/95 lr:0.000003 t:8.2s
+tttg: c93/95 lr:0.000001 t:8.3s
+tttg: c94/95 lr:0.000000 t:8.4s
+ttpr: phase:1/3 t:208.7s
+ttp: b757/782 bl:2.6380 bb:1.0195 rl:2.6521 rb:1.0621 dl:3033-3108 gd:0
+ttp: b756/782 bl:2.7825 bb:1.0785 rl:2.6711 rb:1.0645 dl:2973-3032 gd:0
+ttpp: phase:2/3 pd:1808 gd:1333 t:318.5s
+tttg: c1/158 lr:0.001000 t:0.1s
+tttg: c2/158 lr:0.001000 t:0.1s
+tttg: c3/158 lr:0.001000 t:0.2s
+tttg: c4/158 lr:0.000999 t:0.3s
+tttg: c5/158 lr:0.000998 t:0.4s
+tttg: c6/158 lr:0.000997 t:0.4s
+tttg: c7/158 lr:0.000996 t:0.5s
+tttg: c8/158 lr:0.000995 t:0.6s
+tttg: c9/158 lr:0.000994 t:0.7s
+tttg: c10/158 lr:0.000992 t:0.7s
+tttg: c11/158 lr:0.000990 t:0.8s
+tttg: c12/158 lr:0.000988 t:0.9s
+tttg: c13/158 lr:0.000986 t:0.9s
+tttg: c14/158 lr:0.000983 t:1.0s
+tttg: c15/158 lr:0.000981 t:1.1s
+tttg: c16/158 lr:0.000978 t:1.2s
+tttg: c17/158 lr:0.000975 t:1.2s
+tttg: c18/158 lr:0.000971 t:1.3s
+tttg: c19/158 lr:0.000968 t:1.4s
+tttg: c20/158 lr:0.000964 t:1.4s
+tttg: c21/158 lr:0.000960 t:1.5s
+tttg: c22/158 lr:0.000957 t:1.6s
+tttg: c23/158 lr:0.000952 t:1.7s
+tttg: c24/158 lr:0.000948 t:1.7s
+tttg: c25/158 lr:0.000943 t:1.8s
+tttg: c26/158 lr:0.000939 t:1.9s
+tttg: c27/158 lr:0.000934 t:2.0s
+tttg: c28/158 lr:0.000929 t:2.0s
+tttg: c29/158 lr:0.000924 t:2.1s
+tttg: c30/158 lr:0.000918 t:2.2s
+tttg: c31/158 lr:0.000913 t:2.2s
+tttg: c32/158 lr:0.000907 t:2.3s
+tttg: c33/158 lr:0.000901 t:2.4s
+tttg: c34/158 lr:0.000895 t:2.5s
+tttg: c35/158 lr:0.000889 t:2.6s
+tttg: c36/158 lr:0.000882 t:2.6s
+tttg: c37/158 lr:0.000876 t:2.7s
+tttg: c38/158 lr:0.000869 t:2.8s
+tttg: c39/158 lr:0.000862 t:2.8s
+tttg: c40/158 lr:0.000855 t:2.9s
+tttg: c41/158 lr:0.000848 t:3.0s
+tttg: c42/158 lr:0.000841 t:3.1s
+tttg: c43/158 lr:0.000834 t:3.1s
+tttg: c44/158 lr:0.000826 t:3.2s
+tttg: c45/158 lr:0.000818 t:3.3s
+tttg: c46/158 lr:0.000811 t:3.4s
+tttg: c47/158 lr:0.000803 t:3.4s
+tttg: c48/158 lr:0.000795 t:3.5s
+tttg: c49/158 lr:0.000787 t:3.6s
+tttg: c50/158 lr:0.000778 t:3.6s
+tttg: c51/158 lr:0.000770 t:3.7s
+tttg: c52/158 lr:0.000761 t:3.8s
+tttg: c53/158 lr:0.000753 t:3.9s
+tttg: c54/158 lr:0.000744 t:3.9s
+tttg: c55/158 lr:0.000735 t:4.0s
+tttg: c56/158 lr:0.000727 t:4.1s
+tttg: c57/158 lr:0.000718 t:4.2s
+tttg: c58/158 lr:0.000709 t:4.2s
+tttg: c59/158 lr:0.000699 t:4.3s
+tttg: c60/158 lr:0.000690 t:4.4s
+tttg: c61/158 lr:0.000681 t:4.4s
+tttg: c62/158 lr:0.000672 t:4.5s
+tttg: c63/158 lr:0.000662 t:4.6s
+tttg: c64/158 lr:0.000653 t:4.7s
+tttg: c65/158 lr:0.000643 t:4.7s
+tttg: c66/158 lr:0.000633 t:4.8s
+tttg: c67/158 lr:0.000624 t:4.9s
+tttg: c68/158 lr:0.000614 t:4.9s
+tttg: c69/158 lr:0.000604 t:5.0s
+tttg: c70/158 lr:0.000594 t:5.1s
+tttg: c71/158 lr:0.000585 t:5.2s
+tttg: c72/158 lr:0.000575 t:5.2s
+tttg: c73/158 lr:0.000565 t:5.3s
+tttg: c74/158 lr:0.000555 t:5.4s
+tttg: c75/158 lr:0.000545 t:5.5s
+tttg: c76/158 lr:0.000535 t:5.5s
+tttg: c77/158 lr:0.000525 t:5.6s
+tttg: c78/158 lr:0.000515 t:5.7s
+tttg: c79/158 lr:0.000505 t:5.8s
+tttg: c80/158 lr:0.000495 t:5.8s
+tttg: c81/158 lr:0.000485 t:5.9s
+tttg: c82/158 lr:0.000475 t:6.0s
+tttg: c83/158 lr:0.000465 t:6.0s
+tttg: c84/158 lr:0.000455 t:6.1s
+tttg: c85/158 lr:0.000445 t:6.2s
+tttg: c86/158 lr:0.000435 t:6.3s
+tttg: c87/158 lr:0.000425 t:6.3s
+tttg: c88/158 lr:0.000415 t:6.4s
+tttg: c89/158 lr:0.000406 t:6.5s
+tttg: c90/158 lr:0.000396 t:6.5s
+tttg: c91/158 lr:0.000386 t:6.6s
+tttg: c92/158 lr:0.000376 t:6.7s
+tttg: c93/158 lr:0.000367 t:6.8s
+tttg: c94/158 lr:0.000357 t:6.8s
+tttg: c95/158 lr:0.000347 t:6.9s
+tttg: c96/158 lr:0.000338 t:7.0s
+tttg: c97/158 lr:0.000328 t:7.1s
+tttg: c98/158 lr:0.000319 t:7.1s
+tttg: c99/158 lr:0.000310 t:7.2s
+tttg: c100/158 lr:0.000301 t:7.3s
+tttg: c101/158 lr:0.000291 t:7.3s
+tttg: c102/158 lr:0.000282 t:7.4s
+tttg: c103/158 lr:0.000273 t:7.5s
+tttg: c104/158 lr:0.000265 t:7.6s
+tttg: c105/158 lr:0.000256 t:7.6s
+tttg: c106/158 lr:0.000247 t:7.7s
+tttg: c107/158 lr:0.000239 t:7.8s
+tttg: c108/158 lr:0.000230 t:7.9s
+tttg: c109/158 lr:0.000222 t:8.0s
+tttg: c110/158 lr:0.000213 t:8.1s
+tttg: c111/158 lr:0.000205 t:8.1s
+tttg: c112/158 lr:0.000197 t:8.2s
+tttg: c113/158 lr:0.000189 t:8.3s
+tttg: c114/158 lr:0.000182 t:8.4s
+tttg: c115/158 lr:0.000174 t:8.4s
+tttg: c116/158 lr:0.000166 t:8.5s
+tttg: c117/158 lr:0.000159 t:8.6s
+tttg: c118/158 lr:0.000152 t:8.7s
+tttg: c119/158 lr:0.000145 t:8.7s
+tttg: c120/158 lr:0.000138 t:8.8s
+tttg: c121/158 lr:0.000131 t:8.9s
+tttg: c122/158 lr:0.000124 t:8.9s
+tttg: c123/158 lr:0.000118 t:9.0s
+tttg: c124/158 lr:0.000111 t:9.1s
+tttg: c125/158 lr:0.000105 t:9.2s
+tttg: c126/158 lr:0.000099 t:9.2s
+tttg: c127/158 lr:0.000093 t:9.3s
+tttg: c128/158 lr:0.000087 t:9.4s
+tttg: c129/158 lr:0.000082 t:9.5s
+tttg: c130/158 lr:0.000076 t:9.5s
+tttg: c131/158 lr:0.000071 t:9.6s
+tttg: c132/158 lr:0.000066 t:9.7s
+tttg: c133/158 lr:0.000061 t:9.7s
+tttg: c134/158 lr:0.000057 t:9.8s
+tttg: c135/158 lr:0.000052 t:9.9s
+tttg: c136/158 lr:0.000048 t:10.0s
+tttg: c137/158 lr:0.000043 t:10.0s
+tttg: c138/158 lr:0.000040 t:10.1s
+tttg: c139/158 lr:0.000036 t:10.2s
+tttg: c140/158 lr:0.000032 t:10.3s
+tttg: c141/158 lr:0.000029 t:10.3s
+tttg: c142/158 lr:0.000025 t:10.4s
+tttg: c143/158 lr:0.000022 t:10.5s
+tttg: c144/158 lr:0.000019 t:10.6s
+tttg: c145/158 lr:0.000017 t:10.6s
+tttg: c146/158 lr:0.000014 t:10.7s
+tttg: c147/158 lr:0.000012 t:10.8s
+tttg: c148/158 lr:0.000010 t:10.8s
+tttg: c149/158 lr:0.000008 t:10.9s
+tttg: c150/158 lr:0.000006 t:11.0s
+tttg: c151/158 lr:0.000005 t:11.1s
+tttg: c152/158 lr:0.000004 t:11.1s
+tttg: c153/158 lr:0.000003 t:11.2s
+tttg: c154/158 lr:0.000002 t:11.3s
+tttg: c155/158 lr:0.000001 t:11.3s
+tttg: c156/158 lr:0.000000 t:11.4s
+tttg: c157/158 lr:0.000000 t:11.5s
+ttpr: phase:2/3 t:332.6s
+ttp: b746/782 bl:2.6779 bb:1.0544 rl:2.6718 rb:1.0634 dl:2459-2501 gd:0
+ttp: b744/782 bl:2.6548 bb:1.0577 rl:2.6702 rb:1.0629 dl:2388-2419 gd:0
+ttpp: phase:3/3 pd:2448 gd:2000 t:346.4s
+tttg: c1/213 lr:0.001000 t:0.1s
+tttg: c2/213 lr:0.001000 t:0.1s
+tttg: c3/213 lr:0.001000 t:0.2s
+tttg: c4/213 lr:0.001000 t:0.3s
+tttg: c5/213 lr:0.000999 t:0.4s
+tttg: c6/213 lr:0.000999 t:0.4s
+tttg: c7/213 lr:0.000998 t:0.5s
+tttg: c8/213 lr:0.000997 t:0.6s
+tttg: c9/213 lr:0.000996 t:0.6s
+tttg: c10/213 lr:0.000996 t:0.7s
+tttg: c11/213 lr:0.000995 t:0.8s
+tttg: c12/213 lr:0.000993 t:0.9s
+tttg: c13/213 lr:0.000992 t:0.9s
+tttg: c14/213 lr:0.000991 t:1.0s
+tttg: c15/213 lr:0.000989 t:1.1s
+tttg: c16/213 lr:0.000988 t:1.2s
+tttg: c17/213 lr:0.000986 t:1.2s
+tttg: c18/213 lr:0.000984 t:1.3s
+tttg: c19/213 lr:0.000982 t:1.4s
+tttg: c20/213 lr:0.000980 t:1.4s
+tttg: c21/213 lr:0.000978 t:1.5s
+tttg: c22/213 lr:0.000976 t:1.6s
+tttg: c23/213 lr:0.000974 t:1.7s
+tttg: c24/213 lr:0.000971 t:1.8s
+tttg: c25/213 lr:0.000969 t:1.9s
+tttg: c26/213 lr:0.000966 t:1.9s
+tttg: c27/213 lr:0.000963 t:2.0s
+tttg: c28/213 lr:0.000961 t:2.1s
+tttg: c29/213 lr:0.000958 t:2.1s
+tttg: c30/213 lr:0.000955 t:2.2s
+tttg: c31/213 lr:0.000951 t:2.3s
+tttg: c32/213 lr:0.000948 t:2.4s
+tttg: c33/213 lr:0.000945 t:2.4s
+tttg: c34/213 lr:0.000941 t:2.5s
+tttg: c35/213 lr:0.000938 t:2.6s
+tttg: c36/213 lr:0.000934 t:2.6s
+tttg: c37/213 lr:0.000931 t:2.7s
+tttg: c38/213 lr:0.000927 t:2.8s
+tttg: c39/213 lr:0.000923 t:2.9s
+tttg: c40/213 lr:0.000919 t:2.9s
+tttg: c41/213 lr:0.000915 t:3.0s
+tttg: c42/213 lr:0.000911 t:3.1s
+tttg: c43/213 lr:0.000906 t:3.2s
+tttg: c44/213 lr:0.000902 t:3.3s
+tttg: c45/213 lr:0.000897 t:3.3s
+tttg: c46/213 lr:0.000893 t:3.4s
+tttg: c47/213 lr:0.000888 t:3.5s
+tttg: c48/213 lr:0.000884 t:3.6s
+tttg: c49/213 lr:0.000879 t:3.6s
+tttg: c50/213 lr:0.000874 t:3.7s
+tttg: c51/213 lr:0.000869 t:3.8s
+tttg: c52/213 lr:0.000864 t:3.9s
+tttg: c53/213 lr:0.000859 t:3.9s
+tttg: c54/213 lr:0.000854 t:4.0s
+tttg: c55/213 lr:0.000848 t:4.1s
+tttg: c56/213 lr:0.000843 t:4.1s
+tttg: c57/213 lr:0.000837 t:4.2s
+tttg: c58/213 lr:0.000832 t:4.3s
+tttg: c59/213 lr:0.000826 t:4.4s
+tttg: c60/213 lr:0.000821 t:4.4s
+tttg: c61/213 lr:0.000815 t:4.5s
+tttg: c62/213 lr:0.000809 t:4.6s
+tttg: c63/213 lr:0.000803 t:4.6s
+tttg: c64/213 lr:0.000797 t:4.7s
+tttg: c65/213 lr:0.000791 t:4.8s
+tttg: c66/213 lr:0.000785 t:4.9s
+tttg: c67/213 lr:0.000779 t:4.9s
+tttg: c68/213 lr:0.000773 t:5.0s
+tttg: c69/213 lr:0.000767 t:5.1s
+tttg: c70/213 lr:0.000761 t:5.1s
+tttg: c71/213 lr:0.000754 t:5.2s
+tttg: c72/213 lr:0.000748 t:5.3s
+tttg: c73/213 lr:0.000741 t:5.4s
+tttg: c74/213 lr:0.000735 t:5.4s
+tttg: c75/213 lr:0.000728 t:5.5s
+tttg: c76/213 lr:0.000722 t:5.6s
+tttg: c77/213 lr:0.000715 t:5.7s
+tttg: c78/213 lr:0.000708 t:5.7s
+tttg: c79/213 lr:0.000702 t:5.8s
+tttg: c80/213 lr:0.000695 t:5.9s
+tttg: c81/213 lr:0.000688 t:6.0s
+tttg: c82/213 lr:0.000681 t:6.0s
+tttg: c83/213 lr:0.000674 t:6.1s
+tttg: c84/213 lr:0.000667 t:6.2s
+tttg: c85/213 lr:0.000660 t:6.3s
+tttg: c86/213 lr:0.000653 t:6.3s
+tttg: c87/213 lr:0.000646 t:6.4s
+tttg: c88/213 lr:0.000639 t:6.5s
+tttg: c89/213 lr:0.000632 t:6.5s
+tttg: c90/213 lr:0.000625 t:6.6s
+tttg: c91/213 lr:0.000617 t:6.7s
+tttg: c92/213 lr:0.000610 t:6.8s
+tttg: c93/213 lr:0.000603 t:6.8s
+tttg: c94/213 lr:0.000596 t:6.9s
+tttg: c95/213 lr:0.000588 t:7.0s
+tttg: c96/213 lr:0.000581 t:7.0s
+tttg: c97/213 lr:0.000574 t:7.1s
+tttg: c98/213 lr:0.000566 t:7.2s
+tttg: c99/213 lr:0.000559 t:7.3s
+tttg: c100/213 lr:0.000552 t:7.3s
+tttg: c101/213 lr:0.000544 t:7.4s
+tttg: c102/213 lr:0.000537 t:7.5s
+tttg: c103/213 lr:0.000530 t:7.5s
+tttg: c104/213 lr:0.000522 t:7.6s
+tttg: c105/213 lr:0.000515 t:7.7s
+tttg: c106/213 lr:0.000507 t:7.8s
+tttg: c107/213 lr:0.000500 t:7.8s
+tttg: c108/213 lr:0.000493 t:7.9s
+tttg: c109/213 lr:0.000485 t:8.0s
+tttg: c110/213 lr:0.000478 t:8.0s
+tttg: c111/213 lr:0.000470 t:8.1s
+tttg: c112/213 lr:0.000463 t:8.2s
+tttg: c113/213 lr:0.000456 t:8.3s
+tttg: c114/213 lr:0.000448 t:8.3s
+tttg: c115/213 lr:0.000441 t:8.4s
+tttg: c116/213 lr:0.000434 t:8.5s
+tttg: c117/213 lr:0.000426 t:8.6s
+tttg: c118/213 lr:0.000419 t:8.6s
+tttg: c119/213 lr:0.000412 t:8.7s
+tttg: c120/213 lr:0.000404 t:8.8s
+tttg: c121/213 lr:0.000397 t:8.9s
+tttg: c122/213 lr:0.000390 t:8.9s
+tttg: c123/213 lr:0.000383 t:9.0s
+tttg: c124/213 lr:0.000375 t:9.1s
+tttg: c125/213 lr:0.000368 t:9.1s
+tttg: c126/213 lr:0.000361 t:9.2s
+tttg: c127/213 lr:0.000354 t:9.3s
+tttg: c128/213 lr:0.000347 t:9.4s
+tttg: c129/213 lr:0.000340 t:9.4s
+tttg: c130/213 lr:0.000333 t:9.5s
+tttg: c131/213 lr:0.000326 t:9.6s
+tttg: c132/213 lr:0.000319 t:9.6s
+tttg: c133/213 lr:0.000312 t:9.7s
+tttg: c134/213 lr:0.000305 t:9.8s
+tttg: c135/213 lr:0.000298 t:9.9s
+tttg: c136/213 lr:0.000292 t:9.9s
+tttg: c137/213 lr:0.000285 t:10.0s
+tttg: c138/213 lr:0.000278 t:10.1s
+tttg: c139/213 lr:0.000272 t:10.1s
+tttg: c140/213 lr:0.000265 t:10.2s
+tttg: c141/213 lr:0.000259 t:10.3s
+tttg: c142/213 lr:0.000252 t:10.4s
+tttg: c143/213 lr:0.000246 t:10.4s
+tttg: c144/213 lr:0.000239 t:10.5s
+tttg: c145/213 lr:0.000233 t:10.6s
+tttg: c146/213 lr:0.000227 t:10.6s
+tttg: c147/213 lr:0.000221 t:10.7s
+tttg: c148/213 lr:0.000215 t:10.8s
+tttg: c149/213 lr:0.000209 t:10.9s
+tttg: c150/213 lr:0.000203 t:11.0s
+tttg: c151/213 lr:0.000197 t:11.0s
+tttg: c152/213 lr:0.000191 t:11.1s
+tttg: c153/213 lr:0.000185 t:11.2s
+tttg: c154/213 lr:0.000179 t:11.2s
+tttg: c155/213 lr:0.000174 t:11.3s
+tttg: c156/213 lr:0.000168 t:11.4s
+tttg: c157/213 lr:0.000163 t:11.5s
+tttg: c158/213 lr:0.000157 t:11.5s
+tttg: c159/213 lr:0.000152 t:11.6s
+tttg: c160/213 lr:0.000146 t:11.7s
+tttg: c161/213 lr:0.000141 t:11.8s
+tttg: c162/213 lr:0.000136 t:11.8s
+tttg: c163/213 lr:0.000131 t:11.9s
+tttg: c164/213 lr:0.000126 t:12.0s
+tttg: c165/213 lr:0.000121 t:12.0s
+tttg: c166/213 lr:0.000116 t:12.1s
+tttg: c167/213 lr:0.000112 t:12.2s
+tttg: c168/213 lr:0.000107 t:12.3s
+tttg: c169/213 lr:0.000103 t:12.3s
+tttg: c170/213 lr:0.000098 t:12.4s
+tttg: c171/213 lr:0.000094 t:12.5s
+tttg: c172/213 lr:0.000089 t:12.5s
+tttg: c173/213 lr:0.000085 t:12.6s
+tttg: c174/213 lr:0.000081 t:12.7s
+tttg: c175/213 lr:0.000077 t:12.8s
+tttg: c176/213 lr:0.000073 t:12.8s
+tttg: c177/213 lr:0.000069 t:12.9s
+tttg: c178/213 lr:0.000066 t:13.0s
+tttg: c179/213 lr:0.000062 t:13.0s
+tttg: c180/213 lr:0.000059 t:13.1s
+tttg: c181/213 lr:0.000055 t:13.2s
+tttg: c182/213 lr:0.000052 t:13.2s
+tttg: c183/213 lr:0.000049 t:13.3s
+tttg: c184/213 lr:0.000045 t:13.4s
+tttg: c185/213 lr:0.000042 t:13.5s
+tttg: c186/213 lr:0.000039 t:13.5s
+tttg: c187/213 lr:0.000037 t:13.6s
+tttg: c188/213 lr:0.000034 t:13.7s
+tttg: c189/213 lr:0.000031 t:13.8s
+tttg: c190/213 lr:0.000029 t:13.8s
+tttg: c191/213 lr:0.000026 t:13.9s
+tttg: c192/213 lr:0.000024 t:14.0s
+tttg: c193/213 lr:0.000022 t:14.0s
+tttg: c194/213 lr:0.000020 t:14.1s
+tttg: c195/213 lr:0.000018 t:14.2s
+tttg: c196/213 lr:0.000016 t:14.3s
+tttg: c197/213 lr:0.000014 t:14.3s
+tttg: c198/213 lr:0.000012 t:14.4s
+tttg: c199/213 lr:0.000011 t:14.5s
+tttg: c200/213 lr:0.000009 t:14.5s
+tttg: c201/213 lr:0.000008 t:14.6s
+tttg: c202/213 lr:0.000007 t:14.7s
+tttg: c203/213 lr:0.000005 t:14.8s
+tttg: c204/213 lr:0.000004 t:14.8s
+tttg: c205/213 lr:0.000004 t:14.9s
+tttg: c206/213 lr:0.000003 t:15.0s
+tttg: c207/213 lr:0.000002 t:15.1s
+tttg: c208/213 lr:0.000001 t:15.1s
+tttg: c209/213 lr:0.000001 t:15.2s
+tttg: c210/213 lr:0.000000 t:15.3s
+tttg: c211/213 lr:0.000000 t:15.3s
+tttg: c212/213 lr:0.000000 t:15.4s
+ttpr: phase:3/3 t:364.3s
+ttp: b736/782 bl:2.6716 bb:1.0414 rl:2.6703 rb:1.0612 dl:2140-2165 gd:1
+ttp: b734/782 bl:2.7676 bb:1.0554 rl:2.6772 rb:1.0608 dl:2091-2115 gd:1
+ttp: b724/782 bl:2.7441 bb:1.0490 rl:2.6812 rb:1.0600 dl:1885-1900 gd:1
+ttp: b718/782 bl:2.7732 bb:1.0690 rl:2.6861 rb:1.0605 dl:1773-1792 gd:1
+ttp: b708/782 bl:2.7176 bb:1.0444 rl:2.6876 rb:1.0597 dl:1639-1649 gd:1
+ttp: b699/782 bl:2.8159 bb:1.0421 rl:2.6930 rb:1.0589 dl:1543-1552 gd:1
+ttp: b692/782 bl:2.7673 bb:1.0500 rl:2.6959 rb:1.0586 dl:1477-1484 gd:1
+ttp: b688/782 bl:2.7456 bb:1.0474 rl:2.6977 rb:1.0582 dl:1441-1450 gd:1
+ttp: b673/782 bl:2.8088 bb:1.0547 rl:2.7014 rb:1.0581 dl:1327-1334 gd:1
+ttp: b671/782 bl:2.8806 bb:1.1164 rl:2.7070 rb:1.0599 dl:1316-1321 gd:1
+ttp: b663/782 bl:2.7956 bb:1.0611 rl:2.7095 rb:1.0599 dl:1264-1269 gd:1
+ttp: b655/782 bl:2.6807 bb:1.0197 rl:2.7088 rb:1.0588 dl:1215-1220 gd:1
+ttp: b647/782 bl:2.7480 bb:1.0461 rl:2.7098 rb:1.0585 dl:1171-1177 gd:1
+ttp: b640/782 bl:2.7790 bb:1.0816 rl:2.7114 rb:1.0590 dl:1134-1140 gd:1
+ttp: b607/782 bl:2.6951 bb:1.0387 rl:2.7111 rb:1.0586 dl:986-990 gd:1
+ttp: b599/782 bl:2.7392 bb:1.0521 rl:2.7116 rb:1.0585 dl:954-958 gd:1
+ttp: b591/782 bl:2.6679 bb:1.0081 rl:2.7108 rb:1.0575 dl:927-930 gd:1
+ttp: b583/782 bl:2.8005 bb:1.0924 rl:2.7124 rb:1.0581 dl:901-904 gd:1
+ttp: b575/782 bl:2.7957 bb:1.0527 rl:2.7138 rb:1.0580 dl:874-877 gd:1
+ttp: b567/782 bl:2.6762 bb:1.0308 rl:2.7132 rb:1.0576 dl:849-852 gd:1
+ttp: b559/782 bl:2.7475 bb:1.0442 rl:2.7138 rb:1.0574 dl:824-827 gd:1
+ttp: b551/782 bl:2.8219 bb:1.0636 rl:2.7154 rb:1.0575 dl:801-804 gd:1
+ttp: b543/782 bl:2.7861 bb:1.0459 rl:2.7164 rb:1.0573 dl:779-782 gd:1
+ttp: b535/782 bl:2.7820 bb:1.0548 rl:2.7173 rb:1.0573 dl:759-762 gd:1
+ttp: b528/782 bl:2.7532 bb:1.0314 rl:2.7177 rb:1.0569 dl:742-745 gd:1
+ttp: b521/782 bl:2.7652 bb:1.0492 rl:2.7183 rb:1.0568 dl:725-727 gd:1
+ttp: b514/782 bl:2.9094 bb:1.0974 rl:2.7207 rb:1.0573 dl:707-710 gd:1
+ttp: b507/782 bl:2.7560 bb:1.0404 rl:2.7211 rb:1.0571 dl:690-693 gd:1
+ttp: b500/782 bl:2.8331 bb:1.0822 rl:2.7224 rb:1.0574 dl:675-677 gd:1
+ttp: b493/782 bl:2.8423 bb:1.1146 rl:2.7237 rb:1.0580 dl:659-661 gd:1
+ttp: b486/782 bl:2.7973 bb:1.0617 rl:2.7245 rb:1.0581 dl:645-646 gd:1
+ttp: b478/782 bl:2.7872 bb:1.0496 rl:2.7251 rb:1.0580 dl:628-630 gd:1
+ttp: b469/782 bl:2.7925 bb:1.1104 rl:2.7258 rb:1.0585 dl:610-611 gd:1
+ttp: b461/782 bl:2.7789 bb:1.0598 rl:2.7263 rb:1.0585 dl:595-597 gd:1
+ttp: b453/782 bl:2.7580 bb:1.0583 rl:2.7266 rb:1.0585 dl:580-582 gd:1
+ttp: b442/782 bl:2.8016 bb:1.0522 rl:2.7273 rb:1.0584 dl:560-562 gd:1
+ttp: b434/782 bl:2.7232 bb:1.0406 rl:2.7272 rb:1.0583 dl:545-547 gd:1
+ttp: b426/782 bl:2.7266 bb:1.0670 rl:2.7272 rb:1.0584 dl:532-533 gd:1
+ttp: b418/782 bl:2.8048 bb:1.0699 rl:2.7278 rb:1.0585 dl:517-519 gd:1
+ttp: b410/782 bl:2.7763 bb:1.0542 rl:2.7282 rb:1.0584 dl:505-507 gd:1
+ttp: b402/782 bl:2.7536 bb:1.0374 rl:2.7284 rb:1.0583 dl:492-493 gd:1
+ttp: b394/782 bl:2.8877 bb:1.1137 rl:2.7295 rb:1.0587 dl:479-481 gd:1
+ttp: b390/782 bl:2.8119 bb:1.0907 rl:2.7301 rb:1.0589 dl:473-475 gd:1
+ttp: b382/782 bl:2.9111 bb:1.1333 rl:2.7314 rb:1.0594 dl:461-463 gd:1
+ttp: b373/782 bl:2.7587 bb:1.0768 rl:2.7315 rb:1.0595 dl:449-450 gd:1
+ttp: b365/782 bl:2.7787 bb:1.0829 rl:2.7318 rb:1.0597 dl:437-439 gd:1
+ttp: b356/782 bl:2.6972 bb:1.0480 rl:2.7316 rb:1.0596 dl:424-426 gd:1
+ttp: b348/782 bl:2.8089 bb:1.0674 rl:2.7321 rb:1.0596 dl:414-415 gd:1
+ttp: b340/782 bl:2.8198 bb:1.0907 rl:2.7326 rb:1.0598 dl:403-404 gd:1
+ttp: b332/782 bl:2.8333 bb:1.1002 rl:2.7332 rb:1.0600 dl:393-394 gd:1
+ttp: b323/782 bl:2.8179 bb:1.0482 rl:2.7336 rb:1.0600 dl:381-382 gd:1
+ttp: b316/782 bl:2.7773 bb:1.0922 rl:2.7339 rb:1.0601 dl:371-373 gd:1
+ttp: b308/782 bl:2.7901 bb:1.0840 rl:2.7341 rb:1.0603 dl:362-363 gd:1
+ttp: b300/782 bl:2.8584 bb:1.0895 rl:2.7348 rb:1.0604 dl:352-353 gd:1
+ttp: b292/782 bl:2.7883 bb:1.0804 rl:2.7350 rb:1.0605 dl:342-343 gd:1
+ttp: b284/782 bl:2.8828 bb:1.0868 rl:2.7357 rb:1.0606 dl:333-334 gd:1
+ttp: b277/782 bl:2.8097 bb:1.1066 rl:2.7360 rb:1.0608 dl:325-326 gd:1
+ttp: b269/782 bl:2.9149 bb:1.1235 rl:2.7368 rb:1.0611 dl:316-318 gd:1
+ttp: b261/782 bl:2.8676 bb:1.1217 rl:2.7374 rb:1.0614 dl:308-309 gd:1
+ttp: b253/782 bl:2.7556 bb:1.0821 rl:2.7374 rb:1.0614 dl:298-299 gd:1
+ttp: b245/782 bl:2.8694 bb:1.1019 rl:2.7379 rb:1.0616 dl:290-291 gd:1
+ttp: b233/782 bl:2.8510 bb:1.1201 rl:2.7384 rb:1.0618 dl:278-279 gd:1
+ttp: b225/782 bl:2.8875 bb:1.1246 rl:2.7389 rb:1.0620 dl:270-271 gd:1
+ttp: b217/782 bl:2.8812 bb:1.1286 rl:2.7394 rb:1.0623 dl:262-263 gd:1
+ttp: b209/782 bl:2.9120 bb:1.1528 rl:2.7400 rb:1.0626 dl:254-255 gd:1
+ttp: b201/782 bl:2.8614 bb:1.1153 rl:2.7404 rb:1.0627 dl:247-248 gd:1
+ttp: b193/782 bl:2.8762 bb:1.1588 rl:2.7408 rb:1.0630 dl:240-241 gd:1
+ttp: b188/782 bl:2.9069 bb:1.1516 rl:2.7414 rb:1.0633 dl:236-237 gd:1
+ttp: b180/782 bl:2.9029 bb:1.1320 rl:2.7418 rb:1.0635 dl:229-230 gd:1
+ttp: b174/782 bl:2.9718 bb:1.1538 rl:2.7425 rb:1.0638 dl:224-224 gd:1
+ttp: b162/782 bl:2.9498 bb:1.1445 rl:2.7431 rb:1.0640 dl:213-214 gd:1
+ttp: b153/782 bl:3.0111 bb:1.1615 rl:2.7438 rb:1.0643 dl:206-207 gd:1
+ttp: b146/782 bl:2.9029 bb:1.1524 rl:2.7442 rb:1.0645 dl:200-201 gd:1
+ttp: b139/782 bl:2.9819 bb:1.1541 rl:2.7448 rb:1.0647 dl:195-195 gd:1
+ttp: b130/782 bl:3.1282 bb:1.2296 rl:2.7458 rb:1.0651 dl:187-188 gd:1
+ttp: b123/782 bl:2.9607 bb:1.1829 rl:2.7463 rb:1.0654 dl:182-183 gd:1
+ttp: b115/782 bl:2.8666 bb:1.1567 rl:2.7465 rb:1.0656 dl:176-177 gd:1
+ttp: b106/782 bl:2.9656 bb:1.1978 rl:2.7470 rb:1.0659 dl:170-171 gd:1
+ttp: b99/782 bl:2.9788 bb:1.1844 rl:2.7475 rb:1.0661 dl:164-165 gd:1
+ttp: b91/782 bl:3.0204 bb:1.2089 rl:2.7481 rb:1.0664 dl:158-159 gd:1
+ttp: b83/782 bl:3.0194 bb:1.2066 rl:2.7486 rb:1.0667 dl:152-153 gd:1
+ttp: b75/782 bl:3.0843 bb:1.2110 rl:2.7492 rb:1.0669 dl:146-147 gd:1
+ttp: b65/782 bl:3.0359 bb:1.2189 rl:2.7497 rb:1.0672 dl:139-139 gd:1
+ttp: b56/782 bl:3.0568 bb:1.2047 rl:2.7502 rb:1.0674 dl:131-132 gd:1
+ttp: b49/782 bl:2.9678 bb:1.1708 rl:2.7506 rb:1.0676 dl:126-126 gd:1
+ttp: b39/782 bl:3.1337 bb:1.2384 rl:2.7512 rb:1.0678 dl:118-119 gd:1
+ttp: b32/782 bl:3.0119 bb:1.2040 rl:2.7515 rb:1.0680 dl:112-113 gd:1
+ttp: b24/782 bl:3.0566 bb:1.2093 rl:2.7519 rb:1.0682 dl:105-106 gd:1
+ttp: b16/782 bl:3.0633 bb:1.2214 rl:2.7523 rb:1.0684 dl:97-98 gd:1
+ttp: b5/782 bl:3.3210 bb:1.2954 rl:2.7529 rb:1.0686 dl:80-82 gd:1
+quantized_ttt_phased val_loss:2.77160780 val_bpb:1.07297575 eval_time:448342ms
+total_eval_time:448.3s
+[Tue Apr 21 22:08:32 UTC 2026] Experiment pure_ttt_sp8192_dxwarmwd_seed42_8gpu complete
+Final BPB: diagnostic pre-quantization post-ema val_loss:2.77133954 val_bpb:1.07283732 eval_time:8726ms
+diagnostic quantized val_loss:2.80171217 val_bpb:1.08459514 eval_time:58133ms
+quantized_ttt_phased val_loss:2.77160780 val_bpb:1.07297575 eval_time:448342ms


### PR DESCRIPTION
## Summary

Three composable, small-LOC novel changes on top of @dexhunter's 1.07193 phased-TTT pipeline. All three modify only the LoRA adapter's init / forward / weight-decay — everything else (VarLen attention, Fused MLP, multi-phase global SGD, trimmed GPTQ, int7 embeddings, triple depth recurrence) is unchanged.

### (1) Alpha/rank output scaling on `BatchedLinearLoRA`
Prior phased-TTT code uses `forward(x) = (x @ A.T) @ B.T` with no rank scaling. Raising `TTT_LORA_RANK` from 96 → 128 on that code **diverges** on seeds 314 and 1337 (TTT BPB collapses to ~1.133) while working on seed 42. Adding the standard `alpha/rank` factor decouples rank from effective LR and makes rank 128 stable on all three seeds.

### (2) Warm-start LoRA A across batches
Previously A is re-randomized every batch. Keeping A warm (only B resets to zero) lets the A matrix accumulate feature directions across the ~780 phased-TTT batches. In isolation this helps seeds 42/1337 but **regresses on seed 314** (A drifts into overfit for that seed's doc ordering).

### (3) Raised TTT weight decay 0.5 → 1.0
Introduced specifically to counteract the across-batch A overfit enabled by (2). On seed 314 it restores parity with the rank-96 baseline (1.07200 → 1.07203); on 42/1337 the bulk of the warm-start gain is preserved.

### Results

| Seed | rank-96 baseline | + alpha rank 128 | **+ warm-A + WD=1.0** |
|------|------------------|------------------|-----------------------|
| 1337 | 1.07423 | 1.07379 | **1.07298 (−0.00125)** |
| 42   | 1.07341 | 1.07320 | **1.07298 (−0.00043)** |
| 314  | 1.07214 | 1.07200 | **1.07203 (−0.00011)** |
| **Mean** | 1.07326 | 1.07300 | **1.07266 (−0.00060)** |

All three seeds improve or stay flat vs the rank-96 reproduction.

### Compliance

All runs under 600s train, under 600s eval, <16MB artifact. Issue #1017 conditions 1–4 verified (causal, full normalized distribution, score-before-update, single pass).
