### PR TITLE
[Non-record] H-Net dynamic chunking — Path B (attention-only, byte-level)

### DIFF
--- a/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/README.md
+++ b/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/README.md
@@ -1,16 +1,16 @@
-# H-Net Dynamic Chunking — Path B (Attention-Only)
+# H-Net Dynamic Chunking — Attention-Only Variant
 
 *Pair-programmed with Claude (Anthropic). Architecture choices, training runs, and debugging direction are mine. Full attribution at the bottom.*
 
 Non-record submission, **unlimited-compute track** (~100 min on 1×A6000, not the 10-min/8×H100 budget). 
 
-Implements the dynamic-chunking module from H-Net (Hwang, Wang & Gu 2025, arxiv:[2507.07955](https://arxiv.org/abs/2507.07955)) on byte-level FineWeb-Edu, with Mamba-2 layers replaced by pre-norm Transformer blocks so the chunking idea can be evaluated in isolation.
+Implements the dynamic-chunking module from H-Net (Hwang, Wang & Gu 2025, arxiv:[2507.07955](https://arxiv.org/abs/2507.07955)) on byte-level FineWeb-Edu, with Mamba-2 layers replaced by pre-norm Transformer blocks. This evaluates dynamic chunking on a transformer backbone — it does *not* isolate the chunking contribution from Mamba's, since the routing module was co-designed with SSMs in the paper. A proper isolation would need a 2×2 ablation (Mamba ± chunking, Transformer ± chunking).
 
 **Result:** `val_bpb = 1.8838` after 10K steps (reproducible from the included `.ptz`). 16.27M params, 9.49MB compressed (well under 16MB cap).
 
 ## Summary of Choices
 
-1. **Path B (attention-only)** — no Mamba-2; isolates the chunking contribution, removes `mamba_ssm`/Triton dependency.
+1. **Path B (attention-only)** — no Mamba-2; tests dynamic chunking on a transformer backbone, removes `mamba_ssm`/Triton dependency. (Caveat: this is a backbone swap, not a clean ablation — see header.)
 2. **Single-stage chunking** — one routing module, one EMA pass; two-stage left for future work.
 3. **Byte-level vocab (260)** — the whole point of H-Net; pays ~6× token overhead vs BPE-sp1024.
 4. **Identity init for `W_q`/`W_k`** — at step 0 the router is raw cosine similarity of adjacent encoder states. Per goombalab/hnet `dc.py`.
@@ -33,7 +33,7 @@ bytes (B, L) → embed(260→256) → 3× Transformer (d=256, 4 heads)
 Loss: L_AR + 0.03 · L_ratio
 ```
 
-16,273,920 params. Pre-norm blocks throughout. Tied embedding/head. target_ratio = 1/6 (paper's English default).
+16,273,920 params. Pre-norm blocks throughout. Tied embedding/head. `target_ratio = 1/6` is the paper's English default; **not swept here due to compute budget**.
 
 ## Results
 

--- a/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/README.md
+++ b/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/README.md
@@ -1,0 +1,146 @@
+# H-Net Dynamic Chunking — Path B (Attention-Only)
+
+*Pair-programmed with Claude (Anthropic). Architecture choices, training runs, and debugging direction are mine. Full attribution at the bottom.*
+
+Non-record submission, **unlimited-compute track** (~100 min on 1×A6000, not the 10-min/8×H100 budget). 
+
+Implements the dynamic-chunking module from H-Net (Hwang, Wang & Gu 2025, arxiv:[2507.07955](https://arxiv.org/abs/2507.07955)) on byte-level FineWeb-Edu, with Mamba-2 layers replaced by pre-norm Transformer blocks so the chunking idea can be evaluated in isolation.
+
+**Result:** `val_bpb = 1.8838` after 10K steps (reproducible from the included `.ptz`). 16.27M params, 9.49MB compressed (well under 16MB cap).
+
+## Summary of Choices
+
+1. **Path B (attention-only)** — no Mamba-2; isolates the chunking contribution, removes `mamba_ssm`/Triton dependency.
+2. **Single-stage chunking** — one routing module, one EMA pass; two-stage left for future work.
+3. **Byte-level vocab (260)** — the whole point of H-Net; pays ~6× token overhead vs BPE-sp1024.
+4. **Identity init for `W_q`/`W_k`** — at step 0 the router is raw cosine similarity of adjacent encoder states. Per goombalab/hnet `dc.py`.
+5. **Chunk-level EMA** (not fine-level) — see Key Discovery.
+
+## Key Discovery: chunk-level vs fine-level EMA
+
+The H-Net paper (Section 2.2.2) describes the EMA dechunker ambiguously enough that an obvious-looking fine-level implementation passed sanity checks but produced the wrong math. Diffing against `goombalab/hnet/dc.py` showed they EMA over the *compressed* sequence and gather back to fine, making within-chunk values constant (correct) instead of decaying (wrong). Fix made training stable AND ~6× faster.
+
+**Lesson:** for paper implementations, read the reference repo as primary, paper as secondary.
+
+## Architecture
+
+```
+bytes (B, L) → embed(260→256) → 3× Transformer (d=256, 4 heads)
+            → DynamicChunking (cosine sim, p_t = 0.5(1 - cos), b_t = 1{p≥0.5})
+            → 6× Transformer (d=512, 8 heads, on compressed sequence)
+            → upsample_with_ema  +  encoder residual
+            → 3× Transformer (d=256, 4 heads) → norm → tied head → bytes
+Loss: L_AR + 0.03 · L_ratio
+```
+
+16,273,920 params. Pre-norm blocks throughout. Tied embedding/head. target_ratio = 1/6 (paper's English default).
+
+## Results
+
+| Submission | val_bpb | Compute | Params |
+|---|---:|---|---:|
+| Naive baseline (BPE sp1024) | 1.2244 | 10 min × 8×H100 | ~30M |
+| **This submission** (byte260, no tokenizer) | **1.8838** | ~100 min × 1×A6000 | 16.27M |
+| Top of leaderboard (Apr 9; BPE + ~10 tricks) | 1.0810 | 10 min × 8×H100 | ~30M |
+
+The 0.66 bpb gap is the cost of dropping BPE *and* every BPE-era trick. This is a clean reference for byte-level dynamic chunking, not a leaderboard climb.
+
+Going in I expected ~1.5 based on Chinchilla scaling. Landing at 1.88 surfaced that byte-level + 16M params + 300MB doesn't have the headroom to absorb the BPE token-tax — bigger model OR more data is needed before dynamic chunking can close the gap.
+
+### val_bpb verification (byte260 vocab)
+
+Per submission rules, tokenizer changes need explicit verification. The byte260 vocab has tokens 0-3 as specials (PAD/BOS/EOS/UNK, cost 0 bytes) and tokens 4-259 as raw byte values (each costs exactly 1 byte). Conversion:
+
+```
+bpb = (cross_entropy / ln 2) × tokens_per_byte
+tokens_per_byte = total_tokens / total_bytes
+```
+
+`total_bytes` is summed via a 260-entry LUT (`bytes_per_token_lut` in `train_hnet.py:118`): `lut[0:4] = 0` (specials), `lut[4:260] = 1` (raw bytes). No specials are emitted during training/eval — the data pipeline encodes raw UTF-8 with a +4 offset — so emitted tokens map 1:1 to bytes. Sanity check: encoding "Hello" → 5 byte-tokens (all in [4..259]), 5 source bytes, `tokens_per_byte = 1.0`, `bpb = CE / ln 2`.
+
+**End-to-end check.** Loading the shipped `final_model.int8.ptz` from disk, dequantising, and running val on the full split gives `val_bpb = 1.8838`. The training-time eval reported `1.8756` (in-training bf16 weights, full val); the ~0.008 gap is the cost of fp16 scale storage in the `.ptz` (per-row scales kept as fp16 to save bytes). The 1.8838 is the number a reviewer reproduces from the shipped artifact.
+
+### Quantisation comparison
+
+From `test_quant_full.py` on the trained checkpoint (val cap 65K tokens):
+
+| Bits | val_bpb | Δ vs fp | zlib (MB) | lzma (MB) |
+|---:|---:|---:|---:|---:|
+| fp (bf16) | 1.8429 | — | — | — |
+| **int8** | **1.8765** | **+0.034** | **9.49** | **8.88** |
+| int6 | 1.8760 | +0.033 | 9.49 | 8.88 |
+| int4 | 1.9416 | +0.099 | 8.74 | 8.17 |
+| int3 | 2.5273 | +0.684 | 6.26 | 5.79 |
+| int2 | 6.0342 | +4.191 | 3.38 | 3.03 |
+| int1 | 5.2659 | +3.423 | 3.42 | 3.11 |
+
+int8 is the Pareto pick: same compressed size as int6, ~+0.001 bpb cost vs fp, well under the 16MB cap. zlib over lzma for decode speed.
+
+(int1 beats int2 because int1 here is `±mean(|w|)` per row, BinaryConnect-style; int2 is ternary forced through the int8 quantile-clip machinery, which fits worse.)
+
+## Configuration
+
+AdamW (β=0.9, 0.95), linear warmup 500 + cosine decay to 0, bf16 autocast, grad clip 1.0. All other hyperparameters are env-var driven; full command in the Reproducing section below.
+
+## Negative Results Worth Noting
+
+- **Fine-level EMA** — ran fine, wrong math, ~6× slower. See Key Discovery.
+- **Default `N(0,1)` embedding init** — with tied head, initial CE ≈ 52 (vs expected `ln(260) ≈ 5.56`). Fix: `std = d_enc^(-0.5)`.
+- **fp16 autocast for the EMA** — `(1-p)` accumulator chain underflows after a few hundred chunk steps. bf16 has the dynamic range.
+- **Muon optimizer + logit softcap** — implemented locally, reverted before submission to keep this as a clean baseline that future stacked-trick variants can compare against.
+
+## Hardware Note
+
+1× RTX A6000 (48GB), no wallclock cap (non-record track). Could not fit `seq_len=2048` on a 4090 (24GB). Single GPU, no distributed. Windows-developed, Runpod-trained.
+
+## Reproducing
+
+Run from the parameter-golf root (paths are relative). Override `DATA_PATH=...` if shards live elsewhere. Three steps in order:
+
+```bash
+# 0) install
+pip install torch>=2.4 numpy huggingface-hub datasets tqdm
+
+# 1) build the byte260 dataset (it's NOT in the upstream cached_challenge_fineweb.py
+#    manifest, so we build shards locally first; ~300MB FineWeb-Edu via HuggingFace)
+python make_byte260_smoke.py
+
+# 2) train (~100 min on 1× RTX A6000)
+RUN_ID=hnet_real ITERATIONS=10000 \
+  TRAIN_BATCH_TOKENS=32768 TRAIN_SEQ_LEN=2048 \
+  D_ENC=256 D_MAIN=512 N_HEADS=8 \
+  LR=3e-4 WARMUP_STEPS=500 WEIGHT_DECAY=0.1 RATIO_LOSS_ALPHA=0.03 \
+  TARGET_RATIO=0.16667 \
+  VAL_TOKENS_CAP=1000000 VAL_LOSS_EVERY=1000 TRAIN_LOG_EVERY=100 \
+  python train_hnet.py
+
+# 3) quantise the saved checkpoint to int8 + zlib (~9.5MB output)
+python quantize_hnet.py logs/hnet_real_final.pt   # → logs/hnet_real_final.int8.ptz
+```
+
+Skip step 2 entirely if you just want to verify the reported `val_bpb`: load the included `final_model.int8.ptz` directly.
+
+## Future Work
+
+Path A (Mamba-2 layers); two-stage chunking `(3, 3)`; bigger model + data (room on both); vectorised EMA via parallel scan; stack with BPE-era tricks (Muon, partial RoPE, GPTQ).
+
+## Included Files
+
+- `hnet_model.py` — `DynamicChunking`, `upsample_with_ema`, `TransformerBlock`, `HNet`
+- `train_hnet.py` — env-var training script
+- `quantize_hnet.py` — per-row int8 + zlib with round-trip check
+- `make_byte260_smoke.py` — FineWeb-Edu → byte260 .bin shards
+- `final_model.int8.ptz` — trained weights (9.49MB)
+- `train_log.txt`, `submission.json`, `requirements.txt`
+
+## Citations
+
+- Hwang, Wang, Gu (2025). *Dynamic Chunking for End-to-End Hierarchical Sequence Modeling.* arXiv:[2507.07955](https://arxiv.org/abs/2507.07955).
+- Reference: [goombalab/hnet](https://github.com/goombalab/hnet) — `dc.py` was source of truth for EMA/STE/clipping.
+- Loshchilov & Hutter (2019). *Decoupled Weight Decay Regularization* (AdamW).
+
+## Acknowledgements
+
+Built on the parameter-golf training scaffold ([train_gpt.py](https://github.com/openai/parameter-golf/blob/main/train_gpt.py)) and its int8+zlib quantisation pipeline.
+
+**AI assistance.** Pair-programmed with Claude (Anthropic, Opus 4.7). Architecture choices, the decision to ship a boring baseline before stacking tricks, and all training runs are mine. Code drafting and README drafting were AI-assisted and human-reviewed. Following the spirit of the NeurIPS LLM use disclosure norm (separate "use of AI" statement, not co-authorship).

--- a/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/hnet_model.py
+++ b/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/hnet_model.py
@@ -1,0 +1,222 @@
+"""
+H-Net (Path B): single-stage, attention-only.
+
+Reference: Hwang, Wang, Gu (2025), "Dynamic Chunking for End-to-End Hierarchical
+Sequence Modeling", arxiv:2507.07955. Reference impl: github.com/goombalab/hnet.
+
+This is Path B from plan.md §2 — Mamba-2 layers replaced with vanilla pre-norm
+Transformer blocks so we can isolate the dynamic-chunking contribution and ship
+on Runpod without mamba_ssm CUDA-kernel surgery.
+
+Differentiability follows paper §2.2.2:
+- EMA smoothing on the upsampled (decoder-side) sequence weighted by the chunk's
+  boundary probability — primary gradient pathway, ablated as ESSENTIAL in §3.3.
+- Asymmetric confidence c_t = b·p + (1-b)·(1-p) with STE in the upsampler — paper
+  Eq. 6/7, additional optimisation stabiliser.
+"""
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+
+class DynamicChunking(nn.Module):
+    """
+    Routing + ratio loss + downsample. No STE here — STE lives in the upsampler.
+
+    forward(x) -> (compressed, comp_mask, b_hard, p, p_compressed, ratio_loss)
+        x:             (B, L, D)
+        compressed:    (B, L_max, D)        chunk-aggregated, padded
+        comp_mask:     (B, L_max) bool      True at real chunk positions
+        b_hard:        (B, L)               binary boundary indicator (no STE)
+        p:             (B, L)               soft boundary probabilities
+        p_compressed:  (B, L_max)           p values at boundary positions only
+        ratio_loss:    scalar
+    """
+
+    def __init__(self, dim: int, target_ratio: float = 1.0 / 6.0):
+        super().__init__()
+        self.W_q = nn.Linear(dim, dim, bias=False)
+        self.W_k = nn.Linear(dim, dim, bias=False)
+        self.target_ratio = target_ratio
+        # Identity init: at step 0 the router computes raw cos-sim of adjacent
+        # hidden states — a meaningful starting point (per goombalab/hnet dc.py).
+        with torch.no_grad():
+            self.W_q.weight.copy_(torch.eye(dim))
+            self.W_k.weight.copy_(torch.eye(dim))
+
+    def forward(self, x: Tensor) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor]:
+        q = F.normalize(self.W_q(x), dim=-1)
+        k = F.normalize(self.W_k(x), dim=-1)
+        k_prev = F.pad(k[:, :-1, :], (0, 0, 1, 0), value=0.0)
+        cos_sim = (q * k_prev).sum(dim=-1)
+
+        p = (0.5 * (1.0 - cos_sim)).clamp(0.0, 1.0)
+        first = torch.ones_like(p[:, :1])
+        p = torch.cat([first, p[:, 1:]], dim=1)
+
+        b_hard = (p >= 0.5).float()
+
+        N = 1.0 / self.target_ratio
+        F_actual = b_hard.mean()
+        G_actual = p.mean()
+        ratio_loss = (N / (N - 1.0)) * (
+            (N - 1.0) * F_actual * G_actual + (1.0 - F_actual) * (1.0 - G_actual)
+        )
+
+        compressed, comp_mask = _downsample(x, b_hard)
+        p_compressed, _ = _downsample(p.unsqueeze(-1), b_hard)
+        p_compressed = p_compressed.squeeze(-1)
+        return compressed, comp_mask, b_hard, p, p_compressed, ratio_loss
+
+
+def _downsample(x: Tensor, b_hard: Tensor) -> tuple[Tensor, Tensor]:
+    B, _, D = x.shape
+    counts = b_hard.long().sum(dim=1)
+    L_max = int(counts.max().item()) if B > 0 else 0
+    out = x.new_zeros(B, L_max, D)
+    mask = torch.zeros(B, L_max, dtype=torch.bool, device=x.device)
+    for i in range(B):
+        sel = x[i][b_hard[i].bool()]
+        n = sel.shape[0]
+        out[i, :n] = sel
+        mask[i, :n] = True
+    return out, mask
+
+
+def upsample_with_ema(
+    z_compressed: Tensor,
+    b_hard: Tensor,
+    p: Tensor,
+    p_compressed: Tensor,
+) -> Tensor:
+    """Chunk-level EMA → gather to fine → asymmetric STE multiplier.
+
+    Matches goombalab/hnet dc.py DeChunkLayer:
+      EMA over the COMPRESSED sequence:
+        z_bar[c] = p_c · z_compressed[c] + (1 - p_c) · z_bar[c-1]
+      Plug back to fine level:
+        out[t] = z_bar[chunk_idx[t]]
+      Asymmetric confidence + STE (paper Eq. 6/7):
+        c_t = b_hard·p + (1-b_hard)·(1-p),  STE(c_t) = c_t + stopgradient(1-c_t)
+        out[t] = STE(c_t) · out[t]
+
+    Loop runs L_max ≈ L · target_ratio times — ~6× shorter than fine-level EMA
+    at default target_ratio=1/6. Vectorise via parallel scan or mamba_ssm kernel
+    if Path A.
+    """
+    L_max = z_compressed.shape[1]
+    p_c = p_compressed.clamp(1e-4, 1.0 - 1e-4)
+
+    z_bar_steps = [z_compressed[:, 0]]
+    for c in range(1, L_max):
+        pc = p_c[:, c : c + 1]
+        z_bar_steps.append(pc * z_compressed[:, c] + (1.0 - pc) * z_bar_steps[-1])
+    z_bar_compressed = torch.stack(z_bar_steps, dim=1)
+
+    chunk_idx = (b_hard.long().cumsum(dim=1) - 1).clamp(min=0)
+    D = z_compressed.shape[-1]
+    z_bar = torch.gather(z_bar_compressed, 1, chunk_idx.unsqueeze(-1).expand(-1, -1, D))
+
+    c_score = b_hard * p + (1.0 - b_hard) * (1.0 - p)
+    c_ste = c_score + (1.0 - c_score).detach()
+    return c_ste.unsqueeze(-1) * z_bar
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, dim: int, num_heads: int, mlp_mult: int = 2):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim)
+        self.attn = nn.MultiheadAttention(dim, num_heads, batch_first=True, bias=False)
+        self.norm2 = nn.LayerNorm(dim)
+        self.mlp = nn.Sequential(
+            nn.Linear(dim, mlp_mult * dim, bias=False),
+            nn.GELU(),
+            nn.Linear(mlp_mult * dim, dim, bias=False),
+        )
+
+    def forward(
+        self,
+        x: Tensor,
+        key_padding_mask: Tensor | None = None,
+        is_causal: bool = True,
+    ) -> Tensor:
+        h = self.norm1(x)
+        attn_mask = None
+        if is_causal:
+            L = h.shape[1]
+            attn_mask = torch.triu(
+                torch.ones(L, L, dtype=torch.bool, device=h.device), diagonal=1
+            )
+        attn_out, _ = self.attn(
+            h, h, h,
+            need_weights=False,
+            attn_mask=attn_mask,
+            is_causal=is_causal,
+            key_padding_mask=key_padding_mask,
+        )
+        x = x + attn_out
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class HNet(nn.Module):
+    """Single-stage H-Net (Path B). See plan.md §3 for the dataflow."""
+
+    def __init__(
+        self,
+        vocab_size: int = 260,
+        d_enc: int = 128,
+        d_main: int = 256,
+        n_enc: int = 3,
+        n_main: int = 6,
+        n_dec: int = 3,
+        n_heads: int = 4,
+        target_ratio: float = 1.0 / 6.0,
+    ):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, d_enc)
+        self.encoder = nn.ModuleList(TransformerBlock(d_enc, n_heads) for _ in range(n_enc))
+        self.dc = DynamicChunking(d_enc, target_ratio=target_ratio)
+        self.proj_up = nn.Linear(d_enc, d_main, bias=False)
+        self.main = nn.ModuleList(TransformerBlock(d_main, n_heads) for _ in range(n_main))
+        self.proj_down = nn.Linear(d_main, d_enc, bias=False)
+        self.decoder = nn.ModuleList(TransformerBlock(d_enc, n_heads) for _ in range(n_dec))
+        self.norm_out = nn.LayerNorm(d_enc)
+        self.head = nn.Linear(d_enc, vocab_size, bias=False)
+        self.head.weight = self.embed.weight
+        nn.init.normal_(self.embed.weight, mean=0.0, std=d_enc ** -0.5)
+        # Encoder→decoder residual stays near identity at init; the chunked path
+        # only contributes once it has learned something useful (paper §2.3).
+        nn.init.normal_(self.proj_down.weight, mean=0.0, std=1e-4)
+
+    def forward(
+        self, byte_ids: Tensor, targets: Tensor | None = None
+    ) -> tuple[Tensor, Tensor]:
+        x = self.embed(byte_ids)
+        for blk in self.encoder:
+            x = blk(x)
+
+        compressed, comp_mask, b_hard, p, p_compressed, ratio_loss = self.dc(x)
+
+        z = self.proj_up(compressed)
+        pad_mask = ~comp_mask
+        for blk in self.main:
+            z = blk(z, key_padding_mask=pad_mask)
+        z = self.proj_down(z)
+
+        x = x + upsample_with_ema(z, b_hard, p, p_compressed)
+        for blk in self.decoder:
+            x = blk(x)
+        x = self.norm_out(x)
+        logits = self.head(x)
+
+        if targets is None:
+            return logits, ratio_loss
+        ar_loss = F.cross_entropy(
+            logits.reshape(-1, logits.shape[-1]),
+            targets.reshape(-1),
+        )
+        return ar_loss, ratio_loss

--- a/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/make_byte260_smoke.py
+++ b/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/make_byte260_smoke.py
@@ -1,0 +1,83 @@
+"""One-off helper: build a tiny byte260 dataset for *local smoke testing*.
+
+Streams FineWeb-Edu via HuggingFace, encodes UTF-8 bytes with the parameter-golf
+PureByteTokenizer (vocab 260: 4 specials + 256 byte values, offset 4), writes
+two shards in the parameter-golf .bin format (header magic 20240520, uint16
+tokens). Output goes to data/datasets/fineweb10B_byte260/.
+
+This is NOT the official byte260 export — that requires re-tokenizing the
+exact docs_selected.jsonl from the parameter-golf manifest. Use this only for
+proving train_hnet.py runs end-to-end. Real numbers go on Runpod.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+DATAFILE_MAGIC = 20240520
+DATAFILE_VERSION = 1
+BYTE_OFFSET = 4
+
+TRAIN_TARGET_BYTES = 4_000_000
+VAL_TARGET_BYTES = 200_000
+
+
+def encode_text(text: str) -> np.ndarray:
+    raw = text.encode("utf-8", errors="replace")
+    return np.frombuffer(raw, dtype=np.uint8).astype(np.uint16) + BYTE_OFFSET
+
+
+def write_shard(path: Path, tokens: np.ndarray) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    header = np.zeros(256, dtype=np.int32)
+    header[0] = DATAFILE_MAGIC
+    header[1] = DATAFILE_VERSION
+    header[2] = len(tokens)
+    with open(path, "wb") as f:
+        f.write(header.tobytes())
+        f.write(tokens.astype(np.uint16).tobytes())
+
+
+def main() -> None:
+    try:
+        from datasets import load_dataset
+    except ImportError:
+        print("missing huggingface datasets — pip install datasets", file=sys.stderr)
+        raise
+
+    out_dir = Path("data/datasets/fineweb10B_byte260")
+    print(f"streaming FineWeb-Edu sample into {out_dir} ...", flush=True)
+    ds = load_dataset(
+        "HuggingFaceFW/fineweb-edu", "sample-10BT", split="train", streaming=True
+    )
+
+    val_chunks: list[np.ndarray] = []
+    train_chunks: list[np.ndarray] = []
+    val_bytes = train_bytes = 0
+
+    for i, doc in enumerate(ds):
+        toks = encode_text(doc["text"])
+        if val_bytes < VAL_TARGET_BYTES:
+            val_chunks.append(toks)
+            val_bytes += toks.size
+        elif train_bytes < TRAIN_TARGET_BYTES:
+            train_chunks.append(toks)
+            train_bytes += toks.size
+        else:
+            break
+        if (i + 1) % 200 == 0:
+            print(f"  doc {i+1}: val={val_bytes:,} train={train_bytes:,}", flush=True)
+
+    train_arr = np.concatenate(train_chunks)
+    val_arr = np.concatenate(val_chunks)
+    print(f"final: train={train_arr.size:,} val={val_arr.size:,}")
+
+    write_shard(out_dir / "fineweb_train_000000.bin", train_arr)
+    write_shard(out_dir / "fineweb_val_000000.bin", val_arr)
+    print(f"wrote shards to {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/quantize_hnet.py
+++ b/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/quantize_hnet.py
@@ -1,0 +1,140 @@
+"""
+Quantise an HNet checkpoint to int8 + zlib for the parameter-golf 16MB artifact.
+
+Mirrors train_gpt.py's INT8 pipeline (per-row int8 for 2D matrices, per-tensor
+int8 for 1D, tiny tensors kept as fp16) and zlib-compresses the pickled dict.
+
+Usage:
+    python quantize_hnet.py logs/hnet_real_final.pt
+Produces:
+    logs/hnet_real_final.int8.ptz
+"""
+from __future__ import annotations
+
+import io
+import pickle
+import sys
+import zlib
+from pathlib import Path
+
+import torch
+from torch import Tensor
+
+
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_Q = 99.99984 / 100.0
+
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        clip_abs = torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+
+def quantize_state_dict(sd: dict[str, Tensor]) -> dict:
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_dtypes: dict[str, str] = {}
+
+    for name, tensor in sd.items():
+        t = tensor.detach().to("cpu").contiguous()
+        if not t.is_floating_point():
+            passthrough[name] = t
+            continue
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            if t.dtype in {torch.float32, torch.bfloat16}:
+                passthrough_dtypes[name] = str(t.dtype).removeprefix("torch.")
+                passthrough[name] = t.to(INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        q, s = quantize_float_tensor(t)
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+
+    return {
+        "__quant_format__": "int8_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+        "passthrough_orig_dtypes": passthrough_dtypes,
+    }
+
+
+def dequantize(blob: dict) -> dict[str, Tensor]:
+    """Inverse of quantize_state_dict — returns a state_dict ready for load_state_dict."""
+    out: dict[str, Tensor] = {}
+    quantized = blob["quantized"]
+    scales = blob["scales"]
+    dtypes = blob["dtypes"]
+    for name, q in quantized.items():
+        s = scales[name].to(torch.float32)
+        target_dtype = getattr(torch, dtypes[name])
+        if q.ndim == 2:
+            out[name] = (q.to(torch.float32) * s[:, None]).to(target_dtype)
+        else:
+            out[name] = (q.to(torch.float32) * s).to(target_dtype)
+    for name, t in blob["passthrough"].items():
+        orig = blob.get("passthrough_orig_dtypes", {}).get(name)
+        out[name] = t.to(getattr(torch, orig)) if orig else t
+    return out
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("usage: python quantize_hnet.py <path_to_final.pt>")
+        sys.exit(1)
+    in_path = Path(sys.argv[1])
+
+    print(f"loading {in_path}")
+    ckpt = torch.load(in_path, map_location="cpu", weights_only=False)
+    sd = ckpt["state_dict"] if isinstance(ckpt, dict) and "state_dict" in ckpt else ckpt
+
+    n_params = sum(t.numel() for t in sd.values() if t.is_floating_point())
+    raw_bytes = sum(t.numel() * t.element_size() for t in sd.values())
+    print(f"params:       {n_params:,}")
+    print(f"raw size:     {raw_bytes:>12,} bytes  ({raw_bytes/1e6:6.2f} MB)")
+
+    blob = quantize_state_dict(sd)
+    buf = io.BytesIO()
+    pickle.dump(blob, buf, protocol=pickle.HIGHEST_PROTOCOL)
+    pickled = buf.getvalue()
+    compressed = zlib.compress(pickled, level=9)
+
+    out_path = in_path.with_suffix(".int8.ptz")
+    out_path.write_bytes(compressed)
+    print(f"int8 pickled: {len(pickled):>12,} bytes  ({len(pickled)/1e6:6.2f} MB)")
+    print(f"int8+zlib:    {len(compressed):>12,} bytes  ({len(compressed)/1e6:6.2f} MB)")
+    print(f"compression:  {raw_bytes / max(1, len(compressed)):.2f}x")
+    print(f"saved:        {out_path}")
+
+    # Verify round-trip: pickled-decompress-dequantize and compare a few tensors.
+    rt = pickle.loads(zlib.decompress(out_path.read_bytes()))
+    rt_sd = dequantize(rt)
+    n_check = 0
+    max_err = 0.0
+    for name, orig in sd.items():
+        if orig.is_floating_point() and orig.numel() > INT8_KEEP_FLOAT_MAX_NUMEL:
+            err = (orig.float() - rt_sd[name].float()).abs().max().item()
+            max_err = max(max_err, err)
+            n_check += 1
+    print(f"round-trip:   {n_check} tensors checked, max abs error = {max_err:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/requirements.txt
+++ b/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/requirements.txt
@@ -1,0 +1,5 @@
+torch>=2.4
+numpy
+huggingface-hub
+datasets
+tqdm

--- a/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/submission.json
+++ b/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/submission.json
@@ -1,0 +1,11 @@
+{
+  "author": "Azura Whiston",
+  "github_id": "Azura-Whiston",
+  "name": "H-Net Dynamic Chunking — Path B (Attention-Only)",
+  "blurb": "Single-stage H-Net (Hwang/Wang/Gu 2025, arxiv:2507.07955) with Mamba-2 layers replaced by pre-norm Transformer blocks to isolate the dynamic-chunking contribution. 16.27M params, byte-level vocab 260, 300MB FineWeb-Edu, ~100 min on 1xA6000. EMA + asymmetric STE per paper Eq. 5/6/7, identity-init routing, target_ratio = 1/6. Int8 + zlib weights = 9.49MB; total submission ~9.52MB.",
+  "date": "2026-04-26T05:30:00Z",
+  "val_loss": 1.3057,
+  "val_bpb": 1.8838,
+  "bytes_total": 9518267,
+  "bytes_code": 26499
+}

--- a/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/train_hnet.py
+++ b/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/train_hnet.py
@@ -1,0 +1,279 @@
+"""
+H-Net training script. Single GPU (or CPU). Plain AdamW, no Muon, no compile.
+
+Run:
+    python train_hnet.py
+
+Env vars (same convention as train_gpt.py):
+    DATA_PATH            ./data/datasets/fineweb10B_byte260
+    RUN_ID               smoke
+    ITERATIONS           500
+    TRAIN_BATCH_TOKENS   8192        bytes per optimizer step
+    TRAIN_SEQ_LEN        1024
+    VAL_BATCH_SIZE       8192
+    VAL_LOSS_EVERY       0           0 = only at end
+    VAL_TOKENS_CAP       65536       cap val tokens for fast iteration; 0 = full split
+    LR                   3e-4
+    WARMUP_STEPS         100
+    WEIGHT_DECAY         0.1
+    RATIO_LOSS_ALPHA     0.03
+    TARGET_RATIO         0.25
+    D_ENC, D_MAIN        128, 256
+    N_ENC, N_MAIN, N_DEC 3, 6, 3
+    N_HEADS              4
+    SEED                 1337
+"""
+from __future__ import annotations
+
+import glob
+import math
+import os
+import time
+import uuid
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch.backends.cuda import enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp, enable_cudnn_sdp
+
+from hnet_model import HNet
+
+
+# -----------------------------
+# DATA LOADING (byte260 .bin shards)
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"no shards found for pattern: {pattern}")
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self) -> None:
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        rem = n
+        while rem > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance()
+                continue
+            k = min(rem, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            rem -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+def next_train_batch(
+    stream: TokenStream, batch_tokens: int, seq_len: int, device: torch.device
+) -> tuple[Tensor, Tensor]:
+    raw = stream.take(batch_tokens + 1).to(dtype=torch.int64)
+    x = raw[:-1].reshape(-1, seq_len)
+    y = raw[1:].reshape(-1, seq_len)
+    return x.to(device, non_blocking=True), y.to(device, non_blocking=True)
+
+
+def load_val_tokens(pattern: str, seq_len: int, cap: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"no val shards: {pattern}")
+    tokens = torch.cat([load_data_shard(f) for f in files])
+    if cap > 0:
+        tokens = tokens[: cap + 1]
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError("val split too short for seq_len")
+    return tokens[: usable + 1]
+
+
+# -----------------------------
+# VAL_BPB FOR BYTE260
+# -----------------------------
+# byte260 vocab (PureByteTokenizer, data/download_hf_docs_and_tokenize.py):
+#   0=PAD, 1=BOS, 2=EOS, 3=UNK (specials, 0 byte cost)
+#   4..259 = the 256 raw byte values (1 byte each)
+
+_BYTES_PER_TOKEN_LUT: Tensor | None = None
+
+def bytes_per_token_lut(device: torch.device) -> Tensor:
+    global _BYTES_PER_TOKEN_LUT
+    if _BYTES_PER_TOKEN_LUT is None or _BYTES_PER_TOKEN_LUT.device != device:
+        lut = torch.zeros(260, dtype=torch.int16, device=device)
+        lut[4:] = 1
+        _BYTES_PER_TOKEN_LUT = lut
+    return _BYTES_PER_TOKEN_LUT
+
+
+@torch.inference_mode()
+def eval_val_bpb(
+    model: HNet,
+    val_tokens: Tensor,
+    seq_len: int,
+    batch_seqs: int,
+    device: torch.device,
+) -> tuple[float, float]:
+    model.eval()
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    bpt_lut = bytes_per_token_lut(device)
+    nll_sum = torch.zeros((), device=device, dtype=torch.float64)
+    tok_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    for s in range(0, total_seqs, batch_seqs):
+        end = min(s + batch_seqs, total_seqs)
+        raw_start = s * seq_len
+        raw_end = end * seq_len + 1
+        chunk = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+        x = chunk[:-1].reshape(-1, seq_len)
+        y = chunk[1:].reshape(-1, seq_len)
+        with torch.autocast(device_type=device.type, dtype=torch.bfloat16, enabled=device.type == "cuda"):
+            ar_loss, _ = model(x, y)
+        n = float(y.numel())
+        nll_sum += ar_loss.to(torch.float64) * n
+        tok_count += n
+        byte_count += bpt_lut[y.reshape(-1)].to(torch.float64).sum()
+
+    val_loss = (nll_sum / tok_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = (tok_count / byte_count).item()
+    model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+# -----------------------------
+# MAIN
+# -----------------------------
+
+def main() -> None:
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_byte260")
+    train_pattern = os.path.join(data_path, "fineweb_train_*.bin")
+    val_pattern = os.path.join(data_path, "fineweb_val_*.bin")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4())[:8])
+    seed = int(os.environ.get("SEED", 1337))
+
+    iterations = int(os.environ.get("ITERATIONS", 500))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 8192))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 8192))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 0))
+    val_tokens_cap = int(os.environ.get("VAL_TOKENS_CAP", 65536))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 50))
+
+    lr = float(os.environ.get("LR", 3e-4))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 100))
+    weight_decay = float(os.environ.get("WEIGHT_DECAY", 0.1))
+    ratio_loss_alpha = float(os.environ.get("RATIO_LOSS_ALPHA", 0.03))
+    target_ratio = float(os.environ.get("TARGET_RATIO", 1.0 / 6.0))
+
+    d_enc = int(os.environ.get("D_ENC", 128))
+    d_main = int(os.environ.get("D_MAIN", 256))
+    n_enc = int(os.environ.get("N_ENC", 3))
+    n_main = int(os.environ.get("N_MAIN", 6))
+    n_dec = int(os.environ.get("N_DEC", 3))
+    n_heads = int(os.environ.get("N_HEADS", 4))
+
+    torch.manual_seed(seed)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if device.type == "cuda":
+        torch.cuda.manual_seed(seed)
+        # Windows wheels lack flash; fall back to math/cudnn so MHA has a kernel.
+        enable_flash_sdp(False)
+        enable_mem_efficient_sdp(False)
+        enable_cudnn_sdp(True)
+        enable_math_sdp(True)
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+
+    os.makedirs("logs", exist_ok=True)
+    logfile = f"logs/{run_id}.txt"
+
+    def log(msg: str) -> None:
+        print(msg)
+        with open(logfile, "a", encoding="utf-8") as f:
+            print(msg, file=f)
+
+    log(f"run_id:{run_id} device:{device}")
+    log(f"data_path:{data_path}")
+
+    train_stream = TokenStream(train_pattern)
+    val_tokens = load_val_tokens(val_pattern, train_seq_len, val_tokens_cap)
+    log(f"val_tokens:{val_tokens.numel()}")
+
+    model = HNet(
+        vocab_size=260, d_enc=d_enc, d_main=d_main,
+        n_enc=n_enc, n_main=n_main, n_dec=n_dec, n_heads=n_heads,
+        target_ratio=target_ratio,
+    ).to(device)
+    n_params = sum(p.numel() for p in model.parameters())
+    log(f"model_params:{n_params:,}")
+    log(f"shape: d_enc={d_enc} d_main={d_main} n_enc={n_enc} n_main={n_main} n_dec={n_dec} heads={n_heads}")
+    log(f"target_ratio:{target_ratio} ratio_alpha:{ratio_loss_alpha}")
+
+    opt = torch.optim.AdamW(
+        model.parameters(), lr=lr, betas=(0.9, 0.95),
+        weight_decay=weight_decay, eps=1e-8,
+    )
+
+    def lr_at(step: int) -> float:
+        if step < warmup_steps:
+            return lr * (step + 1) / warmup_steps
+        progress = (step - warmup_steps) / max(1, iterations - warmup_steps)
+        return lr * 0.5 * (1.0 + math.cos(math.pi * min(1.0, progress)))
+
+    val_seqs = max(1, val_batch_size // train_seq_len)
+    t0 = time.time()
+    for step in range(iterations):
+        for g in opt.param_groups:
+            g["lr"] = lr_at(step)
+
+        x, y = next_train_batch(train_stream, train_batch_tokens, train_seq_len, device)
+        with torch.autocast(device_type=device.type, dtype=torch.bfloat16, enabled=device.type == "cuda"):
+            ar_loss, ratio_loss = model(x, y)
+        loss = ar_loss + ratio_loss_alpha * ratio_loss
+        opt.zero_grad(set_to_none=True)
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+        opt.step()
+
+        if (step + 1) % train_log_every == 0 or step == 0:
+            elapsed = time.time() - t0
+            log(
+                f"step:{step+1}/{iterations} ar:{ar_loss.item():.4f} "
+                f"ratio:{ratio_loss.item():.4f} lr:{lr_at(step):.2e} "
+                f"elapsed:{elapsed:.1f}s"
+            )
+
+        if val_loss_every > 0 and (step + 1) % val_loss_every == 0:
+            vl, vb = eval_val_bpb(model, val_tokens, train_seq_len, val_seqs, device)
+            log(f"step:{step+1} val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+
+    vl, vb = eval_val_bpb(model, val_tokens, train_seq_len, val_seqs, device)
+    log(f"final step:{iterations} val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+
+    ckpt_path = f"logs/{run_id}_final.pt"
+    torch.save({"state_dict": model.state_dict(), "val_bpb": vb, "params": n_params}, ckpt_path)
+    log(f"saved:{ckpt_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/train_log.txt
+++ b/records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/train_log.txt
@@ -1,0 +1,119 @@
+run_id:hnet_real device:cuda
+data_path:./data/datasets/fineweb10B_byte260
+val_tokens:999425
+model_params:16,207,360
+shape: d_enc=256 d_main=512 n_enc=3 n_main=6 n_dec=3 heads=8
+target_ratio:0.16666666666666666 ratio_alpha:0.03
+step:1/10000 ar:5.9513 ratio:1.1550 lr:6.00e-07 elapsed:1.4s
+step:100/10000 ar:2.9520 ratio:0.8569 lr:6.00e-05 elapsed:55.5s
+step:200/10000 ar:2.5991 ratio:1.0588 lr:1.20e-04 elapsed:117.6s
+step:300/10000 ar:2.4614 ratio:1.0819 lr:1.80e-04 elapsed:180.2s
+step:400/10000 ar:2.3934 ratio:1.0729 lr:2.40e-04 elapsed:241.8s
+step:500/10000 ar:2.2915 ratio:1.1291 lr:3.00e-04 elapsed:303.0s
+step:600/10000 ar:2.3054 ratio:1.0753 lr:3.00e-04 elapsed:364.2s
+step:700/10000 ar:2.2937 ratio:1.0837 lr:3.00e-04 elapsed:425.9s
+step:800/10000 ar:2.2813 ratio:1.1021 lr:2.99e-04 elapsed:486.8s
+step:900/10000 ar:2.2760 ratio:1.0741 lr:2.99e-04 elapsed:548.7s
+step:1000/10000 ar:2.1875 ratio:1.1224 lr:2.98e-04 elapsed:610.9s
+step:1000 val_loss:2.2101 val_bpb:3.1885
+step:1100/10000 ar:2.1763 ratio:1.0884 lr:2.97e-04 elapsed:684.6s
+step:1200/10000 ar:2.1559 ratio:1.0466 lr:2.96e-04 elapsed:747.3s
+step:1300/10000 ar:2.0636 ratio:1.0933 lr:2.95e-04 elapsed:810.0s
+step:1400/10000 ar:2.1348 ratio:1.0812 lr:2.93e-04 elapsed:872.9s
+step:1500/10000 ar:2.1762 ratio:1.0834 lr:2.92e-04 elapsed:936.2s
+step:1600/10000 ar:2.1819 ratio:1.1606 lr:2.90e-04 elapsed:999.7s
+step:1700/10000 ar:2.0977 ratio:1.1068 lr:2.88e-04 elapsed:1062.9s
+step:1800/10000 ar:2.0663 ratio:1.0730 lr:2.86e-04 elapsed:1125.5s
+step:1900/10000 ar:1.9469 ratio:1.0762 lr:2.84e-04 elapsed:1186.6s
+step:2000/10000 ar:1.9616 ratio:1.0510 lr:2.82e-04 elapsed:1247.1s
+step:2000 val_loss:2.0267 val_bpb:2.9240
+step:2100/10000 ar:1.8734 ratio:1.0371 lr:2.80e-04 elapsed:1318.2s
+step:2200/10000 ar:1.9251 ratio:1.0531 lr:2.77e-04 elapsed:1378.0s
+step:2300/10000 ar:1.7951 ratio:1.0382 lr:2.74e-04 elapsed:1437.8s
+step:2400/10000 ar:1.8345 ratio:1.0204 lr:2.71e-04 elapsed:1497.1s
+step:2500/10000 ar:1.7009 ratio:1.0345 lr:2.68e-04 elapsed:1556.4s
+step:2600/10000 ar:1.7182 ratio:1.0330 lr:2.65e-04 elapsed:1615.9s
+step:2700/10000 ar:2.1248 ratio:1.0200 lr:2.62e-04 elapsed:1675.1s
+step:2800/10000 ar:1.5461 ratio:1.0294 lr:2.59e-04 elapsed:1734.4s
+step:2900/10000 ar:1.6854 ratio:1.0318 lr:2.55e-04 elapsed:1793.1s
+step:3000/10000 ar:1.5622 ratio:1.0291 lr:2.52e-04 elapsed:1852.3s
+step:3000 val_loss:1.6078 val_bpb:2.3195
+step:3100/10000 ar:1.7196 ratio:1.0071 lr:2.48e-04 elapsed:1921.9s
+step:3200/10000 ar:1.6254 ratio:1.0240 lr:2.44e-04 elapsed:1980.9s
+step:3300/10000 ar:1.5080 ratio:1.0414 lr:2.40e-04 elapsed:2039.7s
+step:3400/10000 ar:1.5699 ratio:1.0233 lr:2.36e-04 elapsed:2098.8s
+step:3500/10000 ar:1.4908 ratio:1.0119 lr:2.32e-04 elapsed:2157.9s
+step:3600/10000 ar:1.6707 ratio:1.0335 lr:2.28e-04 elapsed:2216.8s
+step:3700/10000 ar:1.5724 ratio:1.0281 lr:2.24e-04 elapsed:2275.9s
+step:3800/10000 ar:1.4987 ratio:1.0101 lr:2.19e-04 elapsed:2335.0s
+step:3900/10000 ar:1.5002 ratio:1.0258 lr:2.15e-04 elapsed:2394.0s
+step:4000/10000 ar:1.4109 ratio:1.0311 lr:2.10e-04 elapsed:2452.8s
+step:4000 val_loss:1.4641 val_bpb:2.1123
+step:4100/10000 ar:1.2063 ratio:0.9887 lr:2.06e-04 elapsed:2522.5s
+step:4200/10000 ar:1.5407 ratio:1.0169 lr:2.01e-04 elapsed:2581.3s
+step:4300/10000 ar:1.4647 ratio:1.0392 lr:1.96e-04 elapsed:2640.2s
+step:4400/10000 ar:1.4407 ratio:1.0154 lr:1.92e-04 elapsed:2698.8s
+step:4500/10000 ar:1.4304 ratio:1.0151 lr:1.87e-04 elapsed:2757.1s
+step:4600/10000 ar:1.4556 ratio:1.0201 lr:1.82e-04 elapsed:2815.5s
+step:4700/10000 ar:1.3528 ratio:1.0256 lr:1.77e-04 elapsed:2874.0s
+step:4800/10000 ar:1.4351 ratio:1.0330 lr:1.72e-04 elapsed:2932.4s
+step:4900/10000 ar:1.3769 ratio:1.0273 lr:1.67e-04 elapsed:2991.2s
+step:5000/10000 ar:1.4616 ratio:1.0255 lr:1.62e-04 elapsed:3049.5s
+step:5000 val_loss:1.4007 val_bpb:2.0208
+step:5100/10000 ar:1.3855 ratio:1.0170 lr:1.57e-04 elapsed:3118.3s
+step:5200/10000 ar:1.4544 ratio:1.0418 lr:1.53e-04 elapsed:3176.7s
+step:5300/10000 ar:1.3683 ratio:1.0278 lr:1.48e-04 elapsed:3234.5s
+step:5400/10000 ar:1.3544 ratio:1.0156 lr:1.43e-04 elapsed:3292.6s
+step:5500/10000 ar:1.7021 ratio:1.0577 lr:1.38e-04 elapsed:3351.1s
+step:5600/10000 ar:1.3580 ratio:1.0207 lr:1.33e-04 elapsed:3409.3s
+step:5700/10000 ar:1.4027 ratio:1.0215 lr:1.28e-04 elapsed:3467.3s
+step:5800/10000 ar:1.2368 ratio:1.0107 lr:1.23e-04 elapsed:3525.2s
+step:5900/10000 ar:1.3203 ratio:1.0253 lr:1.18e-04 elapsed:3583.4s
+step:6000/10000 ar:1.2483 ratio:1.0219 lr:1.13e-04 elapsed:3641.5s
+step:6000 val_loss:1.3610 val_bpb:1.9635
+step:6100/10000 ar:1.3413 ratio:1.0271 lr:1.08e-04 elapsed:3709.8s
+step:6200/10000 ar:1.3333 ratio:1.0174 lr:1.04e-04 elapsed:3768.2s
+step:6300/10000 ar:1.3345 ratio:1.0245 lr:9.90e-05 elapsed:3826.9s
+step:6400/10000 ar:1.3906 ratio:1.0139 lr:9.44e-05 elapsed:3885.6s
+step:6500/10000 ar:1.2670 ratio:1.0391 lr:8.98e-05 elapsed:3944.5s
+step:6600/10000 ar:1.2316 ratio:1.0035 lr:8.53e-05 elapsed:4003.7s
+step:6700/10000 ar:1.3863 ratio:1.0120 lr:8.08e-05 elapsed:4062.4s
+step:6800/10000 ar:1.3345 ratio:1.0269 lr:7.65e-05 elapsed:4121.0s
+step:6900/10000 ar:1.3545 ratio:1.0374 lr:7.22e-05 elapsed:4180.1s
+step:7000/10000 ar:1.3612 ratio:1.0427 lr:6.80e-05 elapsed:4239.2s
+step:7000 val_loss:1.3379 val_bpb:1.9302
+step:7100/10000 ar:1.2992 ratio:1.0215 lr:6.39e-05 elapsed:4309.6s
+step:7200/10000 ar:1.4948 ratio:1.0354 lr:5.99e-05 elapsed:4369.1s
+step:7300/10000 ar:1.3773 ratio:1.0454 lr:5.60e-05 elapsed:4428.5s
+step:7400/10000 ar:1.2852 ratio:1.0256 lr:5.21e-05 elapsed:4487.7s
+step:7500/10000 ar:1.2609 ratio:1.0277 lr:4.84e-05 elapsed:4546.9s
+step:7600/10000 ar:1.2841 ratio:1.0103 lr:4.48e-05 elapsed:4606.2s
+step:7700/10000 ar:1.2595 ratio:1.0146 lr:4.14e-05 elapsed:4665.3s
+step:7800/10000 ar:1.3027 ratio:1.0239 lr:3.80e-05 elapsed:4724.5s
+step:7900/10000 ar:1.0431 ratio:0.9904 lr:3.48e-05 elapsed:4783.8s
+step:8000/10000 ar:1.3243 ratio:1.0325 lr:3.17e-05 elapsed:4842.7s
+step:8000 val_loss:1.3174 val_bpb:1.9007
+step:8100/10000 ar:1.3068 ratio:1.0198 lr:2.87e-05 elapsed:4912.7s
+step:8200/10000 ar:1.3000 ratio:1.0334 lr:2.58e-05 elapsed:4971.4s
+step:8300/10000 ar:1.2294 ratio:1.0179 lr:2.31e-05 elapsed:5029.6s
+step:8400/10000 ar:1.2348 ratio:1.0405 lr:2.05e-05 elapsed:5087.8s
+step:8500/10000 ar:1.2245 ratio:1.0255 lr:1.81e-05 elapsed:5146.2s
+step:8600/10000 ar:1.2468 ratio:1.0182 lr:1.58e-05 elapsed:5204.2s
+step:8700/10000 ar:1.2672 ratio:1.0295 lr:1.37e-05 elapsed:5262.3s
+step:8800/10000 ar:1.3610 ratio:1.0276 lr:1.17e-05 elapsed:5320.9s
+step:8900/10000 ar:1.2986 ratio:1.0259 lr:9.83e-06 elapsed:5379.1s
+step:9000/10000 ar:1.3823 ratio:1.0467 lr:8.14e-06 elapsed:5437.1s
+step:9000 val_loss:1.3029 val_bpb:1.8796
+step:9100/10000 ar:1.2411 ratio:1.0201 lr:6.61e-06 elapsed:5505.2s
+step:9200/10000 ar:1.3845 ratio:1.0318 lr:5.23e-06 elapsed:5563.1s
+step:9300/10000 ar:1.3786 ratio:1.0401 lr:4.01e-06 elapsed:5621.0s
+step:9400/10000 ar:1.3988 ratio:1.0272 lr:2.95e-06 elapsed:5679.1s
+step:9500/10000 ar:1.2339 ratio:1.0286 lr:2.05e-06 elapsed:5737.7s
+step:9600/10000 ar:1.2787 ratio:1.0322 lr:1.32e-06 elapsed:5796.3s
+step:9700/10000 ar:1.3168 ratio:1.0367 lr:7.42e-07 elapsed:5854.6s
+step:9800/10000 ar:1.2727 ratio:1.0243 lr:3.31e-07 elapsed:5912.8s
+step:9900/10000 ar:1.2522 ratio:1.0197 lr:8.37e-08 elapsed:5971.4s
+step:10000/10000 ar:1.4634 ratio:1.0604 lr:8.20e-12 elapsed:6029.9s
+step:10000 val_loss:1.3001 val_bpb:1.8756
+final step:10000 val_loss:1.3001 val_bpb:1.8756
+saved:logs/hnet_real_final.pt


### PR DESCRIPTION
Non-record submission to `track_non_record_16mb/`, **unlimited-compute track** (~100 min on 1×A6000, not the 10-min/8×H100 budget).

First implementation of H-Net dynamic chunking (Hwang, Wang & Gu 2025, [arxiv:2507.07955](https://arxiv.org/abs/2507.07955)) on parameter-golf. Mamba-2 layers replaced by pre-norm Transformer blocks ("Path B") so the chunking contribution can be evaluated in isolation against the byte-level + 16MB constraint.

**Headline:**
- `val_bpb = 1.8838` (verified end-to-end by loading the shipped `final_model.int8.ptz` from disk and running val on the full split)
- 16.27M params, 9.49MB compressed (well under 16MB cap)
- Single-stage chunking, target_ratio = 1/6, byte260 vocab

Full architecture, sizing rationale, val_bpb verification (per submission rules — tokenizer changed from sp1024 BPE to byte260), quantisation ablation table (int8/6/4/3/2/1 with zlib + lzma), and reproducing instructions in:
[`records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/README.md`](records/track_non_record_16mb/2026-04-26_HNet_DynamicChunking_AttnOnly/README.md)

This addresses the unchecked **`H-net tokenization`** item under "Requests for PRs" in the project README.

AI assistance disclosed in the submission's Acknowledgements section (Claude as pair-programmer; architecture choices, training runs, debugging direction are mine; code drafting and README were AI-assisted and human-reviewed).