### PR TITLE
[train_gpt.py] Autodetect muon warmup from measured step speed

### DIFF
--- a/train_gpt.py
+++ b/train_gpt.py
@@ -80,16 +80,18 @@ class Hyperparameters:
     muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
     muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
     muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
-    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    # -1 means auto-detect from warmup timing. Set MUON_MOMENTUM_WARMUP_STEPS explicitly to override.
+    _muon_warmup_env = os.environ.get("MUON_MOMENTUM_WARMUP_STEPS")
+    muon_momentum_warmup_steps = int(_muon_warmup_env) if _muon_warmup_env is not None else -1
     beta1 = float(os.environ.get("BETA1", 0.9))
     beta2 = float(os.environ.get("BETA2", 0.95))
     adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
     grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
 
 # -----------------------------
-# MUON OPTIMIZER 
+# MUON OPTIMIZER
 # -----------------------------
-# 
+#
 # As borrowed from modded-nanogpt
 # Background on Muon: https://kellerjordan.github.io/posts/muon/
 
@@ -169,7 +171,7 @@ class Muon(torch.optim.Optimizer):
 
 
 # -----------------------------
-# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+# TOKENIZER-AGNOSTIC EVALUATION SETUP
 # -----------------------------
 #
 # It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
@@ -423,7 +425,7 @@ def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
 
 
 # -----------------------------
-# DATA LOADING 
+# DATA LOADING
 # -----------------------------
 
 def load_data_shard(file: Path) -> Tensor:
@@ -934,11 +936,16 @@ def main() -> None:
 
     # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
     # initial weights/optimizer state so measured training starts from the true init.
+    # The second half of warmup steps (after JIT settles) are timed to estimate actual
+    # step speed, which is used to auto-set muon_momentum_warmup_steps when not explicit.
+    warmup_step_times: list[float] = []
     if args.warmup_steps > 0:
         initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
         initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
         model.train()
         for warmup_step in range(args.warmup_steps):
+            torch.cuda.synchronize()
+            _ws_t0 = time.perf_counter()
             zero_grad_all()
             for micro_step in range(grad_accum_steps):
                 if distributed:
@@ -950,6 +957,9 @@ def main() -> None:
             for opt in optimizers:
                 opt.step()
             zero_grad_all()
+            torch.cuda.synchronize()
+            if warmup_step >= args.warmup_steps // 2:
+                warmup_step_times.append(time.perf_counter() - _ws_t0)
             if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
                 log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
         base_model.load_state_dict(initial_model_state, strict=True)
@@ -959,6 +969,22 @@ def main() -> None:
         if distributed:
             model.require_backward_grad_sync = True
         train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # Auto-set Muon momentum warmup steps from measured step speed.
+    # Targets reaching full momentum by 25% of training so 75% runs at peak 0.95.
+    # Override by setting MUON_MOMENTUM_WARMUP_STEPS explicitly.
+    if args.muon_momentum_warmup_steps < 0:
+        if warmup_step_times and max_wallclock_ms is not None:
+            est_step_ms = 1000.0 * sum(warmup_step_times) / len(warmup_step_times)
+            est_total_steps = int(max_wallclock_ms / est_step_ms)
+            args.muon_momentum_warmup_steps = max(20, min(est_total_steps // 4, 500))
+            log0(
+                f"muon_warmup_auto: est_step_ms={est_step_ms:.0f} est_total_steps={est_total_steps} "
+                f"muon_momentum_warmup_steps={args.muon_momentum_warmup_steps}"
+            )
+        else:
+            args.muon_momentum_warmup_steps = 100
+            log0("muon_warmup_auto: no timing data, fallback muon_momentum_warmup_steps=100")
 
     # -----------------------------
     # MAIN TRAINING LOOP

--- a/train_gpt_mlx.py
+++ b/train_gpt_mlx.py
@@ -91,7 +91,9 @@ class Hyperparameters:
     muon_momentum: float = float(os.environ.get("MUON_MOMENTUM", 0.95))
     muon_backend_steps: int = int(os.environ.get("MUON_BACKEND_STEPS", 5))
     muon_momentum_warmup_start: float = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
-    muon_momentum_warmup_steps: int = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    # -1 means auto-detect from warmup timing. Set MUON_MOMENTUM_WARMUP_STEPS explicitly to override.
+    _muon_warmup_env = os.environ.get("MUON_MOMENTUM_WARMUP_STEPS")
+    muon_momentum_warmup_steps: int = int(_muon_warmup_env) if _muon_warmup_env is not None else -1
     grad_clip_norm: float = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
 
     out_dir: str = os.environ.get("OUT_DIR", "logs")
@@ -463,7 +465,7 @@ class Muon:
         self.buffers = {k: mx.zeros_like(params[k]) for k in keys}
 
     def step(self, params: dict[str, mx.array], grads: dict[str, mx.array], step: int, lr_mul: float) -> dict[str, mx.array]:
-        if self.args.muon_momentum_warmup_steps:
+        if self.args.muon_momentum_warmup_steps > 0:
             t = min(step / self.args.muon_momentum_warmup_steps, 1.0)
             momentum = (1.0 - t) * self.args.muon_momentum_warmup_start + t * self.args.muon_momentum
         else:
@@ -960,12 +962,15 @@ def main() -> None:
     # ==============================================================================
     # TRAINING LOOP
     # ==============================================================================
+    # Warmup primes MLX compile/allocation paths. The second half of warmup steps
+    # (after graph compilation settles) are timed to estimate actual step speed,
+    # which is used to auto-set muon_momentum_warmup_steps when not explicit.
+    # Note: MLX warmup does not apply optimizer updates; step time is forward+backward only,
+    # which is a slight underestimate of full step time (optimizer adds ~5-10%).
+    warmup_step_times: list[float] = []
     if args.warmup_steps > 0:
-        # Warmup should only prime MLX compile/allocation paths. Updating parameters here forces us
-        # to snapshot and restore model/optimizer state, which is expensive on unified-memory Macs.
-        # Instead we run the real train shapes, force the loss/grads to materialize, and then reset
-        # the loader so measured training still starts from the true init and token window.
         for warmup_step in range(args.warmup_steps):
+            _ws_t0 = time.perf_counter()
             accum: dict[str, mx.array] | None = None
             warmup_loss = mx.array(0.0, dtype=mx.float32)
             grad_scale = 1.0 / args.grad_accum_steps
@@ -974,6 +979,8 @@ def main() -> None:
                 accum = accumulate_flat_grads(accum, grads, grad_scale)
             mx.eval(warmup_loss, accum)
             mx.synchronize()
+            if warmup_step >= args.warmup_steps // 2:
+                warmup_step_times.append(time.perf_counter() - _ws_t0)
             if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
                 log(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
 
@@ -994,6 +1001,22 @@ def main() -> None:
         mx.synchronize()
 
         train_loader = TokenLoader(args.train_files, log_fn=log, dataset_name=dataset_name)
+
+    # Auto-set Muon momentum warmup steps from measured step speed.
+    # Targets reaching full momentum by 25% of training so 75% runs at peak 0.95.
+    # Override by setting MUON_MOMENTUM_WARMUP_STEPS explicitly.
+    if args.muon_momentum_warmup_steps < 0:
+        if warmup_step_times and args.max_wallclock_seconds > 0:
+            est_step_ms = 1000.0 * sum(warmup_step_times) / len(warmup_step_times)
+            est_total_steps = int(1000.0 * args.max_wallclock_seconds / est_step_ms)
+            args.muon_momentum_warmup_steps = max(20, min(est_total_steps // 4, 500))
+            log(
+                f"muon_warmup_auto: est_step_ms={est_step_ms:.0f} est_total_steps={est_total_steps} "
+                f"muon_momentum_warmup_steps={args.muon_momentum_warmup_steps}"
+            )
+        else:
+            args.muon_momentum_warmup_steps = 100
+            log("muon_warmup_auto: no timing data, fallback muon_momentum_warmup_steps=100")
 
     train_time_ms = 0.0
     max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None


### PR DESCRIPTION
Description:

  Summary

  - Changes the default for MUON_MOMENTUM_WARMUP_STEPS from a hardcoded 500 to auto-detection based on measured warmup step timing
  - During warmup, the second half of steps are timed (after JIT settles) to estimate actual step speed
  - Post-warmup, muon_momentum_warmup_steps is set to 25% of estimated total steps, capped to [20, 500], so ~75% of training runs at peak momentum (0.95)
  - Falls back to 100 if no timing data is available (e.g. WARMUP_STEPS=0)
  - MUON_MOMENTUM_WARMUP_STEPS env var still works as an explicit override

  Motivation

  The hardcoded default of 500 is wrong for wallclock-capped runs on slower hardware. If a GPU only completes ~300 steps in the time limit, momentum never reaches its target value — warmup runs longer than training. The fix
   ties warmup length to actual training length rather than an arbitrary constant.

  Behavior change

  Runs that previously relied on the default 500 will now use an auto-detected value. On fast hardware (e.g. 8xH100, ~3000+ steps), the auto-detected value will often be near 500 anyway. On slower setups with fewer total
  steps, it will be lower. Set MUON_MOMENTUM_WARMUP_STEPS explicitly to restore the old behavior.

  Test plan

  - Run baseline on 1xA100 / 1xH100 and verify muon_warmup_auto log line appears with sensible values
  - Verify MUON_MOMENTUM_WARMUP_STEPS=500 env override still forces 500 regardless
  - Verify WARMUP_STEPS=0 falls back to muon_momentum_warmup_steps=100 with a log message
  - Confirm final val_bpb is equal or better vs the hardcoded-500 baseline