### PR TITLE
Record: #1787 + Sparse Gate + Updated Frozen Carry — val_bpb 1.06287

### DIFF
--- a/records/track_10min_16mb/2026-04-24_SP8192_CaseOps_SparseGate_QuantGate_Loop45_PhasedTTT_PolarNS_MinLR_FusedCE_UpdatedCarry/submission.json
+++ b/records/track_10min_16mb/2026-04-24_SP8192_CaseOps_SparseGate_QuantGate_Loop45_PhasedTTT_PolarNS_MinLR_FusedCE_UpdatedCarry/submission.json
@@ -1,0 +1,14 @@
+{
+  "val_bpb": 1.06287,
+  "val_loss": 2.326951,
+  "seeds": [42, 0, 1234],
+  "per_seed": {
+    "42":   {"steps": 4989, "pre_quant_bpb": 1.06749, "quantized_bpb": 1.07678, "post_ttt_bpb": 1.06366, "artifact_bytes": 15909254},
+    "0":    {"steps": 4974, "pre_quant_bpb": 1.06685, "quantized_bpb": 1.07608, "post_ttt_bpb": 1.06311, "artifact_bytes": 15904209},
+    "1234": {"steps": 4973, "pre_quant_bpb": 1.06578, "quantized_bpb": 1.07509, "post_ttt_bpb": 1.06183, "artifact_bytes": 15909401}
+  },
+  "hardware": "8xH100 SXM 80GB",
+  "region": "NA-1",
+  "base_pr": 1787,
+  "git_commit": "1d12cb6"
+}

--- a/records/track_10min_16mb/2026-04-24_SP8192_CaseOps_SparseGate_QuantGate_Loop45_PhasedTTT_PolarNS_MinLR_FusedCE_UpdatedCarry/train_gpt.py
+++ b/records/track_10min_16mb/2026-04-24_SP8192_CaseOps_SparseGate_QuantGate_Loop45_PhasedTTT_PolarNS_MinLR_FusedCE_UpdatedCarry/train_gpt.py
@@ -1,0 +1,3999 @@
+import base64, collections, copy, fcntl, glob, hashlib, io, lzma, math, os
+from pathlib import Path
+import random, re, subprocess, sys, time, uuid, numpy as np, sentencepiece as spm, torch, torch.distributed as dist, torch.nn.functional as F
+from torch import Tensor, nn
+from flash_attn_interface import (
+    flash_attn_func as flash_attn_3_func,
+    flash_attn_varlen_func,
+)
+from concurrent.futures import ThreadPoolExecutor
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+# ===== Fused softcapped cross-entropy (Triton) — training-only path =====
+_FUSED_CE_LIBRARY = "pg035dfusedce"
+_FUSED_CE_BLOCK_SIZE = 1024
+_FUSED_CE_NUM_WARPS = 4
+
+
+@triton.jit
+def _softcapped_ce_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, softcap,
+    block_size: tl.constexpr,
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    max_val = -float("inf")
+    sum_exp = 0.0
+    A = 2.0 * softcap
+    inv_C = 2.0 / softcap
+    for off in range(0, n_cols, block_size):
+        cols = off + tl.arange(0, block_size)
+        mask = cols < n_cols
+        val = tl.load(
+            logits_row_ptr + cols * stride_logits_v,
+            mask=mask, other=-float("inf"),
+        ).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C)
+        z = tl.where(mask, z, -float("inf"))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    target = tl.load(targets_ptr + row_idx).to(tl.int32)
+    target_val = tl.load(logits_row_ptr + target * stride_logits_v).to(tl.float32)
+    target_z = A * tl.sigmoid(target_val * inv_C)
+    tl.store(losses_ptr + row_idx, lse - target_z)
+
+
+@triton.jit
+def _softcapped_ce_bwd_kernel(
+    grad_logits_ptr, grad_losses_ptr, lse_ptr, logits_ptr, targets_ptr,
+    stride_logits_n, stride_logits_v,
+    stride_grad_n, stride_grad_v,
+    n_rows, n_cols, softcap,
+    block_size: tl.constexpr,
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_logits_ptr + row_idx * stride_grad_n
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_losses_ptr + row_idx).to(tl.float32)
+    target = tl.load(targets_ptr + row_idx).to(tl.int32)
+    A = 2.0 * softcap
+    inv_C = 2.0 / softcap
+    dz_dx_scale = A * inv_C
+    for off in range(0, n_cols, block_size):
+        cols = off + tl.arange(0, block_size)
+        mask = cols < n_cols
+        val = tl.load(
+            logits_row_ptr + cols * stride_logits_v,
+            mask=mask, other=0.0,
+        ).to(tl.float32)
+        sigmoid_u = tl.sigmoid(val * inv_C)
+        z = A * sigmoid_u
+        probs = tl.exp(z - lse)
+        grad_z = grad_loss * (probs - tl.where(cols == target, 1.0, 0.0))
+        grad_x = grad_z * (dz_dx_scale * sigmoid_u * (1.0 - sigmoid_u))
+        tl.store(grad_row_ptr + cols * stride_grad_v, grad_x, mask=mask)
+
+
+def _validate_softcapped_ce_inputs(
+    logits: Tensor, targets: Tensor, softcap: float,
+) -> tuple[Tensor, Tensor]:
+    if logits.ndim != 2:
+        raise ValueError(f"Expected logits.ndim=2, got {logits.ndim}")
+    if targets.ndim != 1:
+        raise ValueError(f"Expected targets.ndim=1, got {targets.ndim}")
+    if logits.shape[0] != targets.shape[0]:
+        raise ValueError(
+            f"Expected matching rows, got logits={tuple(logits.shape)} targets={tuple(targets.shape)}"
+        )
+    if not logits.is_cuda or not targets.is_cuda:
+        raise ValueError("softcapped_cross_entropy requires CUDA tensors")
+    if softcap <= 0.0:
+        raise ValueError(f"softcap must be positive, got {softcap}")
+    if logits.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise ValueError(f"Unsupported logits dtype: {logits.dtype}")
+    logits = logits.contiguous()
+    targets = targets.contiguous()
+    if targets.dtype != torch.int64:
+        targets = targets.to(dtype=torch.int64)
+    return logits, targets
+
+
+@torch.library.custom_op(f"{_FUSED_CE_LIBRARY}::softcapped_ce", mutates_args=())
+def softcapped_ce_op(logits: Tensor, targets: Tensor, softcap: float) -> tuple[Tensor, Tensor]:
+    logits, targets = _validate_softcapped_ce_inputs(logits, targets, float(softcap))
+    n_rows, n_cols = logits.shape
+    losses = torch.empty((n_rows,), device=logits.device, dtype=torch.float32)
+    lse = torch.empty((n_rows,), device=logits.device, dtype=torch.float32)
+    _softcapped_ce_fwd_kernel[(n_rows,)](
+        logits, losses, lse, targets,
+        logits.stride(0), logits.stride(1),
+        n_rows, n_cols, float(softcap),
+        block_size=_FUSED_CE_BLOCK_SIZE, num_warps=_FUSED_CE_NUM_WARPS,
+    )
+    return losses, lse
+
+
+@softcapped_ce_op.register_fake
+def _(logits: Tensor, targets: Tensor, softcap: float):
+    if logits.ndim != 2 or targets.ndim != 1:
+        raise ValueError("softcapped_ce fake impl expects 2D logits and 1D targets")
+    if logits.shape[0] != targets.shape[0]:
+        raise ValueError(
+            f"Expected matching rows, got logits={tuple(logits.shape)} targets={tuple(targets.shape)}"
+        )
+    n_rows = logits.shape[0]
+    return (
+        logits.new_empty((n_rows,), dtype=torch.float32),
+        logits.new_empty((n_rows,), dtype=torch.float32),
+    )
+
+
+@torch.library.custom_op(f"{_FUSED_CE_LIBRARY}::softcapped_ce_backward", mutates_args=())
+def softcapped_ce_backward_op(
+    logits: Tensor, targets: Tensor, lse: Tensor, grad_losses: Tensor, softcap: float,
+) -> Tensor:
+    logits, targets = _validate_softcapped_ce_inputs(logits, targets, float(softcap))
+    lse = lse.contiguous()
+    grad_losses = grad_losses.contiguous().to(dtype=torch.float32)
+    if lse.ndim != 1 or grad_losses.ndim != 1:
+        raise ValueError("Expected 1D lse and grad_losses")
+    if lse.shape[0] != logits.shape[0] or grad_losses.shape[0] != logits.shape[0]:
+        raise ValueError(
+            f"Expected row-aligned lse/grad_losses, got logits={tuple(logits.shape)} "
+            f"lse={tuple(lse.shape)} grad_losses={tuple(grad_losses.shape)}"
+        )
+    grad_logits = torch.empty_like(logits)
+    n_rows, n_cols = logits.shape
+    _softcapped_ce_bwd_kernel[(n_rows,)](
+        grad_logits, grad_losses, lse, logits, targets,
+        logits.stride(0), logits.stride(1),
+        grad_logits.stride(0), grad_logits.stride(1),
+        n_rows, n_cols, float(softcap),
+        block_size=_FUSED_CE_BLOCK_SIZE, num_warps=_FUSED_CE_NUM_WARPS,
+    )
+    return grad_logits
+
+
+@softcapped_ce_backward_op.register_fake
+def _(logits: Tensor, targets: Tensor, lse: Tensor, grad_losses: Tensor, softcap: float):
+    if logits.ndim != 2 or targets.ndim != 1 or lse.ndim != 1 or grad_losses.ndim != 1:
+        raise ValueError("softcapped_ce_backward fake impl expects 2D logits and 1D row tensors")
+    if (
+        logits.shape[0] != targets.shape[0]
+        or logits.shape[0] != lse.shape[0]
+        or logits.shape[0] != grad_losses.shape[0]
+    ):
+        raise ValueError("softcapped_ce_backward fake impl expects row-aligned tensors")
+    return logits.new_empty(logits.shape)
+
+
+def _softcapped_ce_setup_context(
+    ctx: torch.autograd.function.FunctionCtx, inputs, output,
+) -> None:
+    logits, targets, softcap = inputs
+    _losses, lse = output
+    ctx.save_for_backward(logits, targets, lse)
+    ctx.softcap = float(softcap)
+
+
+def _softcapped_ce_backward(
+    ctx: torch.autograd.function.FunctionCtx, grad_losses: Tensor, grad_lse: "Tensor | None",
+):
+    del grad_lse
+    logits, targets, lse = ctx.saved_tensors
+    grad_logits = torch.ops.pg035dfusedce.softcapped_ce_backward(
+        logits, targets, lse, grad_losses, ctx.softcap
+    )
+    return grad_logits, None, None
+
+
+softcapped_ce_op.register_autograd(
+    _softcapped_ce_backward, setup_context=_softcapped_ce_setup_context,
+)
+
+
+def softcapped_cross_entropy(
+    logits: Tensor, targets: Tensor, softcap: float, reduction: str = "mean",
+) -> Tensor:
+    losses, _lse = torch.ops.pg035dfusedce.softcapped_ce(
+        logits, targets, float(softcap)
+    )
+    if reduction == "none":
+        return losses
+    if reduction == "sum":
+        return losses.sum()
+    if reduction == "mean":
+        return losses.mean()
+    raise ValueError(f"Unsupported reduction={reduction!r}")
+
+
+class Hyperparameters:
+    data_dir = os.environ.get("DATA_DIR", "./data/")
+    seed = int(os.environ.get("SEED", 1337))
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.75))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786432))
+    fused_ce_enabled = bool(int(os.environ.get("FUSED_CE_ENABLED", "1")))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 6e2))
+    val_batch_tokens = int(os.environ.get("VAL_BATCH_TOKENS", 524288))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 8192))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 4.0))
+    skip_gates_enabled = bool(int(os.environ.get("SKIP_GATES_ENABLED", "1")))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 3e1))
+    rope_base = float(os.environ.get("ROPE_BASE", 1e4))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    rope_train_seq_len = int(os.environ.get("ROPE_TRAIN_SEQ_LEN", 2048))
+    rope_yarn = bool(int(os.environ.get("ROPE_YARN", "0")))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 5.0))
+    num_loops = int(os.environ.get("NUM_LOOPS", 2))
+    loop_start = int(os.environ.get("LOOP_START", 3))
+    loop_end = int(os.environ.get("LOOP_END", 5))
+    enable_looping_at = float(os.environ.get("ENABLE_LOOPING_AT", 0.35))
+    loop_depth_upgrade_at = float(os.environ.get("LOOP_DEPTH_UPGRADE_AT", 0.0))
+    parallel_start_layer = int(os.environ.get("PARALLEL_START_LAYER", 8))
+    parallel_final_lane = os.environ.get("PARALLEL_FINAL_LANE", "mean")
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.026))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.97))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-08))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.02))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_lora_rank = int(os.environ.get("TTT_LORA_RANK", 96))
+    ttt_lora_alpha = int(os.environ.get("TTT_LORA_ALPHA", 96))
+    ttt_lora_lr = float(os.environ.get("TTT_LORA_LR", 0.0001))
+    ttt_chunk_size = int(os.environ.get("TTT_CHUNK_SIZE", 48))
+    ttt_eval_seq_len = int(os.environ.get("TTT_EVAL_SEQ_LEN", 2048))
+    ttt_batch_size = int(os.environ.get("TTT_BATCH_SIZE", 64))
+    ttt_grad_steps = int(os.environ.get("TTT_GRAD_STEPS", 1))
+    ttt_weight_decay = float(os.environ.get("TTT_WEIGHT_DECAY", 0.5))
+    ttt_beta1 = float(os.environ.get("TTT_BETA1", 0))
+    ttt_beta2 = float(os.environ.get("TTT_BETA2", 0.999))
+    ttt_k_lora = bool(int(os.environ.get("TTT_K_LORA", "1")))
+    ttt_mlp_lora = bool(int(os.environ.get("TTT_MLP_LORA", "1")))
+    ttt_o_lora = bool(int(os.environ.get("TTT_O_LORA", "1")))
+    ttt_optimizer = os.environ.get("TTT_OPTIMIZER", "adam")
+    ttt_eval_batches = os.environ.get("TTT_EVAL_BATCHES", "")
+    val_doc_fraction = float(os.environ.get("VAL_DOC_FRACTION", 1.0))
+    compressor = os.environ.get("COMPRESSOR", "brotli")
+    gptq_calibration_batches = int(os.environ.get("GPTQ_CALIBRATION_BATCHES", 16))
+    gptq_reserve_seconds = float(os.environ.get("GPTQ_RESERVE_SECONDS", 4.0))
+    phased_ttt_prefix_docs = int(os.environ.get("PHASED_TTT_PREFIX_DOCS", 2000))
+    phased_ttt_num_phases = int(os.environ.get("PHASED_TTT_NUM_PHASES", 1))
+    global_ttt_lr = float(os.environ.get("GLOBAL_TTT_LR", 0.001))
+    global_ttt_momentum = float(os.environ.get("GLOBAL_TTT_MOMENTUM", 0.9))
+    global_ttt_epochs = int(os.environ.get("GLOBAL_TTT_EPOCHS", 1))
+    global_ttt_chunk_tokens = int(os.environ.get("GLOBAL_TTT_CHUNK_TOKENS", 32768))
+    global_ttt_batch_seqs = int(os.environ.get("GLOBAL_TTT_BATCH_SEQS", 32))
+    global_ttt_warmup_start_lr = float(os.environ.get("GLOBAL_TTT_WARMUP_START_LR", 0.0))
+    global_ttt_warmup_chunks = int(os.environ.get("GLOBAL_TTT_WARMUP_CHUNKS", 0))
+    global_ttt_grad_clip = float(os.environ.get("GLOBAL_TTT_GRAD_CLIP", 1.0))
+    global_ttt_respect_doc_boundaries = bool(int(os.environ.get("GLOBAL_TTT_RESPECT_DOC_BOUNDARIES", "1")))
+    matrix_bits = int(os.environ.get("MATRIX_BITS", 6))
+    embed_bits = int(os.environ.get("EMBED_BITS", 8))
+    matrix_clip_sigmas = float(os.environ.get("MATRIX_CLIP_SIGMAS", 12.85))
+    embed_clip_sigmas = float(os.environ.get("EMBED_CLIP_SIGMAS", 2e1))
+    mlp_clip_sigmas = float(os.environ.get("MLP_CLIP_SIGMAS", 10.0))
+    attn_clip_sigmas = float(os.environ.get("ATTN_CLIP_SIGMAS", 13.0))
+    # AttnOutGate (per-head multiplicative output gate, PR #1667 MarioPaerle).
+    # Zero-init weight: 2*sigmoid(0)=1 -> transparent at start. Source defaults to
+    # block input x ('proj'); 'q' uses raw Q projection output.
+    attn_out_gate_enabled = bool(int(os.environ.get("ATTN_OUT_GATE_ENABLED", "0")))
+    attn_out_gate_src = os.environ.get("ATTN_OUT_GATE_SRC", "proj")
+    # SmearGate (input-dependent forward-1 token smear, modded-nanogpt @classiclarryd
+    # via PR #1667). x_t <- x_t + lam * sigmoid(W*x_t[:gate_window]) * x_{t-1}.
+    # lam=0 + W=0 -> transparent at init.
+    smear_gate_enabled = bool(int(os.environ.get("SMEAR_GATE_ENABLED", "0")))
+    # Window: first GATE_WINDOW dims of the source feed the gate projection.
+    gate_window = int(os.environ.get("GATE_WINDOW", 12))
+    # Spec 015 Recur-Alpha (port #1714 Anakintano). Learnable scalar per
+    # non-first recurrence pass per looped block. At init all zero -> pure
+    # passthrough on extra passes (equivalent to NUM_LOOPS=0 effective behavior).
+    # Model learns how much to commit per pass via gradient descent.
+    # Default off -> byte-identical to #1736 baseline.
+    recur_alpha_enabled = bool(int(os.environ.get("RECUR_ALPHA_ENABLED", "0")))
+    # Diagnostics: compute/store pass-to-pass cosine similarity on block deltas.
+    # Answers "is cross-pass XSA the right follow-up?" informational side-channel.
+    recur_diag_p2p_cos = bool(int(os.environ.get("RECUR_DIAG_P2P_COS", "0")))
+    # Gated Attention (Qwen, NeurIPS 2025 Best Paper, arXiv:2505.06708;
+    # qiuzh20/gated_attention). Per-head sigmoid gate on SDPA output, BEFORE
+    # out_proj. Gate input = full block input x (paper's headwise G1 variant
+    # driven from hidden_states). W_g shape (num_heads, dim), plain sigmoid.
+    # Near-zero init gives g~0.5 at step 0 (half attention output); per-block
+    # attn_scale (init 1.0) compensates during training. Name contains
+    # "attn_gate" so CONTROL_TENSOR_NAME_PATTERNS routes it to scalar AdamW.
+    gated_attn_enabled = bool(int(os.environ.get("GATED_ATTN_ENABLED", "0")))
+    gated_attn_init_std = float(os.environ.get("GATED_ATTN_INIT_STD", 0.01))
+    sparse_attn_gate_enabled = bool(int(os.environ.get("SPARSE_ATTN_GATE_ENABLED", "0")))
+    sparse_attn_gate_init_std = float(os.environ.get("SPARSE_ATTN_GATE_INIT_STD", 0.0))
+    sparse_attn_gate_scale = float(os.environ.get("SPARSE_ATTN_GATE_SCALE", 1.0))
+    # Dedicated int8-per-row quantization for `attn_gate_w` tensors. These are
+    # small ((num_heads, dim) = (8, 512) = 4096 params) and bypass GPTQ via the
+    # numel<=65536 passthrough branch -> stored as fp16 (8 KB/layer, ~65 KB total
+    # compressed). int8-per-row cuts the raw tensor in half with negligible BPB
+    # impact: scales per head (8 values), symmetric quant over [-127, 127].
+    # No Hessian needed (gate weights not in collect_hessians()).
+    gated_attn_quant_gate = bool(int(os.environ.get("GATED_ATTN_QUANT_GATE", "0")))
+    # SpinQuant V1 port from PR #1695 (X-Abhishek-X). Disabled by default so this
+    # file still reproduces #1736 bit-identically when the env var is absent.
+    # When enabled, four Hadamard rotations are applied online in the forward
+    # pass (pre-QKV, pre-attn-proj, pre-fc, pre-mlp-proj) and correspondingly
+    # baked into the state_dict + Hessian before GPTQ. F.linear(x @ R, W @ R)
+    # == F.linear(x, W) exactly (float-invariant), but GPTQ sees the rotated
+    # basis where outliers are more evenly spread → lower quantization error.
+    # See research/specs/010-port-1695-online-rotation.md for the integration
+    # plan; installation happens in deserialize() and the 4 forward-pass hooks
+    # live in CausalSelfAttention.forward, MLP.forward, and the TTT mirrors.
+    spinquant_enabled = bool(int(os.environ.get("SPINQUANT_ENABLED", "0")))
+    spinquant_seed = int(os.environ.get("SPINQUANT_SEED", "42"))
+    # Comma-separated subset of the 4 rotation sites to apply. Default is "all
+    # 4" so existing SPINQUANT_ENABLED=1 runs (spec 010) behave identically.
+    # Valid tag names: attn_in, attn_proj_in, mlp_in, mlp_proj_in. Spec 010b
+    # uses this to ablate which sites are responsible for the long/short-doc
+    # regime split observed in spec 010.
+    spinquant_sites = os.environ.get(
+        "SPINQUANT_SITES", "attn_in,attn_proj_in,mlp_in,mlp_proj_in"
+    )
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_main_process = rank == 0
+    grad_accum_steps = 8 // world_size
+    # CaseOps integration: optional override of dataset root + tokenizer path.
+    # When CASEOPS_ENABLED=1, the wrapper loads a per-token byte sidecar
+    # (fineweb_val_bytes_*.bin, identical shard layout to val_*.bin) and uses
+    # it as the canonical raw-byte budget for BPB accounting. The sidecar
+    # REPLACES the build_sentencepiece_luts byte-counting path entirely.
+    caseops_enabled = bool(int(os.environ.get("CASEOPS_ENABLED", "0")))
+    _default_caseops_data = os.path.join(
+        data_dir,
+        "datasets",
+        "fineweb10B_sp8192_caseops",
+        "datasets",
+        "datasets",
+        "fineweb10B_sp8192_lossless_caps_caseops_v1_reserved",
+    )
+    _default_caseops_tok = os.path.join(
+        data_dir,
+        "datasets",
+        "fineweb10B_sp8192_caseops",
+        "datasets",
+        "tokenizers",
+        "fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model",
+    )
+    if caseops_enabled:
+        datasets_dir = os.environ.get("DATA_PATH", _default_caseops_data)
+        tokenizer_path = os.environ.get("TOKENIZER_PATH", _default_caseops_tok)
+    else:
+        datasets_dir = os.environ.get(
+            "DATA_PATH",
+            os.path.join(data_dir, "datasets", f"fineweb10B_sp{vocab_size}"),
+        )
+        tokenizer_path = os.environ.get(
+            "TOKENIZER_PATH",
+            os.path.join(data_dir, "tokenizers", f"fineweb_{vocab_size}_bpe.model"),
+        )
+    train_files = os.path.join(datasets_dir, "fineweb_train_*.bin")
+    val_files = os.path.join(datasets_dir, "fineweb_val_*.bin")
+    val_bytes_files = os.path.join(datasets_dir, "fineweb_val_bytes_*.bin")
+    artifact_dir = os.environ.get("ARTIFACT_DIR", "")
+    logfile = (
+        os.path.join(artifact_dir, f"{run_id}.txt")
+        if artifact_dir
+        else f"logs/{run_id}.txt"
+    )
+    model_path = (
+        os.path.join(artifact_dir, "final_model.pt")
+        if artifact_dir
+        else "final_model.pt"
+    )
+    quantized_model_path = (
+        os.path.join(artifact_dir, "final_model.int6.ptz")
+        if artifact_dir
+        else "final_model.int6.ptz"
+    )
+
+
+_logger_hparams = None
+
+
+def set_logging_hparams(h):
+    global _logger_hparams
+    _logger_hparams = h
+
+
+def log(msg, console=True):
+    if _logger_hparams is None:
+        print(msg)
+        return
+    if _logger_hparams.is_main_process:
+        if console:
+            print(msg)
+        if _logger_hparams.logfile is not None:
+            with open(_logger_hparams.logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+
+class ValidationData:
+    def __init__(self, h, device):
+        self.sp = spm.SentencePieceProcessor(model_file=h.tokenizer_path)
+        if int(self.sp.vocab_size()) != h.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={h.vocab_size} does not match tokenizer vocab_size={int(self.sp.vocab_size())}"
+            )
+        self.val_tokens = load_validation_tokens(h.val_files, h.eval_seq_len)
+        (
+            self.base_bytes_lut,
+            self.has_leading_space_lut,
+            self.is_boundary_token_lut,
+        ) = build_sentencepiece_luts(self.sp, h.vocab_size, device)
+        # CaseOps: when enabled, load per-token byte sidecar and stash it as a
+        # CPU tensor aligned 1:1 with self.val_tokens. eval_val/eval_val_ttt
+        # branches use this as the canonical raw-byte budget per token.
+        self.caseops_enabled = bool(getattr(h, "caseops_enabled", False))
+        self.val_bytes = None
+        if self.caseops_enabled:
+            self.val_bytes = load_validation_byte_sidecar(
+                h.val_bytes_files, h.eval_seq_len, self.val_tokens.numel()
+            )
+
+
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sp_vocab_size = int(sp.vocab_size())
+    assert (
+        sp.piece_to_id("▁") != sp.unk_id()
+    ), "Tokenizer must have '▁' (space) as its own token for correct BPB byte counting"
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern, seq_len):
+    # Filter out CaseOps byte sidecar shards which share the val_*.bin glob.
+    files = [
+        Path(p)
+        for p in sorted(glob.glob(pattern))
+        if "_bytes_" not in Path(p).name
+    ]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = (tokens.numel() - 1) // seq_len * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def load_validation_byte_sidecar(pattern, seq_len, expected_len):
+    """Load CaseOps per-token byte sidecar(s). Same shard layout as token shards
+    (256 int32 header + uint16 array). Each entry = canonical raw-text byte
+    budget for that token in the corresponding val shard. Returns a CPU
+    int16 tensor sliced to match expected_len (i.e. val_tokens length)."""
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No byte sidecar files for pattern: {pattern}")
+    shards = [load_data_shard(file) for file in files]
+    # load_data_shard returns uint16 — that's exactly what the sidecar stores.
+    bytes_full = torch.cat(shards).contiguous()
+    if bytes_full.numel() < expected_len:
+        raise ValueError(
+            f"Byte sidecar too short: {bytes_full.numel()} < val_tokens {expected_len}"
+        )
+    return bytes_full[:expected_len].to(torch.int32)
+
+
+def load_data_shard(file):
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE = {}
+_MMAP_CACHE = {}
+
+
+def _read_num_tokens(file):
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+
+def _get_shard_memmap(file):
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode="r", dtype="<u2", offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+BOS_ID = None
+
+
+def get_next_multiple_of_n(v, n):
+    return ((v + n - 1) // n) * n
+
+
+def _build_cu_seqlens(bos_pos, total_len, device, max_doc_len=0, bucket_size=64):
+    if not bos_pos or bos_pos[0] != 0:
+        bos_pos = [0] + bos_pos
+    seg_starts = []
+    starts_with_end = bos_pos + [total_len]
+    for i in range(len(starts_with_end) - 1):
+        start = starts_with_end[i]
+        end = starts_with_end[i + 1]
+        if max_doc_len > 0:
+            pos = start
+            while pos < end:
+                seg_starts.append(pos)
+                pos += max_doc_len
+        else:
+            seg_starts.append(start)
+    boundaries = seg_starts + [total_len]
+    padded_len = get_next_multiple_of_n(len(boundaries), bucket_size)
+    cu = torch.full((padded_len,), total_len, dtype=torch.int32, device=device)
+    cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+    seg_ends = seg_starts[1:] + [total_len]
+    max_seqlen = max(end - start for start, end in zip(seg_starts, seg_ends))
+    return cu, max_seqlen
+
+class DocumentPackingLoader:
+    _shard_pool = ThreadPoolExecutor(1)
+
+    def __init__(self, h, device, cu_bucket_size=64):
+        self.rank = h.rank
+        self.world_size = h.world_size
+        self.device = device
+        self.cu_bucket_size = cu_bucket_size
+        self.max_seq_len = h.train_seq_len
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files
+        self.file_iter = iter(self.files)
+        self._init_shard(load_data_shard(next(self.file_iter)))
+        self._next_shard = self._submit_next_shard()
+        self._batch_pool = ThreadPoolExecutor(1)
+        self._next_batch = None
+
+    def _init_shard(self, tokens):
+        global BOS_ID
+        self.tokens = tokens
+        self.shard_size = tokens.numel()
+        if BOS_ID is None:
+            BOS_ID = 1
+        self.bos_idx = (
+            (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        )
+        if self.bos_idx.size == 0:
+            self.bos_idx = np.array([0], dtype=np.int64)
+        self.cursor = int(self.bos_idx[0])
+
+    def _submit_next_shard(self):
+        try:
+            path = next(self.file_iter)
+            return self._shard_pool.submit(load_data_shard, path)
+        except StopIteration:
+            return None
+
+    def _advance_shard(self):
+        if self._next_shard is None:
+            self.file_iter = iter(self.files)
+            self._next_shard = self._shard_pool.submit(
+                load_data_shard, next(self.file_iter)
+            )
+        self._init_shard(self._next_shard.result())
+        self._next_shard = self._submit_next_shard()
+
+    def _local_doc_starts(self, local_start, total_len):
+        lo = np.searchsorted(self.bos_idx, local_start, side="left")
+        hi = np.searchsorted(self.bos_idx, local_start + total_len, side="left")
+        return (self.bos_idx[lo:hi] - local_start).tolist()
+
+    def _prepare_batch(self, num_tokens_local, max_seq_len):
+        per_rank_span = num_tokens_local + 1
+        global_span = per_rank_span * self.world_size
+        while self.cursor + global_span > self.shard_size:
+            self._advance_shard()
+        local_start = self.cursor + self.rank * per_rank_span
+        buf = self.tokens[local_start : local_start + per_rank_span]
+        inputs = buf[:-1].to(dtype=torch.int64).pin_memory()
+        targets = buf[1:].to(dtype=torch.int64).pin_memory()
+        starts = self._local_doc_starts(local_start, inputs.numel())
+        cu_seqlens, max_seqlen = _build_cu_seqlens(
+            starts, inputs.numel(), inputs.device, max_seq_len, self.cu_bucket_size
+        )
+        cu_seqlens = cu_seqlens.pin_memory()
+        self.cursor += global_span
+        return inputs, targets, cu_seqlens, max_seqlen
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        num_tokens_local = global_tokens // (self.world_size * grad_accum_steps)
+        if self._next_batch is not None:
+            inputs, targets, cu_seqlens, max_seqlen = self._next_batch.result()
+        else:
+            inputs, targets, cu_seqlens, max_seqlen = self._prepare_batch(
+                num_tokens_local, self.max_seq_len
+            )
+        self._next_batch = self._batch_pool.submit(
+            self._prepare_batch, num_tokens_local, self.max_seq_len
+        )
+        return (
+            inputs[None].to(self.device, non_blocking=True),
+            targets[None].to(self.device, non_blocking=True),
+            cu_seqlens.to(self.device, non_blocking=True),
+            max_seqlen,
+        )
+
+
+class ShuffledSequenceLoader:
+    def __init__(self, h, device):
+        self.world_size = h.world_size
+        self.seq_len = h.train_seq_len
+        self.device = device
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files[h.rank :: h.world_size]
+        self.rng = np.random.Generator(np.random.PCG64(h.rank))
+        self.num_tokens = [_read_num_tokens(f) for f in self.files]
+        self.start_inds = [[] for _ in self.files]
+        for si in range(len(self.files)):
+            self._reset_shard(si)
+
+    def _reset_shard(self, si):
+        max_phase = min(
+            self.seq_len - 1, max(0, self.num_tokens[si] - self.seq_len - 1)
+        )
+        phase = int(self.rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        num_sequences = (self.num_tokens[si] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[si] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for bi in range(device_batch_size):
+            total = remaining.sum()
+            if total <= 0:
+                for si in range(len(self.files)):
+                    self._reset_shard(si)
+                remaining = np.array(
+                    [len(s) for s in self.start_inds], dtype=np.float64
+                )
+                total = remaining.sum()
+            probs = remaining / total
+            si = int(self.rng.choice(len(self.files), p=probs))
+            start_ind = self.start_inds[si].pop()
+            remaining[si] -= 1
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[bi] = window[:-1]
+            y[bi] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    # SpinQuant V1: class-level flag gates the forward-pass rotation hooks in
+    # CausalSelfAttention.forward, MLP.forward, _block_with_lora, and
+    # _parallel_block_with_lora. OFF during training (Dynamo constant-folds the
+    # branch away). Flipped to True by deserialize() after install_spinquant_
+    # rotations() registers the R buffers on every attn/mlp module.
+    _sq_active: bool = False
+
+    def forward(self, x):
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+@triton.jit
+def linear_leaky_relu_square_kernel(
+    a_desc,
+    b_desc,
+    c_desc,
+    aux_desc,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    FORWARD: tl.constexpr,
+):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+    tile_id_c = start_pid - NUM_SMS
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+        tile_id_c += NUM_SMS
+        offs_am_c = offs_am
+        offs_bn_c = offs_bn
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+        c0 = acc0.to(dtype)
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            pre0 = aux_desc.load([offs_am_c, offs_bn_c])
+            pre1 = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c0 = c0 * tl.where(pre0 > 0, 2.0 * pre0, 0.5 * pre0)
+            c1 = c1 * tl.where(pre1 > 0, 2.0 * pre1, 0.5 * pre1)
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+        if FORWARD:
+            aux0 = tl.where(c0 > 0, c0, 0.5 * c0)
+            aux1 = tl.where(c1 > 0, c1, 0.5 * c1)
+            aux_desc.store([offs_am_c, offs_bn_c], aux0 * aux0)
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], aux1 * aux1)
+
+
+def linear_leaky_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K2 = b.shape
+    assert K == K2
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    forward = aux is None
+    if aux is None:
+        aux = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 256, 64
+    num_stages = 4 if forward else 3
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    grid = lambda _meta: (
+        min(num_sms, triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N)),
+    )
+    linear_leaky_relu_square_kernel[grid](
+        a_desc,
+        b_desc,
+        c_desc,
+        aux_desc,
+        M,
+        N,
+        K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        NUM_SMS=num_sms,
+        FORWARD=forward,
+        num_stages=num_stages,
+        num_warps=8,
+    )
+    if forward:
+        return c, aux
+    return c
+
+
+class FusedLinearLeakyReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, w1, w2):
+        x_flat = x.reshape(-1, x.shape[-1])
+        pre, post = linear_leaky_relu_square(x_flat, w1)
+        out = F.linear(post, w2)
+        ctx.save_for_backward(x, w1, w2, pre, post)
+        return out.view(*x.shape[:-1], out.shape[-1])
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, w1, w2, pre, post = ctx.saved_tensors
+        x_flat = x.reshape(-1, x.shape[-1])
+        grad_output_flat = grad_output.reshape(-1, grad_output.shape[-1])
+        dw2 = grad_output_flat.T @ post
+        dpre = linear_leaky_relu_square(grad_output_flat, w2.T.contiguous(), aux=pre)
+        dw1 = dpre.T @ x_flat
+        dx = dpre @ w1
+        return dx.view_as(x), dw1, dw2
+
+
+FusedLeakyReLUSquareMLP = FusedLinearLeakyReLUSquareFunction.apply
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=1e4, train_seq_len=1024, rope_dims=0, yarn=True):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.yarn = yarn
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / base ** (
+            torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+
+    def forward(self, seq_len, device, dtype):
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached < seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if self.yarn and seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * scale ** (rd / (rd - 2))
+                inv_freq = 1.0 / new_base ** (
+                    torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd
+                )
+            else:
+                inv_freq = self.inv_freq.float().to(device)
+            t = torch.arange(seq_len, device=device, dtype=torch.float32)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached[:, :seq_len].to(dtype=dtype), self._sin_cached[:, :seq_len].to(dtype=dtype)
+
+
+def apply_rotary_emb(x, cos, sin, rope_dims=0):
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=True,
+        attn_out_gate=False, attn_out_gate_src="proj", gate_window=12,
+        gated_attn=False, gated_attn_init_std=0.01,
+        sparse_attn_gate=False, sparse_attn_gate_init_std=0.0, sparse_attn_gate_scale=1.0,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        if int(attn_out_gate) + int(gated_attn) + int(sparse_attn_gate) > 1:
+            raise ValueError(
+                "attn_out_gate, gated_attn, and sparse_attn_gate are mutually exclusive"
+            )
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len, yarn=yarn)
+        self.use_xsa = False
+        # AttnOutGate (PR #1667 MarioPaerle): per-head multiplicative gate on attention
+        # output. CastedLinear so restore_fp32_params casts back to fp32 for GPTQ.
+        # _zero_init -> 2*sigmoid(0)=1 -> transparent at init.
+        self.attn_out_gate = attn_out_gate
+        self.attn_out_gate_src = attn_out_gate_src
+        self.gate_window = gate_window
+        if attn_out_gate:
+            self.attn_gate_proj = CastedLinear(gate_window, num_heads, bias=False)
+            self.attn_gate_proj._zero_init = True
+        # Gated Attention (arXiv:2505.06708, Qwen, NeurIPS 2025). Per-head sigmoid
+        # gate on SDPA output, BEFORE out_proj. Gate projection W_g: (num_heads, dim).
+        # Name "attn_gate_w" contains "attn_gate" substring so it matches
+        # CONTROL_TENSOR_NAME_PATTERNS and routes to the scalar AdamW group.
+        # fp32 Parameter -> restore_fp32_params path covers it via the ndim<2 OR
+        # name-pattern check (name matches "attn_gate"). Cast to x.dtype on use.
+        self.gated_attn = gated_attn
+        if gated_attn:
+            W = torch.empty(num_heads, dim, dtype=torch.float32)
+            nn.init.normal_(W, mean=0.0, std=gated_attn_init_std)
+            self.attn_gate_w = nn.Parameter(W)
+        self.sparse_attn_gate = sparse_attn_gate
+        self.sparse_attn_gate_scale = sparse_attn_gate_scale
+        if sparse_attn_gate:
+            W = torch.empty(num_heads, gate_window, dtype=torch.float32)
+            if sparse_attn_gate_init_std > 0:
+                nn.init.normal_(W, mean=0.0, std=sparse_attn_gate_init_std)
+            else:
+                nn.init.zeros_(W)
+            self.attn_gate_w = nn.Parameter(W)
+
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x, q_w, k_w, v_w, out_w, cu_seqlens=None, max_seqlen=0):
+        bsz, seqlen, dim = x.shape
+        # SpinQuant V1: rotate residual → Q/K/V input. Branch dies at Dynamo
+        # compile when _sq_active=False (training). Math: F.linear(x @ R, W @ R)
+        # == F.linear(x, W) exactly; the weight rotation lives in state_dict
+        # courtesy of _spinquant_rotate_sd_and_H() before GPTQ.
+        if CastedLinear._sq_active and hasattr(self, "_sq_R_attn_in"):
+            x_qkv = x @ self._sq_R_attn_in.to(x.dtype)
+        else:
+            x_qkv = x
+        # q_raw kept around as a tap point for attn_out_gate_src='q' (post-projection,
+        # pre-reshape, pre-RoPE).
+        q_raw = F.linear(x_qkv, q_w.to(x.dtype))
+        q = q_raw.reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x_qkv, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x_qkv, v_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if cu_seqlens is not None:
+            y = flash_attn_varlen_func(
+                q[0],
+                k[0],
+                v[0],
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+                causal=True,
+                window_size=(-1, -1),
+            )[None]
+        else:
+            y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        # AttnOutGate inlined (PR #1667). Inline + .contiguous() barrier so torch.compile
+        # fullgraph=True is happy (this avoids the @torch.compiler.disable trap that
+        # crashed gates v3). Per-head gate on (B,T,H,D) tensor: g shape [B,T,H], broadcast
+        # over D via [..., None]. zero-init weight -> 2*sigmoid(0)=1 -> transparent.
+        if self.attn_out_gate:
+            gate_src = q_raw if self.attn_out_gate_src == "q" else x
+            gate_in = gate_src[..., : self.gate_window].contiguous()
+            g = 2.0 * torch.sigmoid(self.attn_gate_proj(gate_in))
+            y = y * g[..., None]
+        # Gated Attention (arXiv:2505.06708 G1). Inline + .contiguous() barrier so
+        # torch.compile fullgraph=True is happy. Per-head gate on (B,T,H,D): g shape
+        # [B,T,H], broadcast over D via [..., None]. Paper: g = sigmoid(x @ W_g.T)
+        # where W_g: (H, dim). .to(x.dtype) on fp32 param before broadcast with bf16.
+        if self.gated_attn:
+            x_c = x.contiguous()
+            g = torch.sigmoid(F.linear(x_c, self.attn_gate_w.to(x.dtype)))
+            y = y * g[..., None]
+        if self.sparse_attn_gate:
+            gate_in = x[..., : self.gate_window].contiguous()
+            g = torch.sigmoid(
+                self.sparse_attn_gate_scale
+                * F.linear(gate_in, self.attn_gate_w.to(x.dtype))
+            )
+            y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        self._last_proj_input = y.detach() if getattr(self, "_calib", False) else None
+        # SpinQuant V1: rotate attention output → proj input, matched by the
+        # input-col rotation of attn.proj.weight in state_dict.
+        if CastedLinear._sq_active and hasattr(self, "_sq_R_attn_proj_in"):
+            y = y @ self._sq_R_attn_proj_in.to(x.dtype)
+        return F.linear(y, out_w.to(x.dtype))
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        self.use_fused = True
+
+    def forward(self, x, up_w, down_w):
+        # SpinQuant V1 forward rotations. Branches die at compile when _sq_active=False.
+        sq = CastedLinear._sq_active and hasattr(self, "_sq_R_mlp_in")
+        if sq:
+            x = x @ self._sq_R_mlp_in.to(x.dtype)
+        # Fused kernel cannot express mid-hidden rotation, so disable it when SQ is on.
+        # SQ is only active post-deserialize (eval/TTT) where fused is already typically
+        # off; this guard covers the TTT-train case if it ever arises.
+        if self.training and self.use_fused and not sq:
+            return FusedLeakyReLUSquareMLP(x, up_w.to(x.dtype), down_w.to(x.dtype))
+        hidden = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5).square()
+        # Capture BEFORE the mlp_proj_in rotation so the Hessian stays on unrotated hidden.
+        self._last_down_input = hidden.detach() if getattr(self, "_calib", False) else None
+        if sq and hasattr(self, "_sq_R_mlp_proj_in"):
+            hidden = hidden @ self._sq_R_mlp_proj_in.to(x.dtype)
+        return F.linear(hidden, down_w.to(x.dtype))
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        num_kv_heads,
+        mlp_mult,
+        rope_base,
+        qk_gain_init,
+        train_seq_len,
+        layer_idx=0,
+        ln_scale=False,
+        yarn=True,
+        attn_out_gate=False,
+        attn_out_gate_src="proj",
+        gate_window=12,
+        gated_attn=False,
+        gated_attn_init_std=0.01,
+        sparse_attn_gate=False,
+        sparse_attn_gate_init_std=0.0,
+        sparse_attn_gate_scale=1.0,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=yarn,
+            attn_out_gate=attn_out_gate, attn_out_gate_src=attn_out_gate_src, gate_window=gate_window,
+            gated_attn=gated_attn, gated_attn_init_std=gated_attn_init_std,
+            sparse_attn_gate=sparse_attn_gate,
+            sparse_attn_gate_init_std=sparse_attn_gate_init_std,
+            sparse_attn_gate_scale=sparse_attn_gate_scale,
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(
+            torch.stack((torch.ones(dim), torch.zeros(dim))).float()
+        )
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+
+    def forward(self, x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=None, max_seqlen=0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(
+            self.attn_norm(x_in) * self.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[
+            None, None, :
+        ] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        return x_out
+
+class GPT(nn.Module):
+    def __init__(self, h):
+        super().__init__()
+        if h.logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {h.logit_softcap}")
+        self.tie_embeddings = h.tie_embeddings
+        self.tied_embed_init_std = h.tied_embed_init_std
+        self.logit_softcap = h.logit_softcap
+        self.fused_ce_enabled = bool(h.fused_ce_enabled)
+        self.tok_emb = nn.Embedding(h.vocab_size, h.model_dim)
+        self.num_layers = h.num_layers
+        head_dim = h.model_dim // h.num_heads
+        kv_dim = h.num_kv_heads * head_dim
+        hidden_dim = int(h.mlp_mult * h.model_dim)
+        self.qo_bank = nn.Parameter(torch.empty(2 * h.num_layers, h.model_dim, h.model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * h.num_layers, kv_dim, h.model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(h.num_layers, hidden_dim, h.model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(h.num_layers, h.model_dim, hidden_dim))
+        self.num_encoder_layers = h.num_layers // 2
+        self.num_decoder_layers = h.num_layers - self.num_encoder_layers
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    h.model_dim,
+                    h.num_heads,
+                    h.num_kv_heads,
+                    h.mlp_mult,
+                    h.rope_base,
+                    h.qk_gain_init,
+                    h.train_seq_len,
+                    layer_idx=i,
+                    ln_scale=h.ln_scale,
+                    yarn=h.rope_yarn,
+                    attn_out_gate=h.attn_out_gate_enabled,
+                    attn_out_gate_src=h.attn_out_gate_src,
+                    gate_window=h.gate_window,
+                    gated_attn=h.gated_attn_enabled,
+                    gated_attn_init_std=h.gated_attn_init_std,
+                    sparse_attn_gate=h.sparse_attn_gate_enabled,
+                    sparse_attn_gate_init_std=h.sparse_attn_gate_init_std,
+                    sparse_attn_gate_scale=h.sparse_attn_gate_scale,
+                )
+                for i in range(h.num_layers)
+            ]
+        )
+        if h.rope_dims > 0:
+            head_dim = h.model_dim // h.num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = h.rope_dims
+                block.attn.rotary = Rotary(
+                    head_dim,
+                    base=h.rope_base,
+                    train_seq_len=h.train_seq_len,
+                    rope_dims=h.rope_dims,
+                    yarn=h.rope_yarn,
+                )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None
+            if h.tie_embeddings
+            else CastedLinear(h.model_dim, h.vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if h.xsa_last_n > 0:
+            for i in range(max(0, h.num_layers - h.xsa_last_n), h.num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self.looping_active = False
+        self._num_loops = h.num_loops
+        if h.num_loops > 0:
+            loop_seg = list(range(h.loop_start, h.loop_end + 1))
+            all_indices = list(range(h.loop_start))
+            for _ in range(h.num_loops + 1):
+                all_indices.extend(loop_seg)
+            all_indices.extend(range(h.loop_end + 1, h.num_layers))
+            num_enc = len(all_indices) // 2
+            self.encoder_indices = all_indices[:num_enc]
+            self.decoder_indices = all_indices[num_enc:]
+            # depth curriculum: precompute intermediate (num_loops-1) indices for phase 2
+            if h.loop_depth_upgrade_at > 0 and h.num_loops >= 2:
+                all_int = list(range(h.loop_start))
+                for _ in range(h.num_loops):  # num_loops-1+1 passes = num_loops passes
+                    all_int.extend(loop_seg)
+                all_int.extend(range(h.loop_end + 1, h.num_layers))
+                num_enc_int = len(all_int) // 2
+                self._enc_idx_intermediate = all_int[:num_enc_int]
+                self._dec_idx_intermediate = all_int[num_enc_int:]
+                self.looping_depth = h.num_loops - 1  # start at intermediate after activation
+            else:
+                self.looping_depth = h.num_loops
+        else:
+            self.encoder_indices = list(range(self.num_encoder_layers))
+            self.decoder_indices = list(range(self.num_encoder_layers, h.num_layers))
+            self.looping_depth = 0
+        self.num_skip_weights = min(
+            len(self.encoder_indices), len(self.decoder_indices)
+        )
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+        )
+        self.skip_gates = (
+            nn.Parameter(
+                torch.zeros(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+            )
+            if h.skip_gates_enabled
+            else None
+        )
+        self.parallel_start_layer = h.parallel_start_layer
+        self.parallel_final_lane = h.parallel_final_lane.lower()
+        self.parallel_post_lambdas = nn.Parameter(
+            torch.ones(h.num_layers, 2, 2, dtype=torch.float32)
+        )
+        self.parallel_resid_lambdas = nn.Parameter(
+            torch.full((h.num_layers, 2), 1.1, dtype=torch.float32)
+        )
+        # SmearGate (PR #1667 / modded-nanogpt @classiclarryd):
+        #   x_t <- x_t + lam * sigmoid(W * x_t[:gate_window]) * x_{t-1}.
+        # Per-token forward-1 smear of the embedding lane. W zero-init + lam=0 ->
+        # transparent at init. Uses CastedLinear so restore_fp32_params handles dtype.
+        self.smear_gate_enabled = h.smear_gate_enabled
+        if self.smear_gate_enabled:
+            self.smear_window = h.gate_window
+            self.smear_gate = CastedLinear(self.smear_window, 1, bias=False)
+            self.smear_gate._zero_init = True
+            self.smear_lambda = nn.Parameter(torch.zeros(1, dtype=torch.float32))
+        # Spec 015 Recur-Alpha (port #1714). All state attr-guarded so default=off
+        # is byte-identical to baseline (attr checks in forward look for None).
+        self.recur_alpha_enabled = bool(h.recur_alpha_enabled) and h.num_loops > 0
+        self.recur_diag_p2p_cos = bool(h.recur_diag_p2p_cos) and h.num_loops > 0
+        self.loop_start = h.loop_start
+        self.loop_end = h.loop_end
+        if self.recur_alpha_enabled:
+            num_looped = h.loop_end - h.loop_start + 1
+            self.num_looped = num_looped
+            # Spec 036: sparse-gate 8xH promotion using updated recurrent carry
+            # from the sparse learnable-alpha/beta experiment, rounded to 2
+            # decimal places before freezing.
+            self.register_buffer(
+                "recur_beta",
+                torch.tensor([1.56, 1.85, 2.13], dtype=torch.float32),
+            )
+            self.register_buffer(
+                "recur_alpha",
+                torch.tensor(
+                    [[0.23, 0.04, 0.03],
+                     [0.13, -0.34, 0.01],
+                     [0.06, 0.19, -0.02]],
+                    dtype=torch.float32,
+                ),
+            )
+            # Precompute alpha_info lists: parallel to encoder_indices and
+            # decoder_indices, indicating (pass_offset, local_idx) or None for
+            # each position. Pass counts span encoder + decoder (sequential).
+            visits = {}
+            self._encoder_alpha_info = []
+            for idx in self.encoder_indices:
+                pi = visits.get(idx, 0)
+                visits[idx] = pi + 1
+                if self.loop_start <= idx <= self.loop_end and pi > 0:
+                    self._encoder_alpha_info.append((pi - 1, idx - self.loop_start))
+                else:
+                    self._encoder_alpha_info.append(None)
+            self._decoder_alpha_info = []
+            for idx in self.decoder_indices:
+                pi = visits.get(idx, 0)
+                visits[idx] = pi + 1
+                if self.loop_start <= idx <= self.loop_end and pi > 0:
+                    self._decoder_alpha_info.append((pi - 1, idx - self.loop_start))
+                else:
+                    self._decoder_alpha_info.append(None)
+            # Depth curriculum: _dec_idx_intermediate is NOT a prefix of
+            # decoder_indices (enc/dec split shifts with one fewer loop pass),
+            # so _decoder_alpha_info indexed by dec_int step_idx is misaligned.
+            # Build separate alpha_info lists from the intermediate sequences.
+            if (h.loop_depth_upgrade_at > 0 and h.num_loops >= 2
+                    and hasattr(self, '_enc_idx_intermediate')):
+                visits_int = {}
+                self._encoder_alpha_info_int = []
+                for idx in self._enc_idx_intermediate:
+                    pi = visits_int.get(idx, 0)
+                    visits_int[idx] = pi + 1
+                    if self.loop_start <= idx <= self.loop_end and pi > 0:
+                        self._encoder_alpha_info_int.append((pi - 1, idx - self.loop_start))
+                    else:
+                        self._encoder_alpha_info_int.append(None)
+                self._decoder_alpha_info_int = []
+                for idx in self._dec_idx_intermediate:
+                    pi = visits_int.get(idx, 0)
+                    visits_int[idx] = pi + 1
+                    if self.loop_start <= idx <= self.loop_end and pi > 0:
+                        self._decoder_alpha_info_int.append((pi - 1, idx - self.loop_start))
+                    else:
+                        self._decoder_alpha_info_int.append(None)
+            else:
+                self._encoder_alpha_info_int = None
+                self._decoder_alpha_info_int = None
+        else:
+            self.recur_beta = None
+            self.recur_alpha = None
+            self.num_looped = 0
+            self._encoder_alpha_info = None
+            self._decoder_alpha_info = None
+            self._encoder_alpha_info_int = None
+            self._decoder_alpha_info_int = None
+        # Diagnostic buffers for p2p cosine. Updated in forward, read by logger.
+        # Detached values only; no backprop through these.
+        if self.recur_diag_p2p_cos:
+            num_looped = h.loop_end - h.loop_start + 1
+            # Mean cosine per (pass_pair, layer) — num_loops pass pairs × num_looped layers.
+            self.register_buffer(
+                "_diag_p2p_cos",
+                torch.zeros(h.num_loops, num_looped, dtype=torch.float32),
+                persistent=False,
+            )
+            self._diag_prev_deltas = {}  # layer_idx -> tensor (updated in forward)
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.qo_bank.data[n + i])
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)
+        for i in range(n):
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.mlp_down_bank.data[i])
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _bank_weights(self, i):
+        n = self.num_layers
+        return (
+            self.qo_bank[i],
+            self.kv_bank[i],
+            self.kv_bank[n + i],
+            self.qo_bank[n + i],
+            self.mlp_up_bank[i],
+            self.mlp_down_bank[i],
+        )
+
+    def _parallel_block(
+        self, block_idx, lane0, lane1, x0,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+        cu_seqlens=None, max_seqlen=0,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        attn_out = block.attn(
+            block.attn_norm(attn_read) * block.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+        )
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * block.mlp(
+            block.mlp_norm(mlp_read) * block.ln_scale_factor, up_w, down_w
+        )
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+    def _final_parallel_hidden(self, lane0, lane1):
+        if self.parallel_final_lane == "mlp":
+            return lane1
+        if self.parallel_final_lane == "attn":
+            return lane0
+        return 0.5 * (lane0 + lane1)
+
+    def _forward_hidden(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        x = self.tok_emb(input_ids)
+        # SmearGate (PR #1667). Inline gate compute with .contiguous() on the slice fed
+        # to the projection so torch.compile fullgraph is happy. lam=0 + W=0 -> identity
+        # at init. This block runs unconditionally on the smear path; the cat keeps
+        # position 0 untouched so causality holds.
+        if self.smear_gate_enabled:
+            sl = self.smear_lambda.to(dtype=x.dtype)
+            gate_in = x[:, 1:, : self.smear_window].contiguous()
+            g = sl * torch.sigmoid(self.smear_gate(gate_in))
+            x = torch.cat([x[:, :1], x[:, 1:] + g * x[:, :-1]], dim=1)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips = []
+        if self.looping_active:
+            if self.looping_depth < self._num_loops and hasattr(self, '_enc_idx_intermediate'):
+                enc_iter = self._enc_idx_intermediate
+                dec_iter = self._dec_idx_intermediate
+            else:
+                enc_iter = self.encoder_indices
+                dec_iter = self.decoder_indices
+        else:
+            enc_iter = range(self.num_encoder_layers)
+            dec_iter = range(
+                self.num_encoder_layers,
+                self.num_encoder_layers + self.num_decoder_layers,
+            )
+        # Spec 015: use precomputed alpha_info only when Recur-Alpha enabled AND
+        # looping is active. When inactive, behavior is byte-identical to baseline.
+        # Spec 029: during depth curriculum (looping_depth < _num_loops), use
+        # the intermediate-sequence alpha_info to avoid misalignment.
+        if self.recur_alpha is not None and self.looping_active:
+            if (self.looping_depth < self._num_loops
+                    and self._encoder_alpha_info_int is not None):
+                enc_alpha_info = self._encoder_alpha_info_int
+            else:
+                enc_alpha_info = self._encoder_alpha_info
+        else:
+            enc_alpha_info = None
+        carry = {} if enc_alpha_info is not None else None
+        for step_idx, i in enumerate(enc_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x_before = x
+            x_new = self.blocks[i](x_before, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+            if enc_alpha_info is not None and enc_alpha_info[step_idx] is not None:
+                pass_off, local_idx = enc_alpha_info[step_idx]
+                beta = self.recur_beta[local_idx].to(x_new.dtype)
+                x = beta * x_new
+                for j in range(self.num_looped):
+                    x = x + self.recur_alpha[local_idx, j].to(x_new.dtype) * carry[self.loop_start + j]
+                # Diagnostic: p2p cosine similarity on block deltas (optional).
+                if self.recur_diag_p2p_cos:
+                    delta_this = (x_new - x_before).detach()
+                    prev = self._diag_prev_deltas.get(i, None)
+                    if prev is not None:
+                        flat_this = delta_this.reshape(-1, delta_this.size(-1))
+                        flat_prev = prev.reshape(-1, prev.size(-1))
+                        cos = F.cosine_similarity(flat_this, flat_prev, dim=-1).mean()
+                        self._diag_p2p_cos[pass_off, local_idx] = cos
+                    self._diag_prev_deltas[i] = delta_this
+            else:
+                x = x_new
+                if carry is not None and self.loop_start <= i <= self.loop_end:
+                    carry[i] = x_new.detach()
+                if self.recur_diag_p2p_cos and self.loop_start <= i <= self.loop_end:
+                    self._diag_prev_deltas[i] = (x_new - x_before).detach()
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        # Spec 015: alpha_info for decoder; shares visit-count state with encoder
+        # (see __init__ precompute). None when Recur-Alpha disabled or looping inactive.
+        if self.recur_alpha is not None and self.looping_active:
+            if (self.looping_depth < self._num_loops
+                    and self._decoder_alpha_info_int is not None):
+                dec_alpha_info = self._decoder_alpha_info_int
+            else:
+                dec_alpha_info = self._decoder_alpha_info
+        else:
+            dec_alpha_info = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block(
+                    i, lane0, lane1, x0, q_w, k_w, v_w, out_w, up_w, down_w,
+                    cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x_before = x
+                x_new = self.blocks[i](x_before, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+                if dec_alpha_info is not None and dec_alpha_info[skip_idx] is not None:
+                    pass_off, local_idx = dec_alpha_info[skip_idx]
+                    beta = self.recur_beta[local_idx].to(x_new.dtype)
+                    x = beta * x_new
+                    for j in range(self.num_looped):
+                        x = x + self.recur_alpha[local_idx, j].to(x_new.dtype) * carry[self.loop_start + j]
+                    if self.recur_diag_p2p_cos:
+                        delta_this = (x_new - x_before).detach()
+                        prev = self._diag_prev_deltas.get(i, None)
+                        if prev is not None:
+                            flat_this = delta_this.reshape(-1, delta_this.size(-1))
+                            flat_prev = prev.reshape(-1, prev.size(-1))
+                            cos = F.cosine_similarity(flat_this, flat_prev, dim=-1).mean()
+                            self._diag_p2p_cos[pass_off, local_idx] = cos
+                        self._diag_prev_deltas[i] = delta_this
+                else:
+                    x = x_new
+                    if carry is not None and self.loop_start <= i <= self.loop_end:
+                        carry[i] = x_new.detach()
+                    if self.recur_diag_p2p_cos and self.loop_start <= i <= self.loop_end:
+                        self._diag_prev_deltas[i] = (x_new - x_before).detach()
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        return self.final_norm(x)
+
+    def _project_logits(self, hidden):
+        if self.tie_embeddings:
+            return F.linear(hidden, self.tok_emb.weight)
+        return self.lm_head(hidden)
+
+    def forward_logits(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        logits_proj = self._project_logits(hidden)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(self, input_ids, target_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden(input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        logits_proj = self._project_logits(hidden)
+        flat_targets = target_ids.reshape(-1)
+        if self.fused_ce_enabled:
+            return softcapped_cross_entropy(
+                logits_proj.reshape(-1, logits_proj.size(-1)),
+                flat_targets,
+                self.logit_softcap,
+                reduction="mean",
+            )
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            flat_targets,
+            reduction="mean",
+        )
+
+    def forward_ttt(self, input_ids, target_ids, lora):
+        x = self.tok_emb(input_ids)
+        # SmearGate on the TTT path — same inline compute as forward_logits.
+        if self.smear_gate_enabled:
+            sl = self.smear_lambda.to(dtype=x.dtype)
+            gate_in = x[:, 1:, : self.smear_window].contiguous()
+            g = sl * torch.sigmoid(self.smear_gate(gate_in))
+            x = torch.cat([x[:, :1], x[:, 1:] + g * x[:, :-1]], dim=1)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else list(range(self.num_encoder_layers))
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else list(
+                range(
+                    self.num_encoder_layers,
+                    self.num_encoder_layers + self.num_decoder_layers,
+                )
+            )
+        )
+        # TTT α fix: apply the same blend as forward_logits. Without this,
+        # TTT adaptation sees the un-α-weighted forward pass, which mismatches
+        # training and leaves ~0.002 of TTT delta on the table (017-era bug).
+        enc_alpha_info = (
+            self._encoder_alpha_info
+            if (self.recur_alpha is not None and self.looping_active)
+            else None
+        )
+        carry = {} if enc_alpha_info is not None else None
+        slot = 0
+        for step_idx, i in enumerate(enc_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x_before = x
+            x_new = self._block_with_lora(self.blocks[i], x_before, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            if enc_alpha_info is not None and enc_alpha_info[step_idx] is not None:
+                pass_off, local_idx = enc_alpha_info[step_idx]
+                beta = self.recur_beta[local_idx].to(x_new.dtype)
+                x = beta * x_new
+                for j in range(self.num_looped):
+                    x = x + self.recur_alpha[local_idx, j].to(x_new.dtype) * carry[self.loop_start + j]
+            else:
+                x = x_new
+                if carry is not None and self.loop_start <= i <= self.loop_end:
+                    carry[i] = x_new.detach()
+            slot += 1
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        dec_alpha_info = (
+            self._decoder_alpha_info
+            if (self.recur_alpha is not None and self.looping_active)
+            else None
+        )
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block_with_lora(
+                    i, lane0, lane1, x0, lora, slot,
+                    q_w, k_w, v_w, out_w, up_w, down_w,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x_before = x
+                x_new = self._block_with_lora(self.blocks[i], x_before, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+                if dec_alpha_info is not None and dec_alpha_info[skip_idx] is not None:
+                    pass_off, local_idx = dec_alpha_info[skip_idx]
+                    beta = self.recur_beta[local_idx].to(x_new.dtype)
+                    x = beta * x_new
+                    for j in range(self.num_looped):
+                        x = x + self.recur_alpha[local_idx, j].to(x_new.dtype) * carry[self.loop_start + j]
+                else:
+                    x = x_new
+                    if carry is not None and self.loop_start <= i <= self.loop_end:
+                        carry[i] = x_new.detach()
+            slot += 1
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits = F.linear(x, self.tok_emb.weight)
+        else:
+            logits = self.lm_head(x)
+        logits = logits + lora.lm_head_lora(x)
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        bsz, sl, V = logits.shape
+        return F.cross_entropy(
+            logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none"
+        ).reshape(bsz, sl)
+
+    def _block_with_lora(self, block, x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w):
+        mix = block.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = block.attn_norm(x_in) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        # SpinQuant V1 (TTT path): rotate n for base Q/K/V linears. LoRA continues
+        # to see unrotated n so the adapter output lives in the unrotated basis,
+        # which is the same basis the base path produces after R cancels.
+        if CastedLinear._sq_active and hasattr(attn, "_sq_R_attn_in"):
+            n_qkv = n @ attn._sq_R_attn_in.to(n.dtype)
+        else:
+            n_qkv = n
+        # Keep raw Q for AttnOutGate src='q' (matches forward path semantics).
+        q_raw = F.linear(n_qkv, q_w.to(n.dtype)) + lora.q_loras[slot](n)
+        q = q_raw.reshape(bsz, seqlen, attn.num_heads, attn.head_dim)
+        k = F.linear(n_qkv, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n_qkv, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        # AttnOutGate (TTT path) — inline + .contiguous() barrier, same as the eval path.
+        if attn.attn_out_gate:
+            gate_src = q_raw if attn.attn_out_gate_src == "q" else n
+            gate_in = gate_src[..., : attn.gate_window].contiguous()
+            g = 2.0 * torch.sigmoid(attn.attn_gate_proj(gate_in))
+            y = y * g[..., None]
+        # Gated Attention (TTT path). Gate input is n (post-norm block input), same
+        # as eval path. .to(n.dtype) on fp32 param before bf16 broadcast.
+        if attn.gated_attn:
+            n_c = n.contiguous()
+            g = torch.sigmoid(F.linear(n_c, attn.attn_gate_w.to(n.dtype)))
+            y = y * g[..., None]
+        # Sparse gate (TTT path). Match eval path semantics: gate uses the
+        # post-norm block input restricted to gate_window dims.
+        if attn.sparse_attn_gate:
+            gate_in = n[..., : attn.gate_window].contiguous()
+            g = torch.sigmoid(
+                attn.sparse_attn_gate_scale
+                * F.linear(gate_in, attn.attn_gate_w.to(n.dtype))
+            )
+            y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        # SpinQuant V1 (TTT path): rotate attention output before out_proj.
+        if CastedLinear._sq_active and hasattr(attn, "_sq_R_attn_proj_in"):
+            y_proj = y @ attn._sq_R_attn_proj_in.to(n.dtype)
+        else:
+            y_proj = y
+        attn_out = F.linear(y_proj, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        x_out = x_in + block.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        mlp_n = block.mlp_norm(x_out) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        x_out = x_out + block.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * mlp_out
+        return x_out
+
+    def _parallel_block_with_lora(
+        self, block_idx, lane0, lane1, x0, lora, slot,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        n = block.attn_norm(attn_read) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        # SpinQuant V1 (TTT parallel path): rotate n for base Q/K/V. LoRA uses unrotated n.
+        if CastedLinear._sq_active and hasattr(attn, "_sq_R_attn_in"):
+            n_qkv = n @ attn._sq_R_attn_in.to(n.dtype)
+        else:
+            n_qkv = n
+        q_raw = F.linear(n_qkv, q_w.to(n.dtype)) + lora.q_loras[slot](n)
+        q = q_raw.reshape(bsz, seqlen, attn.num_heads, attn.head_dim)
+        k = F.linear(n_qkv, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n_qkv, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        # AttnOutGate (TTT parallel path) — inline + .contiguous() barrier.
+        if attn.attn_out_gate:
+            gate_src = q_raw if attn.attn_out_gate_src == "q" else n
+            gate_in = gate_src[..., : attn.gate_window].contiguous()
+            g = 2.0 * torch.sigmoid(attn.attn_gate_proj(gate_in))
+            y = y * g[..., None]
+        # Gated Attention (TTT parallel path). Gate input is n (post-norm block input).
+        if attn.gated_attn:
+            n_c = n.contiguous()
+            g = torch.sigmoid(F.linear(n_c, attn.attn_gate_w.to(n.dtype)))
+            y = y * g[..., None]
+        # Sparse gate (TTT parallel path). Match eval path semantics.
+        if attn.sparse_attn_gate:
+            gate_in = n[..., : attn.gate_window].contiguous()
+            g = torch.sigmoid(
+                attn.sparse_attn_gate_scale
+                * F.linear(gate_in, attn.attn_gate_w.to(n.dtype))
+            )
+            y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        # SpinQuant V1 (TTT parallel path): rotate attention output before out_proj.
+        if CastedLinear._sq_active and hasattr(attn, "_sq_R_attn_proj_in"):
+            y_proj = y @ attn._sq_R_attn_proj_in.to(n.dtype)
+        else:
+            y_proj = y
+        attn_out = F.linear(y_proj, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_n = block.mlp_norm(mlp_read) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * mlp_out
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+
+class BatchedLinearLoRA(nn.Module):
+    def __init__(self, bsz, in_features, out_features, rank, alpha=96):
+        super().__init__()
+        self._bound = 1.0 / math.sqrt(in_features)
+        self._scale = alpha / rank
+        self.A = nn.Parameter(
+            torch.empty(bsz, rank, in_features).uniform_(-self._bound, self._bound)
+        )
+        self.B = nn.Parameter(torch.zeros(bsz, out_features, rank))
+
+    def reset(self):
+        with torch.no_grad():
+            # warm-start A: keep accumulated feature directions; only zero B so
+            # LoRA output = 0 at each batch start (per-document reset preserved)
+            self.B.zero_()
+
+    def forward(self, x):
+        return (x @ self.A.transpose(1, 2)) @ self.B.transpose(1, 2) * self._scale
+
+
+class BatchedTTTLoRA(nn.Module):
+    def __init__(self, bsz, model, rank, alpha=96, k_lora=True, mlp_lora=True, o_lora=True):
+        super().__init__()
+        self.bsz = bsz
+        dim = model.qo_bank.shape[-1]
+        vocab = model.tok_emb.num_embeddings
+        if getattr(model, "looping_active", False):
+            num_slots = len(model.encoder_indices) + len(model.decoder_indices)
+        else:
+            num_slots = len(model.blocks)
+        kv_dim = model.blocks[0].attn.num_kv_heads * (
+            dim // model.blocks[0].attn.num_heads
+        )
+        embed_dim = model.tok_emb.embedding_dim
+        self.lm_head_lora = BatchedLinearLoRA(bsz, embed_dim, vocab, rank, alpha)
+        self.q_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, dim, rank, alpha) for _ in range(num_slots)]
+        )
+        self.v_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, kv_dim, rank, alpha) for _ in range(num_slots)]
+        )
+        self.k_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, kv_dim, rank, alpha) for _ in range(num_slots)]
+            )
+            if k_lora
+            else None
+        )
+        self.mlp_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank, alpha) for _ in range(num_slots)]
+            )
+            if mlp_lora
+            else None
+        )
+        self.o_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank, alpha) for _ in range(num_slots)]
+            )
+            if o_lora
+            else None
+        )
+
+    def reset(self):
+        with torch.no_grad():
+            self.lm_head_lora.reset()
+            for loras in [self.q_loras, self.v_loras, self.k_loras,
+                          self.mlp_loras, self.o_loras]:
+                if loras is not None:
+                    for lora in loras:
+                        lora.reset()
+
+
+# Polar Express per-iteration minimax Newton-Schulz coefficients (PR #1344,
+# later reused by PR #1787). This replaces stock Muon's repeated fixed
+# `(3.4445, -4.775, 2.0315)` tuple with 5 optimized per-step tuples while
+# keeping `MUON_BACKEND_STEPS=5`.
+_PE_COEFFS = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps=10, eps=1e-07):
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    coeffs = _PE_COEFFS[:steps] if steps <= len(_PE_COEFFS) else _PE_COEFFS
+    for a, b, c in coeffs:
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr,
+        momentum,
+        backend_steps,
+        nesterov=True,
+        weight_decay=0.0,
+        row_normalize=False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append({
+                    "p": p,
+                    "B": B,
+                    "padded_grad": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard_mom": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "full_update": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "scale": max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                })
+        self._bank_meta.sort(key=lambda m: -m["p"].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m["p"]
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m["padded_grad"]
+            pg[: m["B"]].copy_(p.grad.bfloat16())
+            if pg.shape[0] > m["B"]:
+                pg[m["B"] :].zero_()
+            fut = dist.reduce_scatter_tensor(
+                m["shard"], pg, op=dist.ReduceOp.AVG, async_op=True
+            )
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        if not self._built:
+            self._build()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+            row_normalize = group.get("row_normalize", False)
+            prev_ag_handle = None
+            prev_m = None
+            sharded = self._distributed and hasattr(self, "_rs_futures")
+            for idx, m in enumerate(self._bank_meta):
+                p = m["p"]
+                if p.grad is None:
+                    continue
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m["p"]
+                    upd = prev_m["full_update"][: prev_m["B"]]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+                if sharded and self._rs_futures[idx] is not None:
+                    self._rs_futures[idx].wait()
+                    g = m["shard"]
+                    buf = m["shard_mom"]
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+                if row_normalize:
+                    rn = update.float().norm(dim=-1, keepdim=True).clamp_min(1e-07)
+                    update = update / rn.to(update.dtype)
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m["full_update"], update, async_op=True
+                    )
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update.to(dtype=p.dtype), alpha=-lr * m["scale"])
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m["p"]
+                upd = prev_m["full_update"][: prev_m["B"]]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+            if hasattr(self, "_rs_futures"):
+                del self._rs_futures
+        return loss
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,parallel_post_lambdas,parallel_resid_lambdas,attn_gate_proj,attn_gate_w,smear_gate,smear_lambda",
+    ).split(",")
+    if pattern
+)
+
+
+PACKED_REPLICATED_GRAD_MAX_NUMEL = 1 << 15
+
+
+class Optimizers:
+    def __init__(self, h, base_model):
+        matrix_params = [
+            base_model.qo_bank,
+            base_model.kv_bank,
+            base_model.mlp_up_bank,
+            base_model.mlp_down_bank,
+        ]
+        block_named_params = list(base_model.blocks.named_parameters())
+        scalar_params = [
+            p
+            for (name, p) in block_named_params
+            if p.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        if base_model.skip_weights.numel() > 0:
+            scalar_params.append(base_model.skip_weights)
+        if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
+            scalar_params.append(base_model.skip_gates)
+        if base_model.parallel_post_lambdas is not None:
+            scalar_params.append(base_model.parallel_post_lambdas)
+        if base_model.parallel_resid_lambdas is not None:
+            scalar_params.append(base_model.parallel_resid_lambdas)
+        # SmearGate params live on GPT root (not in .blocks), so add them by hand.
+        # Both are tiny (gate_window scalars + 1 lambda). Optimized via scalar Adam.
+        if getattr(base_model, "smear_gate_enabled", False):
+            scalar_params.append(base_model.smear_gate.weight)
+            scalar_params.append(base_model.smear_lambda)
+        # Spec 015 Recur-Alpha: 6 scalars (num_loops × num_looped), route to scalar AdamW.
+        # Not in .blocks so not picked up by block_named_params. ndim=2 but tiny —
+        # would be silly to send to Muon. Append by hand like SmearGate.
+        # Spec 021: recur_alpha is frozen (buffer or Parameter(requires_grad=False)),
+        # so DO NOT append to optimizer. Guard on requires_grad so the
+        # 015/016/017 learnable-Parameter form still works if we ever revert.
+        if getattr(base_model, "recur_alpha_enabled", False):
+            if base_model.recur_alpha is not None and base_model.recur_alpha.requires_grad:
+                scalar_params.append(base_model.recur_alpha)
+            if getattr(base_model, "recur_beta", None) is not None and base_model.recur_beta.requires_grad:
+                scalar_params.append(base_model.recur_beta)
+        token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
+        tok_params = [
+            {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+        ]
+        self.optimizer_tok = torch.optim.AdamW(
+            tok_params,
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.embed_wd,
+            fused=True,
+        )
+        self.optimizer_muon = Muon(
+            matrix_params,
+            lr=h.matrix_lr,
+            momentum=h.muon_momentum,
+            backend_steps=h.muon_backend_steps,
+            weight_decay=h.muon_wd,
+            row_normalize=h.muon_row_normalize,
+        )
+        for group in self.optimizer_muon.param_groups:
+            group["base_lr"] = h.matrix_lr
+        self.optimizer_scalar = torch.optim.AdamW(
+            [{"params": scalar_params, "lr": h.scalar_lr, "base_lr": h.scalar_lr}],
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.adam_wd,
+            fused=True,
+        )
+        self.optimizers = [
+            self.optimizer_tok,
+            self.optimizer_muon,
+            self.optimizer_scalar,
+        ]
+        self.replicated_params = list(tok_params[0]["params"])
+        self.replicated_params.extend(scalar_params)
+        self.replicated_large_params = []
+        self.replicated_packed_params = []
+        for p in self.replicated_params:
+            if p.numel() <= PACKED_REPLICATED_GRAD_MAX_NUMEL:
+                self.replicated_packed_params.append(p)
+            else:
+                self.replicated_large_params.append(p)
+
+    def __iter__(self):
+        return iter(self.optimizers)
+
+    def zero_grad_all(self):
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    def _all_reduce_packed_grads(self):
+        grads_by_key = collections.defaultdict(list)
+        for p in self.replicated_packed_params:
+            if p.grad is not None:
+                grads_by_key[(p.grad.device, p.grad.dtype)].append(p.grad)
+        for grads in grads_by_key.values():
+            flat = torch.empty(
+                sum(g.numel() for g in grads),
+                device=grads[0].device,
+                dtype=grads[0].dtype,
+            )
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                flat[offset : offset + n].copy_(g.contiguous().view(-1))
+                offset += n
+            dist.all_reduce(flat, op=dist.ReduceOp.AVG)
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                g.copy_(flat[offset : offset + n].view_as(g))
+                offset += n
+
+    def step(self, distributed=False):
+        self.optimizer_muon.launch_reduce_scatters()
+        if distributed:
+            reduce_handles = [
+                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG, async_op=True)
+                for p in self.replicated_large_params
+                if p.grad is not None
+            ]
+            self._all_reduce_packed_grads()
+            for handle in reduce_handles:
+                handle.wait()
+        self.optimizer_tok.step()
+        self.optimizer_scalar.step()
+        self.optimizer_muon.step()
+        self.zero_grad_all()
+
+
+def restore_fp32_params(model):
+    for module in model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    for name, param in model.named_parameters():
+        if (
+            param.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ) and param.dtype != torch.float32:
+            param.data = param.data.float()
+    if hasattr(model, "qo_bank") and model.qo_bank is not None:
+        model.qo_bank.data = model.qo_bank.data.float()
+        model.kv_bank.data = model.kv_bank.data.float()
+    model.mlp_up_bank.data = model.mlp_up_bank.data.float()
+    model.mlp_down_bank.data = model.mlp_down_bank.data.float()
+
+
+def collect_hessians(model, train_loader, h, device, n_calibration_batches=64):
+    hessians = {}
+    hooks = []
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = True
+        block.mlp._calib = True
+        block.mlp.use_fused = False
+
+    def make_attn_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            for suffix in ["c_q", "c_k", "c_v"]:
+                name = f"blocks.{layer_idx}.attn.{suffix}.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            y = module._last_proj_input
+            if y is not None:
+                y = y.float()
+                if y.ndim == 3:
+                    y = y.reshape(-1, y.shape[-1])
+                name = f"blocks.{layer_idx}.attn.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        y.shape[1], y.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(y.T, y)
+        return hook_fn
+
+    def make_mlp_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            name = f"blocks.{layer_idx}.mlp.fc.weight"
+            if name not in hessians:
+                hessians[name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[name].addmm_(x.T, x)
+            h_act = module._last_down_input
+            if h_act is not None:
+                h_act = h_act.float()
+                if h_act.ndim == 3:
+                    h_act = h_act.reshape(-1, h_act.shape[-1])
+                name = f"blocks.{layer_idx}.mlp.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        h_act.shape[1], h_act.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(h_act.T, h_act)
+        return hook_fn
+
+    for i, block in enumerate(model.blocks):
+        hooks.append(block.attn.register_forward_hook(make_attn_hook(i)))
+        hooks.append(block.mlp.register_forward_hook(make_mlp_hook(i)))
+
+    # Hessian hooks for embedding factorization projection layers
+    def make_linear_input_hook(weight_name):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            if weight_name not in hessians:
+                hessians[weight_name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[weight_name].addmm_(x.T, x)
+        return hook_fn
+
+    if model.tie_embeddings:
+        hook_module = model.final_norm
+
+        def make_output_hook(name):
+            def hook_fn(module, inp, out):
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            return hook_fn
+
+        hooks.append(
+            hook_module.register_forward_hook(make_output_hook("tok_emb.weight"))
+        )
+    model.eval()
+    with torch.no_grad():
+        for _ in range(n_calibration_batches):
+            x, _ = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+            model.forward_logits(x)
+    for hook in hooks:
+        hook.remove()
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = False
+        block.mlp._calib = False
+        block.mlp.use_fused = True
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / n_calibration_batches
+    return hessians
+
+
+def gptq_quantize_weight(w, H, clip_sigmas=3.0, clip_range=63, block_size=128):
+    W_orig = w.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * H.diag().mean()
+    H.diagonal().add_(damp)
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+    Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    row_std = W_orig.std(dim=1)
+    s = (clip_sigmas * row_std / clip_range).clamp_min(1e-10).to(torch.float16)
+    sf = s.float()
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    W_work = W_perm.clone()
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W_work[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros(rows, i2 - i1)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            d = Hinv_block[j, j]
+            q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - q_col.float() * sf) / d
+            Err[:, j] = err
+            W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+        if i2 < cols:
+            W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+    return Q[:, invperm], s
+
+
+def _quantize_gate_int8_row(w):
+    # Symmetric int8-per-row quantization for small gate tensors. w shape
+    # (R, C) -> (R,) scales in fp16, int8 values in [-127, 127]. Single scale
+    # per row keeps accuracy high while halving storage vs fp16.
+    W = w.float().contiguous()
+    row_max = W.abs().amax(dim=1).clamp_min(1e-10)
+    s = (row_max / 127.0).to(torch.float16)
+    sf = s.float().view(-1, 1)
+    q = torch.clamp(torch.round(W / sf), -127, 127).to(torch.int8)
+    return q, s
+
+
+def gptq_mixed_quantize(state_dict, hessians, h):
+    result = {}
+    meta = {}
+    quant_gate = bool(getattr(h, "gated_attn_quant_gate", False))
+    for (name, tensor) in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        # Dedicated int8-per-row path for attn_gate_w (bypasses both GPTQ and
+        # fp16 passthrough). Applied BEFORE the numel<=65536 passthrough check
+        # so the gate tensor is routed here instead of to fp16.
+        if (
+            quant_gate
+            and t.is_floating_point()
+            and t.ndim == 2
+            and name.endswith(".attn_gate_w")
+            and 1024 <= t.numel() <= 8192
+        ):
+            gq, gs = _quantize_gate_int8_row(t)
+            result[name + ".gq"] = gq
+            result[name + ".gs"] = gs
+            meta[name] = "gate_int8_row"
+            continue
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough (float16)"
+            continue
+        if "tok_emb" in name:
+            cs = h.embed_clip_sigmas
+        elif ".mlp." in name:
+            cs = h.mlp_clip_sigmas
+        elif ".attn." in name:
+            cs = h.attn_clip_sigmas
+        else:
+            cs = h.matrix_clip_sigmas
+        bits = h.embed_bits if "tok_emb" in name else h.matrix_bits
+        clip_range = 2 ** (bits - 1) - 1
+        ret = gptq_quantize_weight(
+            t, hessians[name], clip_sigmas=cs, clip_range=clip_range
+        )
+        q, s = ret
+        result[name + ".q"] = q
+        result[name + ".scale"] = s
+        meta[name] = f"gptq (int{bits})"
+    categories = collections.defaultdict(set)
+    for (name, cat) in meta.items():
+        short = re.sub("\\.\\d+$", "", re.sub("blocks\\.\\d+", "blocks", name))
+        categories[cat].add(short)
+    log("Quantized weights:")
+    for cat in sorted(categories):
+        log(f"  {cat}: {', '.join(sorted(categories[cat]))}")
+    return result, meta
+
+def dequantize_mixed(result, meta, template_sd):
+    out = {}
+    for (name, orig) in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if "passthrough" in info:
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        if info == "gate_int8_row":
+            gq = result[name + ".gq"]
+            gs = result[name + ".gs"]
+            out[name] = (gq.float() * gs.float().view(-1, 1)).to(orig_dtype)
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (
+                q.float() * s.float().view(q.shape[0], *[1] * (q.ndim - 1))
+            ).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+_BSHF_MAGIC = b"BSHF"
+
+
+def _byte_shuffle(data, stride=2):
+    if stride <= 1 or len(data) < stride:
+        return data
+    src = np.frombuffer(data, dtype=np.uint8)
+    n = len(src)
+    out = np.empty(n, dtype=np.uint8)
+    dest_off = 0
+    for pos in range(stride):
+        chunk = src[pos::stride]
+        out[dest_off : dest_off + len(chunk)] = chunk
+        dest_off += len(chunk)
+    return _BSHF_MAGIC + bytes([stride]) + out.tobytes()
+
+
+def _byte_unshuffle(data):
+    if len(data) < 5 or data[:4] != _BSHF_MAGIC:
+        return data
+    stride = data[4]
+    if stride < 2:
+        return data[5:]
+    payload = np.frombuffer(data, dtype=np.uint8, offset=5)
+    n = len(payload)
+    out = np.empty(n, dtype=np.uint8)
+    src_off = 0
+    for pos in range(stride):
+        chunk_len = n // stride + (1 if pos < n % stride else 0)
+        out[pos::stride][:chunk_len] = payload[src_off : src_off + chunk_len]
+        src_off += chunk_len
+    return out.tobytes()
+
+
+def _compress(data, compressor):
+    data = _byte_shuffle(data)
+    if compressor == "lzma":
+        return lzma.compress(data, preset=6)
+    elif compressor == "brotli":
+        import brotli
+
+        return brotli.compress(data, quality=11)
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def _decompress(data, compressor):
+    if compressor == "lzma":
+        raw = lzma.decompress(data)
+    elif compressor == "brotli":
+        import brotli
+
+        raw = brotli.decompress(data)
+    else:
+        raise ValueError(f"Unknown compressor: {compressor!r}")
+    raw = _byte_unshuffle(raw)
+    return raw
+
+
+def _unbank_state_dict(state_dict, num_layers):
+    sd = {}
+    n = num_layers
+    for k, v in state_dict.items():
+        t = v.detach().cpu() if v is not None else None
+        if k == "qo_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_q.weight"] = t[i]
+                sd[f"blocks.{i}.attn.proj.weight"] = t[n + i]
+        elif k == "kv_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_k.weight"] = t[i]
+                sd[f"blocks.{i}.attn.c_v.weight"] = t[n + i]
+        elif k == "mlp_up_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.fc.weight"] = t[i]
+        elif k == "mlp_down_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.proj.weight"] = t[i]
+        else:
+            if t is not None:
+                sd[k] = t
+    return sd
+
+
+def _rebank_state_dict(flat_sd, num_layers, model_dim, kv_dim, hidden_dim):
+    sd = {}
+    n = num_layers
+    sd["qo_bank"] = torch.zeros(2 * n, model_dim, model_dim)
+    sd["kv_bank"] = torch.zeros(2 * n, kv_dim, model_dim)
+    for i in range(n):
+        sd["qo_bank"][i] = flat_sd[f"blocks.{i}.attn.c_q.weight"]
+        sd["qo_bank"][n + i] = flat_sd[f"blocks.{i}.attn.proj.weight"]
+        sd["kv_bank"][i] = flat_sd[f"blocks.{i}.attn.c_k.weight"]
+        sd["kv_bank"][n + i] = flat_sd[f"blocks.{i}.attn.c_v.weight"]
+    sd["mlp_up_bank"] = torch.zeros(n, hidden_dim, model_dim)
+    sd["mlp_down_bank"] = torch.zeros(n, model_dim, hidden_dim)
+    for i in range(n):
+        sd["mlp_up_bank"][i] = flat_sd[f"blocks.{i}.mlp.fc.weight"]
+        sd["mlp_down_bank"][i] = flat_sd[f"blocks.{i}.mlp.proj.weight"]
+    for k, v in flat_sd.items():
+        if not (
+            k.startswith("blocks.")
+            and any(
+                p in k
+                for p in [
+                    ".attn.c_q.", ".attn.c_k.", ".attn.c_v.",
+                    ".attn.proj.", ".mlp.fc.", ".mlp.proj.",
+                ]
+            )
+        ):
+            sd[k] = v
+    return sd
+
+
+# =============================================================================
+# SpinQuant V1 — Hadamard rotation primitives (port from PR #1695)
+# =============================================================================
+# Zero serialized bytes: rotations are regenerated deterministically from
+# (SPINQUANT_SEED, tag) at load time. Applied in two places:
+#
+#   1. Statically on the state_dict + Hessians, right before GPTQ quantizes:
+#      W_rot = W @ R   (input-col rotation, so F.linear(x @ R, W_rot) == F.linear(x, W))
+#      H_rot = R.T @ H @ R  (matches the rotated activation covariance)
+#
+#   2. Online at forward time, gated by CastedLinear._sq_active:
+#      x_rotated = x @ R  before each of the 4 target linear layers.
+#
+# Math: orthogonal R means R @ R.T == I, so the static + online rotations
+# cancel at fp precision. Pre-quant forward is bit-identical to unrotated.
+# Only GPTQ sees the rotated basis, where outliers are spread more evenly
+# and quantization error is reduced.
+#
+# Four rotation sites:
+#   - R_attn_in        (d_model) — residual → Q/K/V input
+#   - R_attn_proj_in   (d_model) — attention output → proj input
+#   - R_mlp_in         (d_model) — residual → fc input
+#   - R_mlp_proj_in    (d_ff)    — post-LeakyReLU² → proj input
+#
+# The MLP proj rotation is applied AFTER the nonlinearity, so the rotation
+# never has to commute with LeakyReLU. Residual stream is untouched, so all
+# per-channel multipliers (attn_scale, mlp_scale, resid_mix, skip_weights)
+# operate in their trained basis.
+
+_SPINQUANT_CACHE: "dict[tuple[int, str, int], torch.Tensor]" = {}
+
+
+def _stable_seed(seed: int, tag: str) -> int:
+    """SHA-256-derived seed. Deterministic across processes; Python's built-in
+    hash() varies with PYTHONHASHSEED and would desync train vs eval."""
+    h = hashlib.sha256(f"{seed}:{tag}".encode("utf-8")).digest()
+    return int.from_bytes(h[:4], "big")
+
+
+def _hadamard_rotation(n: int, seed: int, tag: str) -> torch.Tensor:
+    """Sylvester-Hadamard × random sign diagonal → QR re-orthonormalize.
+    Deterministic in (seed, tag, n). Returns orthogonal R of shape (n, n)
+    such that R.T @ R == I (to QR precision ~2e-6)."""
+    key = (seed, tag, n)
+    if key in _SPINQUANT_CACHE:
+        return _SPINQUANT_CACHE[key]
+    p = 1
+    while p < n:
+        p *= 2
+    H = torch.ones(1, 1)
+    while H.shape[0] < p:
+        H = torch.cat(
+            [torch.cat([H, H], dim=1), torch.cat([H, -H], dim=1)],
+            dim=0,
+        )
+    H = H / math.sqrt(p)
+    g = torch.Generator().manual_seed(_stable_seed(seed, tag))
+    D = torch.diag(torch.randint(0, 2, (p,), generator=g).float() * 2 - 1)
+    R = (D @ H)[:n, :n]
+    Q, _ = torch.linalg.qr(R)
+    _SPINQUANT_CACHE[key] = Q
+    return Q
+
+
+def _parse_spinquant_sites(h) -> "frozenset[str]":
+    """Parse h.spinquant_sites (comma-separated) into a frozenset of tag names.
+    Unknown tags are silently dropped (with a log). Returns empty set if the
+    env var is empty or 'none'."""
+    raw = getattr(h, "spinquant_sites", "attn_in,attn_proj_in,mlp_in,mlp_proj_in")
+    if raw.strip().lower() in ("", "none"):
+        return frozenset()
+    valid = {"attn_in", "attn_proj_in", "mlp_in", "mlp_proj_in"}
+    tags = {t.strip() for t in raw.split(",") if t.strip()}
+    unknown = tags - valid
+    if unknown:
+        log(f"spinquant:unknown_sites_ignored:{sorted(unknown)}")
+    return frozenset(tags & valid)
+
+
+def install_spinquant_rotations(model, h, seed=None, log_fn=print) -> int:
+    """Install the global rotation buffers on every CausalSelfAttention and MLP
+    in `model`, restricted to sites in h.spinquant_sites. Buffers are
+    non-persistent (regenerated deterministically at load). Returns number of
+    modules touched. Does NOT flip CastedLinear._sq_active — caller does that
+    after banks have been loaded with rotated weights."""
+    if seed is None:
+        seed = int(os.environ.get("SPINQUANT_SEED", "42"))
+    sites = _parse_spinquant_sites(h)
+    model_dim = h.model_dim
+    hidden_dim = int(h.mlp_mult * h.model_dim)
+    # Generate rotations only for sites we're actually installing.
+    R_attn_in = _hadamard_rotation(model_dim, seed, "attn_in") if "attn_in" in sites else None
+    R_attn_proj_in = _hadamard_rotation(model_dim, seed, "attn_proj_in") if "attn_proj_in" in sites else None
+    R_mlp_in = _hadamard_rotation(model_dim, seed, "mlp_in") if "mlp_in" in sites else None
+    R_mlp_proj_in = _hadamard_rotation(hidden_dim, seed, "mlp_proj_in") if "mlp_proj_in" in sites else None
+    try:
+        device = next(model.parameters()).device
+    except StopIteration:
+        device = torch.device("cpu")
+    touched = 0
+    for m in model.modules():
+        if isinstance(m, CausalSelfAttention):
+            if R_attn_in is not None:
+                m.register_buffer("_sq_R_attn_in", R_attn_in.to(device), persistent=False)
+            if R_attn_proj_in is not None:
+                m.register_buffer("_sq_R_attn_proj_in", R_attn_proj_in.to(device), persistent=False)
+            touched += 1
+        elif isinstance(m, MLP):
+            if R_mlp_in is not None:
+                m.register_buffer("_sq_R_mlp_in", R_mlp_in.to(device), persistent=False)
+            if R_mlp_proj_in is not None:
+                m.register_buffer("_sq_R_mlp_proj_in", R_mlp_proj_in.to(device), persistent=False)
+            touched += 1
+    log_fn(
+        f"spinquant:installed_rotations:{touched}_modules seed:{seed} "
+        f"sites:{sorted(sites)} model_dim:{model_dim} hidden_dim:{hidden_dim}"
+    )
+    return touched
+
+
+# Which globally-shared rotation applies to each flat state_dict key suffix.
+# Only the 6 attn/mlp bank weights are rotated in V1.
+_SQ_KEY_TO_TAG: "dict[str, str]" = {
+    ".attn.c_q.weight":   "attn_in",
+    ".attn.c_k.weight":   "attn_in",
+    ".attn.c_v.weight":   "attn_in",
+    ".attn.proj.weight":  "attn_proj_in",
+    ".mlp.fc.weight":     "mlp_in",
+    ".mlp.proj.weight":   "mlp_proj_in",
+}
+
+
+def _spinquant_rotate_sd_and_H(sd_cpu: dict, hessians: dict, h, log_fn=print) -> None:
+    """In-place: rotate the 6 canonical flat weights and their matching Hessians.
+    Must be called AFTER collect_hessians() returns (so H is collected on
+    unrotated activations) and BEFORE gptq_mixed_quantize() consumes them.
+
+    Math:
+        x_rot = x @ R
+        W_rot = W @ R             (W is [out, in], R is [in, in])
+        H_rot = R.T @ (x.T @ x) @ R = R.T @ H @ R
+
+    After this call, F.linear(x_rot, W_rot) == F.linear(x, W) exactly (to fp
+    precision), so GPTQ quantizing W_rot with H_rot is mathematically matched.
+
+    h.spinquant_sites filters which of the 4 tags get rotated; tags not in the
+    set are skipped here AND in install_spinquant_rotations, keeping the two
+    code paths in sync."""
+    seed = h.spinquant_seed
+    sites = _parse_spinquant_sites(h)
+    tag_to_R: "dict[str, torch.Tensor]" = {}
+
+    def _R_for(tag: str, in_dim: int) -> torch.Tensor:
+        if tag not in tag_to_R:
+            tag_to_R[tag] = _hadamard_rotation(in_dim, seed, tag).float().cpu()
+        return tag_to_R[tag]
+
+    baked_weights = 0
+    baked_hessians = 0
+    missing_hessian = 0
+    skipped_by_sites = 0
+    for name in list(sd_cpu.keys()):
+        tag = None
+        for suffix, t in _SQ_KEY_TO_TAG.items():
+            if name.endswith(suffix) and name.startswith("blocks."):
+                tag = t
+                break
+        if tag is None:
+            continue
+        if tag not in sites:
+            skipped_by_sites += 1
+            continue
+        W = sd_cpu[name]
+        if W.ndim != 2:
+            continue
+        in_dim = W.shape[1]
+        R = _R_for(tag, in_dim)
+        assert R.shape == (in_dim, in_dim), (
+            f"spinquant: R shape {tuple(R.shape)} != ({in_dim},{in_dim}) "
+            f"for {name} tag={tag}"
+        )
+        orig_dtype = W.dtype
+        sd_cpu[name] = (W.float() @ R).to(orig_dtype).contiguous()
+        baked_weights += 1
+
+        if name in hessians:
+            H = hessians[name]
+            assert H.shape == (in_dim, in_dim), (
+                f"spinquant: H shape {tuple(H.shape)} != ({in_dim},{in_dim}) for {name}"
+            )
+            H_dev = H.device
+            H32 = H.float().cpu()
+            hessians[name] = (R.T @ H32 @ R).to(H.dtype).to(H_dev)
+            baked_hessians += 1
+        else:
+            missing_hessian += 1
+
+    log_fn(
+        f"spinquant:rotated_weights:{baked_weights} hessians:{baked_hessians} "
+        f"missing_hessians:{missing_hessian} skipped_by_sites:{skipped_by_sites} "
+        f"active_sites:{sorted(sites)}"
+    )
+
+
+
+def _compressed_code_size(code):
+    code_raw = code.encode("utf-8")
+    minified = subprocess.run(
+        ["pyminify", "--no-rename-locals", "--no-hoist-literals", "--remove-literal-statements", "-"],
+        input=code_raw, capture_output=True, check=True,
+    ).stdout
+    compressed = lzma.compress(minified)
+    encoded = base64.b85encode(compressed)
+    wrapper = b'import lzma as L,base64 as B\nexec(L.decompress(B.b85decode("' + encoded + b'")))\n'
+    return len(code_raw), len(wrapper)
+
+
+def serialize(h, base_model, code):
+    if h.is_main_process:
+        torch.save(base_model.state_dict(), h.model_path)
+        model_bytes = os.path.getsize(h.model_path)
+        log(f"Serialized model: {model_bytes} bytes")
+    try:
+        code_bytes_uncompressed, code_bytes = _compressed_code_size(code)
+    except (FileNotFoundError, subprocess.CalledProcessError) as e:
+        code_bytes_uncompressed, code_bytes = len(code.encode("utf-8")), 0
+        log(f"pyminify unavailable ({type(e).__name__}); skipping compressed-code-size measurement")
+    if h.is_main_process:
+        log(f"Code size (uncompressed): {code_bytes_uncompressed} bytes")
+        log(f"Code size (compressed): {code_bytes} bytes")
+    sd_cpu = _unbank_state_dict(base_model.state_dict(), h.num_layers)
+    device = torch.device("cuda", h.local_rank)
+    t0 = time.perf_counter()
+    calib_loader = ShuffledSequenceLoader(h, device)
+    log("GPTQ:collecting Hessians from calibration data...")
+    hessians = collect_hessians(
+        base_model,
+        calib_loader,
+        h,
+        device,
+        n_calibration_batches=h.gptq_calibration_batches,
+    )
+    log(f"GPTQ:collected {len(hessians)} Hessians in {time.perf_counter()-t0:.1f}s")
+    # SpinQuant V1 bake: rotate weights W ← W @ R and Hessians H ← R.T H R.
+    # Runs AFTER Hessian collection (so H was measured on unrotated activations)
+    # and BEFORE GPTQ (so the quantizer sees the rotated frame end-to-end).
+    if getattr(h, "spinquant_enabled", False):
+        _spinquant_rotate_sd_and_H(sd_cpu, hessians, h, log_fn=log)
+    quant_result, quant_meta = gptq_mixed_quantize(sd_cpu, hessians, h)
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = _compress(quant_raw, h.compressor)
+    quant_file_bytes = len(quant_blob)
+    bytes_total = quant_file_bytes + code_bytes
+    if h.is_main_process:
+        with open(h.quantized_model_path, "wb") as f:
+            f.write(quant_blob)
+        log(f"Serialized model quantized+{h.compressor}: {quant_file_bytes} bytes")
+        log(f"Total submission size quantized+{h.compressor}: {bytes_total} bytes")
+    return bytes_total, quant_file_bytes
+
+
+def deserialize(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    flat_template = _unbank_state_dict(eval_model.state_dict(), h.num_layers)
+    with open(h.quantized_model_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(_decompress(quant_blob_disk, h.compressor)), map_location="cpu"
+    )
+    deq_flat = dequantize_mixed(quant_state["w"], quant_state["m"], flat_template)
+    head_dim = h.model_dim // h.num_heads
+    kv_dim = h.num_kv_heads * head_dim
+    hidden_dim = int(h.mlp_mult * h.model_dim)
+    deq_state = _rebank_state_dict(deq_flat, h.num_layers, h.model_dim, kv_dim, hidden_dim)
+    eval_model.load_state_dict(deq_state, strict=True)
+    # SpinQuant V1: banks now hold rotated weights (W @ R). Install the matching
+    # R buffers and flip the class-level flag so the forward rotation hooks fire.
+    # Math: F.linear(x @ R, W @ R) == F.linear(x, W) exactly (to fp precision).
+    if getattr(h, "spinquant_enabled", False):
+        install_spinquant_rotations(eval_model, h, seed=h.spinquant_seed, log_fn=log)
+        CastedLinear._sq_active = True
+        log(f"spinquant:_sq_active=True (forward rotations armed)")
+    return eval_model
+
+
+def _loss_bpb(loss_sum, token_count, byte_count):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    return val_loss, val_bpb
+
+
+def eval_val(h, device, val_data, model, forward_logits_fn=None):
+    seq_len = h.eval_seq_len
+    local_batch_tokens = h.val_batch_tokens // (h.world_size * h.grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            f"VAL_BATCH_SIZE must provide at least one sequence per rank; got VAL_BATCH_SIZE={h.val_batch_tokens}, WORLD_SIZE={h.world_size}, GRAD_ACCUM_STEPS={h.grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = total_seqs * h.rank // h.world_size
+    seq_end = total_seqs * (h.rank + 1) // h.world_size
+
+    # TODO: Don't truncate this.
+    seq_end = seq_start + ((seq_end - seq_start) // local_batch_seqs) * local_batch_seqs
+
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    run_forward_logits = (
+        (model.module.forward_logits if hasattr(model, "module") else model.forward_logits)
+        if forward_logits_fn is None
+        else forward_logits_fn
+    )
+    model.eval()
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    with torch.no_grad():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_data.val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1]
+            y = local[1:]
+            bos_pos = (x == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                bos_pos, x.numel(), x.device, h.eval_seq_len, 64
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = run_forward_logits(
+                    x[None], cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                ).detach()
+            per_token_loss = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y.reshape(-1),
+                reduction="none",
+            )
+            val_loss_sum += per_token_loss.to(torch.float64).sum()
+            val_token_count += float(y.numel())
+            prev_ids = x
+            tgt_ids = y
+            if val_data.caseops_enabled and val_data.val_bytes is not None:
+                # CaseOps: read per-token byte budget from sidecar at the same
+                # global positions as the target tokens y. raw_start/raw_end
+                # span [raw_start, raw_end), x = local[:-1], y = local[1:],
+                # so y is at sidecar positions [raw_start + 1, raw_end).
+                sidecar_slice = val_data.val_bytes[raw_start + 1 : raw_end].to(
+                    device=device, dtype=torch.int32, non_blocking=True
+                )
+                val_byte_count += sidecar_slice.to(torch.float64).sum()
+            else:
+                token_bytes = val_data.base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                token_bytes += (
+                    val_data.has_leading_space_lut[tgt_ids]
+                    & ~val_data.is_boundary_token_lut[prev_ids]
+                ).to(dtype=torch.int16)
+                val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    model.train()
+    return _loss_bpb(val_loss_sum, val_token_count, val_byte_count)
+
+
+def _find_docs(all_tokens):
+    bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0].numpy()
+    docs = []
+    for i in range(len(bos_positions)):
+        start = int(bos_positions[i])
+        end = (
+            int(bos_positions[i + 1])
+            if i + 1 < len(bos_positions)
+            else all_tokens.numel()
+        )
+        if i + 1 < len(bos_positions):
+            end += 1
+        assert end - start >= 2
+        docs.append((start, end - start))
+    return docs
+
+
+def _build_ttt_global_batches(doc_entries, h, ascending=False):
+    batch_size = h.ttt_batch_size
+    global_doc_entries = sorted(doc_entries, key=lambda x: x[1][1])
+    global_batches = [
+        global_doc_entries[i : i + batch_size]
+        for i in range(0, len(global_doc_entries), batch_size)
+    ]
+    indexed = list(enumerate(global_batches))
+    if not ascending:
+        indexed.sort(key=lambda ib: -max(dl for _, (_, dl) in ib[1]))
+    return indexed
+
+
+def _init_batch_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(4, "little"))
+
+
+def _claim_next_batch(counter_path, queue_len):
+    try:
+        with open(counter_path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            idx = int.from_bytes(f.read(4), "little")
+            f.seek(0)
+            f.write((idx + 1).to_bytes(4, "little"))
+            f.flush()
+    except FileNotFoundError:
+        return queue_len
+    return idx
+
+
+def _compute_chunk_window(ci, pred_len, num_chunks, chunk_size, eval_seq_len):
+    chunk_end = pred_len if ci == num_chunks - 1 else (ci + 1) * chunk_size
+    win_start = max(0, chunk_end - eval_seq_len)
+    win_len = chunk_end - win_start
+    chunk_start = ci * chunk_size
+    chunk_offset = chunk_start - win_start
+    chunk_len = chunk_end - chunk_start
+    return win_start, win_len, chunk_offset, chunk_len
+
+
+def _accumulate_bpb(
+    ptl,
+    x,
+    y,
+    chunk_offsets,
+    chunk_lens,
+    pos_idx,
+    base_bytes_lut,
+    has_leading_space_lut,
+    is_boundary_token_lut,
+    loss_sum,
+    byte_sum,
+    token_count,
+    y_bytes=None,
+):
+    pos = pos_idx[: x.size(1)].unsqueeze(0)
+    mask = (
+        (chunk_lens.unsqueeze(1) > 0)
+        & (pos >= chunk_offsets.unsqueeze(1))
+        & (pos < (chunk_offsets + chunk_lens).unsqueeze(1))
+    )
+    mask_f64 = mask.to(torch.float64)
+    if y_bytes is not None:
+        tok_bytes = y_bytes.to(torch.float64)
+    else:
+        tok_bytes = base_bytes_lut[y].to(torch.float64)
+        tok_bytes += (has_leading_space_lut[y] & ~is_boundary_token_lut[x]).to(
+            torch.float64
+        )
+    loss_sum += (ptl.to(torch.float64) * mask_f64).sum()
+    byte_sum += (tok_bytes * mask_f64).sum()
+    token_count += chunk_lens.to(torch.float64).sum()
+
+
+def _loss_bpb_from_sums(loss_sum, token_count, byte_sum):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_sum.item())
+    return val_loss, val_bpb
+
+
+def _add_to_counter(path, delta):
+    try:
+        with open(path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            cur = int.from_bytes(f.read(8), "little", signed=True)
+            cur += int(delta)
+            f.seek(0)
+            f.write(int(cur).to_bytes(8, "little", signed=True))
+            f.flush()
+            return cur
+    except FileNotFoundError:
+        return int(delta)
+
+
+def _init_int64_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(8, "little", signed=True))
+
+
+def _select_ttt_doc_entries(docs, h):
+    doc_entries = list(enumerate(docs))
+    if h.val_doc_fraction < 1.0:
+        sample_n = max(1, int(round(len(docs) * h.val_doc_fraction)))
+        sampled_indices = sorted(
+            random.Random(h.seed).sample(range(len(docs)), sample_n)
+        )
+        return [(i, docs[i]) for i in sampled_indices]
+    return doc_entries
+
+
+def train_val_ttt_global_sgd_distributed(h, device, val_data, base_model, val_tokens, batch_seqs=None):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    seq_len = h.eval_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = h.global_ttt_chunk_tokens
+    batch_seqs = h.global_ttt_batch_seqs if batch_seqs is None else batch_seqs
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    ttt_params = [p for p in base_model.parameters()]
+    for p in ttt_params:
+        p.requires_grad_(True)
+    optimizer = torch.optim.SGD(
+        ttt_params, lr=h.global_ttt_lr, momentum=h.global_ttt_momentum
+    )
+    t_start = time.perf_counter()
+    for ci in range(num_chunks):
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+        is_last_chunk = ci == num_chunks - 1
+        if is_last_chunk or h.global_ttt_epochs <= 0:
+            continue
+        base_model.train()
+        chunk_seqs = (chunk_end - chunk_start) // seq_len
+        if chunk_seqs <= 0:
+            continue
+        warmup_chunks = max(0, min(h.global_ttt_warmup_chunks, num_chunks - 1))
+        if warmup_chunks > 0 and ci < warmup_chunks:
+            warmup_denom = max(warmup_chunks - 1, 1)
+            warmup_t = ci / warmup_denom
+            lr_now = (
+                h.global_ttt_warmup_start_lr
+                + (h.global_ttt_lr - h.global_ttt_warmup_start_lr) * warmup_t
+            )
+        else:
+            decay_steps = max(num_chunks - 1 - warmup_chunks, 1)
+            decay_ci = max(ci - warmup_chunks, 0)
+            lr_now = h.global_ttt_lr * 0.5 * (
+                1.0 + math.cos(math.pi * decay_ci / decay_steps)
+            )
+        for pg in optimizer.param_groups:
+            pg["lr"] = lr_now
+        my_seq_s = chunk_seqs * h.rank // h.world_size
+        my_seq_e = chunk_seqs * (h.rank + 1) // h.world_size
+        my_chunk_seqs = my_seq_e - my_seq_s
+        for _ in range(h.global_ttt_epochs):
+            for bs in range(0, my_chunk_seqs, batch_seqs):
+                be = min(bs + batch_seqs, my_chunk_seqs)
+                actual_bs = my_seq_s + bs
+                start_tok = chunk_start + actual_bs * seq_len
+                end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                if end_tok > val_tokens.numel():
+                    continue
+                local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                x_flat = local[:-1]
+                y_flat = local[1:]
+                optimizer.zero_grad(set_to_none=True)
+                with torch.enable_grad():
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        if h.global_ttt_respect_doc_boundaries:
+                            bos_pos = (x_flat == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+                            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                                bos_pos, x_flat.numel(), x_flat.device, h.eval_seq_len, 64
+                            )
+                            loss = base_model(
+                                x_flat[None],
+                                y_flat[None],
+                                cu_seqlens=cu_seqlens,
+                                max_seqlen=max_seqlen,
+                            )
+                        else:
+                            x = x_flat.reshape(-1, seq_len)
+                            y = y_flat.reshape(-1, seq_len)
+                            loss = base_model(x, y)
+                loss.backward()
+                if dist.is_available() and dist.is_initialized():
+                    for p in ttt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+                            p.grad.mul_(1.0 / h.world_size)
+                if h.global_ttt_grad_clip > 0:
+                    torch.nn.utils.clip_grad_norm_(ttt_params, h.global_ttt_grad_clip)
+                optimizer.step()
+        base_model.eval()
+        if h.rank == 0:
+            elapsed = time.perf_counter() - t_start
+            log(
+                f"tttg: c{ci+1}/{num_chunks} lr:{lr_now:.6f} t:{elapsed:.1f}s"
+            )
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+
+def eval_val_ttt_phased(h, base_model, device, val_data, forward_ttt_train):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+    all_tokens = val_data.val_tokens
+    all_tokens_idx = all_tokens.to(torch.int32)
+    docs = _find_docs(all_tokens)
+    doc_entries = _select_ttt_doc_entries(docs, h)
+    prefix_doc_limit = max(0, min(len(doc_entries), int(h.phased_ttt_prefix_docs)))
+    num_phases = max(1, int(h.phased_ttt_num_phases))
+    phase_boundaries = []
+    for pi in range(num_phases):
+        boundary = prefix_doc_limit * (pi + 1) // num_phases
+        phase_boundaries.append(boundary)
+    current_phase = 0
+    current_phase_boundary = phase_boundaries[0]
+    log(
+        "ttt_phased:"
+        f" total_docs:{len(doc_entries)} prefix_docs:{prefix_doc_limit} "
+        f"suffix_docs:{len(doc_entries) - prefix_doc_limit}"
+        f" num_phases:{num_phases} boundaries:{phase_boundaries}"
+    )
+    chunk_size, eval_seq_len = h.ttt_chunk_size, h.ttt_eval_seq_len
+    eval_batch_set = None
+    if h.ttt_eval_batches:
+        eval_batch_set = set(int(x) for x in h.ttt_eval_batches.split(",") if x.strip())
+    use_ascending = eval_batch_set is not None
+    global_batches_sorted = _build_ttt_global_batches(
+        doc_entries, h, ascending=use_ascending
+    )
+    queue_len = len(global_batches_sorted)
+    counter_path = f"/tmp/ttt_counter_{h.run_id}"
+    prefix_counter_path = f"/tmp/ttt_prefix_counter_{h.run_id}"
+    pause_flag_path = f"/tmp/ttt_pause_flag_{h.run_id}"
+    if h.rank == 0:
+        _init_batch_counter(counter_path)
+        _init_int64_counter(prefix_counter_path)
+        try:
+            os.remove(pause_flag_path)
+        except FileNotFoundError:
+            pass
+    if dist.is_available() and dist.is_initialized():
+        path_list = [counter_path, prefix_counter_path, pause_flag_path]
+        dist.broadcast_object_list(path_list, src=0)
+        counter_path, prefix_counter_path, pause_flag_path = path_list
+        dist.barrier()
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    t_start = time.perf_counter()
+    reusable_lora = BatchedTTTLoRA(
+        h.ttt_batch_size, base_model, h.ttt_lora_rank, alpha=h.ttt_lora_alpha,
+        k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+    ).to(device)
+
+    def _build_opt(lora):
+        if h.ttt_optimizer == "sgd":
+            return torch.optim.SGD(
+                lora.parameters(), lr=h.ttt_lora_lr,
+                momentum=h.ttt_beta1, weight_decay=h.ttt_weight_decay,
+            )
+        return torch.optim.AdamW(
+            lora.parameters(), lr=h.ttt_lora_lr,
+            betas=(h.ttt_beta1, h.ttt_beta2),
+            eps=1e-10, weight_decay=h.ttt_weight_decay, fused=True,
+        )
+
+    reusable_opt = _build_opt(reusable_lora)
+    local_scored_docs = []
+    global_ttt_done = prefix_doc_limit == 0
+    try:
+      while True:
+        queue_idx = _claim_next_batch(counter_path, queue_len)
+        if queue_idx >= queue_len:
+            break
+        orig_batch_idx, batch_entries = global_batches_sorted[queue_idx]
+        batch = [doc for _, doc in batch_entries]
+        bsz = len(batch)
+        prev_loss = loss_sum.item()
+        prev_bytes = byte_sum.item()
+        prev_tokens = token_count.item()
+        if bsz == reusable_lora.bsz:
+            reusable_lora.reset()
+            for s in reusable_opt.state.values():
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor):
+                        v.zero_()
+                    elif k == "step":
+                        s[k] = 0
+            cur_lora = reusable_lora
+            cur_opt = reusable_opt
+        else:
+            cur_lora = BatchedTTTLoRA(
+                bsz, base_model, h.ttt_lora_rank, alpha=h.ttt_lora_alpha,
+                k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+            ).to(device)
+            cur_opt = _build_opt(cur_lora)
+        pred_lens = [doc_len - 1 for _, doc_len in batch]
+        num_chunks = [(pl + chunk_size - 1) // chunk_size for pl in pred_lens]
+        max_nc = max(num_chunks)
+        num_chunks_t = torch.tensor(num_chunks, dtype=torch.int64, device=device)
+        for ci in range(max_nc):
+            active = [ci < nc for nc in num_chunks]
+            needs_train = any(ci < nc - 1 for nc in num_chunks)
+            tok_starts = torch.zeros(bsz, dtype=torch.int64)
+            tok_wls = torch.zeros(bsz, dtype=torch.int64)
+            chunk_offsets_cpu = torch.zeros(bsz, dtype=torch.int64)
+            chunk_lens_cpu = torch.zeros(bsz, dtype=torch.int64)
+            for b in range(bsz):
+                if not active[b]:
+                    continue
+                doc_start, doc_len = batch[b]
+                win_start, win_len, chunk_offset, chunk_len = _compute_chunk_window(
+                    ci, pred_lens[b], num_chunks[b], chunk_size, eval_seq_len
+                )
+                tok_starts[b] = doc_start + win_start
+                tok_wls[b] = win_len
+                chunk_offsets_cpu[b] = chunk_offset
+                chunk_lens_cpu[b] = chunk_len
+            _, context_size, chunk_offset, _ = _compute_chunk_window(
+                ci, (ci + 1) * chunk_size, ci + 1, chunk_size, eval_seq_len
+            )
+            col_idx = torch.arange(context_size + 1)
+            idx = tok_starts.unsqueeze(1) + col_idx.unsqueeze(0)
+            idx.clamp_(max=all_tokens.numel() - 1)
+            gathered_gpu = all_tokens_idx[idx].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            valid = (col_idx[:context_size].unsqueeze(0) < tok_wls.unsqueeze(1)).to(
+                device, non_blocking=True
+            )
+            chunk_offsets = chunk_offsets_cpu.to(device, non_blocking=True)
+            chunk_lens = chunk_lens_cpu.to(device, non_blocking=True)
+            x = torch.where(valid, gathered_gpu[:, :context_size], 0)
+            y = torch.where(valid, gathered_gpu[:, 1 : context_size + 1], 0)
+            ctx_pos = torch.arange(context_size, device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+            # CaseOps sidecar-driven byte budget. Mirror the index pattern
+            # used to build y from all_tokens: y[b, j] corresponds to the
+            # token at global position tok_starts[b] + 1 + j (when valid).
+            y_bytes_arg = None
+            if val_data.caseops_enabled and val_data.val_bytes is not None:
+                y_idx = (
+                    tok_starts.unsqueeze(1)
+                    + 1
+                    + col_idx[:context_size].unsqueeze(0)
+                )
+                y_idx = y_idx.clamp_(max=val_data.val_bytes.numel() - 1)
+                y_bytes_arg = val_data.val_bytes[y_idx].to(
+                    device=device, dtype=torch.int32, non_blocking=True
+                )
+                # Mirror the `valid` masking used for y so out-of-range tokens
+                # contribute zero bytes (matches y=0 substitution above).
+                y_bytes_arg = torch.where(
+                    valid, y_bytes_arg, torch.zeros_like(y_bytes_arg)
+                )
+            with torch.no_grad():
+                _accumulate_bpb(
+                    per_tok_loss,
+                    x,
+                    y,
+                    chunk_offsets,
+                    chunk_lens,
+                    ctx_pos,
+                    val_data.base_bytes_lut,
+                    val_data.has_leading_space_lut,
+                    val_data.is_boundary_token_lut,
+                    loss_sum,
+                    byte_sum,
+                    token_count,
+                    y_bytes=y_bytes_arg,
+                )
+            if needs_train:
+                activate_chunk_mask = (num_chunks_t - 1 > ci).float()
+                for gi in range(h.ttt_grad_steps):
+                    if gi > 0:
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+                    per_doc = per_tok_loss[
+                        :, chunk_offset : chunk_offset + chunk_size
+                    ].mean(dim=-1)
+                    cur_opt.zero_grad(set_to_none=True)
+                    (per_doc * activate_chunk_mask).sum().backward()
+                    cur_opt.step()
+            else:
+                del per_tok_loss
+        batch_num = orig_batch_idx + 1
+        doc_lens = [dl for _, dl in batch]
+        should_report = batch_num in eval_batch_set if eval_batch_set is not None else True
+        if should_report:
+            cur_tokens = token_count.item()
+            cur_loss_val = loss_sum.item()
+            cur_bytes_val = byte_sum.item()
+            dt = cur_tokens - prev_tokens
+            db = cur_bytes_val - prev_bytes
+            if dt > 0 and db > 0:
+                b_loss = (cur_loss_val - prev_loss) / dt
+                b_bpb = b_loss / math.log(2.0) * (dt / db)
+            else:
+                b_loss = b_bpb = 0.0
+            r_loss = cur_loss_val / max(cur_tokens, 1)
+            r_bpb = r_loss / math.log(2.0) * (cur_tokens / max(cur_bytes_val, 1))
+            elapsed = time.perf_counter() - t_start
+            log(
+                f"ttp: b{batch_num}/{queue_len} bl:{b_loss:.4f} bb:{b_bpb:.4f} "
+                f"rl:{r_loss:.4f} rb:{r_bpb:.4f} dl:{min(doc_lens)}-{max(doc_lens)} "
+                f"gd:{int(global_ttt_done)}"
+            )
+        if not global_ttt_done:
+            local_scored_docs.extend(
+                (orig_batch_idx, pos, doc_start, doc_len)
+                for pos, (doc_start, doc_len) in enumerate(batch)
+            )
+            prefix_done = _add_to_counter(prefix_counter_path, len(batch_entries))
+            if prefix_done >= current_phase_boundary:
+                try:
+                    with open(pause_flag_path, "x"):
+                        pass
+                except FileExistsError:
+                    pass
+            should_pause = os.path.exists(pause_flag_path)
+            if should_pause:
+                if dist.is_available() and dist.is_initialized():
+                    dist.barrier()
+                gathered_scored_docs = [None] * h.world_size
+                if dist.is_available() and dist.is_initialized():
+                    dist.all_gather_object(gathered_scored_docs, local_scored_docs)
+                else:
+                    gathered_scored_docs = [local_scored_docs]
+                scored_docs_for_global = []
+                for rank_docs in gathered_scored_docs:
+                    if rank_docs:
+                        scored_docs_for_global.extend(rank_docs)
+                scored_docs_for_global.sort(key=lambda x: (x[0], x[1]))
+                scored_docs_for_global = scored_docs_for_global[:current_phase_boundary]
+                scored_token_chunks = [
+                    val_data.val_tokens[doc_start : doc_start + doc_len]
+                    for _, _, doc_start, doc_len in scored_docs_for_global
+                ]
+                if scored_token_chunks:
+                    global_ttt_tokens = torch.cat(scored_token_chunks)
+                else:
+                    global_ttt_tokens = val_data.val_tokens[:0]
+                if h.rank == 0:
+                    prefix_done = 0
+                    try:
+                        with open(prefix_counter_path, "rb") as f:
+                            prefix_done = int.from_bytes(
+                                f.read(8), "little", signed=True
+                            )
+                    except FileNotFoundError:
+                        pass
+                    log(
+                        f"ttpp: phase:{current_phase + 1}/{num_phases} pd:{prefix_done} "
+                        f"gd:{len(scored_docs_for_global)} "
+                        f"t:{time.perf_counter() - t_start:.1f}s"
+                    )
+                train_val_ttt_global_sgd_distributed(
+                    h, device, val_data, base_model, global_ttt_tokens
+                )
+                for p in base_model.parameters():
+                    p.requires_grad_(False)
+                reusable_lora = BatchedTTTLoRA(
+                    h.ttt_batch_size, base_model, h.ttt_lora_rank,
+                    k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+                ).to(device)
+                reusable_opt = _build_opt(reusable_lora)
+                current_phase += 1
+                if current_phase >= num_phases:
+                    global_ttt_done = True
+                else:
+                    current_phase_boundary = phase_boundaries[current_phase]
+                    if h.rank == 0:
+                        try:
+                            os.remove(pause_flag_path)
+                        except FileNotFoundError:
+                            pass
+                if dist.is_available() and dist.is_initialized():
+                    dist.barrier()
+                if h.rank == 0:
+                    log(f"ttpr: phase:{current_phase}/{num_phases} t:{time.perf_counter() - t_start:.1f}s")
+        del cur_lora, cur_opt
+    finally:
+        pass
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.train()
+    return _loss_bpb_from_sums(loss_sum, token_count, byte_sum)
+
+
+def timed_eval(label, fn, *args, **kwargs):
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    val_loss, val_bpb = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    elapsed_ms = 1e3 * (time.perf_counter() - t0)
+    log(
+        f"{label} val_loss:{val_loss:.8f} val_bpb:{val_bpb:.8f} eval_time:{elapsed_ms:.0f}ms"
+    )
+    return val_loss, val_bpb
+
+
+def train_model(h, device, val_data):
+    base_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        base_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    model = compiled_model
+    log(f"model_params:{sum(p.numel()for p in base_model.parameters())}")
+    log(
+        f"recur_alpha: enabled={h.recur_alpha_enabled} "
+        f"num_loops={h.num_loops} loop_start={h.loop_start} loop_end={h.loop_end} "
+        f"diag_p2p_cos={h.recur_diag_p2p_cos}"
+    )
+    optimizers = Optimizers(h, base_model)
+    train_loader = DocumentPackingLoader(h, device)
+    max_wallclock_ms = (
+        1e3 * h.max_wallclock_seconds if h.max_wallclock_seconds > 0 else None
+    )
+    if max_wallclock_ms is not None:
+        max_wallclock_ms -= h.gptq_reserve_seconds * 1e3
+        log(
+            f"gptq:reserving {h.gptq_reserve_seconds:.0f}s, effective={max_wallclock_ms:.0f}ms"
+        )
+
+    def training_frac(step, elapsed_ms):
+        if max_wallclock_ms is None:
+            return step / max(h.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-09)
+
+    def lr_mul(frac):
+        if h.warmdown_frac <= 0:
+            return 1.0
+        if frac >= 1.0 - h.warmdown_frac:
+            return max((1.0 - frac) / h.warmdown_frac, h.min_lr)
+        return 1.0
+
+    def step_fn(step, lr_scale):
+        optimizers.zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(h.grad_accum_steps):
+            x, y, cu_seqlens, _max_seqlen = train_loader.next_batch(
+                h.train_batch_tokens, h.grad_accum_steps
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y, cu_seqlens=cu_seqlens, max_seqlen=h.train_seq_len)
+            train_loss += loss.detach()
+            (loss / h.grad_accum_steps).backward()
+        train_loss /= h.grad_accum_steps
+        frac = (
+            min(step / h.muon_momentum_warmup_steps, 1.0)
+            if h.muon_momentum_warmup_steps > 0
+            else 1.0
+        )
+        muon_momentum = (
+            1 - frac
+        ) * h.muon_momentum_warmup_start + frac * h.muon_momentum
+        for group in optimizers.optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * lr_scale
+        if h.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), h.grad_clip_norm)
+        # Snapshot α grad norm BEFORE optimizers.step() since step() ends with
+        # zero_grad_all(); reading recur_alpha.grad after step() always sees None/0.
+        # Spec 015 hit this bug — cosmetic (α values moved fine) but the logged
+        # grad_norm was unusable as a plumbing-check signal.
+        alpha_grad_norm = None  # Spec 025b: recur_beta/recur_alpha are frozen buffers
+        optimizers.step(distributed=h.distributed)
+        return train_loss, alpha_grad_norm
+
+    if h.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for (name, tensor) in base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in optimizers
+        ]
+        model.train()
+        num_tokens_local = h.train_batch_tokens // h.world_size
+        for blk in base_model.blocks:
+            blk.attn.rotary(num_tokens_local, device, torch.bfloat16)
+        cu_bucket_size = train_loader.cu_bucket_size
+        warmup_cu_buckets = tuple(cu_bucket_size * i for i in range(1, 5))
+        warmup_cu_iters = 3
+        x, y, cu_seqlens, _ = train_loader.next_batch(
+            h.train_batch_tokens, h.grad_accum_steps
+        )
+        log(f"warmup_cu_buckets:{','.join(str(b) for b in warmup_cu_buckets)} iters_each:{warmup_cu_iters}")
+        def _run_cu_bucket_warmup():
+            for bucket_len in warmup_cu_buckets:
+                boundaries = list(range(0, x.size(1), max(h.train_seq_len, 1)))
+                if boundaries[-1] != x.size(1):
+                    boundaries.append(x.size(1))
+                cu = torch.full((bucket_len,), x.size(1), dtype=torch.int32, device=device)
+                cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+                for _ in range(warmup_cu_iters):
+                    optimizers.zero_grad_all()
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                        wloss = model(x, y, cu_seqlens=cu, max_seqlen=h.train_seq_len)
+                    (wloss / h.grad_accum_steps).backward()
+            optimizers.zero_grad_all()
+        _run_cu_bucket_warmup()
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            _run_cu_bucket_warmup()
+            if h.loop_depth_upgrade_at > 0 and h.num_loops >= 2:
+                base_model.looping_depth = h.num_loops  # pre-warm full-depth state
+                _run_cu_bucket_warmup()
+                base_model.looping_depth = h.num_loops - 1  # reset to curriculum start
+            base_model.looping_active = False
+        for warmup_step in range(h.warmup_steps):
+            step_fn(warmup_step, 1.0)
+            if (
+                warmup_step <= 5
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == h.warmup_steps
+            ):
+                log(f"warmup_step: {warmup_step+1}/{h.warmup_steps}")
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            log(
+                f"loop_warmup:enabled encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            for warmup_step in range(h.warmup_steps):
+                step_fn(warmup_step, 1.0)
+                if (
+                    warmup_step <= 5
+                    or (warmup_step + 1) % 10 == 0
+                    or warmup_step + 1 == h.warmup_steps
+                ):
+                    log(f"loop_warmup_step: {warmup_step+1}/{h.warmup_steps}")
+            if h.loop_depth_upgrade_at > 0 and h.num_loops >= 2:
+                base_model.looping_depth = h.num_loops  # pre-warm full-depth state
+                log(f"loop_warmup:depth_upgraded looping_depth:{h.num_loops + 1}")
+                for warmup_step in range(h.warmup_steps):
+                    step_fn(warmup_step, 1.0)
+                    if (
+                        warmup_step <= 5
+                        or (warmup_step + 1) % 10 == 0
+                        or warmup_step + 1 == h.warmup_steps
+                    ):
+                        log(f"loop_depth_warmup_step: {warmup_step+1}/{h.warmup_steps}")
+                base_model.looping_depth = h.num_loops - 1  # reset to curriculum start
+            base_model.looping_active = False
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for (opt, state) in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        optimizers.zero_grad_all()
+        train_loader = DocumentPackingLoader(h, device)
+    ema_state = {
+        name: t.detach().float().clone()
+        for (name, t) in base_model.state_dict().items()
+    }
+    ema_decay = h.ema_decay
+    training_time_ms = 0.0
+    stop_after_step = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = (
+            step == h.iterations
+            or stop_after_step is not None
+            and step >= stop_after_step
+        )
+        should_validate = (
+            last_step or h.val_loss_every > 0 and step % h.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1e3 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                h, device, val_data, model, compiled_forward_logits
+            )
+            log(
+                f"{step}/{h.iterations} val_loss: {val_loss:.4f} val_bpb: {val_bpb:.4f}"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < h.iterations:
+                log(
+                    f"stopping_early: wallclock_cap train_time: {training_time_ms:.0f}ms step: {step}/{h.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        frac = training_frac(step, elapsed_ms)
+        scale = lr_mul(frac)
+        if (
+            h.num_loops > 0
+            and not base_model.looping_active
+            and frac >= h.enable_looping_at
+        ):
+            base_model.looping_active = True
+            log(
+                f"layer_loop:enabled step:{step} frac:{frac:.3f} depth:{base_model.looping_depth + 1} encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+        if (
+            h.loop_depth_upgrade_at > 0
+            and base_model.looping_active
+            and base_model.looping_depth < h.num_loops
+            and frac >= h.loop_depth_upgrade_at
+        ):
+            base_model.looping_depth = h.num_loops
+            log(
+                f"loop_depth:upgraded step:{step} frac:{frac:.3f} depth:{h.num_loops + 1} encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+        train_loss, alpha_grad_norm = step_fn(step, scale)
+        with torch.no_grad():
+            for (name, t) in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(
+                    t.detach().float(), alpha=1.0 - ema_decay
+                )
+        step += 1
+        approx_training_time_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        should_log_train = h.train_log_every > 0 and (
+            step <= 5 or step % h.train_log_every == 0 or stop_after_step is not None
+        )
+        if should_log_train:
+            tok_per_sec = step * h.train_batch_tokens / (approx_training_time_ms / 1e3)
+            log(
+                f"{step}/{h.iterations} train_loss: {train_loss.item():.4f} train_time: {approx_training_time_ms/60000:.1f}m tok/s: {tok_per_sec:.0f}"
+            )
+            # Spec 015/016: Recur-Alpha diagnostics (alpha values, grad norms, p2p cosine).
+            # alpha_grad_norm comes from step_fn (snapshotted before optimizers.step()
+            # zeros grads); reading base_model.recur_alpha.grad here would always be None.
+            if getattr(base_model, "recur_alpha", None) is not None:
+                alpha_tensor = base_model.recur_alpha.detach().float().cpu().tolist()
+                beta_tensor = None
+                if getattr(base_model, "recur_beta", None) is not None:
+                    beta_tensor = base_model.recur_beta.detach().float().cpu().tolist()
+                if alpha_grad_norm is None:
+                    alpha_grad_norm = 0.0
+                p2p_cos_str = ""
+                if getattr(base_model, "recur_diag_p2p_cos", False):
+                    p2p = base_model._diag_p2p_cos.detach().float().cpu().tolist()
+                    p2p_cos_str = f" p2p_cos: {p2p}"
+                log(
+                    f"recur_alpha: beta={beta_tensor} alpha={alpha_tensor} grad_norm={alpha_grad_norm:.6f}{p2p_cos_str}"
+                )
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if h.distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated()//1024//1024} MiB reserved: {torch.cuda.max_memory_reserved()//1024//1024} MiB"
+    )
+    log("ema:applying EMA weights")
+    current_state = base_model.state_dict()
+    avg_state = {
+        name: t.to(dtype=current_state[name].dtype) for (name, t) in ema_state.items()
+    }
+    base_model.load_state_dict(avg_state, strict=True)
+    return base_model, compiled_model, compiled_forward_logits
+
+
+def train_and_eval(h, device):
+    random.seed(h.seed)
+    np.random.seed(h.seed)
+    torch.manual_seed(h.seed)
+    torch.cuda.manual_seed_all(h.seed)
+    if h.artifact_dir and h.is_main_process:
+        os.makedirs(h.artifact_dir, exist_ok=True)
+    val_data = ValidationData(h, device)
+    log(
+        f"train_shards: {len(list(Path(h.datasets_dir).resolve().glob('fineweb_train_*.bin')))}"
+    )
+    log(f"val_tokens: {val_data.val_tokens.numel()-1}")
+    base_model, compiled_model, compiled_forward_logits = train_model(
+        h, device, val_data
+    )
+    torch._dynamo.reset()
+    timed_eval(
+        "diagnostic pre-quantization post-ema",
+        eval_val,
+        h,
+        device,
+        val_data,
+        compiled_model,
+        compiled_forward_logits,
+    )
+    serialize(h, base_model, Path(__file__).read_text(encoding="utf-8"))
+    if h.distributed:
+        dist.barrier()
+    eval_model = deserialize(h, device)
+    if h.num_loops > 0:
+        eval_model.looping_active = True
+        eval_model.looping_depth = h.num_loops  # always full depth at eval/TTT
+    compiled_model = torch.compile(eval_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        eval_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    timed_eval(
+        "diagnostic quantized",
+        eval_val,
+        h,
+        device,
+        val_data,
+        compiled_model,
+        compiled_forward_logits,
+    )
+    if h.ttt_enabled:
+        del eval_model, compiled_model
+        torch._dynamo.reset()
+        torch.cuda.empty_cache()
+        ttt_model = deserialize(h, device)
+        if h.num_loops > 0:
+            ttt_model.looping_active = True
+            ttt_model.looping_depth = h.num_loops  # always full depth at TTT
+        for p in ttt_model.parameters():
+            p.requires_grad_(False)
+
+        if h.rope_yarn:
+            _yarn_seqlen = h.train_batch_tokens // h.grad_accum_steps
+            for block in ttt_model.blocks:
+                block.attn.rotary(_yarn_seqlen, device, torch.bfloat16)
+        else:
+            for block in ttt_model.blocks:
+                block.attn.rotary._cos_cached = None
+                block.attn.rotary._sin_cached = None
+                block.attn.rotary._seq_len_cached = 0
+                block.attn.rotary(h.ttt_eval_seq_len, device, torch.bfloat16)
+
+        def _fwd_ttt_inner(input_ids, target_ids, lora):
+            return ttt_model.forward_ttt(input_ids, target_ids, lora=lora)
+
+        _fwd_ttt_compiled_inner = None
+
+        def _fwd_ttt(input_ids, target_ids, lora):
+            nonlocal _fwd_ttt_compiled_inner
+            if _fwd_ttt_compiled_inner is None:
+                _fwd_ttt_compiled_inner = torch.compile(_fwd_ttt_inner, dynamic=True)
+            return _fwd_ttt_compiled_inner(input_ids, target_ids, lora=lora)
+
+        fwd_ttt_compiled = _fwd_ttt
+        log(f"ttt_lora:warming up compile (random tokens, no val data)")
+        global BOS_ID
+        if BOS_ID is None:
+            BOS_ID = 1
+        t_warmup = time.perf_counter()
+        warmup_bszes = [h.ttt_batch_size]
+        for bsz in warmup_bszes:
+            wl = BatchedTTTLoRA(
+                bsz, ttt_model, h.ttt_lora_rank, alpha=h.ttt_lora_alpha,
+                k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+            ).to(device)
+            wo = torch.optim.AdamW(
+                wl.parameters(),
+                lr=h.ttt_lora_lr,
+                betas=(h.ttt_beta1, h.ttt_beta2),
+                eps=1e-10,
+                weight_decay=h.ttt_weight_decay,
+                fused=True,
+            )
+            for ctx_len in (h.ttt_chunk_size, h.ttt_eval_seq_len):
+                xw = torch.randint(0, h.vocab_size, (bsz, ctx_len), device=device, dtype=torch.int64)
+                yw = torch.randint(0, h.vocab_size, (bsz, ctx_len), device=device, dtype=torch.int64)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    ptl = fwd_ttt_compiled(xw, yw, lora=wl)
+                ptl[:, : min(h.ttt_chunk_size, ctx_len)].mean(dim=-1).sum().backward()
+                wo.step()
+                wo.zero_grad(set_to_none=True)
+            del wl, wo
+        torch.cuda.empty_cache()
+        compile_elapsed = time.perf_counter() - t_warmup
+        log(f"ttt_lora:compile warmup done ({compile_elapsed:.1f}s)")
+        log("\nbeginning TTT eval timer")
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_val_loss, ttt_val_bpb = eval_val_ttt_phased(
+            h, ttt_model, device, val_data, forward_ttt_train=fwd_ttt_compiled
+        )
+        torch.cuda.synchronize()
+        ttt_eval_elapsed = time.perf_counter() - t_ttt
+        log(
+            "quantized_ttt_phased "
+            f"val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f} "
+            f"eval_time:{1e3*ttt_eval_elapsed:.0f}ms"
+        )
+        log(f"total_eval_time:{ttt_eval_elapsed:.1f}s")
+        del ttt_model
+
+
+def main():
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    torch._dynamo.config.optimize_ddp = False
+    torch._dynamo.config.cache_size_limit = 16
+    h = Hyperparameters()
+    set_logging_hparams(h)
+    if h.is_main_process:
+        os.makedirs(h.artifact_dir if h.artifact_dir else "logs", exist_ok=True)
+        log(100 * "=", console=False)
+        log("Hyperparameters:", console=True)
+        for (k, v) in sorted(vars(type(h)).items()):
+            if not k.startswith("_"):
+                log(f"  {k}: {v}", console=True)
+        log("=" * 100, console=False)
+        log("Source code:", console=False)
+        log("=" * 100, console=False)
+        with open(__file__, "r", encoding="utf-8") as _src:
+            log(_src.read(), console=False)
+        log("=" * 100, console=False)
+        log(f"Running Python {sys.version}", console=False)
+        log(f"Running PyTorch {torch.__version__}", console=False)
+        log("=" * 100, console=False)
+    train_and_eval(h, device)
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-04-24_SP8192_CaseOps_SparseGate_QuantGate_Loop45_PhasedTTT_PolarNS_MinLR_FusedCE_UpdatedCarry/train_seed0.log
+++ b/records/track_10min_16mb/2026-04-24_SP8192_CaseOps_SparseGate_QuantGate_Loop45_PhasedTTT_PolarNS_MinLR_FusedCE_UpdatedCarry/train_seed0.log
@@ -1,0 +1,932 @@
+W0423 23:04:49.690000 183720 torch/distributed/run.py:803] 
+W0423 23:04:49.690000 183720 torch/distributed/run.py:803] *****************************************
+W0423 23:04:49.690000 183720 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0423 23:04:49.690000 183720 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  artifact_dir: /workspace/runs/036-035e-8h-promotion/seed_0
+  attn_clip_sigmas: 13.0
+  attn_out_gate_enabled: False
+  attn_out_gate_src: proj
+  beta1: 0.9
+  beta2: 0.95
+  caseops_enabled: True
+  compressor: brotli
+  data_dir: /workspace/parameter-golf/data
+  datasets_dir: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_caseops/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved
+  distributed: True
+  ema_decay: 0.9965
+  embed_bits: 7
+  embed_clip_sigmas: 15.0
+  embed_lr: 0.6
+  embed_wd: 0.085
+  enable_looping_at: 0.35
+  eval_seq_len: 2048
+  eval_stride: 64
+  fused_ce_enabled: True
+  gate_window: 12
+  gated_attn_enabled: False
+  gated_attn_init_std: 0.005
+  gated_attn_quant_gate: True
+  global_ttt_batch_seqs: 32
+  global_ttt_chunk_tokens: 32768
+  global_ttt_epochs: 1
+  global_ttt_grad_clip: 1.0
+  global_ttt_lr: 0.001
+  global_ttt_momentum: 0.9
+  global_ttt_respect_doc_boundaries: True
+  global_ttt_warmup_chunks: 0
+  global_ttt_warmup_start_lr: 0.0
+  gptq_calibration_batches: 16
+  gptq_reserve_seconds: 0.5
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  is_main_process: True
+  iterations: 20000
+  ln_scale: True
+  local_rank: 0
+  logfile: /workspace/runs/036-035e-8h-promotion/seed_0/b1427e96-6f17-4287-90c9-7028df16b516.txt
+  logit_softcap: 30.0
+  loop_depth_upgrade_at: 0.0
+  loop_end: 5
+  loop_start: 3
+  matrix_bits: 6
+  matrix_clip_sigmas: 12.85
+  matrix_lr: 0.026
+  max_wallclock_seconds: 600.0
+  min_lr: 0.1
+  mlp_clip_sigmas: 12.0
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: /workspace/runs/036-035e-8h-promotion/seed_0/final_model.pt
+  muon_backend_steps: 5
+  muon_momentum: 0.97
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_row_normalize: True
+  muon_wd: 0.095
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  num_loops: 2
+  parallel_final_lane: mean
+  parallel_start_layer: 8
+  phased_ttt_num_phases: 3
+  phased_ttt_prefix_docs: 2000
+  qk_gain_init: 5.0
+  quantized_model_path: /workspace/runs/036-035e-8h-promotion/seed_0/final_model.int6.ptz
+  rank: 0
+  recur_alpha_enabled: True
+  recur_diag_p2p_cos: False
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  rope_yarn: False
+  run_id: b1427e96-6f17-4287-90c9-7028df16b516
+  scalar_lr: 0.02
+  seed: 0
+  skip_gates_enabled: True
+  smear_gate_enabled: False
+  sparse_attn_gate_enabled: True
+  sparse_attn_gate_init_std: 0.0
+  sparse_attn_gate_scale: 1.0
+  spinquant_enabled: False
+  spinquant_seed: 42
+  spinquant_sites: attn_in,attn_proj_in,mlp_in,mlp_proj_in
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  tokenizer_path: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_caseops/datasets/tokenizers/fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model
+  train_batch_tokens: 786432
+  train_files: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_caseops/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_train_*.bin
+  train_log_every: 100
+  train_seq_len: 2048
+  ttt_batch_size: 64
+  ttt_beta1: 0.0
+  ttt_beta2: 0.999
+  ttt_chunk_size: 48
+  ttt_enabled: True
+  ttt_eval_batches: 
+  ttt_eval_seq_len: 2048
+  ttt_grad_steps: 1
+  ttt_k_lora: True
+  ttt_lora_alpha: 144
+  ttt_lora_lr: 0.0001
+  ttt_lora_rank: 96
+  ttt_mlp_lora: True
+  ttt_o_lora: True
+  ttt_optimizer: adam
+  ttt_weight_decay: 1.0
+  val_batch_tokens: 524288
+  val_bytes_files: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_caseops/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_val_bytes_*.bin
+  val_doc_fraction: 1.0
+  val_files: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_caseops/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_val_*.bin
+  val_loss_every: 0
+  vocab_size: 8192
+  warmdown_frac: 0.75
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+train_shards: 80
+val_tokens: 47851520
+model_params:35945658
+recur_alpha: enabled=True num_loops=2 loop_start=3 loop_end=5 diag_p2p_cos=False
+gptq:reserving 0s, effective=599500ms
+warmup_cu_buckets:64,128,192,256 iters_each:3
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup:enabled encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+loop_warmup_step: 1/20
+loop_warmup_step: 2/20
+loop_warmup_step: 3/20
+loop_warmup_step: 4/20
+loop_warmup_step: 5/20
+loop_warmup_step: 6/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+1/20000 train_loss: 9.0086 train_time: 0.0m tok/s: 12585054
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2/20000 train_loss: 12.8192 train_time: 0.0m tok/s: 10765241
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3/20000 train_loss: 10.2218 train_time: 0.0m tok/s: 9413340
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4/20000 train_loss: 8.7237 train_time: 0.0m tok/s: 8896976
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+5/20000 train_loss: 7.9377 train_time: 0.0m tok/s: 8616992
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+100/20000 train_loss: 3.6015 train_time: 0.2m tok/s: 8456801
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+200/20000 train_loss: 3.1515 train_time: 0.3m tok/s: 8328127
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+300/20000 train_loss: 2.9221 train_time: 0.5m tok/s: 8302802
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+400/20000 train_loss: 2.5910 train_time: 0.6m tok/s: 8275445
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+500/20000 train_loss: 2.5756 train_time: 0.8m tok/s: 8303175
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+600/20000 train_loss: 2.6776 train_time: 1.0m tok/s: 8257307
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+700/20000 train_loss: 2.8786 train_time: 1.1m tok/s: 8244885
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+800/20000 train_loss: 2.7167 train_time: 1.3m tok/s: 8242585
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+900/20000 train_loss: 2.7614 train_time: 1.4m tok/s: 8245578
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1000/20000 train_loss: 2.8115 train_time: 1.6m tok/s: 8261910
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1100/20000 train_loss: 2.7714 train_time: 1.7m tok/s: 8263243
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1200/20000 train_loss: 2.7718 train_time: 1.9m tok/s: 8263986
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1300/20000 train_loss: 2.8340 train_time: 2.1m tok/s: 8267027
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1400/20000 train_loss: 2.5954 train_time: 2.2m tok/s: 8268520
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1500/20000 train_loss: 2.6376 train_time: 2.4m tok/s: 8278537
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1600/20000 train_loss: 2.7120 train_time: 2.5m tok/s: 8277956
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1700/20000 train_loss: 2.6823 train_time: 2.7m tok/s: 8277224
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1800/20000 train_loss: 2.6502 train_time: 2.9m tok/s: 8274668
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1900/20000 train_loss: 2.7465 train_time: 3.0m tok/s: 8282405
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2000/20000 train_loss: 2.6702 train_time: 3.2m tok/s: 8277917
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2100/20000 train_loss: 2.6933 train_time: 3.3m tok/s: 8276382
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2200/20000 train_loss: 2.5350 train_time: 3.5m tok/s: 8274428
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+layer_loop:enabled step:2208 frac:0.350 depth:3 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2300/20000 train_loss: 2.6093 train_time: 3.7m tok/s: 8120218
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2400/20000 train_loss: 2.6319 train_time: 3.9m tok/s: 7976413
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2500/20000 train_loss: 2.5590 train_time: 4.2m tok/s: 7840992
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2600/20000 train_loss: 2.5264 train_time: 4.4m tok/s: 7723683
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2700/20000 train_loss: 2.5126 train_time: 4.6m tok/s: 7619317
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2800/20000 train_loss: 2.5727 train_time: 4.9m tok/s: 7525248
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2900/20000 train_loss: 2.5492 train_time: 5.1m tok/s: 7440559
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3000/20000 train_loss: 2.5767 train_time: 5.3m tok/s: 7360576
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3100/20000 train_loss: 2.5035 train_time: 5.6m tok/s: 7285918
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3200/20000 train_loss: 2.4742 train_time: 5.8m tok/s: 7220028
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3300/20000 train_loss: 2.6636 train_time: 6.0m tok/s: 7160895
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3400/20000 train_loss: 2.5640 train_time: 6.3m tok/s: 7103390
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3500/20000 train_loss: 2.5757 train_time: 6.5m tok/s: 7050563
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3600/20000 train_loss: 2.4717 train_time: 6.7m tok/s: 7001071
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3700/20000 train_loss: 2.5584 train_time: 7.0m tok/s: 6936012
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3800/20000 train_loss: 2.5040 train_time: 7.2m tok/s: 6896057
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3900/20000 train_loss: 2.6271 train_time: 7.5m tok/s: 6856869
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4000/20000 train_loss: 2.4178 train_time: 7.7m tok/s: 6819657
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4100/20000 train_loss: 2.4215 train_time: 7.9m tok/s: 6784851
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4200/20000 train_loss: 2.3964 train_time: 8.2m tok/s: 6752110
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4300/20000 train_loss: 2.5155 train_time: 8.4m tok/s: 6691291
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4400/20000 train_loss: 2.4593 train_time: 8.7m tok/s: 6662989
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4500/20000 train_loss: 2.2924 train_time: 8.9m tok/s: 6635899
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4600/20000 train_loss: 2.3856 train_time: 9.1m tok/s: 6610132
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4700/20000 train_loss: 2.3330 train_time: 9.4m tok/s: 6585856
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4800/20000 train_loss: 2.3143 train_time: 9.6m tok/s: 6562623
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4900/20000 train_loss: 2.3084 train_time: 9.8m tok/s: 6540963
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4974/20000 val_loss: 2.3577 val_bpb: 1.0773
+stopping_early: wallclock_cap train_time: 599552ms step: 4974/20000
+peak memory allocated: 41610 MiB reserved: 46918 MiB
+ema:applying EMA weights
+diagnostic pre-quantization post-ema val_loss:2.33482249 val_bpb:1.06685349 eval_time:7741ms
+Serialized model: 135417469 bytes
+pyminify unavailable (FileNotFoundError); skipping compressed-code-size measurement
+Code size (uncompressed): 175063 bytes
+Code size (compressed): 0 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 3.6s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int7): tok_emb.weight
+  passthrough (float16): blocks.attn.attn_gate_w, blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, recur_alpha, recur_beta, skip_gates, skip_weights
+Serialized model quantized+brotli: 15904209 bytes
+Total submission size quantized+brotli: 15904209 bytes
+diagnostic quantized val_loss:2.35502122 val_bpb:1.07608292 eval_time:11888ms
+ttt_lora:warming up compile (random tokens, no val data)
+ttt_lora:compile warmup done (95.9s)
+
+beginning TTT eval timer
+ttt_phased: total_docs:50000 prefix_docs:2000 suffix_docs:48000 num_phases:3 boundaries:[666, 1333, 2000]
+ttp: b780/782 bl:2.2436 bb:1.0809 rl:2.2436 rb:1.0809 dl:13091-17244 gd:0
+ttp: b767/782 bl:2.2734 bb:1.0757 rl:2.2509 rb:1.0796 dl:4681-4858 gd:0
+ttpp: phase:1/3 pd:1104 gd:666 t:206.3s
+tttg: c1/111 lr:0.001000 t:0.4s
+tttg: c2/111 lr:0.001000 t:0.5s
+tttg: c3/111 lr:0.000999 t:0.5s
+tttg: c4/111 lr:0.000998 t:0.6s
+tttg: c5/111 lr:0.000997 t:0.7s
+tttg: c6/111 lr:0.000995 t:0.8s
+tttg: c7/111 lr:0.000993 t:0.8s
+tttg: c8/111 lr:0.000990 t:0.9s
+tttg: c9/111 lr:0.000987 t:1.0s
+tttg: c10/111 lr:0.000984 t:1.0s
+tttg: c11/111 lr:0.000980 t:1.1s
+tttg: c12/111 lr:0.000976 t:1.2s
+tttg: c13/111 lr:0.000971 t:1.2s
+tttg: c14/111 lr:0.000966 t:1.3s
+tttg: c15/111 lr:0.000961 t:1.4s
+tttg: c16/111 lr:0.000955 t:1.4s
+tttg: c17/111 lr:0.000949 t:1.5s
+tttg: c18/111 lr:0.000942 t:1.6s
+tttg: c19/111 lr:0.000935 t:1.7s
+tttg: c20/111 lr:0.000928 t:1.7s
+tttg: c21/111 lr:0.000921 t:1.8s
+tttg: c22/111 lr:0.000913 t:1.9s
+tttg: c23/111 lr:0.000905 t:1.9s
+tttg: c24/111 lr:0.000896 t:2.0s
+tttg: c25/111 lr:0.000887 t:2.1s
+tttg: c26/111 lr:0.000878 t:2.1s
+tttg: c27/111 lr:0.000868 t:2.2s
+tttg: c28/111 lr:0.000859 t:2.3s
+tttg: c29/111 lr:0.000848 t:2.4s
+tttg: c30/111 lr:0.000838 t:2.4s
+tttg: c31/111 lr:0.000827 t:2.5s
+tttg: c32/111 lr:0.000817 t:2.6s
+tttg: c33/111 lr:0.000805 t:2.6s
+tttg: c34/111 lr:0.000794 t:2.7s
+tttg: c35/111 lr:0.000782 t:2.8s
+tttg: c36/111 lr:0.000770 t:2.8s
+tttg: c37/111 lr:0.000758 t:2.9s
+tttg: c38/111 lr:0.000746 t:3.0s
+tttg: c39/111 lr:0.000733 t:3.0s
+tttg: c40/111 lr:0.000721 t:3.1s
+tttg: c41/111 lr:0.000708 t:3.2s
+tttg: c42/111 lr:0.000695 t:3.3s
+tttg: c43/111 lr:0.000681 t:3.3s
+tttg: c44/111 lr:0.000668 t:3.4s
+tttg: c45/111 lr:0.000655 t:3.5s
+tttg: c46/111 lr:0.000641 t:3.5s
+tttg: c47/111 lr:0.000627 t:3.6s
+tttg: c48/111 lr:0.000613 t:3.7s
+tttg: c49/111 lr:0.000599 t:3.8s
+tttg: c50/111 lr:0.000585 t:3.8s
+tttg: c51/111 lr:0.000571 t:3.9s
+tttg: c52/111 lr:0.000557 t:4.0s
+tttg: c53/111 lr:0.000543 t:4.0s
+tttg: c54/111 lr:0.000529 t:4.1s
+tttg: c55/111 lr:0.000514 t:4.2s
+tttg: c56/111 lr:0.000500 t:4.2s
+tttg: c57/111 lr:0.000486 t:4.3s
+tttg: c58/111 lr:0.000471 t:4.4s
+tttg: c59/111 lr:0.000457 t:4.4s
+tttg: c60/111 lr:0.000443 t:4.5s
+tttg: c61/111 lr:0.000429 t:4.6s
+tttg: c62/111 lr:0.000415 t:4.7s
+tttg: c63/111 lr:0.000401 t:4.7s
+tttg: c64/111 lr:0.000387 t:4.8s
+tttg: c65/111 lr:0.000373 t:4.9s
+tttg: c66/111 lr:0.000359 t:4.9s
+tttg: c67/111 lr:0.000345 t:5.0s
+tttg: c68/111 lr:0.000332 t:5.1s
+tttg: c69/111 lr:0.000319 t:5.1s
+tttg: c70/111 lr:0.000305 t:5.2s
+tttg: c71/111 lr:0.000292 t:5.3s
+tttg: c72/111 lr:0.000279 t:5.3s
+tttg: c73/111 lr:0.000267 t:5.4s
+tttg: c74/111 lr:0.000254 t:5.5s
+tttg: c75/111 lr:0.000242 t:5.5s
+tttg: c76/111 lr:0.000230 t:5.6s
+tttg: c77/111 lr:0.000218 t:5.7s
+tttg: c78/111 lr:0.000206 t:5.8s
+tttg: c79/111 lr:0.000195 t:5.8s
+tttg: c80/111 lr:0.000183 t:5.9s
+tttg: c81/111 lr:0.000173 t:6.0s
+tttg: c82/111 lr:0.000162 t:6.0s
+tttg: c83/111 lr:0.000152 t:6.1s
+tttg: c84/111 lr:0.000141 t:6.2s
+tttg: c85/111 lr:0.000132 t:6.2s
+tttg: c86/111 lr:0.000122 t:6.3s
+tttg: c87/111 lr:0.000113 t:6.4s
+tttg: c88/111 lr:0.000104 t:6.4s
+tttg: c89/111 lr:0.000095 t:6.5s
+tttg: c90/111 lr:0.000087 t:6.6s
+tttg: c91/111 lr:0.000079 t:6.7s
+tttg: c92/111 lr:0.000072 t:6.7s
+tttg: c93/111 lr:0.000065 t:6.8s
+tttg: c94/111 lr:0.000058 t:6.9s
+tttg: c95/111 lr:0.000051 t:6.9s
+tttg: c96/111 lr:0.000045 t:7.0s
+tttg: c97/111 lr:0.000039 t:7.1s
+tttg: c98/111 lr:0.000034 t:7.1s
+tttg: c99/111 lr:0.000029 t:7.2s
+tttg: c100/111 lr:0.000024 t:7.3s
+tttg: c101/111 lr:0.000020 t:7.3s
+tttg: c102/111 lr:0.000016 t:7.4s
+tttg: c103/111 lr:0.000013 t:7.5s
+tttg: c104/111 lr:0.000010 t:7.5s
+tttg: c105/111 lr:0.000007 t:7.6s
+tttg: c106/111 lr:0.000005 t:7.7s
+tttg: c107/111 lr:0.000003 t:7.8s
+tttg: c108/111 lr:0.000002 t:7.8s
+tttg: c109/111 lr:0.000001 t:7.9s
+tttg: c110/111 lr:0.000000 t:8.0s
+ttpr: phase:1/3 t:216.1s
+ttp: b757/782 bl:2.2857 bb:1.0640 rl:2.2563 rb:1.0771 dl:3550-3633 gd:0
+ttp: b754/782 bl:2.2908 bb:1.0596 rl:2.2607 rb:1.0748 dl:3345-3397 gd:0
+ttpp: phase:2/3 pd:1808 gd:1333 t:281.4s
+tttg: c1/185 lr:0.001000 t:0.1s
+tttg: c2/185 lr:0.001000 t:0.1s
+tttg: c3/185 lr:0.001000 t:0.2s
+tttg: c4/185 lr:0.000999 t:0.3s
+tttg: c5/185 lr:0.000999 t:0.4s
+tttg: c6/185 lr:0.000998 t:0.4s
+tttg: c7/185 lr:0.000997 t:0.5s
+tttg: c8/185 lr:0.000996 t:0.6s
+tttg: c9/185 lr:0.000995 t:0.6s
+tttg: c10/185 lr:0.000994 t:0.7s
+tttg: c11/185 lr:0.000993 t:0.8s
+tttg: c12/185 lr:0.000991 t:0.9s
+tttg: c13/185 lr:0.000990 t:0.9s
+tttg: c14/185 lr:0.000988 t:1.0s
+tttg: c15/185 lr:0.000986 t:1.1s
+tttg: c16/185 lr:0.000984 t:1.1s
+tttg: c17/185 lr:0.000981 t:1.2s
+tttg: c18/185 lr:0.000979 t:1.3s
+tttg: c19/185 lr:0.000977 t:1.3s
+tttg: c20/185 lr:0.000974 t:1.4s
+tttg: c21/185 lr:0.000971 t:1.5s
+tttg: c22/185 lr:0.000968 t:1.6s
+tttg: c23/185 lr:0.000965 t:1.6s
+tttg: c24/185 lr:0.000962 t:1.7s
+tttg: c25/185 lr:0.000959 t:1.8s
+tttg: c26/185 lr:0.000955 t:1.8s
+tttg: c27/185 lr:0.000952 t:1.9s
+tttg: c28/185 lr:0.000948 t:2.0s
+tttg: c29/185 lr:0.000944 t:2.1s
+tttg: c30/185 lr:0.000940 t:2.1s
+tttg: c31/185 lr:0.000936 t:2.2s
+tttg: c32/185 lr:0.000932 t:2.3s
+tttg: c33/185 lr:0.000927 t:2.3s
+tttg: c34/185 lr:0.000923 t:2.4s
+tttg: c35/185 lr:0.000918 t:2.5s
+tttg: c36/185 lr:0.000913 t:2.6s
+tttg: c37/185 lr:0.000908 t:2.6s
+tttg: c38/185 lr:0.000904 t:2.7s
+tttg: c39/185 lr:0.000898 t:2.8s
+tttg: c40/185 lr:0.000893 t:2.8s
+tttg: c41/185 lr:0.000888 t:2.9s
+tttg: c42/185 lr:0.000882 t:3.0s
+tttg: c43/185 lr:0.000877 t:3.0s
+tttg: c44/185 lr:0.000871 t:3.1s
+tttg: c45/185 lr:0.000865 t:3.2s
+tttg: c46/185 lr:0.000860 t:3.2s
+tttg: c47/185 lr:0.000854 t:3.3s
+tttg: c48/185 lr:0.000847 t:3.4s
+tttg: c49/185 lr:0.000841 t:3.5s
+tttg: c50/185 lr:0.000835 t:3.5s
+tttg: c51/185 lr:0.000829 t:3.6s
+tttg: c52/185 lr:0.000822 t:3.7s
+tttg: c53/185 lr:0.000816 t:3.7s
+tttg: c54/185 lr:0.000809 t:3.8s
+tttg: c55/185 lr:0.000802 t:3.9s
+tttg: c56/185 lr:0.000795 t:4.0s
+tttg: c57/185 lr:0.000788 t:4.0s
+tttg: c58/185 lr:0.000781 t:4.1s
+tttg: c59/185 lr:0.000774 t:4.2s
+tttg: c60/185 lr:0.000767 t:4.2s
+tttg: c61/185 lr:0.000760 t:4.3s
+tttg: c62/185 lr:0.000752 t:4.4s
+tttg: c63/185 lr:0.000745 t:4.4s
+tttg: c64/185 lr:0.000738 t:4.5s
+tttg: c65/185 lr:0.000730 t:4.6s
+tttg: c66/185 lr:0.000722 t:4.7s
+tttg: c67/185 lr:0.000715 t:4.7s
+tttg: c68/185 lr:0.000707 t:4.8s
+tttg: c69/185 lr:0.000699 t:4.9s
+tttg: c70/185 lr:0.000691 t:4.9s
+tttg: c71/185 lr:0.000683 t:5.0s
+tttg: c72/185 lr:0.000675 t:5.1s
+tttg: c73/185 lr:0.000667 t:5.1s
+tttg: c74/185 lr:0.000659 t:5.2s
+tttg: c75/185 lr:0.000651 t:5.3s
+tttg: c76/185 lr:0.000643 t:5.3s
+tttg: c77/185 lr:0.000635 t:5.4s
+tttg: c78/185 lr:0.000627 t:5.5s
+tttg: c79/185 lr:0.000618 t:5.6s
+tttg: c80/185 lr:0.000610 t:5.6s
+tttg: c81/185 lr:0.000602 t:5.7s
+tttg: c82/185 lr:0.000593 t:5.8s
+tttg: c83/185 lr:0.000585 t:5.9s
+tttg: c84/185 lr:0.000577 t:5.9s
+tttg: c85/185 lr:0.000568 t:6.0s
+tttg: c86/185 lr:0.000560 t:6.1s
+tttg: c87/185 lr:0.000551 t:6.1s
+tttg: c88/185 lr:0.000543 t:6.2s
+tttg: c89/185 lr:0.000534 t:6.3s
+tttg: c90/185 lr:0.000526 t:6.3s
+tttg: c91/185 lr:0.000517 t:6.4s
+tttg: c92/185 lr:0.000509 t:6.5s
+tttg: c93/185 lr:0.000500 t:6.6s
+tttg: c94/185 lr:0.000491 t:6.6s
+tttg: c95/185 lr:0.000483 t:6.7s
+tttg: c96/185 lr:0.000474 t:6.8s
+tttg: c97/185 lr:0.000466 t:6.8s
+tttg: c98/185 lr:0.000457 t:6.9s
+tttg: c99/185 lr:0.000449 t:7.0s
+tttg: c100/185 lr:0.000440 t:7.1s
+tttg: c101/185 lr:0.000432 t:7.1s
+tttg: c102/185 lr:0.000423 t:7.2s
+tttg: c103/185 lr:0.000415 t:7.3s
+tttg: c104/185 lr:0.000407 t:7.3s
+tttg: c105/185 lr:0.000398 t:7.4s
+tttg: c106/185 lr:0.000390 t:7.5s
+tttg: c107/185 lr:0.000382 t:7.5s
+tttg: c108/185 lr:0.000373 t:7.6s
+tttg: c109/185 lr:0.000365 t:7.7s
+tttg: c110/185 lr:0.000357 t:7.8s
+tttg: c111/185 lr:0.000349 t:7.8s
+tttg: c112/185 lr:0.000341 t:7.9s
+tttg: c113/185 lr:0.000333 t:8.0s
+tttg: c114/185 lr:0.000325 t:8.1s
+tttg: c115/185 lr:0.000317 t:8.1s
+tttg: c116/185 lr:0.000309 t:8.2s
+tttg: c117/185 lr:0.000301 t:8.3s
+tttg: c118/185 lr:0.000293 t:8.3s
+tttg: c119/185 lr:0.000285 t:8.5s
+tttg: c120/185 lr:0.000278 t:8.5s
+tttg: c121/185 lr:0.000270 t:8.6s
+tttg: c122/185 lr:0.000262 t:8.7s
+tttg: c123/185 lr:0.000255 t:8.8s
+tttg: c124/185 lr:0.000248 t:8.8s
+tttg: c125/185 lr:0.000240 t:8.9s
+tttg: c126/185 lr:0.000233 t:9.0s
+tttg: c127/185 lr:0.000226 t:9.0s
+tttg: c128/185 lr:0.000219 t:9.1s
+tttg: c129/185 lr:0.000212 t:9.2s
+tttg: c130/185 lr:0.000205 t:9.2s
+tttg: c131/185 lr:0.000198 t:9.3s
+tttg: c132/185 lr:0.000191 t:9.4s
+tttg: c133/185 lr:0.000184 t:9.5s
+tttg: c134/185 lr:0.000178 t:9.5s
+tttg: c135/185 lr:0.000171 t:9.6s
+tttg: c136/185 lr:0.000165 t:9.7s
+tttg: c137/185 lr:0.000159 t:9.8s
+tttg: c138/185 lr:0.000153 t:9.8s
+tttg: c139/185 lr:0.000146 t:9.9s
+tttg: c140/185 lr:0.000140 t:10.0s
+tttg: c141/185 lr:0.000135 t:10.0s
+tttg: c142/185 lr:0.000129 t:10.1s
+tttg: c143/185 lr:0.000123 t:10.2s
+tttg: c144/185 lr:0.000118 t:10.2s
+tttg: c145/185 lr:0.000112 t:10.3s
+tttg: c146/185 lr:0.000107 t:10.4s
+tttg: c147/185 lr:0.000102 t:10.5s
+tttg: c148/185 lr:0.000096 t:10.5s
+tttg: c149/185 lr:0.000092 t:10.6s
+tttg: c150/185 lr:0.000087 t:10.7s
+tttg: c151/185 lr:0.000082 t:10.7s
+tttg: c152/185 lr:0.000077 t:10.8s
+tttg: c153/185 lr:0.000073 t:12.5s
+tttg: c154/185 lr:0.000068 t:12.6s
+tttg: c155/185 lr:0.000064 t:12.7s
+tttg: c156/185 lr:0.000060 t:12.7s
+tttg: c157/185 lr:0.000056 t:12.8s
+tttg: c158/185 lr:0.000052 t:12.9s
+tttg: c159/185 lr:0.000048 t:12.9s
+tttg: c160/185 lr:0.000045 t:13.0s
+tttg: c161/185 lr:0.000041 t:13.1s
+tttg: c162/185 lr:0.000038 t:13.2s
+tttg: c163/185 lr:0.000035 t:13.2s
+tttg: c164/185 lr:0.000032 t:13.3s
+tttg: c165/185 lr:0.000029 t:13.4s
+tttg: c166/185 lr:0.000026 t:13.4s
+tttg: c167/185 lr:0.000023 t:13.5s
+tttg: c168/185 lr:0.000021 t:13.6s
+tttg: c169/185 lr:0.000019 t:13.7s
+tttg: c170/185 lr:0.000016 t:13.7s
+tttg: c171/185 lr:0.000014 t:13.8s
+tttg: c172/185 lr:0.000012 t:13.9s
+tttg: c173/185 lr:0.000010 t:13.9s
+tttg: c174/185 lr:0.000009 t:14.0s
+tttg: c175/185 lr:0.000007 t:14.1s
+tttg: c176/185 lr:0.000006 t:14.1s
+tttg: c177/185 lr:0.000005 t:14.2s
+tttg: c178/185 lr:0.000004 t:14.3s
+tttg: c179/185 lr:0.000003 t:14.4s
+tttg: c180/185 lr:0.000002 t:14.4s
+tttg: c181/185 lr:0.000001 t:14.5s
+tttg: c182/185 lr:0.000001 t:14.6s
+tttg: c183/185 lr:0.000000 t:14.7s
+tttg: c184/185 lr:0.000000 t:14.8s
+ttpr: phase:2/3 t:298.0s
+ttp: b746/782 bl:2.4182 bb:1.0655 rl:2.2764 rb:1.0738 dl:2884-2943 gd:0
+ttp: b745/782 bl:2.2406 bb:1.0258 rl:2.2732 rb:1.0694 dl:2842-2883 gd:0
+ttpp: phase:3/3 pd:2448 gd:2000 t:315.1s
+tttg: c1/250 lr:0.001000 t:0.1s
+tttg: c2/250 lr:0.001000 t:0.2s
+tttg: c3/250 lr:0.001000 t:0.2s
+tttg: c4/250 lr:0.001000 t:0.3s
+tttg: c5/250 lr:0.000999 t:0.4s
+tttg: c6/250 lr:0.000999 t:0.4s
+tttg: c7/250 lr:0.000999 t:0.5s
+tttg: c8/250 lr:0.000998 t:0.6s
+tttg: c9/250 lr:0.000997 t:0.7s
+tttg: c10/250 lr:0.000997 t:0.7s
+tttg: c11/250 lr:0.000996 t:0.8s
+tttg: c12/250 lr:0.000995 t:0.9s
+tttg: c13/250 lr:0.000994 t:0.9s
+tttg: c14/250 lr:0.000993 t:1.0s
+tttg: c15/250 lr:0.000992 t:1.1s
+tttg: c16/250 lr:0.000991 t:1.2s
+tttg: c17/250 lr:0.000990 t:1.2s
+tttg: c18/250 lr:0.000989 t:1.3s
+tttg: c19/250 lr:0.000987 t:1.4s
+tttg: c20/250 lr:0.000986 t:1.4s
+tttg: c21/250 lr:0.000984 t:1.5s
+tttg: c22/250 lr:0.000983 t:1.6s
+tttg: c23/250 lr:0.000981 t:1.6s
+tttg: c24/250 lr:0.000979 t:1.7s
+tttg: c25/250 lr:0.000977 t:1.8s
+tttg: c26/250 lr:0.000975 t:1.9s
+tttg: c27/250 lr:0.000973 t:1.9s
+tttg: c28/250 lr:0.000971 t:2.0s
+tttg: c29/250 lr:0.000969 t:2.1s
+tttg: c30/250 lr:0.000967 t:2.2s
+tttg: c31/250 lr:0.000965 t:2.2s
+tttg: c32/250 lr:0.000962 t:2.3s
+tttg: c33/250 lr:0.000960 t:2.4s
+tttg: c34/250 lr:0.000957 t:2.4s
+tttg: c35/250 lr:0.000955 t:2.5s
+tttg: c36/250 lr:0.000952 t:2.6s
+tttg: c37/250 lr:0.000949 t:2.7s
+tttg: c38/250 lr:0.000947 t:2.7s
+tttg: c39/250 lr:0.000944 t:2.8s
+tttg: c40/250 lr:0.000941 t:2.9s
+tttg: c41/250 lr:0.000938 t:2.9s
+tttg: c42/250 lr:0.000935 t:3.0s
+tttg: c43/250 lr:0.000931 t:3.1s
+tttg: c44/250 lr:0.000928 t:3.2s
+tttg: c45/250 lr:0.000925 t:3.2s
+tttg: c46/250 lr:0.000922 t:3.3s
+tttg: c47/250 lr:0.000918 t:3.4s
+tttg: c48/250 lr:0.000915 t:3.4s
+tttg: c49/250 lr:0.000911 t:3.5s
+tttg: c50/250 lr:0.000907 t:3.6s
+tttg: c51/250 lr:0.000904 t:3.6s
+tttg: c52/250 lr:0.000900 t:3.7s
+tttg: c53/250 lr:0.000896 t:3.8s
+tttg: c54/250 lr:0.000892 t:3.9s
+tttg: c55/250 lr:0.000888 t:3.9s
+tttg: c56/250 lr:0.000884 t:4.0s
+tttg: c57/250 lr:0.000880 t:4.1s
+tttg: c58/250 lr:0.000876 t:4.2s
+tttg: c59/250 lr:0.000872 t:4.2s
+tttg: c60/250 lr:0.000868 t:4.3s
+tttg: c61/250 lr:0.000863 t:4.4s
+tttg: c62/250 lr:0.000859 t:4.4s
+tttg: c63/250 lr:0.000855 t:4.5s
+tttg: c64/250 lr:0.000850 t:4.6s
+tttg: c65/250 lr:0.000846 t:4.7s
+tttg: c66/250 lr:0.000841 t:4.7s
+tttg: c67/250 lr:0.000836 t:4.8s
+tttg: c68/250 lr:0.000832 t:4.9s
+tttg: c69/250 lr:0.000827 t:4.9s
+tttg: c70/250 lr:0.000822 t:5.0s
+tttg: c71/250 lr:0.000817 t:5.1s
+tttg: c72/250 lr:0.000812 t:5.2s
+tttg: c73/250 lr:0.000807 t:5.2s
+tttg: c74/250 lr:0.000803 t:5.3s
+tttg: c75/250 lr:0.000797 t:5.4s
+tttg: c76/250 lr:0.000792 t:5.5s
+tttg: c77/250 lr:0.000787 t:5.5s
+tttg: c78/250 lr:0.000782 t:5.6s
+tttg: c79/250 lr:0.000777 t:5.7s
+tttg: c80/250 lr:0.000772 t:5.7s
+tttg: c81/250 lr:0.000766 t:5.8s
+tttg: c82/250 lr:0.000761 t:5.9s
+tttg: c83/250 lr:0.000755 t:6.0s
+tttg: c84/250 lr:0.000750 t:6.0s
+tttg: c85/250 lr:0.000745 t:6.1s
+tttg: c86/250 lr:0.000739 t:6.2s
+tttg: c87/250 lr:0.000733 t:6.2s
+tttg: c88/250 lr:0.000728 t:6.3s
+tttg: c89/250 lr:0.000722 t:6.4s
+tttg: c90/250 lr:0.000717 t:6.4s
+tttg: c91/250 lr:0.000711 t:6.5s
+tttg: c92/250 lr:0.000705 t:6.6s
+tttg: c93/250 lr:0.000699 t:6.7s
+tttg: c94/250 lr:0.000694 t:6.7s
+tttg: c95/250 lr:0.000688 t:6.8s
+tttg: c96/250 lr:0.000682 t:6.9s
+tttg: c97/250 lr:0.000676 t:6.9s
+tttg: c98/250 lr:0.000670 t:7.0s
+tttg: c99/250 lr:0.000664 t:7.1s
+tttg: c100/250 lr:0.000658 t:7.2s
+tttg: c101/250 lr:0.000652 t:7.2s
+tttg: c102/250 lr:0.000646 t:7.3s
+tttg: c103/250 lr:0.000640 t:7.4s
+tttg: c104/250 lr:0.000634 t:7.4s
+tttg: c105/250 lr:0.000628 t:7.5s
+tttg: c106/250 lr:0.000622 t:7.6s
+tttg: c107/250 lr:0.000616 t:7.6s
+tttg: c108/250 lr:0.000610 t:7.7s
+tttg: c109/250 lr:0.000603 t:7.8s
+tttg: c110/250 lr:0.000597 t:7.9s
+tttg: c111/250 lr:0.000591 t:7.9s
+tttg: c112/250 lr:0.000585 t:8.0s
+tttg: c113/250 lr:0.000579 t:8.1s
+tttg: c114/250 lr:0.000572 t:8.1s
+tttg: c115/250 lr:0.000566 t:8.2s
+tttg: c116/250 lr:0.000560 t:8.3s
+tttg: c117/250 lr:0.000554 t:8.3s
+tttg: c118/250 lr:0.000547 t:8.4s
+tttg: c119/250 lr:0.000541 t:8.5s
+tttg: c120/250 lr:0.000535 t:8.6s
+tttg: c121/250 lr:0.000528 t:8.6s
+tttg: c122/250 lr:0.000522 t:8.7s
+tttg: c123/250 lr:0.000516 t:8.8s
+tttg: c124/250 lr:0.000509 t:8.8s
+tttg: c125/250 lr:0.000503 t:8.9s
+tttg: c126/250 lr:0.000497 t:9.0s
+tttg: c127/250 lr:0.000491 t:9.1s
+tttg: c128/250 lr:0.000484 t:9.2s
+tttg: c129/250 lr:0.000478 t:9.2s
+tttg: c130/250 lr:0.000472 t:9.3s
+tttg: c131/250 lr:0.000465 t:9.4s
+tttg: c132/250 lr:0.000459 t:9.4s
+tttg: c133/250 lr:0.000453 t:9.5s
+tttg: c134/250 lr:0.000446 t:11.6s
+tttg: c135/250 lr:0.000440 t:11.6s
+tttg: c136/250 lr:0.000434 t:11.7s
+tttg: c137/250 lr:0.000428 t:11.8s
+tttg: c138/250 lr:0.000421 t:11.9s
+tttg: c139/250 lr:0.000415 t:11.9s
+tttg: c140/250 lr:0.000409 t:12.0s
+tttg: c141/250 lr:0.000403 t:12.1s
+tttg: c142/250 lr:0.000397 t:12.2s
+tttg: c143/250 lr:0.000390 t:12.2s
+tttg: c144/250 lr:0.000384 t:12.3s
+tttg: c145/250 lr:0.000378 t:12.4s
+tttg: c146/250 lr:0.000372 t:12.4s
+tttg: c147/250 lr:0.000366 t:12.5s
+tttg: c148/250 lr:0.000360 t:12.6s
+tttg: c149/250 lr:0.000354 t:12.7s
+tttg: c150/250 lr:0.000348 t:12.7s
+tttg: c151/250 lr:0.000342 t:12.8s
+tttg: c152/250 lr:0.000336 t:12.9s
+tttg: c153/250 lr:0.000330 t:13.0s
+tttg: c154/250 lr:0.000324 t:13.0s
+tttg: c155/250 lr:0.000318 t:13.1s
+tttg: c156/250 lr:0.000312 t:13.2s
+tttg: c157/250 lr:0.000306 t:13.2s
+tttg: c158/250 lr:0.000301 t:13.3s
+tttg: c159/250 lr:0.000295 t:13.4s
+tttg: c160/250 lr:0.000289 t:13.4s
+tttg: c161/250 lr:0.000283 t:13.5s
+tttg: c162/250 lr:0.000278 t:13.6s
+tttg: c163/250 lr:0.000272 t:13.7s
+tttg: c164/250 lr:0.000267 t:13.7s
+tttg: c165/250 lr:0.000261 t:13.8s
+tttg: c166/250 lr:0.000255 t:13.9s
+tttg: c167/250 lr:0.000250 t:13.9s
+tttg: c168/250 lr:0.000245 t:14.0s
+tttg: c169/250 lr:0.000239 t:14.1s
+tttg: c170/250 lr:0.000234 t:14.2s
+tttg: c171/250 lr:0.000228 t:14.2s
+tttg: c172/250 lr:0.000223 t:14.3s
+tttg: c173/250 lr:0.000218 t:14.4s
+tttg: c174/250 lr:0.000213 t:14.4s
+tttg: c175/250 lr:0.000208 t:14.5s
+tttg: c176/250 lr:0.000203 t:14.6s
+tttg: c177/250 lr:0.000197 t:14.7s
+tttg: c178/250 lr:0.000193 t:14.7s
+tttg: c179/250 lr:0.000188 t:14.8s
+tttg: c180/250 lr:0.000183 t:14.9s
+tttg: c181/250 lr:0.000178 t:14.9s
+tttg: c182/250 lr:0.000173 t:15.0s
+tttg: c183/250 lr:0.000168 t:15.1s
+tttg: c184/250 lr:0.000164 t:15.1s
+tttg: c185/250 lr:0.000159 t:15.2s
+tttg: c186/250 lr:0.000154 t:15.3s
+tttg: c187/250 lr:0.000150 t:15.4s
+tttg: c188/250 lr:0.000145 t:15.4s
+tttg: c189/250 lr:0.000141 t:15.5s
+tttg: c190/250 lr:0.000137 t:15.6s
+tttg: c191/250 lr:0.000132 t:15.6s
+tttg: c192/250 lr:0.000128 t:15.7s
+tttg: c193/250 lr:0.000124 t:15.8s
+tttg: c194/250 lr:0.000120 t:15.8s
+tttg: c195/250 lr:0.000116 t:15.9s
+tttg: c196/250 lr:0.000112 t:16.0s
+tttg: c197/250 lr:0.000108 t:16.1s
+tttg: c198/250 lr:0.000104 t:16.1s
+tttg: c199/250 lr:0.000100 t:16.2s
+tttg: c200/250 lr:0.000096 t:16.3s
+tttg: c201/250 lr:0.000093 t:16.4s
+tttg: c202/250 lr:0.000089 t:16.4s
+tttg: c203/250 lr:0.000085 t:16.5s
+tttg: c204/250 lr:0.000082 t:16.6s
+tttg: c205/250 lr:0.000078 t:16.6s
+tttg: c206/250 lr:0.000075 t:16.7s
+tttg: c207/250 lr:0.000072 t:16.8s
+tttg: c208/250 lr:0.000069 t:16.8s
+tttg: c209/250 lr:0.000065 t:16.9s
+tttg: c210/250 lr:0.000062 t:17.0s
+tttg: c211/250 lr:0.000059 t:17.1s
+tttg: c212/250 lr:0.000056 t:17.1s
+tttg: c213/250 lr:0.000053 t:17.2s
+tttg: c214/250 lr:0.000051 t:17.3s
+tttg: c215/250 lr:0.000048 t:17.3s
+tttg: c216/250 lr:0.000045 t:17.4s
+tttg: c217/250 lr:0.000043 t:17.5s
+tttg: c218/250 lr:0.000040 t:17.5s
+tttg: c219/250 lr:0.000038 t:17.6s
+tttg: c220/250 lr:0.000035 t:17.7s
+tttg: c221/250 lr:0.000033 t:17.8s
+tttg: c222/250 lr:0.000031 t:17.8s
+tttg: c223/250 lr:0.000029 t:17.9s
+tttg: c224/250 lr:0.000027 t:18.0s
+tttg: c225/250 lr:0.000025 t:18.0s
+tttg: c226/250 lr:0.000023 t:18.1s
+tttg: c227/250 lr:0.000021 t:18.2s
+tttg: c228/250 lr:0.000019 t:18.2s
+tttg: c229/250 lr:0.000017 t:18.3s
+tttg: c230/250 lr:0.000016 t:18.4s
+tttg: c231/250 lr:0.000014 t:18.5s
+tttg: c232/250 lr:0.000013 t:18.5s
+tttg: c233/250 lr:0.000011 t:18.6s
+tttg: c234/250 lr:0.000010 t:18.7s
+tttg: c235/250 lr:0.000009 t:18.7s
+tttg: c236/250 lr:0.000008 t:18.8s
+tttg: c237/250 lr:0.000007 t:18.9s
+tttg: c238/250 lr:0.000006 t:18.9s
+tttg: c239/250 lr:0.000005 t:19.0s
+tttg: c240/250 lr:0.000004 t:19.1s
+tttg: c241/250 lr:0.000003 t:19.2s
+tttg: c242/250 lr:0.000003 t:19.2s
+tttg: c243/250 lr:0.000002 t:19.3s
+tttg: c244/250 lr:0.000001 t:19.4s
+tttg: c245/250 lr:0.000001 t:19.4s
+tttg: c246/250 lr:0.000001 t:19.5s
+tttg: c247/250 lr:0.000000 t:19.6s
+tttg: c248/250 lr:0.000000 t:19.6s
+tttg: c249/250 lr:0.000000 t:19.7s
+ttpr: phase:3/3 t:336.7s
+ttp: b736/782 bl:2.2505 bb:1.0603 rl:2.2715 rb:1.0688 dl:2526-2550 gd:1
+ttp: b735/782 bl:2.3932 bb:1.1010 rl:2.2797 rb:1.0710 dl:2495-2526 gd:1
+ttp: b724/782 bl:2.3217 bb:1.0601 rl:2.2821 rb:1.0703 dl:2203-2231 gd:1
+ttp: b714/782 bl:2.3135 bb:1.0247 rl:2.2836 rb:1.0680 dl:2018-2035 gd:1
+ttp: b709/782 bl:2.4496 bb:1.0957 rl:2.2911 rb:1.0693 dl:1937-1952 gd:1
+ttp: b701/782 bl:2.3140 bb:1.0375 rl:2.2920 rb:1.0679 dl:1835-1847 gd:1
+ttp: b689/782 bl:2.3983 bb:1.0798 rl:2.2959 rb:1.0684 dl:1706-1715 gd:1
+ttp: b684/782 bl:2.3772 bb:1.0473 rl:2.2986 rb:1.0676 dl:1658-1665 gd:1
+ttp: b677/782 bl:2.3129 bb:1.0362 rl:2.2991 rb:1.0666 dl:1595-1601 gd:1
+ttp: b667/782 bl:2.3717 bb:1.0721 rl:2.3012 rb:1.0668 dl:1514-1521 gd:1
+ttp: b660/782 bl:2.3768 bb:1.0507 rl:2.3033 rb:1.0663 dl:1466-1474 gd:1
+ttp: b653/782 bl:2.2946 bb:1.0403 rl:2.3031 rb:1.0656 dl:1419-1425 gd:1
+ttp: b645/782 bl:2.3032 bb:1.0305 rl:2.3031 rb:1.0647 dl:1367-1375 gd:1
+ttp: b637/782 bl:2.3691 bb:1.0804 rl:2.3046 rb:1.0651 dl:1320-1325 gd:1
+ttp: b629/782 bl:2.3570 bb:1.0143 rl:2.3058 rb:1.0639 dl:1276-1280 gd:1
+ttp: b621/782 bl:2.3037 bb:1.0520 rl:2.3057 rb:1.0637 dl:1231-1237 gd:1
+ttp: b613/782 bl:2.3392 bb:1.0415 rl:2.3064 rb:1.0632 dl:1190-1195 gd:1
+ttp: b605/782 bl:2.2518 bb:1.0269 rl:2.3053 rb:1.0625 dl:1154-1159 gd:1
+ttp: b593/782 bl:2.2957 bb:1.0134 rl:2.3052 rb:1.0616 dl:1103-1107 gd:1
+ttp: b584/782 bl:2.3022 bb:1.0409 rl:2.3051 rb:1.0613 dl:1064-1069 gd:1
+ttp: b576/782 bl:2.3821 bb:1.0957 rl:2.3063 rb:1.0618 dl:1033-1037 gd:1
+ttp: b568/782 bl:2.3608 bb:1.0838 rl:2.3072 rb:1.0622 dl:1004-1007 gd:1
+ttp: b565/782 bl:2.3914 bb:1.0360 rl:2.3084 rb:1.0617 dl:993-997 gd:1
+ttp: b556/782 bl:2.3813 bb:1.0706 rl:2.3094 rb:1.0619 dl:961-965 gd:1
+ttp: b545/782 bl:2.3352 bb:1.0326 rl:2.3098 rb:1.0615 dl:927-930 gd:1
+ttp: b537/782 bl:2.3818 bb:1.0743 rl:2.3107 rb:1.0616 dl:902-905 gd:1
+ttp: b531/782 bl:2.3007 bb:1.0444 rl:2.3106 rb:1.0614 dl:884-887 gd:1
+ttp: b522/782 bl:2.3093 bb:1.0357 rl:2.3106 rb:1.0611 dl:858-860 gd:1
+ttp: b518/782 bl:2.2469 bb:1.0113 rl:2.3098 rb:1.0605 dl:846-850 gd:1
+ttp: b509/782 bl:2.3646 bb:1.0381 rl:2.3104 rb:1.0603 dl:820-823 gd:1
+ttp: b497/782 bl:2.3415 bb:1.0442 rl:2.3108 rb:1.0601 dl:788-791 gd:1
+ttp: b489/782 bl:2.3942 bb:1.0772 rl:2.3116 rb:1.0603 dl:769-771 gd:1
+ttp: b481/782 bl:2.3049 bb:1.0477 rl:2.3116 rb:1.0601 dl:749-752 gd:1
+ttp: b473/782 bl:2.2691 bb:1.0325 rl:2.3112 rb:1.0599 dl:730-733 gd:1
+ttp: b467/782 bl:2.3552 bb:1.0557 rl:2.3116 rb:1.0598 dl:717-719 gd:1
+ttp: b461/782 bl:2.3802 bb:1.0413 rl:2.3122 rb:1.0597 dl:703-706 gd:1
+ttp: b453/782 bl:2.3445 bb:1.0593 rl:2.3125 rb:1.0596 dl:687-689 gd:1
+ttp: b445/782 bl:2.3621 bb:1.0498 rl:2.3129 rb:1.0596 dl:670-672 gd:1
+ttp: b441/782 bl:2.3487 bb:1.0473 rl:2.3132 rb:1.0595 dl:662-664 gd:1
+ttp: b423/782 bl:2.3104 bb:1.0542 rl:2.3132 rb:1.0594 dl:626-629 gd:1
+ttp: b415/782 bl:2.2901 bb:1.0608 rl:2.3130 rb:1.0594 dl:611-613 gd:1
+ttp: b407/782 bl:2.2741 bb:1.0411 rl:2.3127 rb:1.0593 dl:595-597 gd:1
+ttp: b399/782 bl:2.2867 bb:1.0320 rl:2.3125 rb:1.0591 dl:581-582 gd:1
+ttp: b391/782 bl:2.3160 bb:1.0668 rl:2.3125 rb:1.0592 dl:566-568 gd:1
+ttp: b383/782 bl:2.2844 bb:1.0474 rl:2.3124 rb:1.0591 dl:552-554 gd:1
+ttp: b375/782 bl:2.4123 bb:1.0759 rl:2.3130 rb:1.0592 dl:538-540 gd:1
+ttp: b367/782 bl:2.3056 bb:1.0880 rl:2.3130 rb:1.0594 dl:525-527 gd:1
+ttp: b359/782 bl:2.2592 bb:1.0374 rl:2.3126 rb:1.0592 dl:512-513 gd:1
+ttp: b351/782 bl:2.3667 bb:1.0835 rl:2.3129 rb:1.0594 dl:498-499 gd:1
+ttp: b343/782 bl:2.2273 bb:1.0482 rl:2.3125 rb:1.0593 dl:486-488 gd:1
+ttp: b335/782 bl:2.3751 bb:1.0760 rl:2.3128 rb:1.0594 dl:474-476 gd:1
+ttp: b327/782 bl:2.3333 bb:1.0849 rl:2.3129 rb:1.0595 dl:462-463 gd:1
+ttp: b319/782 bl:2.3983 bb:1.0815 rl:2.3134 rb:1.0596 dl:450-451 gd:1
+ttp: b311/782 bl:2.3468 bb:1.0817 rl:2.3135 rb:1.0598 dl:438-439 gd:1
+ttp: b304/782 bl:2.3481 bb:1.0770 rl:2.3137 rb:1.0598 dl:427-429 gd:1
+ttp: b297/782 bl:2.4047 bb:1.0865 rl:2.3141 rb:1.0600 dl:417-418 gd:1
+ttp: b289/782 bl:2.3276 bb:1.0825 rl:2.3142 rb:1.0601 dl:405-406 gd:1
+ttp: b281/782 bl:2.2940 bb:1.0875 rl:2.3141 rb:1.0602 dl:394-395 gd:1
+ttp: b273/782 bl:2.3394 bb:1.0784 rl:2.3142 rb:1.0603 dl:383-384 gd:1
+ttp: b265/782 bl:2.3682 bb:1.1019 rl:2.3144 rb:1.0604 dl:372-374 gd:1
+ttp: b257/782 bl:2.4489 bb:1.1140 rl:2.3149 rb:1.0606 dl:362-364 gd:1
+ttp: b248/782 bl:2.4711 bb:1.1926 rl:2.3156 rb:1.0611 dl:351-352 gd:1
+ttp: b239/782 bl:2.3808 bb:1.1055 rl:2.3158 rb:1.0613 dl:340-341 gd:1
+ttp: b229/782 bl:2.3679 bb:1.0672 rl:2.3160 rb:1.0613 dl:328-329 gd:1
+ttp: b220/782 bl:2.4162 bb:1.1432 rl:2.3163 rb:1.0616 dl:317-318 gd:1
+ttp: b211/782 bl:2.4082 bb:1.0970 rl:2.3166 rb:1.0617 dl:307-308 gd:1
+ttp: b203/782 bl:2.4376 bb:1.1120 rl:2.3170 rb:1.0619 dl:299-300 gd:1
+ttp: b195/782 bl:2.4303 bb:1.1335 rl:2.3174 rb:1.0621 dl:290-291 gd:1
+ttp: b187/782 bl:2.4558 bb:1.1348 rl:2.3178 rb:1.0623 dl:281-282 gd:1
+ttp: b179/782 bl:2.3774 bb:1.1334 rl:2.3180 rb:1.0625 dl:273-274 gd:1
+ttp: b171/782 bl:2.4731 bb:1.1404 rl:2.3184 rb:1.0627 dl:266-266 gd:1
+ttp: b163/782 bl:2.3812 bb:1.1218 rl:2.3186 rb:1.0629 dl:257-259 gd:1
+ttp: b155/782 bl:2.4093 bb:1.1139 rl:2.3188 rb:1.0630 dl:250-251 gd:1
+ttp: b147/782 bl:2.4708 bb:1.1238 rl:2.3192 rb:1.0632 dl:242-243 gd:1
+ttp: b138/782 bl:2.3912 bb:1.1125 rl:2.3194 rb:1.0633 dl:233-234 gd:1
+ttp: b130/782 bl:2.5817 bb:1.1831 rl:2.3200 rb:1.0636 dl:226-227 gd:1
+ttp: b120/782 bl:2.3940 bb:1.1124 rl:2.3202 rb:1.0637 dl:217-218 gd:1
+ttp: b112/782 bl:2.4757 bb:1.1817 rl:2.3205 rb:1.0639 dl:210-210 gd:1
+ttp: b102/782 bl:2.5835 bb:1.1975 rl:2.3211 rb:1.0642 dl:201-202 gd:1
+ttp: b94/782 bl:2.5635 bb:1.2113 rl:2.3215 rb:1.0645 dl:193-194 gd:1
+ttp: b84/782 bl:2.5272 bb:1.2017 rl:2.3219 rb:1.0647 dl:184-185 gd:1
+ttp: b76/782 bl:2.4965 bb:1.1725 rl:2.3223 rb:1.0649 dl:177-178 gd:1
+ttp: b68/782 bl:2.5205 bb:1.1763 rl:2.3226 rb:1.0651 dl:170-171 gd:1
+ttp: b60/782 bl:2.4753 bb:1.1897 rl:2.3229 rb:1.0653 dl:163-164 gd:1
+ttp: b51/782 bl:2.4837 bb:1.1883 rl:2.3231 rb:1.0655 dl:154-155 gd:1
+ttp: b42/782 bl:2.4840 bb:1.2095 rl:2.3234 rb:1.0657 dl:145-146 gd:1
+ttp: b30/782 bl:2.6031 bb:1.2692 rl:2.3237 rb:1.0660 dl:133-134 gd:1
+ttp: b22/782 bl:2.5640 bb:1.2002 rl:2.3241 rb:1.0662 dl:124-126 gd:1
+ttp: b14/782 bl:2.6006 bb:1.1872 rl:2.3244 rb:1.0663 dl:114-115 gd:1
+ttp: b6/782 bl:2.7099 bb:1.2082 rl:2.3248 rb:1.0664 dl:99-101 gd:1
+quantized_ttt_phased val_loss:2.32648401 val_bpb:1.06311240 eval_time:436134ms
+total_eval_time:436.1s

--- a/records/track_10min_16mb/2026-04-24_SP8192_CaseOps_SparseGate_QuantGate_Loop45_PhasedTTT_PolarNS_MinLR_FusedCE_UpdatedCarry/train_seed1234.log
+++ b/records/track_10min_16mb/2026-04-24_SP8192_CaseOps_SparseGate_QuantGate_Loop45_PhasedTTT_PolarNS_MinLR_FusedCE_UpdatedCarry/train_seed1234.log
@@ -1,0 +1,933 @@
+W0423 23:28:06.360000 203907 torch/distributed/run.py:803] 
+W0423 23:28:06.360000 203907 torch/distributed/run.py:803] *****************************************
+W0423 23:28:06.360000 203907 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0423 23:28:06.360000 203907 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  artifact_dir: /workspace/runs/036-035e-8h-promotion/seed_1234
+  attn_clip_sigmas: 13.0
+  attn_out_gate_enabled: False
+  attn_out_gate_src: proj
+  beta1: 0.9
+  beta2: 0.95
+  caseops_enabled: True
+  compressor: brotli
+  data_dir: /workspace/parameter-golf/data
+  datasets_dir: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_caseops/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved
+  distributed: True
+  ema_decay: 0.9965
+  embed_bits: 7
+  embed_clip_sigmas: 15.0
+  embed_lr: 0.6
+  embed_wd: 0.085
+  enable_looping_at: 0.35
+  eval_seq_len: 2048
+  eval_stride: 64
+  fused_ce_enabled: True
+  gate_window: 12
+  gated_attn_enabled: False
+  gated_attn_init_std: 0.005
+  gated_attn_quant_gate: True
+  global_ttt_batch_seqs: 32
+  global_ttt_chunk_tokens: 32768
+  global_ttt_epochs: 1
+  global_ttt_grad_clip: 1.0
+  global_ttt_lr: 0.001
+  global_ttt_momentum: 0.9
+  global_ttt_respect_doc_boundaries: True
+  global_ttt_warmup_chunks: 0
+  global_ttt_warmup_start_lr: 0.0
+  gptq_calibration_batches: 16
+  gptq_reserve_seconds: 0.5
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  is_main_process: True
+  iterations: 20000
+  ln_scale: True
+  local_rank: 0
+  logfile: /workspace/runs/036-035e-8h-promotion/seed_1234/af3a1db6-4929-4c62-9c52-a3634d2bff54.txt
+  logit_softcap: 30.0
+  loop_depth_upgrade_at: 0.0
+  loop_end: 5
+  loop_start: 3
+  matrix_bits: 6
+  matrix_clip_sigmas: 12.85
+  matrix_lr: 0.026
+  max_wallclock_seconds: 600.0
+  min_lr: 0.1
+  mlp_clip_sigmas: 12.0
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: /workspace/runs/036-035e-8h-promotion/seed_1234/final_model.pt
+  muon_backend_steps: 5
+  muon_momentum: 0.97
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_row_normalize: True
+  muon_wd: 0.095
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  num_loops: 2
+  parallel_final_lane: mean
+  parallel_start_layer: 8
+  phased_ttt_num_phases: 3
+  phased_ttt_prefix_docs: 2000
+  qk_gain_init: 5.0
+  quantized_model_path: /workspace/runs/036-035e-8h-promotion/seed_1234/final_model.int6.ptz
+  rank: 0
+  recur_alpha_enabled: True
+  recur_diag_p2p_cos: False
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  rope_yarn: False
+  run_id: af3a1db6-4929-4c62-9c52-a3634d2bff54
+  scalar_lr: 0.02
+  seed: 1234
+  skip_gates_enabled: True
+  smear_gate_enabled: False
+  sparse_attn_gate_enabled: True
+  sparse_attn_gate_init_std: 0.0
+  sparse_attn_gate_scale: 1.0
+  spinquant_enabled: False
+  spinquant_seed: 42
+  spinquant_sites: attn_in,attn_proj_in,mlp_in,mlp_proj_in
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  tokenizer_path: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_caseops/datasets/tokenizers/fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model
+  train_batch_tokens: 786432
+  train_files: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_caseops/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_train_*.bin
+  train_log_every: 100
+  train_seq_len: 2048
+  ttt_batch_size: 64
+  ttt_beta1: 0.0
+  ttt_beta2: 0.999
+  ttt_chunk_size: 48
+  ttt_enabled: True
+  ttt_eval_batches: 
+  ttt_eval_seq_len: 2048
+  ttt_grad_steps: 1
+  ttt_k_lora: True
+  ttt_lora_alpha: 144
+  ttt_lora_lr: 0.0001
+  ttt_lora_rank: 96
+  ttt_mlp_lora: True
+  ttt_o_lora: True
+  ttt_optimizer: adam
+  ttt_weight_decay: 1.0
+  val_batch_tokens: 524288
+  val_bytes_files: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_caseops/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_val_bytes_*.bin
+  val_doc_fraction: 1.0
+  val_files: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_caseops/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_val_*.bin
+  val_loss_every: 0
+  vocab_size: 8192
+  warmdown_frac: 0.75
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+train_shards: 80
+val_tokens: 47851520
+model_params:35945658
+recur_alpha: enabled=True num_loops=2 loop_start=3 loop_end=5 diag_p2p_cos=False
+gptq:reserving 0s, effective=599500ms
+warmup_cu_buckets:64,128,192,256 iters_each:3
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup:enabled encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+loop_warmup_step: 1/20
+loop_warmup_step: 2/20
+loop_warmup_step: 3/20
+loop_warmup_step: 4/20
+loop_warmup_step: 5/20
+loop_warmup_step: 6/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+1/20000 train_loss: 9.0077 train_time: 0.0m tok/s: 12744235
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2/20000 train_loss: 12.8821 train_time: 0.0m tok/s: 7617729
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3/20000 train_loss: 10.2472 train_time: 0.0m tok/s: 7641064
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4/20000 train_loss: 8.7833 train_time: 0.0m tok/s: 7640919
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+5/20000 train_loss: 8.0392 train_time: 0.0m tok/s: 7615960
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+100/20000 train_loss: 3.6121 train_time: 0.2m tok/s: 8413313
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+200/20000 train_loss: 3.1502 train_time: 0.3m tok/s: 8328220
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+300/20000 train_loss: 2.9134 train_time: 0.5m tok/s: 8302230
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+400/20000 train_loss: 2.5797 train_time: 0.6m tok/s: 8297802
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+500/20000 train_loss: 2.5709 train_time: 0.8m tok/s: 8323272
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+600/20000 train_loss: 2.6752 train_time: 0.9m tok/s: 8313899
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+700/20000 train_loss: 2.8714 train_time: 1.1m tok/s: 8310031
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+800/20000 train_loss: 2.7168 train_time: 1.3m tok/s: 8306262
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+900/20000 train_loss: 2.7582 train_time: 1.4m tok/s: 8304979
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1000/20000 train_loss: 2.8074 train_time: 1.6m tok/s: 8316385
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1100/20000 train_loss: 2.7670 train_time: 1.7m tok/s: 8311841
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1200/20000 train_loss: 2.7662 train_time: 1.9m tok/s: 8306361
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1300/20000 train_loss: 2.8331 train_time: 2.1m tok/s: 8304923
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1400/20000 train_loss: 2.5870 train_time: 2.2m tok/s: 8301161
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1500/20000 train_loss: 2.6375 train_time: 2.4m tok/s: 8309357
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1600/20000 train_loss: 2.7075 train_time: 2.5m tok/s: 8306190
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1700/20000 train_loss: 2.6801 train_time: 2.7m tok/s: 8304059
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1800/20000 train_loss: 2.6482 train_time: 2.8m tok/s: 8302200
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1900/20000 train_loss: 2.7408 train_time: 3.0m tok/s: 8308664
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2000/20000 train_loss: 2.6654 train_time: 3.2m tok/s: 8306974
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2100/20000 train_loss: 2.6840 train_time: 3.3m tok/s: 8304083
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2200/20000 train_loss: 2.5310 train_time: 3.5m tok/s: 8302323
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+layer_loop:enabled step:2215 frac:0.350 depth:3 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2300/20000 train_loss: 2.6126 train_time: 3.7m tok/s: 8158764
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2400/20000 train_loss: 2.6285 train_time: 3.9m tok/s: 8011988
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2500/20000 train_loss: 2.5528 train_time: 4.2m tok/s: 7877034
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2600/20000 train_loss: 2.5205 train_time: 4.4m tok/s: 7757885
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2700/20000 train_loss: 2.5068 train_time: 4.6m tok/s: 7650732
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2800/20000 train_loss: 2.5707 train_time: 4.9m tok/s: 7551597
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2900/20000 train_loss: 2.5478 train_time: 5.1m tok/s: 7465922
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3000/20000 train_loss: 2.5696 train_time: 5.3m tok/s: 7385194
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3100/20000 train_loss: 2.4997 train_time: 5.6m tok/s: 7311845
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3200/20000 train_loss: 2.4714 train_time: 5.8m tok/s: 7244250
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3300/20000 train_loss: 2.6616 train_time: 6.0m tok/s: 7184309
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3400/20000 train_loss: 2.5665 train_time: 6.3m tok/s: 7124465
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3500/20000 train_loss: 2.5709 train_time: 6.5m tok/s: 7069879
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3600/20000 train_loss: 2.4660 train_time: 6.7m tok/s: 7019391
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3700/20000 train_loss: 2.5541 train_time: 7.0m tok/s: 6938495
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3800/20000 train_loss: 2.5010 train_time: 7.2m tok/s: 6898388
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3900/20000 train_loss: 2.6288 train_time: 7.5m tok/s: 6858864
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4000/20000 train_loss: 2.4178 train_time: 7.7m tok/s: 6821417
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4100/20000 train_loss: 2.4178 train_time: 7.9m tok/s: 6786592
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4200/20000 train_loss: 2.4096 train_time: 8.2m tok/s: 6752411
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4300/20000 train_loss: 2.5105 train_time: 8.4m tok/s: 6689408
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4400/20000 train_loss: 2.4573 train_time: 8.7m tok/s: 6660712
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4500/20000 train_loss: 2.2876 train_time: 8.9m tok/s: 6633429
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4600/20000 train_loss: 2.3834 train_time: 9.1m tok/s: 6607625
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4700/20000 train_loss: 2.3298 train_time: 9.4m tok/s: 6584006
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4800/20000 train_loss: 2.3104 train_time: 9.6m tok/s: 6560918
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4900/20000 train_loss: 2.3039 train_time: 9.8m tok/s: 6538983
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4973/20000 val_loss: 2.3553 val_bpb: 1.0762
+stopping_early: wallclock_cap train_time: 599598ms step: 4973/20000
+peak memory allocated: 41610 MiB reserved: 46918 MiB
+ema:applying EMA weights
+diagnostic pre-quantization post-ema val_loss:2.33247035 val_bpb:1.06577872 eval_time:7636ms
+Serialized model: 135417469 bytes
+pyminify unavailable (FileNotFoundError); skipping compressed-code-size measurement
+Code size (uncompressed): 175063 bytes
+Code size (compressed): 0 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 3.6s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int7): tok_emb.weight
+  passthrough (float16): blocks.attn.attn_gate_w, blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, recur_alpha, recur_beta, skip_gates, skip_weights
+Serialized model quantized+brotli: 15909401 bytes
+Total submission size quantized+brotli: 15909401 bytes
+diagnostic quantized val_loss:2.35283859 val_bpb:1.07508561 eval_time:11996ms
+ttt_lora:warming up compile (random tokens, no val data)
+ttt_lora:compile warmup done (86.1s)
+
+beginning TTT eval timer
+ttt_phased: total_docs:50000 prefix_docs:2000 suffix_docs:48000 num_phases:3 boundaries:[666, 1333, 2000]
+ttp: b776/782 bl:2.2582 bb:1.0707 rl:2.2582 rb:1.0707 dl:7534-8350 gd:0
+ttp: b773/782 bl:2.2019 bb:1.0369 rl:2.2333 rb:1.0557 dl:6104-6447 gd:0
+ttp: b768/782 bl:2.2432 bb:1.0447 rl:2.2358 rb:1.0528 dl:4859-5083 gd:0
+ttpp: phase:1/3 pd:1104 gd:666 t:169.5s
+tttg: c1/111 lr:0.001000 t:0.4s
+tttg: c2/111 lr:0.001000 t:0.5s
+tttg: c3/111 lr:0.000999 t:0.6s
+tttg: c4/111 lr:0.000998 t:0.6s
+tttg: c5/111 lr:0.000997 t:0.7s
+tttg: c6/111 lr:0.000995 t:0.8s
+tttg: c7/111 lr:0.000993 t:0.8s
+tttg: c8/111 lr:0.000990 t:0.9s
+tttg: c9/111 lr:0.000987 t:1.0s
+tttg: c10/111 lr:0.000984 t:1.1s
+tttg: c11/111 lr:0.000980 t:1.1s
+tttg: c12/111 lr:0.000976 t:1.2s
+tttg: c13/111 lr:0.000971 t:1.3s
+tttg: c14/111 lr:0.000966 t:1.3s
+tttg: c15/111 lr:0.000961 t:1.4s
+tttg: c16/111 lr:0.000955 t:1.5s
+tttg: c17/111 lr:0.000949 t:1.5s
+tttg: c18/111 lr:0.000942 t:1.6s
+tttg: c19/111 lr:0.000935 t:1.7s
+tttg: c20/111 lr:0.000928 t:1.7s
+tttg: c21/111 lr:0.000921 t:1.8s
+tttg: c22/111 lr:0.000913 t:1.9s
+tttg: c23/111 lr:0.000905 t:1.9s
+tttg: c24/111 lr:0.000896 t:2.0s
+tttg: c25/111 lr:0.000887 t:2.1s
+tttg: c26/111 lr:0.000878 t:2.2s
+tttg: c27/111 lr:0.000868 t:2.2s
+tttg: c28/111 lr:0.000859 t:2.3s
+tttg: c29/111 lr:0.000848 t:2.4s
+tttg: c30/111 lr:0.000838 t:2.4s
+tttg: c31/111 lr:0.000827 t:2.5s
+tttg: c32/111 lr:0.000817 t:2.6s
+tttg: c33/111 lr:0.000805 t:2.7s
+tttg: c34/111 lr:0.000794 t:2.7s
+tttg: c35/111 lr:0.000782 t:2.8s
+tttg: c36/111 lr:0.000770 t:2.9s
+tttg: c37/111 lr:0.000758 t:2.9s
+tttg: c38/111 lr:0.000746 t:3.0s
+tttg: c39/111 lr:0.000733 t:3.1s
+tttg: c40/111 lr:0.000721 t:3.1s
+tttg: c41/111 lr:0.000708 t:3.2s
+tttg: c42/111 lr:0.000695 t:3.3s
+tttg: c43/111 lr:0.000681 t:3.3s
+tttg: c44/111 lr:0.000668 t:3.4s
+tttg: c45/111 lr:0.000655 t:3.5s
+tttg: c46/111 lr:0.000641 t:3.6s
+tttg: c47/111 lr:0.000627 t:3.6s
+tttg: c48/111 lr:0.000613 t:3.7s
+tttg: c49/111 lr:0.000599 t:3.8s
+tttg: c50/111 lr:0.000585 t:3.8s
+tttg: c51/111 lr:0.000571 t:3.9s
+tttg: c52/111 lr:0.000557 t:4.0s
+tttg: c53/111 lr:0.000543 t:4.0s
+tttg: c54/111 lr:0.000529 t:4.1s
+tttg: c55/111 lr:0.000514 t:4.2s
+tttg: c56/111 lr:0.000500 t:4.2s
+tttg: c57/111 lr:0.000486 t:4.3s
+tttg: c58/111 lr:0.000471 t:4.4s
+tttg: c59/111 lr:0.000457 t:4.5s
+tttg: c60/111 lr:0.000443 t:4.5s
+tttg: c61/111 lr:0.000429 t:4.6s
+tttg: c62/111 lr:0.000415 t:4.7s
+tttg: c63/111 lr:0.000401 t:4.7s
+tttg: c64/111 lr:0.000387 t:4.8s
+tttg: c65/111 lr:0.000373 t:4.9s
+tttg: c66/111 lr:0.000359 t:4.9s
+tttg: c67/111 lr:0.000345 t:5.0s
+tttg: c68/111 lr:0.000332 t:5.1s
+tttg: c69/111 lr:0.000319 t:5.1s
+tttg: c70/111 lr:0.000305 t:5.2s
+tttg: c71/111 lr:0.000292 t:5.3s
+tttg: c72/111 lr:0.000279 t:5.4s
+tttg: c73/111 lr:0.000267 t:5.4s
+tttg: c74/111 lr:0.000254 t:5.5s
+tttg: c75/111 lr:0.000242 t:5.6s
+tttg: c76/111 lr:0.000230 t:5.6s
+tttg: c77/111 lr:0.000218 t:5.7s
+tttg: c78/111 lr:0.000206 t:5.8s
+tttg: c79/111 lr:0.000195 t:5.8s
+tttg: c80/111 lr:0.000183 t:5.9s
+tttg: c81/111 lr:0.000173 t:6.0s
+tttg: c82/111 lr:0.000162 t:6.0s
+tttg: c83/111 lr:0.000152 t:6.1s
+tttg: c84/111 lr:0.000141 t:6.2s
+tttg: c85/111 lr:0.000132 t:6.2s
+tttg: c86/111 lr:0.000122 t:6.3s
+tttg: c87/111 lr:0.000113 t:6.4s
+tttg: c88/111 lr:0.000104 t:6.5s
+tttg: c89/111 lr:0.000095 t:6.5s
+tttg: c90/111 lr:0.000087 t:6.6s
+tttg: c91/111 lr:0.000079 t:6.7s
+tttg: c92/111 lr:0.000072 t:6.7s
+tttg: c93/111 lr:0.000065 t:6.8s
+tttg: c94/111 lr:0.000058 t:6.9s
+tttg: c95/111 lr:0.000051 t:6.9s
+tttg: c96/111 lr:0.000045 t:7.0s
+tttg: c97/111 lr:0.000039 t:7.1s
+tttg: c98/111 lr:0.000034 t:7.2s
+tttg: c99/111 lr:0.000029 t:7.2s
+tttg: c100/111 lr:0.000024 t:7.3s
+tttg: c101/111 lr:0.000020 t:7.4s
+tttg: c102/111 lr:0.000016 t:7.4s
+tttg: c103/111 lr:0.000013 t:7.5s
+tttg: c104/111 lr:0.000010 t:7.6s
+tttg: c105/111 lr:0.000007 t:7.6s
+tttg: c106/111 lr:0.000005 t:7.7s
+tttg: c107/111 lr:0.000003 t:7.8s
+tttg: c108/111 lr:0.000002 t:7.8s
+tttg: c109/111 lr:0.000001 t:7.9s
+tttg: c110/111 lr:0.000000 t:8.0s
+ttpr: phase:1/3 t:179.3s
+ttp: b757/782 bl:2.2828 bb:1.0626 rl:2.2432 rb:1.0543 dl:3550-3633 gd:0
+ttp: b756/782 bl:2.3320 bb:1.0379 rl:2.2551 rb:1.0520 dl:3466-3549 gd:0
+ttpp: phase:2/3 pd:1808 gd:1333 t:244.6s
+tttg: c1/185 lr:0.001000 t:0.1s
+tttg: c2/185 lr:0.001000 t:0.1s
+tttg: c3/185 lr:0.001000 t:0.2s
+tttg: c4/185 lr:0.000999 t:0.3s
+tttg: c5/185 lr:0.000999 t:0.3s
+tttg: c6/185 lr:0.000998 t:0.4s
+tttg: c7/185 lr:0.000997 t:0.5s
+tttg: c8/185 lr:0.000996 t:0.6s
+tttg: c9/185 lr:0.000995 t:0.6s
+tttg: c10/185 lr:0.000994 t:0.7s
+tttg: c11/185 lr:0.000993 t:0.8s
+tttg: c12/185 lr:0.000991 t:0.8s
+tttg: c13/185 lr:0.000990 t:0.9s
+tttg: c14/185 lr:0.000988 t:1.0s
+tttg: c15/185 lr:0.000986 t:1.0s
+tttg: c16/185 lr:0.000984 t:1.1s
+tttg: c17/185 lr:0.000981 t:1.2s
+tttg: c18/185 lr:0.000979 t:1.3s
+tttg: c19/185 lr:0.000977 t:1.3s
+tttg: c20/185 lr:0.000974 t:1.4s
+tttg: c21/185 lr:0.000971 t:1.5s
+tttg: c22/185 lr:0.000968 t:1.5s
+tttg: c23/185 lr:0.000965 t:1.6s
+tttg: c24/185 lr:0.000962 t:1.7s
+tttg: c25/185 lr:0.000959 t:1.7s
+tttg: c26/185 lr:0.000955 t:1.8s
+tttg: c27/185 lr:0.000952 t:1.9s
+tttg: c28/185 lr:0.000948 t:1.9s
+tttg: c29/185 lr:0.000944 t:2.0s
+tttg: c30/185 lr:0.000940 t:2.1s
+tttg: c31/185 lr:0.000936 t:2.2s
+tttg: c32/185 lr:0.000932 t:2.2s
+tttg: c33/185 lr:0.000927 t:2.3s
+tttg: c34/185 lr:0.000923 t:2.4s
+tttg: c35/185 lr:0.000918 t:2.4s
+tttg: c36/185 lr:0.000913 t:2.5s
+tttg: c37/185 lr:0.000908 t:2.6s
+tttg: c38/185 lr:0.000904 t:2.6s
+tttg: c39/185 lr:0.000898 t:2.7s
+tttg: c40/185 lr:0.000893 t:2.8s
+tttg: c41/185 lr:0.000888 t:2.9s
+tttg: c42/185 lr:0.000882 t:2.9s
+tttg: c43/185 lr:0.000877 t:3.0s
+tttg: c44/185 lr:0.000871 t:3.1s
+tttg: c45/185 lr:0.000865 t:3.1s
+tttg: c46/185 lr:0.000860 t:3.2s
+tttg: c47/185 lr:0.000854 t:3.3s
+tttg: c48/185 lr:0.000847 t:3.3s
+tttg: c49/185 lr:0.000841 t:3.4s
+tttg: c50/185 lr:0.000835 t:3.5s
+tttg: c51/185 lr:0.000829 t:3.6s
+tttg: c52/185 lr:0.000822 t:3.6s
+tttg: c53/185 lr:0.000816 t:3.7s
+tttg: c54/185 lr:0.000809 t:3.8s
+tttg: c55/185 lr:0.000802 t:3.8s
+tttg: c56/185 lr:0.000795 t:3.9s
+tttg: c57/185 lr:0.000788 t:4.0s
+tttg: c58/185 lr:0.000781 t:4.0s
+tttg: c59/185 lr:0.000774 t:4.1s
+tttg: c60/185 lr:0.000767 t:4.2s
+tttg: c61/185 lr:0.000760 t:4.3s
+tttg: c62/185 lr:0.000752 t:4.3s
+tttg: c63/185 lr:0.000745 t:4.4s
+tttg: c64/185 lr:0.000738 t:4.5s
+tttg: c65/185 lr:0.000730 t:4.5s
+tttg: c66/185 lr:0.000722 t:4.6s
+tttg: c67/185 lr:0.000715 t:4.7s
+tttg: c68/185 lr:0.000707 t:4.7s
+tttg: c69/185 lr:0.000699 t:4.8s
+tttg: c70/185 lr:0.000691 t:4.9s
+tttg: c71/185 lr:0.000683 t:5.0s
+tttg: c72/185 lr:0.000675 t:5.0s
+tttg: c73/185 lr:0.000667 t:5.1s
+tttg: c74/185 lr:0.000659 t:5.2s
+tttg: c75/185 lr:0.000651 t:5.2s
+tttg: c76/185 lr:0.000643 t:5.3s
+tttg: c77/185 lr:0.000635 t:5.4s
+tttg: c78/185 lr:0.000627 t:5.4s
+tttg: c79/185 lr:0.000618 t:5.5s
+tttg: c80/185 lr:0.000610 t:5.6s
+tttg: c81/185 lr:0.000602 t:5.7s
+tttg: c82/185 lr:0.000593 t:5.7s
+tttg: c83/185 lr:0.000585 t:5.8s
+tttg: c84/185 lr:0.000577 t:5.9s
+tttg: c85/185 lr:0.000568 t:5.9s
+tttg: c86/185 lr:0.000560 t:6.0s
+tttg: c87/185 lr:0.000551 t:6.1s
+tttg: c88/185 lr:0.000543 t:6.1s
+tttg: c89/185 lr:0.000534 t:6.2s
+tttg: c90/185 lr:0.000526 t:6.3s
+tttg: c91/185 lr:0.000517 t:6.3s
+tttg: c92/185 lr:0.000509 t:6.4s
+tttg: c93/185 lr:0.000500 t:6.5s
+tttg: c94/185 lr:0.000491 t:6.6s
+tttg: c95/185 lr:0.000483 t:6.6s
+tttg: c96/185 lr:0.000474 t:6.7s
+tttg: c97/185 lr:0.000466 t:6.8s
+tttg: c98/185 lr:0.000457 t:6.8s
+tttg: c99/185 lr:0.000449 t:6.9s
+tttg: c100/185 lr:0.000440 t:7.0s
+tttg: c101/185 lr:0.000432 t:7.1s
+tttg: c102/185 lr:0.000423 t:7.1s
+tttg: c103/185 lr:0.000415 t:7.2s
+tttg: c104/185 lr:0.000407 t:7.3s
+tttg: c105/185 lr:0.000398 t:7.3s
+tttg: c106/185 lr:0.000390 t:7.4s
+tttg: c107/185 lr:0.000382 t:7.5s
+tttg: c108/185 lr:0.000373 t:7.5s
+tttg: c109/185 lr:0.000365 t:7.6s
+tttg: c110/185 lr:0.000357 t:7.7s
+tttg: c111/185 lr:0.000349 t:7.8s
+tttg: c112/185 lr:0.000341 t:7.8s
+tttg: c113/185 lr:0.000333 t:7.9s
+tttg: c114/185 lr:0.000325 t:8.0s
+tttg: c115/185 lr:0.000317 t:8.0s
+tttg: c116/185 lr:0.000309 t:8.1s
+tttg: c117/185 lr:0.000301 t:8.2s
+tttg: c118/185 lr:0.000293 t:8.2s
+tttg: c119/185 lr:0.000285 t:8.3s
+tttg: c120/185 lr:0.000278 t:8.4s
+tttg: c121/185 lr:0.000270 t:8.4s
+tttg: c122/185 lr:0.000262 t:8.5s
+tttg: c123/185 lr:0.000255 t:8.6s
+tttg: c124/185 lr:0.000248 t:8.7s
+tttg: c125/185 lr:0.000240 t:8.7s
+tttg: c126/185 lr:0.000233 t:8.8s
+tttg: c127/185 lr:0.000226 t:8.9s
+tttg: c128/185 lr:0.000219 t:8.9s
+tttg: c129/185 lr:0.000212 t:9.0s
+tttg: c130/185 lr:0.000205 t:9.1s
+tttg: c131/185 lr:0.000198 t:9.1s
+tttg: c132/185 lr:0.000191 t:9.2s
+tttg: c133/185 lr:0.000184 t:9.3s
+tttg: c134/185 lr:0.000178 t:9.3s
+tttg: c135/185 lr:0.000171 t:9.4s
+tttg: c136/185 lr:0.000165 t:9.5s
+tttg: c137/185 lr:0.000159 t:9.6s
+tttg: c138/185 lr:0.000153 t:9.6s
+tttg: c139/185 lr:0.000146 t:9.7s
+tttg: c140/185 lr:0.000140 t:9.8s
+tttg: c141/185 lr:0.000135 t:9.9s
+tttg: c142/185 lr:0.000129 t:9.9s
+tttg: c143/185 lr:0.000123 t:10.0s
+tttg: c144/185 lr:0.000118 t:10.1s
+tttg: c145/185 lr:0.000112 t:10.1s
+tttg: c146/185 lr:0.000107 t:10.2s
+tttg: c147/185 lr:0.000102 t:10.3s
+tttg: c148/185 lr:0.000096 t:10.4s
+tttg: c149/185 lr:0.000092 t:10.4s
+tttg: c150/185 lr:0.000087 t:10.5s
+tttg: c151/185 lr:0.000082 t:10.6s
+tttg: c152/185 lr:0.000077 t:10.6s
+tttg: c153/185 lr:0.000073 t:10.7s
+tttg: c154/185 lr:0.000068 t:10.8s
+tttg: c155/185 lr:0.000064 t:10.9s
+tttg: c156/185 lr:0.000060 t:10.9s
+tttg: c157/185 lr:0.000056 t:11.0s
+tttg: c158/185 lr:0.000052 t:11.1s
+tttg: c159/185 lr:0.000048 t:11.1s
+tttg: c160/185 lr:0.000045 t:11.2s
+tttg: c161/185 lr:0.000041 t:11.3s
+tttg: c162/185 lr:0.000038 t:11.4s
+tttg: c163/185 lr:0.000035 t:11.4s
+tttg: c164/185 lr:0.000032 t:11.5s
+tttg: c165/185 lr:0.000029 t:11.6s
+tttg: c166/185 lr:0.000026 t:11.6s
+tttg: c167/185 lr:0.000023 t:11.7s
+tttg: c168/185 lr:0.000021 t:11.8s
+tttg: c169/185 lr:0.000019 t:11.8s
+tttg: c170/185 lr:0.000016 t:11.9s
+tttg: c171/185 lr:0.000014 t:12.0s
+tttg: c172/185 lr:0.000012 t:12.1s
+tttg: c173/185 lr:0.000010 t:12.1s
+tttg: c174/185 lr:0.000009 t:12.2s
+tttg: c175/185 lr:0.000007 t:12.3s
+tttg: c176/185 lr:0.000006 t:12.3s
+tttg: c177/185 lr:0.000005 t:12.4s
+tttg: c178/185 lr:0.000004 t:12.5s
+tttg: c179/185 lr:0.000003 t:12.6s
+tttg: c180/185 lr:0.000002 t:12.6s
+tttg: c181/185 lr:0.000001 t:12.7s
+tttg: c182/185 lr:0.000001 t:12.8s
+tttg: c183/185 lr:0.000000 t:12.9s
+tttg: c184/185 lr:0.000000 t:12.9s
+ttpr: phase:2/3 t:259.4s
+ttp: b746/782 bl:2.4147 bb:1.0640 rl:2.2710 rb:1.0533 dl:2884-2943 gd:0
+ttp: b745/782 bl:2.2377 bb:1.0244 rl:2.2680 rb:1.0507 dl:2842-2883 gd:0
+ttpp: phase:3/3 pd:2448 gd:2000 t:276.4s
+tttg: c1/250 lr:0.001000 t:0.1s
+tttg: c2/250 lr:0.001000 t:0.1s
+tttg: c3/250 lr:0.001000 t:0.2s
+tttg: c4/250 lr:0.001000 t:0.3s
+tttg: c5/250 lr:0.000999 t:0.3s
+tttg: c6/250 lr:0.000999 t:0.4s
+tttg: c7/250 lr:0.000999 t:0.5s
+tttg: c8/250 lr:0.000998 t:0.6s
+tttg: c9/250 lr:0.000997 t:0.6s
+tttg: c10/250 lr:0.000997 t:0.7s
+tttg: c11/250 lr:0.000996 t:0.8s
+tttg: c12/250 lr:0.000995 t:0.8s
+tttg: c13/250 lr:0.000994 t:0.9s
+tttg: c14/250 lr:0.000993 t:1.0s
+tttg: c15/250 lr:0.000992 t:1.0s
+tttg: c16/250 lr:0.000991 t:1.1s
+tttg: c17/250 lr:0.000990 t:1.2s
+tttg: c18/250 lr:0.000989 t:1.2s
+tttg: c19/250 lr:0.000987 t:1.3s
+tttg: c20/250 lr:0.000986 t:1.4s
+tttg: c21/250 lr:0.000984 t:1.5s
+tttg: c22/250 lr:0.000983 t:1.5s
+tttg: c23/250 lr:0.000981 t:1.6s
+tttg: c24/250 lr:0.000979 t:1.7s
+tttg: c25/250 lr:0.000977 t:1.7s
+tttg: c26/250 lr:0.000975 t:1.8s
+tttg: c27/250 lr:0.000973 t:1.9s
+tttg: c28/250 lr:0.000971 t:1.9s
+tttg: c29/250 lr:0.000969 t:2.0s
+tttg: c30/250 lr:0.000967 t:2.1s
+tttg: c31/250 lr:0.000965 t:2.2s
+tttg: c32/250 lr:0.000962 t:2.2s
+tttg: c33/250 lr:0.000960 t:2.3s
+tttg: c34/250 lr:0.000957 t:2.4s
+tttg: c35/250 lr:0.000955 t:2.4s
+tttg: c36/250 lr:0.000952 t:2.5s
+tttg: c37/250 lr:0.000949 t:2.6s
+tttg: c38/250 lr:0.000947 t:2.6s
+tttg: c39/250 lr:0.000944 t:2.7s
+tttg: c40/250 lr:0.000941 t:2.8s
+tttg: c41/250 lr:0.000938 t:2.8s
+tttg: c42/250 lr:0.000935 t:2.9s
+tttg: c43/250 lr:0.000931 t:3.0s
+tttg: c44/250 lr:0.000928 t:3.0s
+tttg: c45/250 lr:0.000925 t:3.1s
+tttg: c46/250 lr:0.000922 t:3.2s
+tttg: c47/250 lr:0.000918 t:3.3s
+tttg: c48/250 lr:0.000915 t:3.3s
+tttg: c49/250 lr:0.000911 t:3.4s
+tttg: c50/250 lr:0.000907 t:3.5s
+tttg: c51/250 lr:0.000904 t:3.5s
+tttg: c52/250 lr:0.000900 t:3.6s
+tttg: c53/250 lr:0.000896 t:3.7s
+tttg: c54/250 lr:0.000892 t:3.7s
+tttg: c55/250 lr:0.000888 t:3.8s
+tttg: c56/250 lr:0.000884 t:3.9s
+tttg: c57/250 lr:0.000880 t:3.9s
+tttg: c58/250 lr:0.000876 t:4.0s
+tttg: c59/250 lr:0.000872 t:4.1s
+tttg: c60/250 lr:0.000868 t:4.2s
+tttg: c61/250 lr:0.000863 t:4.2s
+tttg: c62/250 lr:0.000859 t:4.3s
+tttg: c63/250 lr:0.000855 t:4.4s
+tttg: c64/250 lr:0.000850 t:4.4s
+tttg: c65/250 lr:0.000846 t:4.5s
+tttg: c66/250 lr:0.000841 t:4.6s
+tttg: c67/250 lr:0.000836 t:4.6s
+tttg: c68/250 lr:0.000832 t:4.7s
+tttg: c69/250 lr:0.000827 t:4.8s
+tttg: c70/250 lr:0.000822 t:4.8s
+tttg: c71/250 lr:0.000817 t:4.9s
+tttg: c72/250 lr:0.000812 t:5.0s
+tttg: c73/250 lr:0.000807 t:5.1s
+tttg: c74/250 lr:0.000803 t:5.1s
+tttg: c75/250 lr:0.000797 t:5.2s
+tttg: c76/250 lr:0.000792 t:5.3s
+tttg: c77/250 lr:0.000787 t:5.3s
+tttg: c78/250 lr:0.000782 t:5.4s
+tttg: c79/250 lr:0.000777 t:5.5s
+tttg: c80/250 lr:0.000772 t:5.5s
+tttg: c81/250 lr:0.000766 t:5.6s
+tttg: c82/250 lr:0.000761 t:5.7s
+tttg: c83/250 lr:0.000755 t:5.8s
+tttg: c84/250 lr:0.000750 t:5.8s
+tttg: c85/250 lr:0.000745 t:5.9s
+tttg: c86/250 lr:0.000739 t:6.0s
+tttg: c87/250 lr:0.000733 t:6.0s
+tttg: c88/250 lr:0.000728 t:6.1s
+tttg: c89/250 lr:0.000722 t:6.2s
+tttg: c90/250 lr:0.000717 t:6.3s
+tttg: c91/250 lr:0.000711 t:6.3s
+tttg: c92/250 lr:0.000705 t:6.4s
+tttg: c93/250 lr:0.000699 t:6.5s
+tttg: c94/250 lr:0.000694 t:6.5s
+tttg: c95/250 lr:0.000688 t:6.6s
+tttg: c96/250 lr:0.000682 t:6.7s
+tttg: c97/250 lr:0.000676 t:6.7s
+tttg: c98/250 lr:0.000670 t:6.8s
+tttg: c99/250 lr:0.000664 t:6.9s
+tttg: c100/250 lr:0.000658 t:7.0s
+tttg: c101/250 lr:0.000652 t:7.0s
+tttg: c102/250 lr:0.000646 t:7.1s
+tttg: c103/250 lr:0.000640 t:7.2s
+tttg: c104/250 lr:0.000634 t:7.2s
+tttg: c105/250 lr:0.000628 t:7.3s
+tttg: c106/250 lr:0.000622 t:7.4s
+tttg: c107/250 lr:0.000616 t:7.4s
+tttg: c108/250 lr:0.000610 t:7.5s
+tttg: c109/250 lr:0.000603 t:7.6s
+tttg: c110/250 lr:0.000597 t:7.7s
+tttg: c111/250 lr:0.000591 t:7.7s
+tttg: c112/250 lr:0.000585 t:7.8s
+tttg: c113/250 lr:0.000579 t:7.9s
+tttg: c114/250 lr:0.000572 t:7.9s
+tttg: c115/250 lr:0.000566 t:8.0s
+tttg: c116/250 lr:0.000560 t:8.1s
+tttg: c117/250 lr:0.000554 t:8.1s
+tttg: c118/250 lr:0.000547 t:8.2s
+tttg: c119/250 lr:0.000541 t:8.3s
+tttg: c120/250 lr:0.000535 t:8.4s
+tttg: c121/250 lr:0.000528 t:8.4s
+tttg: c122/250 lr:0.000522 t:8.5s
+tttg: c123/250 lr:0.000516 t:8.6s
+tttg: c124/250 lr:0.000509 t:8.6s
+tttg: c125/250 lr:0.000503 t:8.7s
+tttg: c126/250 lr:0.000497 t:8.8s
+tttg: c127/250 lr:0.000491 t:8.8s
+tttg: c128/250 lr:0.000484 t:8.9s
+tttg: c129/250 lr:0.000478 t:9.0s
+tttg: c130/250 lr:0.000472 t:9.1s
+tttg: c131/250 lr:0.000465 t:9.1s
+tttg: c132/250 lr:0.000459 t:9.2s
+tttg: c133/250 lr:0.000453 t:9.3s
+tttg: c134/250 lr:0.000446 t:9.3s
+tttg: c135/250 lr:0.000440 t:9.4s
+tttg: c136/250 lr:0.000434 t:9.5s
+tttg: c137/250 lr:0.000428 t:9.5s
+tttg: c138/250 lr:0.000421 t:9.6s
+tttg: c139/250 lr:0.000415 t:9.7s
+tttg: c140/250 lr:0.000409 t:9.7s
+tttg: c141/250 lr:0.000403 t:9.8s
+tttg: c142/250 lr:0.000397 t:9.9s
+tttg: c143/250 lr:0.000390 t:10.0s
+tttg: c144/250 lr:0.000384 t:10.0s
+tttg: c145/250 lr:0.000378 t:10.1s
+tttg: c146/250 lr:0.000372 t:10.2s
+tttg: c147/250 lr:0.000366 t:10.2s
+tttg: c148/250 lr:0.000360 t:10.3s
+tttg: c149/250 lr:0.000354 t:10.4s
+tttg: c150/250 lr:0.000348 t:10.4s
+tttg: c151/250 lr:0.000342 t:10.5s
+tttg: c152/250 lr:0.000336 t:10.6s
+tttg: c153/250 lr:0.000330 t:10.7s
+tttg: c154/250 lr:0.000324 t:10.7s
+tttg: c155/250 lr:0.000318 t:10.8s
+tttg: c156/250 lr:0.000312 t:10.9s
+tttg: c157/250 lr:0.000306 t:10.9s
+tttg: c158/250 lr:0.000301 t:11.0s
+tttg: c159/250 lr:0.000295 t:11.1s
+tttg: c160/250 lr:0.000289 t:11.1s
+tttg: c161/250 lr:0.000283 t:11.2s
+tttg: c162/250 lr:0.000278 t:11.3s
+tttg: c163/250 lr:0.000272 t:11.4s
+tttg: c164/250 lr:0.000267 t:11.4s
+tttg: c165/250 lr:0.000261 t:11.5s
+tttg: c166/250 lr:0.000255 t:11.6s
+tttg: c167/250 lr:0.000250 t:11.6s
+tttg: c168/250 lr:0.000245 t:11.7s
+tttg: c169/250 lr:0.000239 t:11.8s
+tttg: c170/250 lr:0.000234 t:11.8s
+tttg: c171/250 lr:0.000228 t:11.9s
+tttg: c172/250 lr:0.000223 t:12.0s
+tttg: c173/250 lr:0.000218 t:12.0s
+tttg: c174/250 lr:0.000213 t:12.1s
+tttg: c175/250 lr:0.000208 t:12.2s
+tttg: c176/250 lr:0.000203 t:12.3s
+tttg: c177/250 lr:0.000197 t:12.3s
+tttg: c178/250 lr:0.000193 t:12.4s
+tttg: c179/250 lr:0.000188 t:12.5s
+tttg: c180/250 lr:0.000183 t:12.5s
+tttg: c181/250 lr:0.000178 t:12.6s
+tttg: c182/250 lr:0.000173 t:12.7s
+tttg: c183/250 lr:0.000168 t:12.7s
+tttg: c184/250 lr:0.000164 t:12.8s
+tttg: c185/250 lr:0.000159 t:12.9s
+tttg: c186/250 lr:0.000154 t:13.0s
+tttg: c187/250 lr:0.000150 t:13.0s
+tttg: c188/250 lr:0.000145 t:13.1s
+tttg: c189/250 lr:0.000141 t:13.2s
+tttg: c190/250 lr:0.000137 t:13.2s
+tttg: c191/250 lr:0.000132 t:13.3s
+tttg: c192/250 lr:0.000128 t:13.4s
+tttg: c193/250 lr:0.000124 t:13.4s
+tttg: c194/250 lr:0.000120 t:13.5s
+tttg: c195/250 lr:0.000116 t:13.6s
+tttg: c196/250 lr:0.000112 t:13.7s
+tttg: c197/250 lr:0.000108 t:13.7s
+tttg: c198/250 lr:0.000104 t:13.8s
+tttg: c199/250 lr:0.000100 t:13.9s
+tttg: c200/250 lr:0.000096 t:15.5s
+tttg: c201/250 lr:0.000093 t:15.6s
+tttg: c202/250 lr:0.000089 t:15.7s
+tttg: c203/250 lr:0.000085 t:15.8s
+tttg: c204/250 lr:0.000082 t:15.8s
+tttg: c205/250 lr:0.000078 t:15.9s
+tttg: c206/250 lr:0.000075 t:16.0s
+tttg: c207/250 lr:0.000072 t:16.0s
+tttg: c208/250 lr:0.000069 t:16.1s
+tttg: c209/250 lr:0.000065 t:16.2s
+tttg: c210/250 lr:0.000062 t:16.2s
+tttg: c211/250 lr:0.000059 t:16.3s
+tttg: c212/250 lr:0.000056 t:16.4s
+tttg: c213/250 lr:0.000053 t:16.5s
+tttg: c214/250 lr:0.000051 t:16.5s
+tttg: c215/250 lr:0.000048 t:16.6s
+tttg: c216/250 lr:0.000045 t:16.7s
+tttg: c217/250 lr:0.000043 t:16.7s
+tttg: c218/250 lr:0.000040 t:16.8s
+tttg: c219/250 lr:0.000038 t:16.9s
+tttg: c220/250 lr:0.000035 t:16.9s
+tttg: c221/250 lr:0.000033 t:17.0s
+tttg: c222/250 lr:0.000031 t:17.1s
+tttg: c223/250 lr:0.000029 t:17.1s
+tttg: c224/250 lr:0.000027 t:17.2s
+tttg: c225/250 lr:0.000025 t:17.3s
+tttg: c226/250 lr:0.000023 t:17.4s
+tttg: c227/250 lr:0.000021 t:17.4s
+tttg: c228/250 lr:0.000019 t:17.5s
+tttg: c229/250 lr:0.000017 t:17.6s
+tttg: c230/250 lr:0.000016 t:17.6s
+tttg: c231/250 lr:0.000014 t:17.7s
+tttg: c232/250 lr:0.000013 t:17.8s
+tttg: c233/250 lr:0.000011 t:17.8s
+tttg: c234/250 lr:0.000010 t:17.9s
+tttg: c235/250 lr:0.000009 t:18.0s
+tttg: c236/250 lr:0.000008 t:18.1s
+tttg: c237/250 lr:0.000007 t:18.1s
+tttg: c238/250 lr:0.000006 t:18.2s
+tttg: c239/250 lr:0.000005 t:18.3s
+tttg: c240/250 lr:0.000004 t:18.3s
+tttg: c241/250 lr:0.000003 t:18.4s
+tttg: c242/250 lr:0.000003 t:18.5s
+tttg: c243/250 lr:0.000002 t:18.6s
+tttg: c244/250 lr:0.000001 t:18.6s
+tttg: c245/250 lr:0.000001 t:18.7s
+tttg: c246/250 lr:0.000001 t:18.8s
+tttg: c247/250 lr:0.000000 t:18.8s
+tttg: c248/250 lr:0.000000 t:18.9s
+tttg: c249/250 lr:0.000000 t:19.0s
+ttpr: phase:3/3 t:297.2s
+ttp: b736/782 bl:2.2463 bb:1.0583 rl:2.2664 rb:1.0512 dl:2526-2550 gd:1
+ttp: b735/782 bl:2.3914 bb:1.1001 rl:2.2749 rb:1.0546 dl:2495-2526 gd:1
+ttp: b725/782 bl:2.3227 bb:1.0448 rl:2.2776 rb:1.0540 dl:2232-2254 gd:1
+ttp: b718/782 bl:2.2950 bb:1.0301 rl:2.2785 rb:1.0528 dl:2089-2106 gd:1
+ttp: b708/782 bl:2.3118 bb:1.0341 rl:2.2800 rb:1.0519 dl:1924-1937 gd:1
+ttp: b698/782 bl:2.2498 bb:1.0298 rl:2.2788 rb:1.0510 dl:1803-1814 gd:1
+ttp: b693/782 bl:2.3372 bb:1.0499 rl:2.2810 rb:1.0510 dl:1746-1757 gd:1
+ttp: b684/782 bl:2.3758 bb:1.0467 rl:2.2842 rb:1.0508 dl:1658-1665 gd:1
+ttp: b677/782 bl:2.3070 bb:1.0336 rl:2.2849 rb:1.0502 dl:1595-1601 gd:1
+ttp: b665/782 bl:2.3346 bb:1.0488 rl:2.2864 rb:1.0502 dl:1500-1507 gd:1
+ttp: b659/782 bl:2.3087 bb:1.0419 rl:2.2870 rb:1.0500 dl:1459-1466 gd:1
+ttp: b652/782 bl:2.2516 bb:1.0235 rl:2.2861 rb:1.0493 dl:1411-1419 gd:1
+ttp: b643/782 bl:2.3583 bb:1.0270 rl:2.2878 rb:1.0487 dl:1356-1362 gd:1
+ttp: b635/782 bl:2.3449 bb:1.0582 rl:2.2891 rb:1.0489 dl:1308-1314 gd:1
+ttp: b626/782 bl:2.3144 bb:1.0284 rl:2.2897 rb:1.0485 dl:1260-1265 gd:1
+ttp: b618/782 bl:2.4159 bb:1.0753 rl:2.2922 rb:1.0490 dl:1216-1221 gd:1
+ttp: b610/782 bl:2.2558 bb:1.0087 rl:2.2915 rb:1.0482 dl:1177-1182 gd:1
+ttp: b602/782 bl:2.3797 bb:1.0497 rl:2.2932 rb:1.0483 dl:1141-1146 gd:1
+ttp: b597/782 bl:2.3704 bb:1.0541 rl:2.2945 rb:1.0484 dl:1119-1124 gd:1
+ttp: b588/782 bl:2.3230 bb:1.0455 rl:2.2950 rb:1.0483 dl:1081-1086 gd:1
+ttp: b580/782 bl:2.3138 bb:1.0151 rl:2.2953 rb:1.0478 dl:1048-1052 gd:1
+ttp: b573/782 bl:2.3662 bb:1.0666 rl:2.2964 rb:1.0481 dl:1021-1025 gd:1
+ttp: b565/782 bl:2.3858 bb:1.0336 rl:2.2977 rb:1.0478 dl:993-997 gd:1
+ttp: b557/782 bl:2.3422 bb:1.0521 rl:2.2984 rb:1.0479 dl:965-968 gd:1
+ttp: b547/782 bl:2.3355 bb:1.0497 rl:2.2989 rb:1.0479 dl:934-937 gd:1
+ttp: b538/782 bl:2.3395 bb:1.0474 rl:2.2994 rb:1.0479 dl:905-909 gd:1
+ttp: b535/782 bl:2.3811 bb:1.0327 rl:2.3004 rb:1.0477 dl:896-899 gd:1
+ttp: b527/782 bl:2.3429 bb:1.0283 rl:2.3009 rb:1.0475 dl:872-875 gd:1
+ttp: b516/782 bl:2.3570 bb:1.0459 rl:2.3016 rb:1.0474 dl:841-843 gd:1
+ttp: b508/782 bl:2.3969 bb:1.0538 rl:2.3026 rb:1.0475 dl:817-820 gd:1
+ttp: b498/782 bl:2.3561 bb:1.0529 rl:2.3032 rb:1.0476 dl:791-794 gd:1
+ttp: b490/782 bl:2.3910 bb:1.0559 rl:2.3041 rb:1.0477 dl:771-773 gd:1
+ttp: b482/782 bl:2.3297 bb:1.0474 rl:2.3044 rb:1.0477 dl:752-754 gd:1
+ttp: b474/782 bl:2.3473 bb:1.0748 rl:2.3048 rb:1.0479 dl:733-735 gd:1
+ttp: b466/782 bl:2.3896 bb:1.0302 rl:2.3056 rb:1.0478 dl:714-717 gd:1
+ttp: b459/782 bl:2.2859 bb:1.0466 rl:2.3054 rb:1.0477 dl:700-701 gd:1
+ttp: b451/782 bl:2.4042 bb:1.0879 rl:2.3062 rb:1.0481 dl:682-685 gd:1
+ttp: b443/782 bl:2.2312 bb:1.0498 rl:2.3056 rb:1.0481 dl:666-668 gd:1
+ttp: b436/782 bl:2.2731 bb:1.0500 rl:2.3054 rb:1.0481 dl:651-653 gd:1
+ttp: b431/782 bl:2.3762 bb:1.0541 rl:2.3059 rb:1.0482 dl:642-643 gd:1
+ttp: b424/782 bl:2.3483 bb:1.0648 rl:2.3062 rb:1.0483 dl:629-630 gd:1
+ttp: b418/782 bl:2.2851 bb:1.0376 rl:2.3061 rb:1.0482 dl:617-618 gd:1
+ttp: b410/782 bl:2.3200 bb:1.0186 rl:2.3062 rb:1.0480 dl:601-603 gd:1
+ttp: b402/782 bl:2.2423 bb:0.9979 rl:2.3057 rb:1.0476 dl:586-588 gd:1
+ttp: b394/782 bl:2.2544 bb:0.9925 rl:2.3054 rb:1.0472 dl:571-573 gd:1
+ttp: b386/782 bl:2.3424 bb:1.1000 rl:2.3056 rb:1.0476 dl:557-559 gd:1
+ttp: b378/782 bl:2.4302 bb:1.0545 rl:2.3064 rb:1.0476 dl:544-545 gd:1
+ttp: b370/782 bl:2.3723 bb:1.0860 rl:2.3068 rb:1.0479 dl:530-532 gd:1
+ttp: b363/782 bl:2.3830 bb:1.0666 rl:2.3073 rb:1.0480 dl:518-521 gd:1
+ttp: b356/782 bl:2.3445 bb:1.0557 rl:2.3075 rb:1.0480 dl:506-508 gd:1
+ttp: b348/782 bl:2.3603 bb:1.0586 rl:2.3078 rb:1.0481 dl:494-495 gd:1
+ttp: b340/782 bl:2.4576 bb:1.0804 rl:2.3086 rb:1.0483 dl:482-483 gd:1
+ttp: b332/782 bl:2.3101 bb:1.0457 rl:2.3087 rb:1.0483 dl:469-471 gd:1
+ttp: b323/782 bl:2.3866 bb:1.0775 rl:2.3091 rb:1.0484 dl:457-458 gd:1
+ttp: b315/782 bl:2.4012 bb:1.1031 rl:2.3095 rb:1.0487 dl:444-445 gd:1
+ttp: b307/782 bl:2.3346 bb:1.1286 rl:2.3096 rb:1.0490 dl:432-433 gd:1
+ttp: b301/782 bl:2.3573 bb:1.0943 rl:2.3099 rb:1.0493 dl:422-424 gd:1
+ttp: b293/782 bl:2.4392 bb:1.0998 rl:2.3105 rb:1.0495 dl:410-412 gd:1
+ttp: b285/782 bl:2.3703 bb:1.0798 rl:2.3107 rb:1.0496 dl:399-400 gd:1
+ttp: b277/782 bl:2.2669 bb:1.0675 rl:2.3105 rb:1.0497 dl:388-389 gd:1
+ttp: b268/782 bl:2.3598 bb:1.0781 rl:2.3107 rb:1.0498 dl:376-378 gd:1
+ttp: b259/782 bl:2.3385 bb:1.0967 rl:2.3108 rb:1.0500 dl:365-366 gd:1
+ttp: b251/782 bl:2.3737 bb:1.0974 rl:2.3111 rb:1.0502 dl:355-356 gd:1
+ttp: b242/782 bl:2.3807 bb:1.1020 rl:2.3113 rb:1.0504 dl:344-345 gd:1
+ttp: b234/782 bl:2.4143 bb:1.1440 rl:2.3117 rb:1.0507 dl:334-335 gd:1
+ttp: b201/782 bl:2.2932 bb:1.0939 rl:2.3117 rb:1.0508 dl:297-298 gd:1
+ttp: b192/782 bl:2.3792 bb:1.1555 rl:2.3119 rb:1.0511 dl:286-288 gd:1
+ttp: b184/782 bl:2.3965 bb:1.1298 rl:2.3121 rb:1.0513 dl:278-279 gd:1
+ttp: b175/782 bl:2.3992 bb:1.1593 rl:2.3124 rb:1.0516 dl:269-270 gd:1
+ttp: b166/782 bl:2.4746 bb:1.1061 rl:2.3128 rb:1.0518 dl:260-262 gd:1
+ttp: b157/782 bl:2.3694 bb:1.1348 rl:2.3130 rb:1.0520 dl:252-253 gd:1
+ttp: b149/782 bl:2.3663 bb:1.1526 rl:2.3131 rb:1.0522 dl:244-245 gd:1
+ttp: b141/782 bl:2.4713 bb:1.1278 rl:2.3135 rb:1.0524 dl:236-237 gd:1
+ttp: b133/782 bl:2.3664 bb:1.1350 rl:2.3136 rb:1.0526 dl:229-230 gd:1
+ttp: b124/782 bl:2.3901 bb:1.1675 rl:2.3138 rb:1.0529 dl:220-222 gd:1
+ttp: b118/782 bl:2.4712 bb:1.1280 rl:2.3142 rb:1.0530 dl:215-216 gd:1
+ttp: b112/782 bl:2.4764 bb:1.1819 rl:2.3145 rb:1.0533 dl:210-210 gd:1
+ttp: b104/782 bl:2.4991 bb:1.1798 rl:2.3149 rb:1.0536 dl:202-203 gd:1
+ttp: b97/782 bl:2.4556 bb:1.1622 rl:2.3152 rb:1.0538 dl:196-197 gd:1
+ttp: b89/782 bl:2.5002 bb:1.1553 rl:2.3156 rb:1.0540 dl:189-190 gd:1
+ttp: b81/782 bl:2.4694 bb:1.1207 rl:2.3158 rb:1.0541 dl:182-183 gd:1
+ttp: b73/782 bl:2.5522 bb:1.2527 rl:2.3163 rb:1.0544 dl:174-175 gd:1
+ttp: b66/782 bl:2.6471 bb:1.2388 rl:2.3168 rb:1.0547 dl:169-169 gd:1
+ttp: b56/782 bl:2.5427 bb:1.2188 rl:2.3172 rb:1.0550 dl:159-160 gd:1
+ttp: b48/782 bl:2.5187 bb:1.2144 rl:2.3175 rb:1.0552 dl:151-152 gd:1
+ttp: b40/782 bl:2.4833 bb:1.1504 rl:2.3178 rb:1.0554 dl:143-144 gd:1
+ttp: b32/782 bl:2.6153 bb:1.2194 rl:2.3182 rb:1.0556 dl:135-136 gd:1
+ttp: b23/782 bl:2.6064 bb:1.2241 rl:2.3186 rb:1.0558 dl:126-127 gd:1
+ttp: b15/782 bl:2.6523 bb:1.2317 rl:2.3189 rb:1.0560 dl:115-117 gd:1
+ttp: b7/782 bl:2.7490 bb:1.2372 rl:2.3194 rb:1.0562 dl:101-103 gd:1
+quantized_ttt_phased val_loss:2.32368487 val_bpb:1.06183331 eval_time:406521ms
+total_eval_time:406.5s

--- a/records/track_10min_16mb/2026-04-24_SP8192_CaseOps_SparseGate_QuantGate_Loop45_PhasedTTT_PolarNS_MinLR_FusedCE_UpdatedCarry/train_seed42.log
+++ b/records/track_10min_16mb/2026-04-24_SP8192_CaseOps_SparseGate_QuantGate_Loop45_PhasedTTT_PolarNS_MinLR_FusedCE_UpdatedCarry/train_seed42.log
@@ -1,0 +1,934 @@
+W0423 22:39:32.672000 145471 torch/distributed/run.py:803] 
+W0423 22:39:32.672000 145471 torch/distributed/run.py:803] *****************************************
+W0423 22:39:32.672000 145471 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0423 22:39:32.672000 145471 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  artifact_dir: /workspace/runs/036-035e-8h-promotion/seed_42
+  attn_clip_sigmas: 13.0
+  attn_out_gate_enabled: False
+  attn_out_gate_src: proj
+  beta1: 0.9
+  beta2: 0.95
+  caseops_enabled: True
+  compressor: brotli
+  data_dir: /workspace/parameter-golf/data
+  datasets_dir: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_caseops/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved
+  distributed: True
+  ema_decay: 0.9965
+  embed_bits: 7
+  embed_clip_sigmas: 15.0
+  embed_lr: 0.6
+  embed_wd: 0.085
+  enable_looping_at: 0.35
+  eval_seq_len: 2048
+  eval_stride: 64
+  fused_ce_enabled: True
+  gate_window: 12
+  gated_attn_enabled: False
+  gated_attn_init_std: 0.005
+  gated_attn_quant_gate: True
+  global_ttt_batch_seqs: 32
+  global_ttt_chunk_tokens: 32768
+  global_ttt_epochs: 1
+  global_ttt_grad_clip: 1.0
+  global_ttt_lr: 0.001
+  global_ttt_momentum: 0.9
+  global_ttt_respect_doc_boundaries: True
+  global_ttt_warmup_chunks: 0
+  global_ttt_warmup_start_lr: 0.0
+  gptq_calibration_batches: 16
+  gptq_reserve_seconds: 0.5
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  is_main_process: True
+  iterations: 20000
+  ln_scale: True
+  local_rank: 0
+  logfile: /workspace/runs/036-035e-8h-promotion/seed_42/e75febaa-ac16-46e3-acbc-087c22dd08e3.txt
+  logit_softcap: 30.0
+  loop_depth_upgrade_at: 0.0
+  loop_end: 5
+  loop_start: 3
+  matrix_bits: 6
+  matrix_clip_sigmas: 12.85
+  matrix_lr: 0.026
+  max_wallclock_seconds: 600.0
+  min_lr: 0.1
+  mlp_clip_sigmas: 12.0
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: /workspace/runs/036-035e-8h-promotion/seed_42/final_model.pt
+  muon_backend_steps: 5
+  muon_momentum: 0.97
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_row_normalize: True
+  muon_wd: 0.095
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  num_loops: 2
+  parallel_final_lane: mean
+  parallel_start_layer: 8
+  phased_ttt_num_phases: 3
+  phased_ttt_prefix_docs: 2000
+  qk_gain_init: 5.0
+  quantized_model_path: /workspace/runs/036-035e-8h-promotion/seed_42/final_model.int6.ptz
+  rank: 0
+  recur_alpha_enabled: True
+  recur_diag_p2p_cos: False
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  rope_yarn: False
+  run_id: e75febaa-ac16-46e3-acbc-087c22dd08e3
+  scalar_lr: 0.02
+  seed: 42
+  skip_gates_enabled: True
+  smear_gate_enabled: False
+  sparse_attn_gate_enabled: True
+  sparse_attn_gate_init_std: 0.0
+  sparse_attn_gate_scale: 1.0
+  spinquant_enabled: False
+  spinquant_seed: 42
+  spinquant_sites: attn_in,attn_proj_in,mlp_in,mlp_proj_in
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  tokenizer_path: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_caseops/datasets/tokenizers/fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model
+  train_batch_tokens: 786432
+  train_files: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_caseops/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_train_*.bin
+  train_log_every: 100
+  train_seq_len: 2048
+  ttt_batch_size: 64
+  ttt_beta1: 0.0
+  ttt_beta2: 0.999
+  ttt_chunk_size: 48
+  ttt_enabled: True
+  ttt_eval_batches: 
+  ttt_eval_seq_len: 2048
+  ttt_grad_steps: 1
+  ttt_k_lora: True
+  ttt_lora_alpha: 144
+  ttt_lora_lr: 0.0001
+  ttt_lora_rank: 96
+  ttt_mlp_lora: True
+  ttt_o_lora: True
+  ttt_optimizer: adam
+  ttt_weight_decay: 1.0
+  val_batch_tokens: 524288
+  val_bytes_files: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_caseops/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_val_bytes_*.bin
+  val_doc_fraction: 1.0
+  val_files: /workspace/parameter-golf/data/datasets/fineweb10B_sp8192_caseops/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_val_*.bin
+  val_loss_every: 0
+  vocab_size: 8192
+  warmdown_frac: 0.75
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+train_shards: 80
+val_tokens: 47851520
+model_params:35945658
+recur_alpha: enabled=True num_loops=2 loop_start=3 loop_end=5 diag_p2p_cos=False
+gptq:reserving 0s, effective=599500ms
+warmup_cu_buckets:64,128,192,256 iters_each:3
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup:enabled encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+loop_warmup_step: 1/20
+loop_warmup_step: 2/20
+loop_warmup_step: 3/20
+loop_warmup_step: 4/20
+loop_warmup_step: 5/20
+loop_warmup_step: 6/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+1/20000 train_loss: 9.0168 train_time: 0.0m tok/s: 12785698
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2/20000 train_loss: 12.8636 train_time: 0.0m tok/s: 7648299
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3/20000 train_loss: 10.2423 train_time: 0.0m tok/s: 7629634
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4/20000 train_loss: 8.7625 train_time: 0.0m tok/s: 7656935
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+5/20000 train_loss: 8.0144 train_time: 0.0m tok/s: 7657453
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+100/20000 train_loss: 3.6336 train_time: 0.2m tok/s: 8427902
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+200/20000 train_loss: 3.1446 train_time: 0.3m tok/s: 8348721
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+300/20000 train_loss: 2.9201 train_time: 0.5m tok/s: 8333068
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+400/20000 train_loss: 2.5840 train_time: 0.6m tok/s: 8319550
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+500/20000 train_loss: 2.5802 train_time: 0.8m tok/s: 8342231
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+600/20000 train_loss: 2.6791 train_time: 0.9m tok/s: 8332819
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+700/20000 train_loss: 2.8796 train_time: 1.1m tok/s: 8326420
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+800/20000 train_loss: 2.7150 train_time: 1.3m tok/s: 8318389
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+900/20000 train_loss: 2.7603 train_time: 1.4m tok/s: 8317397
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1000/20000 train_loss: 2.8126 train_time: 1.6m tok/s: 8327956
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1100/20000 train_loss: 2.7757 train_time: 1.7m tok/s: 8321685
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1200/20000 train_loss: 2.7716 train_time: 1.9m tok/s: 8318258
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1300/20000 train_loss: 2.8392 train_time: 2.0m tok/s: 8315040
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1400/20000 train_loss: 2.5971 train_time: 2.2m tok/s: 8311573
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1500/20000 train_loss: 2.6449 train_time: 2.4m tok/s: 8319236
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1600/20000 train_loss: 2.7156 train_time: 2.5m tok/s: 8316749
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1700/20000 train_loss: 2.6935 train_time: 2.7m tok/s: 8314151
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1800/20000 train_loss: 2.6543 train_time: 2.8m tok/s: 8312328
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+1900/20000 train_loss: 2.7530 train_time: 3.0m tok/s: 8318143
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2000/20000 train_loss: 2.6717 train_time: 3.2m tok/s: 8315645
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2100/20000 train_loss: 2.6977 train_time: 3.3m tok/s: 8314212
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2200/20000 train_loss: 2.5385 train_time: 3.5m tok/s: 8312192
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+layer_loop:enabled step:2218 frac:0.350 depth:3 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2300/20000 train_loss: 2.6160 train_time: 3.7m tok/s: 8171686
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2400/20000 train_loss: 2.6368 train_time: 3.9m tok/s: 8024439
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2500/20000 train_loss: 2.5592 train_time: 4.2m tok/s: 7889734
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2600/20000 train_loss: 2.5258 train_time: 4.4m tok/s: 7769062
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2700/20000 train_loss: 2.5149 train_time: 4.6m tok/s: 7661531
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2800/20000 train_loss: 2.5748 train_time: 4.9m tok/s: 7565097
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+2900/20000 train_loss: 2.5499 train_time: 5.1m tok/s: 7478504
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3000/20000 train_loss: 2.5740 train_time: 5.3m tok/s: 7397182
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3100/20000 train_loss: 2.5060 train_time: 5.5m tok/s: 7322692
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3200/20000 train_loss: 2.4783 train_time: 5.8m tok/s: 7254698
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3300/20000 train_loss: 2.6665 train_time: 6.0m tok/s: 7194160
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3400/20000 train_loss: 2.5669 train_time: 6.2m tok/s: 7135135
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3500/20000 train_loss: 2.5776 train_time: 6.5m tok/s: 7081014
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3600/20000 train_loss: 2.4741 train_time: 6.7m tok/s: 7030519
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3700/20000 train_loss: 2.5608 train_time: 7.0m tok/s: 6949972
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3800/20000 train_loss: 2.5064 train_time: 7.2m tok/s: 6909441
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+3900/20000 train_loss: 2.6304 train_time: 7.4m tok/s: 6869734
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4000/20000 train_loss: 2.4203 train_time: 7.7m tok/s: 6832479
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4100/20000 train_loss: 2.4229 train_time: 7.9m tok/s: 6797076
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4200/20000 train_loss: 2.4368 train_time: 8.1m tok/s: 6763111
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4300/20000 train_loss: 2.5136 train_time: 8.4m tok/s: 6715365
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4400/20000 train_loss: 2.4612 train_time: 8.6m tok/s: 6686101
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4500/20000 train_loss: 2.2934 train_time: 8.9m tok/s: 6658473
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4600/20000 train_loss: 2.3888 train_time: 9.1m tok/s: 6632392
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4700/20000 train_loss: 2.3347 train_time: 9.3m tok/s: 6608101
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4800/20000 train_loss: 2.3132 train_time: 9.6m tok/s: 6585338
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4900/20000 train_loss: 2.3087 train_time: 9.8m tok/s: 6562880
+recur_alpha: beta=[1.5625, 1.8515625, 2.125] alpha=[[0.23046875, 0.0400390625, 0.030029296875], [0.1298828125, -0.33984375, 0.010009765625], [0.06005859375, 0.1904296875, -0.02001953125]] grad_norm=0.000000
+4989/20000 val_loss: 2.3587 val_bpb: 1.0778
+stopping_early: wallclock_cap train_time: 599631ms step: 4989/20000
+peak memory allocated: 41610 MiB reserved: 46918 MiB
+ema:applying EMA weights
+diagnostic pre-quantization post-ema val_loss:2.33621683 val_bpb:1.06749061 eval_time:7600ms
+Serialized model: 135417469 bytes
+pyminify unavailable (FileNotFoundError); skipping compressed-code-size measurement
+Code size (uncompressed): 175063 bytes
+Code size (compressed): 0 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 3.6s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int7): tok_emb.weight
+  passthrough (float16): blocks.attn.attn_gate_w, blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, recur_alpha, recur_beta, skip_gates, skip_weights
+Serialized model quantized+brotli: 15909254 bytes
+Total submission size quantized+brotli: 15909254 bytes
+diagnostic quantized val_loss:2.35655108 val_bpb:1.07678196 eval_time:11855ms
+ttt_lora:warming up compile (random tokens, no val data)
+ttt_lora:compile warmup done (148.7s)
+
+beginning TTT eval timer
+ttt_phased: total_docs:50000 prefix_docs:2000 suffix_docs:48000 num_phases:3 boundaries:[666, 1333, 2000]
+ttp: b775/782 bl:2.2839 bb:1.0618 rl:2.2839 rb:1.0618 dl:6892-7524 gd:0
+ttp: b774/782 bl:2.2945 bb:1.0683 rl:2.2890 rb:1.0649 dl:6447-6872 gd:0
+ttp: b768/782 bl:2.2491 bb:1.0474 rl:2.2785 rb:1.0603 dl:4859-5083 gd:0
+ttpp: phase:1/3 pd:1104 gd:666 t:222.2s
+tttg: c1/111 lr:0.001000 t:0.4s
+tttg: c2/111 lr:0.001000 t:0.5s
+tttg: c3/111 lr:0.000999 t:0.5s
+tttg: c4/111 lr:0.000998 t:0.6s
+tttg: c5/111 lr:0.000997 t:0.7s
+tttg: c6/111 lr:0.000995 t:0.8s
+tttg: c7/111 lr:0.000993 t:0.8s
+tttg: c8/111 lr:0.000990 t:0.9s
+tttg: c9/111 lr:0.000987 t:1.0s
+tttg: c10/111 lr:0.000984 t:1.0s
+tttg: c11/111 lr:0.000980 t:1.1s
+tttg: c12/111 lr:0.000976 t:1.2s
+tttg: c13/111 lr:0.000971 t:1.2s
+tttg: c14/111 lr:0.000966 t:1.3s
+tttg: c15/111 lr:0.000961 t:1.4s
+tttg: c16/111 lr:0.000955 t:1.4s
+tttg: c17/111 lr:0.000949 t:1.5s
+tttg: c18/111 lr:0.000942 t:1.6s
+tttg: c19/111 lr:0.000935 t:1.6s
+tttg: c20/111 lr:0.000928 t:1.7s
+tttg: c21/111 lr:0.000921 t:1.8s
+tttg: c22/111 lr:0.000913 t:1.8s
+tttg: c23/111 lr:0.000905 t:1.9s
+tttg: c24/111 lr:0.000896 t:2.0s
+tttg: c25/111 lr:0.000887 t:2.0s
+tttg: c26/111 lr:0.000878 t:2.1s
+tttg: c27/111 lr:0.000868 t:2.2s
+tttg: c28/111 lr:0.000859 t:2.2s
+tttg: c29/111 lr:0.000848 t:2.3s
+tttg: c30/111 lr:0.000838 t:2.4s
+tttg: c31/111 lr:0.000827 t:2.4s
+tttg: c32/111 lr:0.000817 t:2.5s
+tttg: c33/111 lr:0.000805 t:2.6s
+tttg: c34/111 lr:0.000794 t:2.6s
+tttg: c35/111 lr:0.000782 t:2.7s
+tttg: c36/111 lr:0.000770 t:2.8s
+tttg: c37/111 lr:0.000758 t:2.8s
+tttg: c38/111 lr:0.000746 t:4.7s
+tttg: c39/111 lr:0.000733 t:4.8s
+tttg: c40/111 lr:0.000721 t:4.8s
+tttg: c41/111 lr:0.000708 t:4.9s
+tttg: c42/111 lr:0.000695 t:5.0s
+tttg: c43/111 lr:0.000681 t:5.0s
+tttg: c44/111 lr:0.000668 t:5.1s
+tttg: c45/111 lr:0.000655 t:5.2s
+tttg: c46/111 lr:0.000641 t:5.2s
+tttg: c47/111 lr:0.000627 t:5.3s
+tttg: c48/111 lr:0.000613 t:5.4s
+tttg: c49/111 lr:0.000599 t:5.4s
+tttg: c50/111 lr:0.000585 t:5.5s
+tttg: c51/111 lr:0.000571 t:5.6s
+tttg: c52/111 lr:0.000557 t:5.6s
+tttg: c53/111 lr:0.000543 t:5.7s
+tttg: c54/111 lr:0.000529 t:5.8s
+tttg: c55/111 lr:0.000514 t:5.8s
+tttg: c56/111 lr:0.000500 t:5.9s
+tttg: c57/111 lr:0.000486 t:6.0s
+tttg: c58/111 lr:0.000471 t:6.0s
+tttg: c59/111 lr:0.000457 t:6.1s
+tttg: c60/111 lr:0.000443 t:6.2s
+tttg: c61/111 lr:0.000429 t:6.2s
+tttg: c62/111 lr:0.000415 t:6.3s
+tttg: c63/111 lr:0.000401 t:6.4s
+tttg: c64/111 lr:0.000387 t:6.4s
+tttg: c65/111 lr:0.000373 t:6.5s
+tttg: c66/111 lr:0.000359 t:6.6s
+tttg: c67/111 lr:0.000345 t:6.6s
+tttg: c68/111 lr:0.000332 t:6.7s
+tttg: c69/111 lr:0.000319 t:6.8s
+tttg: c70/111 lr:0.000305 t:6.8s
+tttg: c71/111 lr:0.000292 t:6.9s
+tttg: c72/111 lr:0.000279 t:7.0s
+tttg: c73/111 lr:0.000267 t:7.0s
+tttg: c74/111 lr:0.000254 t:7.1s
+tttg: c75/111 lr:0.000242 t:7.2s
+tttg: c76/111 lr:0.000230 t:7.2s
+tttg: c77/111 lr:0.000218 t:7.3s
+tttg: c78/111 lr:0.000206 t:7.4s
+tttg: c79/111 lr:0.000195 t:7.4s
+tttg: c80/111 lr:0.000183 t:7.5s
+tttg: c81/111 lr:0.000173 t:7.6s
+tttg: c82/111 lr:0.000162 t:7.6s
+tttg: c83/111 lr:0.000152 t:7.7s
+tttg: c84/111 lr:0.000141 t:7.8s
+tttg: c85/111 lr:0.000132 t:7.9s
+tttg: c86/111 lr:0.000122 t:7.9s
+tttg: c87/111 lr:0.000113 t:8.0s
+tttg: c88/111 lr:0.000104 t:8.1s
+tttg: c89/111 lr:0.000095 t:8.1s
+tttg: c90/111 lr:0.000087 t:8.2s
+tttg: c91/111 lr:0.000079 t:8.3s
+tttg: c92/111 lr:0.000072 t:8.3s
+tttg: c93/111 lr:0.000065 t:8.4s
+tttg: c94/111 lr:0.000058 t:8.5s
+tttg: c95/111 lr:0.000051 t:8.5s
+tttg: c96/111 lr:0.000045 t:8.6s
+tttg: c97/111 lr:0.000039 t:8.7s
+tttg: c98/111 lr:0.000034 t:8.7s
+tttg: c99/111 lr:0.000029 t:8.8s
+tttg: c100/111 lr:0.000024 t:8.9s
+tttg: c101/111 lr:0.000020 t:8.9s
+tttg: c102/111 lr:0.000016 t:9.0s
+tttg: c103/111 lr:0.000013 t:9.1s
+tttg: c104/111 lr:0.000010 t:9.1s
+tttg: c105/111 lr:0.000007 t:9.2s
+tttg: c106/111 lr:0.000005 t:9.3s
+tttg: c107/111 lr:0.000003 t:9.3s
+tttg: c108/111 lr:0.000002 t:9.4s
+tttg: c109/111 lr:0.000001 t:9.5s
+tttg: c110/111 lr:0.000000 t:9.5s
+ttpr: phase:1/3 t:233.6s
+ttp: b757/782 bl:2.2864 bb:1.0643 rl:2.2797 rb:1.0609 dl:3550-3633 gd:0
+ttpp: phase:2/3 pd:1808 gd:1333 t:349.5s
+tttg: c1/185 lr:0.001000 t:0.1s
+tttg: c2/185 lr:0.001000 t:0.1s
+tttg: c3/185 lr:0.001000 t:0.2s
+tttg: c4/185 lr:0.000999 t:0.3s
+tttg: c5/185 lr:0.000999 t:0.3s
+tttg: c6/185 lr:0.000998 t:0.4s
+tttg: c7/185 lr:0.000997 t:0.5s
+tttg: c8/185 lr:0.000996 t:0.6s
+tttg: c9/185 lr:0.000995 t:0.6s
+tttg: c10/185 lr:0.000994 t:0.7s
+tttg: c11/185 lr:0.000993 t:0.8s
+tttg: c12/185 lr:0.000991 t:0.8s
+tttg: c13/185 lr:0.000990 t:0.9s
+tttg: c14/185 lr:0.000988 t:1.0s
+tttg: c15/185 lr:0.000986 t:1.0s
+tttg: c16/185 lr:0.000984 t:1.1s
+tttg: c17/185 lr:0.000981 t:1.2s
+tttg: c18/185 lr:0.000979 t:1.2s
+tttg: c19/185 lr:0.000977 t:1.3s
+tttg: c20/185 lr:0.000974 t:1.4s
+tttg: c21/185 lr:0.000971 t:1.4s
+tttg: c22/185 lr:0.000968 t:1.5s
+tttg: c23/185 lr:0.000965 t:1.6s
+tttg: c24/185 lr:0.000962 t:1.6s
+tttg: c25/185 lr:0.000959 t:1.7s
+tttg: c26/185 lr:0.000955 t:1.8s
+tttg: c27/185 lr:0.000952 t:1.8s
+tttg: c28/185 lr:0.000948 t:1.9s
+tttg: c29/185 lr:0.000944 t:2.0s
+tttg: c30/185 lr:0.000940 t:2.0s
+tttg: c31/185 lr:0.000936 t:2.1s
+tttg: c32/185 lr:0.000932 t:2.2s
+tttg: c33/185 lr:0.000927 t:2.2s
+tttg: c34/185 lr:0.000923 t:2.3s
+tttg: c35/185 lr:0.000918 t:2.4s
+tttg: c36/185 lr:0.000913 t:2.4s
+tttg: c37/185 lr:0.000908 t:2.5s
+tttg: c38/185 lr:0.000904 t:2.6s
+tttg: c39/185 lr:0.000898 t:2.6s
+tttg: c40/185 lr:0.000893 t:2.7s
+tttg: c41/185 lr:0.000888 t:2.8s
+tttg: c42/185 lr:0.000882 t:2.8s
+tttg: c43/185 lr:0.000877 t:2.9s
+tttg: c44/185 lr:0.000871 t:3.0s
+tttg: c45/185 lr:0.000865 t:3.0s
+tttg: c46/185 lr:0.000860 t:3.1s
+tttg: c47/185 lr:0.000854 t:3.2s
+tttg: c48/185 lr:0.000847 t:3.2s
+tttg: c49/185 lr:0.000841 t:3.3s
+tttg: c50/185 lr:0.000835 t:3.4s
+tttg: c51/185 lr:0.000829 t:3.4s
+tttg: c52/185 lr:0.000822 t:3.5s
+tttg: c53/185 lr:0.000816 t:3.6s
+tttg: c54/185 lr:0.000809 t:3.6s
+tttg: c55/185 lr:0.000802 t:3.7s
+tttg: c56/185 lr:0.000795 t:3.8s
+tttg: c57/185 lr:0.000788 t:3.9s
+tttg: c58/185 lr:0.000781 t:3.9s
+tttg: c59/185 lr:0.000774 t:4.0s
+tttg: c60/185 lr:0.000767 t:4.1s
+tttg: c61/185 lr:0.000760 t:4.1s
+tttg: c62/185 lr:0.000752 t:4.2s
+tttg: c63/185 lr:0.000745 t:4.3s
+tttg: c64/185 lr:0.000738 t:4.3s
+tttg: c65/185 lr:0.000730 t:4.4s
+tttg: c66/185 lr:0.000722 t:4.5s
+tttg: c67/185 lr:0.000715 t:4.5s
+tttg: c68/185 lr:0.000707 t:4.6s
+tttg: c69/185 lr:0.000699 t:4.7s
+tttg: c70/185 lr:0.000691 t:4.7s
+tttg: c71/185 lr:0.000683 t:4.8s
+tttg: c72/185 lr:0.000675 t:4.9s
+tttg: c73/185 lr:0.000667 t:4.9s
+tttg: c74/185 lr:0.000659 t:5.0s
+tttg: c75/185 lr:0.000651 t:5.1s
+tttg: c76/185 lr:0.000643 t:5.1s
+tttg: c77/185 lr:0.000635 t:5.2s
+tttg: c78/185 lr:0.000627 t:5.3s
+tttg: c79/185 lr:0.000618 t:5.3s
+tttg: c80/185 lr:0.000610 t:5.4s
+tttg: c81/185 lr:0.000602 t:5.5s
+tttg: c82/185 lr:0.000593 t:5.5s
+tttg: c83/185 lr:0.000585 t:5.6s
+tttg: c84/185 lr:0.000577 t:5.7s
+tttg: c85/185 lr:0.000568 t:5.8s
+tttg: c86/185 lr:0.000560 t:5.8s
+tttg: c87/185 lr:0.000551 t:5.9s
+tttg: c88/185 lr:0.000543 t:6.0s
+tttg: c89/185 lr:0.000534 t:6.0s
+tttg: c90/185 lr:0.000526 t:6.1s
+tttg: c91/185 lr:0.000517 t:6.2s
+tttg: c92/185 lr:0.000509 t:6.2s
+tttg: c93/185 lr:0.000500 t:6.3s
+tttg: c94/185 lr:0.000491 t:6.4s
+tttg: c95/185 lr:0.000483 t:6.4s
+tttg: c96/185 lr:0.000474 t:6.5s
+tttg: c97/185 lr:0.000466 t:6.6s
+tttg: c98/185 lr:0.000457 t:6.6s
+tttg: c99/185 lr:0.000449 t:6.7s
+tttg: c100/185 lr:0.000440 t:6.8s
+tttg: c101/185 lr:0.000432 t:6.8s
+tttg: c102/185 lr:0.000423 t:6.9s
+tttg: c103/185 lr:0.000415 t:7.0s
+tttg: c104/185 lr:0.000407 t:7.0s
+tttg: c105/185 lr:0.000398 t:7.1s
+tttg: c106/185 lr:0.000390 t:7.2s
+tttg: c107/185 lr:0.000382 t:7.2s
+tttg: c108/185 lr:0.000373 t:7.3s
+tttg: c109/185 lr:0.000365 t:7.4s
+tttg: c110/185 lr:0.000357 t:7.4s
+tttg: c111/185 lr:0.000349 t:7.5s
+tttg: c112/185 lr:0.000341 t:7.6s
+tttg: c113/185 lr:0.000333 t:7.6s
+tttg: c114/185 lr:0.000325 t:7.7s
+tttg: c115/185 lr:0.000317 t:7.8s
+tttg: c116/185 lr:0.000309 t:7.8s
+tttg: c117/185 lr:0.000301 t:7.9s
+tttg: c118/185 lr:0.000293 t:8.0s
+tttg: c119/185 lr:0.000285 t:8.0s
+tttg: c120/185 lr:0.000278 t:8.1s
+tttg: c121/185 lr:0.000270 t:8.2s
+tttg: c122/185 lr:0.000262 t:8.2s
+tttg: c123/185 lr:0.000255 t:8.3s
+tttg: c124/185 lr:0.000248 t:8.4s
+tttg: c125/185 lr:0.000240 t:8.5s
+tttg: c126/185 lr:0.000233 t:8.5s
+tttg: c127/185 lr:0.000226 t:8.6s
+tttg: c128/185 lr:0.000219 t:8.7s
+tttg: c129/185 lr:0.000212 t:8.7s
+tttg: c130/185 lr:0.000205 t:8.8s
+tttg: c131/185 lr:0.000198 t:8.9s
+tttg: c132/185 lr:0.000191 t:8.9s
+tttg: c133/185 lr:0.000184 t:9.0s
+tttg: c134/185 lr:0.000178 t:9.1s
+tttg: c135/185 lr:0.000171 t:9.1s
+tttg: c136/185 lr:0.000165 t:9.2s
+tttg: c137/185 lr:0.000159 t:9.3s
+tttg: c138/185 lr:0.000153 t:9.3s
+tttg: c139/185 lr:0.000146 t:9.4s
+tttg: c140/185 lr:0.000140 t:9.5s
+tttg: c141/185 lr:0.000135 t:9.5s
+tttg: c142/185 lr:0.000129 t:9.6s
+tttg: c143/185 lr:0.000123 t:9.7s
+tttg: c144/185 lr:0.000118 t:9.7s
+tttg: c145/185 lr:0.000112 t:9.8s
+tttg: c146/185 lr:0.000107 t:9.9s
+tttg: c147/185 lr:0.000102 t:9.9s
+tttg: c148/185 lr:0.000096 t:10.0s
+tttg: c149/185 lr:0.000092 t:10.1s
+tttg: c150/185 lr:0.000087 t:10.2s
+tttg: c151/185 lr:0.000082 t:10.2s
+tttg: c152/185 lr:0.000077 t:10.3s
+tttg: c153/185 lr:0.000073 t:10.4s
+tttg: c154/185 lr:0.000068 t:10.4s
+tttg: c155/185 lr:0.000064 t:10.5s
+tttg: c156/185 lr:0.000060 t:10.6s
+tttg: c157/185 lr:0.000056 t:10.6s
+tttg: c158/185 lr:0.000052 t:10.7s
+tttg: c159/185 lr:0.000048 t:10.8s
+tttg: c160/185 lr:0.000045 t:10.8s
+tttg: c161/185 lr:0.000041 t:10.9s
+tttg: c162/185 lr:0.000038 t:11.0s
+tttg: c163/185 lr:0.000035 t:11.0s
+tttg: c164/185 lr:0.000032 t:11.1s
+tttg: c165/185 lr:0.000029 t:11.2s
+tttg: c166/185 lr:0.000026 t:11.2s
+tttg: c167/185 lr:0.000023 t:11.3s
+tttg: c168/185 lr:0.000021 t:11.4s
+tttg: c169/185 lr:0.000019 t:11.4s
+tttg: c170/185 lr:0.000016 t:11.5s
+tttg: c171/185 lr:0.000014 t:11.6s
+tttg: c172/185 lr:0.000012 t:11.6s
+tttg: c173/185 lr:0.000010 t:11.7s
+tttg: c174/185 lr:0.000009 t:11.8s
+tttg: c175/185 lr:0.000007 t:11.8s
+tttg: c176/185 lr:0.000006 t:11.9s
+tttg: c177/185 lr:0.000005 t:12.0s
+tttg: c178/185 lr:0.000004 t:12.1s
+tttg: c179/185 lr:0.000003 t:12.1s
+tttg: c180/185 lr:0.000002 t:12.2s
+tttg: c181/185 lr:0.000001 t:12.3s
+tttg: c182/185 lr:0.000001 t:12.3s
+tttg: c183/185 lr:0.000000 t:12.4s
+tttg: c184/185 lr:0.000000 t:12.5s
+ttpr: phase:2/3 t:363.9s
+ttp: b746/782 bl:2.4164 bb:1.0647 rl:2.2955 rb:1.0614 dl:2884-2943 gd:0
+ttp: b745/782 bl:2.2430 bb:1.0269 rl:2.2901 rb:1.0579 dl:2842-2883 gd:0
+ttpp: phase:3/3 pd:2448 gd:2000 t:380.9s
+tttg: c1/250 lr:0.001000 t:0.1s
+tttg: c2/250 lr:0.001000 t:0.1s
+tttg: c3/250 lr:0.001000 t:0.2s
+tttg: c4/250 lr:0.001000 t:0.3s
+tttg: c5/250 lr:0.000999 t:0.3s
+tttg: c6/250 lr:0.000999 t:0.4s
+tttg: c7/250 lr:0.000999 t:0.5s
+tttg: c8/250 lr:0.000998 t:0.5s
+tttg: c9/250 lr:0.000997 t:0.6s
+tttg: c10/250 lr:0.000997 t:0.7s
+tttg: c11/250 lr:0.000996 t:0.7s
+tttg: c12/250 lr:0.000995 t:0.8s
+tttg: c13/250 lr:0.000994 t:0.9s
+tttg: c14/250 lr:0.000993 t:0.9s
+tttg: c15/250 lr:0.000992 t:1.0s
+tttg: c16/250 lr:0.000991 t:1.1s
+tttg: c17/250 lr:0.000990 t:1.2s
+tttg: c18/250 lr:0.000989 t:1.2s
+tttg: c19/250 lr:0.000987 t:1.3s
+tttg: c20/250 lr:0.000986 t:1.4s
+tttg: c21/250 lr:0.000984 t:1.4s
+tttg: c22/250 lr:0.000983 t:1.5s
+tttg: c23/250 lr:0.000981 t:1.6s
+tttg: c24/250 lr:0.000979 t:1.6s
+tttg: c25/250 lr:0.000977 t:1.7s
+tttg: c26/250 lr:0.000975 t:1.8s
+tttg: c27/250 lr:0.000973 t:1.8s
+tttg: c28/250 lr:0.000971 t:1.9s
+tttg: c29/250 lr:0.000969 t:2.0s
+tttg: c30/250 lr:0.000967 t:2.0s
+tttg: c31/250 lr:0.000965 t:2.1s
+tttg: c32/250 lr:0.000962 t:2.2s
+tttg: c33/250 lr:0.000960 t:2.2s
+tttg: c34/250 lr:0.000957 t:2.3s
+tttg: c35/250 lr:0.000955 t:2.4s
+tttg: c36/250 lr:0.000952 t:2.4s
+tttg: c37/250 lr:0.000949 t:2.5s
+tttg: c38/250 lr:0.000947 t:2.6s
+tttg: c39/250 lr:0.000944 t:2.6s
+tttg: c40/250 lr:0.000941 t:2.7s
+tttg: c41/250 lr:0.000938 t:2.8s
+tttg: c42/250 lr:0.000935 t:2.8s
+tttg: c43/250 lr:0.000931 t:2.9s
+tttg: c44/250 lr:0.000928 t:3.0s
+tttg: c45/250 lr:0.000925 t:3.0s
+tttg: c46/250 lr:0.000922 t:3.1s
+tttg: c47/250 lr:0.000918 t:3.2s
+tttg: c48/250 lr:0.000915 t:3.2s
+tttg: c49/250 lr:0.000911 t:3.3s
+tttg: c50/250 lr:0.000907 t:3.4s
+tttg: c51/250 lr:0.000904 t:3.4s
+tttg: c52/250 lr:0.000900 t:3.5s
+tttg: c53/250 lr:0.000896 t:3.6s
+tttg: c54/250 lr:0.000892 t:3.6s
+tttg: c55/250 lr:0.000888 t:3.7s
+tttg: c56/250 lr:0.000884 t:3.8s
+tttg: c57/250 lr:0.000880 t:3.8s
+tttg: c58/250 lr:0.000876 t:3.9s
+tttg: c59/250 lr:0.000872 t:4.0s
+tttg: c60/250 lr:0.000868 t:4.0s
+tttg: c61/250 lr:0.000863 t:4.1s
+tttg: c62/250 lr:0.000859 t:4.2s
+tttg: c63/250 lr:0.000855 t:4.3s
+tttg: c64/250 lr:0.000850 t:4.3s
+tttg: c65/250 lr:0.000846 t:4.4s
+tttg: c66/250 lr:0.000841 t:4.5s
+tttg: c67/250 lr:0.000836 t:4.5s
+tttg: c68/250 lr:0.000832 t:4.6s
+tttg: c69/250 lr:0.000827 t:4.7s
+tttg: c70/250 lr:0.000822 t:4.7s
+tttg: c71/250 lr:0.000817 t:4.8s
+tttg: c72/250 lr:0.000812 t:4.9s
+tttg: c73/250 lr:0.000807 t:4.9s
+tttg: c74/250 lr:0.000803 t:5.0s
+tttg: c75/250 lr:0.000797 t:5.1s
+tttg: c76/250 lr:0.000792 t:5.1s
+tttg: c77/250 lr:0.000787 t:5.2s
+tttg: c78/250 lr:0.000782 t:5.3s
+tttg: c79/250 lr:0.000777 t:5.3s
+tttg: c80/250 lr:0.000772 t:5.4s
+tttg: c81/250 lr:0.000766 t:5.5s
+tttg: c82/250 lr:0.000761 t:5.5s
+tttg: c83/250 lr:0.000755 t:5.6s
+tttg: c84/250 lr:0.000750 t:5.7s
+tttg: c85/250 lr:0.000745 t:5.7s
+tttg: c86/250 lr:0.000739 t:5.8s
+tttg: c87/250 lr:0.000733 t:5.9s
+tttg: c88/250 lr:0.000728 t:5.9s
+tttg: c89/250 lr:0.000722 t:6.0s
+tttg: c90/250 lr:0.000717 t:6.1s
+tttg: c91/250 lr:0.000711 t:6.1s
+tttg: c92/250 lr:0.000705 t:6.2s
+tttg: c93/250 lr:0.000699 t:6.3s
+tttg: c94/250 lr:0.000694 t:6.4s
+tttg: c95/250 lr:0.000688 t:6.4s
+tttg: c96/250 lr:0.000682 t:6.5s
+tttg: c97/250 lr:0.000676 t:6.6s
+tttg: c98/250 lr:0.000670 t:6.6s
+tttg: c99/250 lr:0.000664 t:6.7s
+tttg: c100/250 lr:0.000658 t:6.8s
+tttg: c101/250 lr:0.000652 t:6.8s
+tttg: c102/250 lr:0.000646 t:6.9s
+tttg: c103/250 lr:0.000640 t:7.0s
+tttg: c104/250 lr:0.000634 t:7.0s
+tttg: c105/250 lr:0.000628 t:7.1s
+tttg: c106/250 lr:0.000622 t:7.2s
+tttg: c107/250 lr:0.000616 t:7.2s
+tttg: c108/250 lr:0.000610 t:7.3s
+tttg: c109/250 lr:0.000603 t:7.4s
+tttg: c110/250 lr:0.000597 t:7.4s
+tttg: c111/250 lr:0.000591 t:7.5s
+tttg: c112/250 lr:0.000585 t:7.6s
+tttg: c113/250 lr:0.000579 t:7.6s
+tttg: c114/250 lr:0.000572 t:7.7s
+tttg: c115/250 lr:0.000566 t:7.8s
+tttg: c116/250 lr:0.000560 t:7.8s
+tttg: c117/250 lr:0.000554 t:7.9s
+tttg: c118/250 lr:0.000547 t:8.0s
+tttg: c119/250 lr:0.000541 t:8.0s
+tttg: c120/250 lr:0.000535 t:8.1s
+tttg: c121/250 lr:0.000528 t:8.2s
+tttg: c122/250 lr:0.000522 t:8.2s
+tttg: c123/250 lr:0.000516 t:8.3s
+tttg: c124/250 lr:0.000509 t:8.4s
+tttg: c125/250 lr:0.000503 t:8.4s
+tttg: c126/250 lr:0.000497 t:8.5s
+tttg: c127/250 lr:0.000491 t:8.6s
+tttg: c128/250 lr:0.000484 t:8.7s
+tttg: c129/250 lr:0.000478 t:8.7s
+tttg: c130/250 lr:0.000472 t:8.8s
+tttg: c131/250 lr:0.000465 t:8.9s
+tttg: c132/250 lr:0.000459 t:8.9s
+tttg: c133/250 lr:0.000453 t:9.0s
+tttg: c134/250 lr:0.000446 t:9.1s
+tttg: c135/250 lr:0.000440 t:9.1s
+tttg: c136/250 lr:0.000434 t:9.2s
+tttg: c137/250 lr:0.000428 t:9.3s
+tttg: c138/250 lr:0.000421 t:9.3s
+tttg: c139/250 lr:0.000415 t:9.4s
+tttg: c140/250 lr:0.000409 t:9.5s
+tttg: c141/250 lr:0.000403 t:9.5s
+tttg: c142/250 lr:0.000397 t:9.6s
+tttg: c143/250 lr:0.000390 t:9.7s
+tttg: c144/250 lr:0.000384 t:9.7s
+tttg: c145/250 lr:0.000378 t:9.8s
+tttg: c146/250 lr:0.000372 t:9.9s
+tttg: c147/250 lr:0.000366 t:9.9s
+tttg: c148/250 lr:0.000360 t:10.0s
+tttg: c149/250 lr:0.000354 t:10.1s
+tttg: c150/250 lr:0.000348 t:10.1s
+tttg: c151/250 lr:0.000342 t:10.2s
+tttg: c152/250 lr:0.000336 t:10.3s
+tttg: c153/250 lr:0.000330 t:10.3s
+tttg: c154/250 lr:0.000324 t:10.4s
+tttg: c155/250 lr:0.000318 t:10.5s
+tttg: c156/250 lr:0.000312 t:10.5s
+tttg: c157/250 lr:0.000306 t:10.6s
+tttg: c158/250 lr:0.000301 t:10.7s
+tttg: c159/250 lr:0.000295 t:10.7s
+tttg: c160/250 lr:0.000289 t:10.8s
+tttg: c161/250 lr:0.000283 t:10.9s
+tttg: c162/250 lr:0.000278 t:10.9s
+tttg: c163/250 lr:0.000272 t:11.0s
+tttg: c164/250 lr:0.000267 t:11.1s
+tttg: c165/250 lr:0.000261 t:11.2s
+tttg: c166/250 lr:0.000255 t:11.2s
+tttg: c167/250 lr:0.000250 t:11.3s
+tttg: c168/250 lr:0.000245 t:11.4s
+tttg: c169/250 lr:0.000239 t:11.4s
+tttg: c170/250 lr:0.000234 t:11.5s
+tttg: c171/250 lr:0.000228 t:11.6s
+tttg: c172/250 lr:0.000223 t:11.6s
+tttg: c173/250 lr:0.000218 t:11.7s
+tttg: c174/250 lr:0.000213 t:11.8s
+tttg: c175/250 lr:0.000208 t:11.8s
+tttg: c176/250 lr:0.000203 t:11.9s
+tttg: c177/250 lr:0.000197 t:12.0s
+tttg: c178/250 lr:0.000193 t:12.0s
+tttg: c179/250 lr:0.000188 t:12.1s
+tttg: c180/250 lr:0.000183 t:12.2s
+tttg: c181/250 lr:0.000178 t:12.2s
+tttg: c182/250 lr:0.000173 t:12.3s
+tttg: c183/250 lr:0.000168 t:12.4s
+tttg: c184/250 lr:0.000164 t:12.4s
+tttg: c185/250 lr:0.000159 t:12.5s
+tttg: c186/250 lr:0.000154 t:12.6s
+tttg: c187/250 lr:0.000150 t:12.6s
+tttg: c188/250 lr:0.000145 t:12.7s
+tttg: c189/250 lr:0.000141 t:12.8s
+tttg: c190/250 lr:0.000137 t:12.8s
+tttg: c191/250 lr:0.000132 t:12.9s
+tttg: c192/250 lr:0.000128 t:13.0s
+tttg: c193/250 lr:0.000124 t:13.0s
+tttg: c194/250 lr:0.000120 t:13.1s
+tttg: c195/250 lr:0.000116 t:13.2s
+tttg: c196/250 lr:0.000112 t:13.3s
+tttg: c197/250 lr:0.000108 t:13.3s
+tttg: c198/250 lr:0.000104 t:13.4s
+tttg: c199/250 lr:0.000100 t:13.5s
+tttg: c200/250 lr:0.000096 t:13.5s
+tttg: c201/250 lr:0.000093 t:13.6s
+tttg: c202/250 lr:0.000089 t:13.7s
+tttg: c203/250 lr:0.000085 t:13.7s
+tttg: c204/250 lr:0.000082 t:13.8s
+tttg: c205/250 lr:0.000078 t:13.9s
+tttg: c206/250 lr:0.000075 t:13.9s
+tttg: c207/250 lr:0.000072 t:14.0s
+tttg: c208/250 lr:0.000069 t:14.1s
+tttg: c209/250 lr:0.000065 t:14.1s
+tttg: c210/250 lr:0.000062 t:14.2s
+tttg: c211/250 lr:0.000059 t:14.3s
+tttg: c212/250 lr:0.000056 t:14.3s
+tttg: c213/250 lr:0.000053 t:14.4s
+tttg: c214/250 lr:0.000051 t:14.5s
+tttg: c215/250 lr:0.000048 t:14.5s
+tttg: c216/250 lr:0.000045 t:14.6s
+tttg: c217/250 lr:0.000043 t:14.7s
+tttg: c218/250 lr:0.000040 t:14.7s
+tttg: c219/250 lr:0.000038 t:14.8s
+tttg: c220/250 lr:0.000035 t:14.9s
+tttg: c221/250 lr:0.000033 t:14.9s
+tttg: c222/250 lr:0.000031 t:15.0s
+tttg: c223/250 lr:0.000029 t:15.1s
+tttg: c224/250 lr:0.000027 t:15.2s
+tttg: c225/250 lr:0.000025 t:15.2s
+tttg: c226/250 lr:0.000023 t:15.3s
+tttg: c227/250 lr:0.000021 t:15.4s
+tttg: c228/250 lr:0.000019 t:15.4s
+tttg: c229/250 lr:0.000017 t:15.5s
+tttg: c230/250 lr:0.000016 t:15.6s
+tttg: c231/250 lr:0.000014 t:15.6s
+tttg: c232/250 lr:0.000013 t:15.7s
+tttg: c233/250 lr:0.000011 t:15.8s
+tttg: c234/250 lr:0.000010 t:15.8s
+tttg: c235/250 lr:0.000009 t:15.9s
+tttg: c236/250 lr:0.000008 t:16.0s
+tttg: c237/250 lr:0.000007 t:16.0s
+tttg: c238/250 lr:0.000006 t:16.1s
+tttg: c239/250 lr:0.000005 t:16.2s
+tttg: c240/250 lr:0.000004 t:16.2s
+tttg: c241/250 lr:0.000003 t:16.3s
+tttg: c242/250 lr:0.000003 t:16.4s
+tttg: c243/250 lr:0.000002 t:16.4s
+tttg: c244/250 lr:0.000001 t:16.5s
+tttg: c245/250 lr:0.000001 t:16.6s
+tttg: c246/250 lr:0.000001 t:16.6s
+tttg: c247/250 lr:0.000000 t:16.7s
+tttg: c248/250 lr:0.000000 t:16.8s
+tttg: c249/250 lr:0.000000 t:16.8s
+ttpr: phase:3/3 t:399.6s
+ttp: b736/782 bl:2.2515 bb:1.0608 rl:2.2869 rb:1.0581 dl:2526-2550 gd:1
+ttp: b735/782 bl:2.3910 bb:1.1000 rl:2.2948 rb:1.0613 dl:2495-2526 gd:1
+ttp: b725/782 bl:2.3259 bb:1.0463 rl:2.2968 rb:1.0603 dl:2232-2254 gd:1
+ttp: b715/782 bl:2.3634 bb:1.0304 rl:2.3004 rb:1.0586 dl:2036-2053 gd:1
+ttp: b709/782 bl:2.4496 bb:1.0957 rl:2.3077 rb:1.0605 dl:1937-1952 gd:1
+ttp: b698/782 bl:2.2566 bb:1.0329 rl:2.3055 rb:1.0592 dl:1803-1814 gd:1
+ttp: b693/782 bl:2.3435 bb:1.0528 rl:2.3071 rb:1.0590 dl:1746-1757 gd:1
+ttp: b683/782 bl:2.2796 bb:1.0611 rl:2.3060 rb:1.0591 dl:1646-1657 gd:1
+ttp: b675/782 bl:2.3703 bb:1.0600 rl:2.3082 rb:1.0591 dl:1578-1586 gd:1
+ttp: b664/782 bl:2.3435 bb:1.0285 rl:2.3093 rb:1.0581 dl:1493-1499 gd:1
+ttp: b657/782 bl:2.3336 bb:1.0605 rl:2.3101 rb:1.0582 dl:1445-1452 gd:1
+ttp: b649/782 bl:2.2910 bb:1.0186 rl:2.3095 rb:1.0570 dl:1392-1398 gd:1
+ttp: b640/782 bl:2.3170 bb:1.0555 rl:2.3097 rb:1.0570 dl:1337-1343 gd:1
+ttp: b639/782 bl:2.3150 bb:1.0338 rl:2.3099 rb:1.0564 dl:1331-1337 gd:1
+ttp: b629/782 bl:2.3583 bb:1.0149 rl:2.3110 rb:1.0554 dl:1276-1280 gd:1
+ttp: b621/782 bl:2.3031 bb:1.0517 rl:2.3108 rb:1.0553 dl:1231-1237 gd:1
+ttp: b612/782 bl:2.2445 bb:1.0169 rl:2.3094 rb:1.0545 dl:1186-1190 gd:1
+ttp: b605/782 bl:2.2556 bb:1.0287 rl:2.3084 rb:1.0540 dl:1154-1159 gd:1
+ttp: b593/782 bl:2.2960 bb:1.0135 rl:2.3081 rb:1.0532 dl:1103-1107 gd:1
+ttp: b584/782 bl:2.3057 bb:1.0424 rl:2.3081 rb:1.0530 dl:1064-1069 gd:1
+ttp: b576/782 bl:2.3839 bb:1.0965 rl:2.3094 rb:1.0537 dl:1033-1037 gd:1
+ttp: b568/782 bl:2.3619 bb:1.0843 rl:2.3102 rb:1.0542 dl:1004-1007 gd:1
+ttp: b566/782 bl:2.3076 bb:1.0307 rl:2.3102 rb:1.0538 dl:997-1001 gd:1
+ttp: b558/782 bl:2.3771 bb:1.0631 rl:2.3112 rb:1.0540 dl:968-972 gd:1
+ttp: b547/782 bl:2.3409 bb:1.0521 rl:2.3116 rb:1.0540 dl:934-937 gd:1
+ttp: b539/782 bl:2.3413 bb:1.0379 rl:2.3120 rb:1.0537 dl:909-912 gd:1
+ttp: b535/782 bl:2.3836 bb:1.0338 rl:2.3130 rb:1.0534 dl:896-899 gd:1
+ttp: b527/782 bl:2.3491 bb:1.0310 rl:2.3134 rb:1.0531 dl:872-875 gd:1
+ttp: b516/782 bl:2.3601 bb:1.0473 rl:2.3140 rb:1.0531 dl:841-843 gd:1
+ttp: b508/782 bl:2.3972 bb:1.0539 rl:2.3150 rb:1.0531 dl:817-820 gd:1
+ttp: b498/782 bl:2.3618 bb:1.0555 rl:2.3155 rb:1.0531 dl:791-794 gd:1
+ttp: b490/782 bl:2.3982 bb:1.0591 rl:2.3164 rb:1.0532 dl:771-773 gd:1
+ttp: b482/782 bl:2.3376 bb:1.0509 rl:2.3166 rb:1.0532 dl:752-754 gd:1
+ttp: b474/782 bl:2.3463 bb:1.0743 rl:2.3169 rb:1.0534 dl:733-735 gd:1
+ttp: b466/782 bl:2.3918 bb:1.0312 rl:2.3177 rb:1.0531 dl:714-717 gd:1
+ttp: b458/782 bl:2.2083 bb:1.0242 rl:2.3166 rb:1.0529 dl:697-700 gd:1
+ttp: b450/782 bl:2.3679 bb:1.0380 rl:2.3171 rb:1.0527 dl:680-682 gd:1
+ttp: b442/782 bl:2.2612 bb:1.0319 rl:2.3166 rb:1.0525 dl:664-666 gd:1
+ttp: b434/782 bl:2.3762 bb:1.0549 rl:2.3171 rb:1.0526 dl:647-648 gd:1
+ttp: b426/782 bl:2.2645 bb:1.0479 rl:2.3167 rb:1.0525 dl:632-634 gd:1
+ttp: b418/782 bl:2.2907 bb:1.0401 rl:2.3165 rb:1.0524 dl:617-618 gd:1
+ttp: b412/782 bl:2.3385 bb:1.0485 rl:2.3166 rb:1.0524 dl:605-607 gd:1
+ttp: b403/782 bl:2.3326 bb:1.0466 rl:2.3168 rb:1.0524 dl:588-590 gd:1
+ttp: b394/782 bl:2.2564 bb:0.9934 rl:2.3163 rb:1.0519 dl:571-573 gd:1
+ttp: b387/782 bl:2.3655 bb:1.0850 rl:2.3167 rb:1.0521 dl:559-561 gd:1
+ttp: b379/782 bl:2.4309 bb:1.0928 rl:2.3175 rb:1.0524 dl:545-547 gd:1
+ttp: b371/782 bl:2.2616 bb:1.1043 rl:2.3171 rb:1.0527 dl:532-533 gd:1
+ttp: b363/782 bl:2.3864 bb:1.0682 rl:2.3175 rb:1.0528 dl:518-521 gd:1
+ttp: b355/782 bl:2.3145 bb:1.0740 rl:2.3175 rb:1.0530 dl:504-506 gd:1
+ttp: b347/782 bl:2.3434 bb:1.1137 rl:2.3177 rb:1.0533 dl:492-494 gd:1
+ttp: b339/782 bl:2.3405 bb:1.0807 rl:2.3178 rb:1.0535 dl:480-482 gd:1
+ttp: b330/782 bl:2.2500 bb:1.0722 rl:2.3174 rb:1.0536 dl:466-468 gd:1
+ttp: b322/782 bl:2.3767 bb:1.0608 rl:2.3177 rb:1.0536 dl:455-457 gd:1
+ttp: b314/782 bl:2.2502 bb:1.0613 rl:2.3174 rb:1.0537 dl:442-444 gd:1
+ttp: b306/782 bl:2.4019 bb:1.0678 rl:2.3178 rb:1.0537 dl:430-432 gd:1
+ttp: b298/782 bl:2.4243 bb:1.1039 rl:2.3183 rb:1.0540 dl:418-420 gd:1
+ttp: b290/782 bl:2.3468 bb:1.0750 rl:2.3185 rb:1.0541 dl:406-407 gd:1
+ttp: b282/782 bl:2.3232 bb:1.0721 rl:2.3185 rb:1.0542 dl:395-396 gd:1
+ttp: b274/782 bl:2.3022 bb:1.0702 rl:2.3184 rb:1.0542 dl:384-385 gd:1
+ttp: b266/782 bl:2.3869 bb:1.1106 rl:2.3187 rb:1.0545 dl:374-375 gd:1
+ttp: b259/782 bl:2.3490 bb:1.1016 rl:2.3188 rb:1.0547 dl:365-366 gd:1
+ttp: b252/782 bl:2.3903 bb:1.0714 rl:2.3191 rb:1.0547 dl:356-357 gd:1
+ttp: b245/782 bl:2.3800 bb:1.1142 rl:2.3194 rb:1.0550 dl:347-349 gd:1
+ttp: b238/782 bl:2.3314 bb:1.1119 rl:2.3194 rb:1.0552 dl:338-340 gd:1
+ttp: b231/782 bl:2.3113 bb:1.0857 rl:2.3194 rb:1.0553 dl:330-331 gd:1
+ttp: b224/782 bl:2.3907 bb:1.0955 rl:2.3197 rb:1.0554 dl:322-323 gd:1
+ttp: b217/782 bl:2.3753 bb:1.1341 rl:2.3198 rb:1.0557 dl:314-315 gd:1
+ttp: b210/782 bl:2.2620 bb:1.0846 rl:2.3197 rb:1.0558 dl:306-307 gd:1
+ttp: b202/782 bl:2.3689 bb:1.1087 rl:2.3198 rb:1.0560 dl:298-299 gd:1
+ttp: b194/782 bl:2.4451 bb:1.1202 rl:2.3202 rb:1.0562 dl:289-290 gd:1
+ttp: b185/782 bl:2.4394 bb:1.1185 rl:2.3206 rb:1.0563 dl:279-280 gd:1
+ttp: b177/782 bl:2.4122 bb:1.1114 rl:2.3209 rb:1.0565 dl:271-272 gd:1
+ttp: b169/782 bl:2.3763 bb:1.1169 rl:2.3210 rb:1.0567 dl:263-264 gd:1
+ttp: b161/782 bl:2.3686 bb:1.1401 rl:2.3212 rb:1.0569 dl:256-256 gd:1
+ttp: b153/782 bl:2.2622 bb:1.0464 rl:2.3210 rb:1.0569 dl:248-249 gd:1
+ttp: b144/782 bl:2.3589 bb:1.1088 rl:2.3211 rb:1.0570 dl:239-240 gd:1
+ttp: b135/782 bl:2.4417 bb:1.1832 rl:2.3214 rb:1.0573 dl:231-232 gd:1
+ttp: b127/782 bl:2.4886 bb:1.1937 rl:2.3218 rb:1.0576 dl:223-224 gd:1
+ttp: b118/782 bl:2.4596 bb:1.1227 rl:2.3221 rb:1.0578 dl:215-216 gd:1
+ttp: b109/782 bl:2.5059 bb:1.1942 rl:2.3225 rb:1.0581 dl:207-208 gd:1
+ttp: b103/782 bl:2.4597 bb:1.1840 rl:2.3228 rb:1.0583 dl:202-202 gd:1
+ttp: b94/782 bl:2.5692 bb:1.2140 rl:2.3234 rb:1.0586 dl:193-194 gd:1
+ttp: b84/782 bl:2.5301 bb:1.2030 rl:2.3238 rb:1.0589 dl:184-185 gd:1
+ttp: b76/782 bl:2.4966 bb:1.1725 rl:2.3241 rb:1.0591 dl:177-178 gd:1
+ttp: b68/782 bl:2.5223 bb:1.1772 rl:2.3245 rb:1.0593 dl:170-171 gd:1
+ttp: b60/782 bl:2.4750 bb:1.1896 rl:2.3247 rb:1.0595 dl:163-164 gd:1
+ttp: b52/782 bl:2.6826 bb:1.2522 rl:2.3253 rb:1.0599 dl:155-156 gd:1
+ttp: b44/782 bl:2.5707 bb:1.1996 rl:2.3257 rb:1.0601 dl:147-148 gd:1
+ttp: b32/782 bl:2.6119 bb:1.2178 rl:2.3261 rb:1.0603 dl:135-136 gd:1
+ttp: b24/782 bl:2.4641 bb:1.1621 rl:2.3263 rb:1.0604 dl:127-128 gd:1
+ttp: b16/782 bl:2.6308 bb:1.2606 rl:2.3267 rb:1.0607 dl:117-118 gd:1
+ttp: b8/782 bl:2.8027 bb:1.3009 rl:2.3272 rb:1.0609 dl:103-105 gd:1
+quantized_ttt_phased val_loss:2.32767903 val_bpb:1.06365848 eval_time:498524ms
+total_eval_time:498.5s


### PR DESCRIPTION
## Summary

- **3-seed mean val_bpb = 1.06287** (seeds 42, 0, 1234), val_loss = 2.32695 nats/token
- **−0.00134 vs #1779** (1.06421, our last submission), **−0.00048 vs #1787** (1.06335), **−0.00262 vs #1736** (1.06549)
- Inherits from #1779; adds a sparse attention-output gate and updated frozen recurrent carry
- Stackable with the smear gate and LQER from #1797

## Results (8×H100 80GB SXM, phased LoRA-TTT, 10-min train / 10-min eval)

| Seed | Steps | Post-EMA (pre-quant) | Quantized | **Post-TTT** | Artifact (bytes) |
|------|------:|---------------------:|----------:|-------------:|-----------------:|
| 42   | 4989  | 1.06749              | 1.07678   | **1.06366**  | 15,909,254       |
| 0    | 4974  | 1.06685              | 1.07608   | **1.06311**  | 15,904,209       |
| 1234 | 4973  | 1.06578              | 1.07509   | **1.06183**  | 15,909,401       |
| **Mean** | **4979** | **1.06671** | **1.07598** | **1.06287** | **15,907,621** |

## Frozen Recurrent Carry

The recurrent α/β carry coefficients (first introduced in #1779) were learned end-to-end on a full training run with no validation set involvement, then quantized to 2 decimal places before this promotion run:

- `β = [1.56, 1.85, 2.13]`
- `α = [[0.23, 0.04, 0.03], [0.13, −0.34, 0.01], [0.06, 0.19, −0.02]]`

Full-precision learned values: `β = [1.5610, 1.8531, 2.1320]`, `α = [[0.2314, 0.0388, 0.0347], [0.1260, −0.3438, 0.0145], [0.0557, 0.1934, −0.0172]]`.

The legality of offline-learned frozen scalars was discussed in #1779 — the data-size budget provides a natural bound on this class of technique.

## What this adds over #1779

**From #1787 (nprime06):**
- Polar Express Newton-Schulz coefficients
- `MIN_LR=0.10` warmdown floor
- Fused softcapped CE
- `GPTQ_RESERVE_SECONDS=0.5`, `VAL_LOSS_EVERY=0`

**New in this PR:**
- **Sparse attention-output gate** — replaces the dense `GatedAttn` with a narrow-input sparse gate
- **Updated frozen recurrent carry** — α/β re-learned on the sparse-gate stack and frozen to 2 decimal places (values above)

## Rule Compliance

- Score-first phased TTT (Condition 3), no pre-quant TTT, no n-gram cache
- All artifacts ≤ 16 MB (max 15,909,401 bytes), train ≤ 600s, eval ≤ 600s
- CaseOps tokenizer (pending issue #1604, same as #1779/#1787)

## Test Plan

- [ ] Reviewer reproduces any single seed with the provided `train_gpt.py` and env vars
- [ ] Verify artifact size `< 16,000,000` bytes in each seed log
- [ ] Verify score-first TTT ordering in code

