### PR TITLE
Non-record submission: Activation-Space CSA on SP1024 (8xH100)

### DIFF
--- a/records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100/README.md
+++ b/records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100/README.md
@@ -1,0 +1,295 @@
+# Activation-Space CSA on SP1024 (8xH100)
+
+This folder contains a **non-record submission** for **Activation-Space Compressed-Sensing Adapters** derived from the `2026-03-17_LoRA_TTT` reference and executed on `8xH100 SXM 80GB`.
+
+## Scope
+
+- submission type: `non-record`, still under the `16,000,000` byte artifact cap
+- current tracked run: `8xH100 SXM 80GB`
+- historical lineage: local-first pilot on `GeForce RTX 3060 12GB`
+- `sp1024` tokenizer family
+- score-before-update evaluation loop preserved
+- LoRA replacement by activation-space adapters with:
+  - shared structured sensing map
+  - per-layer tiny gates
+  - `top-k` sparse reconstruction in measurement space
+
+This is still an experimental `SP1024` stack. It is packaged as a non-record submission because it does not make a leaderboard or statistical-significance claim, but it does include a full `8xH100` run, the compressed artifact, and the evaluation result for the current ACSA mechanism.
+
+## Summary
+
+This experiment starts from the `2026-03-17_LoRA_TTT` record and replaces LoRA-based evaluation-time adaptation with **Activation-Space Compressed-Sensing Adapters (ACSA)**. The main idea is to adapt the model through a tiny sparse code in activation space instead of attaching trainable low-rank matrices to the model weights.
+
+The implementation keeps the existing score-before-update evaluation discipline and document-level reset behavior. Adaptation is injected into the post-block residual stream, with optional support for a `prehead` target through an environment variable.
+
+## Main Result
+
+From the committed `8xH100` run in [training.log](/home/lus/git/ia/parameter-golf/records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100/training.log):
+
+- pre-ACSA quantized roundtrip: `val_bpb 1.2875`
+- final ACSA evaluation: `val_bpb 1.2580`
+- compressed artifact size: `15,829,207` bytes
+- total ACSA eval time: `144,491 ms`
+
+This demonstrates that the activation-space adapter materially improves the final compressed model without breaking the artifact-size budget.
+
+## Gain / Loss Versus the Starting Baseline
+
+The initial code baseline for this experiment lineage is the `2026-03-17_LoRA_TTT` record, which reports a mean result of `1.1928 bpb` on the full validation set.
+
+Relative to that starting baseline:
+
+- `LoRA_TTT` baseline: `1.1928 bpb`
+- current ACSA non-record result: `1.2580 bpb`
+- delta versus baseline: `+0.0652 bpb`
+
+So this ACSA implementation is currently **worse than the original LoRA-TTT baseline** in absolute compression quality.
+
+However, within the current ACSA run itself, the eval-time adapter is still contributing a real gain:
+
+- quantized roundtrip without ACSA: `1.2875 bpb`
+- final quantized eval with ACSA: `1.2580 bpb`
+- ACSA gain over quantized roundtrip: `-0.0296 bpb`
+
+This is the main positive result of the submission: even though the full ACSA stack does not yet beat the original LoRA-TTT baseline, the activation-space adapter materially improves the compressed model relative to its own no-adaptation quantized evaluation.
+
+## Why Non-Record
+
+- this folder is being submitted as `non-record`, not as a leaderboard claim
+- no multi-seed package or `p < 0.01` significance claim is included
+- the stack remains `SP1024`, well behind the current leaderboard family
+- the value here is the mechanism: replacing LoRA-style eval-time adaptation with sparse activation-space adaptation
+
+## Method
+
+The underlying hypothesis is that document-specific adaptation does not necessarily need to modify the model weights directly. Instead, a useful portion of the adaptation can be expressed as a small corrective signal in the hidden-state trajectory of the network.
+
+ACSA implements this by freezing the base model and learning a compact per-document adapter during evaluation. For each selected target location, the hidden activation is:
+
+1. projected into a lower-dimensional measurement space,
+2. sparsified in that measurement space,
+3. reconstructed back to model dimension, and
+4. added back to the original activation as a residual delta.
+
+The measurement operator is a structured random map built from sign flips, a random permutation, and a Fast Walsh-Hadamard Transform. The reconstruction path uses the inverse permutation and the same transform structure. This gives a cheap compressed-sensing-style bottleneck without introducing a full learned projection matrix.
+
+The trainable adapter state is intentionally small. Instead of learning dense matrices, ACSA learns:
+
+- per-measurement gates,
+- a per-target scaling factor `alpha`, and
+- a per-target sparsity threshold `tau`
+
+Sparsification is controlled either by `top-k` support selection or by threshold shrinkage, with `top-k` used by default in the current pilot.
+
+Conceptually, this changes the adaptation object from a weight update to an activation update:
+
+- LoRA-style TTT: learn a low-rank change in the model parameters
+- ACSA-style TTT: learn a sparse corrective code that edits hidden activations online
+
+In the current pilot, these activation deltas are applied after transformer blocks (`postblock`) and may also be applied just before the output head (`prehead`).
+
+During evaluation, the script preserves the same legal score-before-update protocol used in the LoRA TTT reference:
+
+1. score the current chunk causally,
+2. accumulate the compression metric on already-scored tokens,
+3. update only the ACSA parameters using those scored tokens, and
+4. carry the updated adapter state forward to later chunks from the same document
+
+The adapter state is reset between documents, so no adaptation information leaks across document boundaries.
+
+## What Was Implemented
+
+- a new ACSA run folder under `records/track_non_record_16mb/`
+- a derived `train_gpt.py` specialized for ACSA evaluation
+- dataset/tokenizer verification before launching runs
+- local knobs for adapter dimension, sparsity, target locations, initialization, and learning rate
+
+The current default ACSA path uses:
+
+- a shared structured sensing map
+- tiny per-layer gates
+- `top-k` sparse reconstruction in measurement space
+- `postblock` residual injection
+
+## Numerical Validation
+
+This record includes a stabilized localhost smoke configuration with:
+
+- `ACSA_LR=0.001`
+- `ACSA_ALPHA_INIT=0.01`
+- `ACSA_TAU_INIT=0.05`
+- `DEBUG_VAL_DOCS=32`
+- `ITERATIONS=2`
+- `TRAIN_SEQ_LEN=512`
+- `TRAIN_BATCH_TOKENS=8192`
+- `TTT_BATCH_SIZE=4`
+- `TTT_EVAL_SEQ_LEN=512`
+- `TTT_CHUNK_SIZE=128`
+
+Observed smoke metrics:
+
+- `step:2/2 val_bpb:4.1369`
+- `final_int8_zlib_roundtrip val_bpb:4.1401`
+- `final_int8_ttt_acsa val_bpb:4.1415`
+
+Historical local development included longer localhost runs before the final `8xH100` package. Those traces were manually interrupted before final evaluation and should be treated as partial development logs rather than the current submission artifact. One representative intermediate validation point from that phase is:
+
+- `step:13800/20000 val_bpb:1.4124`
+
+The current submission artifact is instead based on the committed `8xH100` run in `training.log`, whose final lines show:
+
+- `final_int8_zlib_roundtrip val_bpb:1.2875`
+- `final_int8_ttt_acsa val_bpb:1.2580`
+
+## Why This Is Interesting
+
+LoRA TTT adapts model weights at evaluation time. ACSA instead adapts a sparse latent code over activation-space measurements. This changes the adaptation surface substantially:
+
+- fewer trainable adaptation degrees of freedom per update step
+- a natural sparsity bottleneck
+- the possibility of sharing the sensing structure across layers
+- a cleaner bridge to future compressed or token-budget-aware eval-time adaptation schemes
+
+The project started as a local-first pilot to answer “does this mechanism train and evaluate stably at all?” and then moved to an `8xH100` execution path to test challenge-aligned wallclock and evaluation budgets.
+
+## Local Setup
+
+Use `uv` on localhost.
+
+```bash
+uv venv
+uv pip install -r records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100/requirements.txt
+uv run python3 data/cached_challenge_fineweb.py --variant sp1024 --train-shards 1
+```
+
+## Smoke Run
+
+```bash
+RUN_ID=acsa_local_smoke \
+COMPILE_MODEL=0 \
+AUTOCAST_DTYPE=fp16 \
+DEBUG_VAL_DOCS=128 \
+TRAIN_SEQ_LEN=512 \
+TRAIN_BATCH_TOKENS=8192 \
+VAL_BATCH_SIZE=8192 \
+TTT_BATCH_SIZE=4 \
+TTT_EVAL_SEQ_LEN=512 \
+TTT_CHUNK_SIZE=128 \
+ACSA_DIM=64 \
+ACSA_TOPK=16 \
+ACSA_LR=0.001 \
+ACSA_ALPHA_INIT=0.01 \
+ACSA_TAU_INIT=0.05 \
+ACSA_TARGETS=postblock \
+uv run torchrun --standalone --nproc_per_node=1 \
+records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100/train_gpt.py
+```
+
+## Reproduction
+
+The folder is self-contained around `train_gpt.py`, `requirements.txt`, `submission.json`, `training.log`, and the compressed artifact.
+
+Example localhost smoke command:
+
+```bash
+RUN_ID=acsa_local_smoke \
+COMPILE_MODEL=0 \
+AUTOCAST_DTYPE=fp16 \
+DEBUG_VAL_DOCS=128 \
+TRAIN_SEQ_LEN=512 \
+TRAIN_BATCH_TOKENS=8192 \
+VAL_BATCH_SIZE=8192 \
+TTT_BATCH_SIZE=4 \
+TTT_EVAL_SEQ_LEN=512 \
+TTT_CHUNK_SIZE=128 \
+ACSA_DIM=64 \
+ACSA_TOPK=16 \
+ACSA_LR=0.001 \
+ACSA_ALPHA_INIT=0.01 \
+ACSA_TAU_INIT=0.05 \
+ACSA_TARGETS=postblock \
+uv run torchrun --standalone --nproc_per_node=1 \
+records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100/train_gpt.py
+```
+
+Example `8xH100` command in the style used for the committed run:
+
+```bash
+SUBMISSION_AUTHOR="Your Name" \
+SUBMISSION_GITHUB_ID="your_github" \
+SUBMISSION_NAME="Activation-Space Compressed-Sensing Adapters (SP1024, 8xH100)" \
+SUBMISSION_BLURB="Non-record ACSA submission on SP1024 with score-before-update eval-time adaptation." \
+SUBMISSION_TRACK="non_record_16mb" \
+SUBMISSION_HARDWARE="8xH100 SXM 80GB" \
+WRITE_SUBMISSION_JSON=1 \
+LOG_FILENAME=training.log \
+SUBMISSION_FILENAME=submission.json \
+OUTPUT_DIR=records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100 \
+COMPILE_MODEL=1 \
+AUTOCAST_DTYPE=bf16 \
+DEBUG_VAL_DOCS=0 \
+TRAIN_SHARDS=10 \
+TRAIN_SEQ_LEN=1024 \
+TRAIN_BATCH_TOKENS=65536 \
+VAL_BATCH_SIZE=65536 \
+VAL_LOSS_EVERY=0 \
+ITERATIONS=50000 \
+WARMUP_STEPS=20 \
+TRAIN_LOG_EVERY=50 \
+MAX_WALLCLOCK_SECONDS=590 \
+TTT_BATCH_SIZE=64 \
+TTT_EVAL_SEQ_LEN=1024 \
+TTT_CHUNK_SIZE=256 \
+ACSA_DIM=96 \
+ACSA_TOPK=24 \
+ACSA_LR=0.001 \
+ACSA_ALPHA_INIT=0.01 \
+ACSA_TAU_INIT=0.05 \
+ACSA_TARGETS=postblock \
+ENFORCE_ARTIFACT_LIMIT=1 \
+SUBMISSION_MAX_BYTES=16000000 \
+ENFORCE_EVAL_LIMIT=1 \
+EVAL_MAX_SECONDS=600 \
+ENABLE_ACSA_EVAL=1 \
+uv run python -m torch.distributed.run --standalone --nproc_per_node=8 \
+records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100/train_gpt.py
+```
+
+If this line of work is ever pushed toward a record-track attempt, the next missing piece is a proper multi-seed package with separate logs and statistical analysis. That is intentionally not claimed in the current non-record packaging.
+
+## Notable Knobs
+
+- `COMPILE_MODEL=0|1`
+- `AUTOCAST_DTYPE=bf16|fp16`
+- `DEBUG_VAL_DOCS=<int>`
+- `ACSA_DIM=<int>`
+- `ACSA_TOPK=<int>`
+- `ACSA_LR=<float>`
+- `ACSA_ALPHA_INIT=<float>`
+- `ACSA_TAU_INIT=<float>`
+- `ACSA_TARGETS=postblock[,prehead]`
+- `ACSA_SHRINK_MODE=topk|threshold`
+
+## Current Limitations
+
+- no `SP4096` or `SP8192` port yet
+- no multi-seed statistical package yet
+- no multi-seed statistical claim
+- one preserved `training.log` path line still references the earlier `RTX3060_Pilot` folder label from before the final packaging rename
+
+## Provenance
+
+The pilot was introduced and stabilized across commits `189f0ae` through `045db69`, which added the ACSA experiment folder, the dedicated runner, smoke/full profiles, dataset verification, and committed localhost logs.
+
+## Next Steps
+
+- consolidate the best `8xH100` run and its compliance details
+- compare `postblock` versus `postblock,prehead` ACSA targets under the 10-minute budget
+- decide whether the next bridge should be `SP4096` first or a direct `SP8192` path
+- build a proper multi-seed package if this line is pushed toward record candidacy
+
+## Status
+
+Implementation, logs, submission metadata, and a record-local `requirements.txt` are present.
+
+Note: this folder was renamed after the original run organization changed from the local `RTX3060_Pilot` naming to the current `8xH100` packaging. The committed `training.log` is preserved as generated, so one internal `wrote_submission_json:` line still points to the older path label.

--- a/records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100/requirements.txt
+++ b/records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100/requirements.txt
@@ -1,0 +1,10 @@
+numpy
+tqdm
+torch
+huggingface-hub
+kernels
+setuptools
+typing-extensions==4.15.0
+datasets
+tiktoken
+sentencepiece

--- a/records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100/submission.json
+++ b/records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100/submission.json
@@ -1,0 +1,29 @@
+{
+  "author": "Luciano Ribas",
+  "github_id": "lucribas",
+  "name": "Activation-Space Compressed-Sensing Adapters (SP1024, 8xH100)",
+  "blurb": "Non-record submission: ACSA on SP1024 with score-before-update eval-time adaptation, validated on 8xH100 and packaged under the 16MB artifact cap.",
+  "date": "2026-04-28T00:00:00Z",
+  "track": "non_record_16mb",
+  "val_loss": 2.12404399,
+  "val_bpb": 1.25797841,
+  "pre_quant_val_loss": 2.16657313,
+  "pre_quant_val_bpb": 1.28316664,
+  "step_stop": 16858,
+  "wallclock_seconds": 590,
+  "bytes_total": 15829207,
+  "artifact_bytes": 15829207,
+  "bytes_model_int8_zlib": 15790377,
+  "bytes_code": 38830,
+  "artifact_file": "final_model.int8.ptz",
+  "gpu": "8xH100 SXM 80GB",
+  "hardware": "8xH100 SXM 80GB",
+  "compliance": {
+    "train_under_limit": false,
+    "artifact_under_limit": true,
+    "eval_under_limit": true,
+    "score_first_ttt": true,
+    "debug_val_docs": 0,
+    "eval_time_ms": 144491
+  }
+}

--- a/records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100/train_gpt.py
+++ b/records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100/train_gpt.py
@@ -1,0 +1,874 @@
+"""
+Local pilot for Activation-Space Compressed-Sensing Adapters (ACSA).
+
+This script is intentionally derived from the LoRA TTT reference run instead of
+starting from the current SOTA stack. The goal is to validate the adapter
+mechanism and the score-before-update evaluation loop on a smaller, cheaper
+pilot before porting the idea to stronger SP4096 / SP8192 stacks.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import glob
+import importlib.util
+import io
+import json
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BASE_SCRIPT = REPO_ROOT / "records" / "track_10min_16mb" / "2026-03-17_LoRA_TTT" / "train_gpt.py"
+if not BASE_SCRIPT.exists():
+    raise FileNotFoundError(f"Base script not found: {BASE_SCRIPT}")
+_spec = importlib.util.spec_from_file_location("lora_ttt_base", BASE_SCRIPT)
+if _spec is None or _spec.loader is None:
+    raise ImportError(f"Could not load base script: {BASE_SCRIPT}")
+base = importlib.util.module_from_spec(_spec)
+# TorchDynamo may later try to re-import this module by name during compilation.
+sys.modules[_spec.name] = base
+_spec.loader.exec_module(base)
+
+
+class Hyperparameters(base.Hyperparameters):
+    compile_model = bool(int(os.environ.get("COMPILE_MODEL", "0")))
+    autocast_dtype = os.environ.get("AUTOCAST_DTYPE", "bf16").strip().lower()
+    debug_val_docs = int(os.environ.get("DEBUG_VAL_DOCS", "0"))
+    output_dir = os.environ.get("OUTPUT_DIR", ".").strip() or "."
+    log_filename = os.environ.get("LOG_FILENAME", "").strip()
+    write_submission_json = bool(int(os.environ.get("WRITE_SUBMISSION_JSON", "0")))
+    submission_filename = os.environ.get("SUBMISSION_FILENAME", "submission.json").strip() or "submission.json"
+    submission_author = os.environ.get("SUBMISSION_AUTHOR", "").strip()
+    submission_github_id = os.environ.get("SUBMISSION_GITHUB_ID", "").strip()
+    submission_name = os.environ.get("SUBMISSION_NAME", "Activation-Space Compressed-Sensing Adapters").strip()
+    submission_blurb = os.environ.get("SUBMISSION_BLURB", "").strip()
+    submission_track = os.environ.get("SUBMISSION_TRACK", "non-record-16mb").strip()
+    submission_hardware = os.environ.get("SUBMISSION_HARDWARE", "").strip()
+    enforce_artifact_limit = bool(int(os.environ.get("ENFORCE_ARTIFACT_LIMIT", "0")))
+    submission_max_bytes = int(os.environ.get("SUBMISSION_MAX_BYTES", "16000000"))
+    enforce_eval_limit = bool(int(os.environ.get("ENFORCE_EVAL_LIMIT", "0")))
+    eval_max_seconds = float(os.environ.get("EVAL_MAX_SECONDS", "600"))
+    enable_acsa_eval = bool(int(os.environ.get("ENABLE_ACSA_EVAL", "1")))
+    acsa_progress_every_seconds = float(os.environ.get("ACSA_PROGRESS_EVERY_SECONDS", "15"))
+    acsa_dim = int(os.environ.get("ACSA_DIM", "64"))
+    acsa_topk = int(os.environ.get("ACSA_TOPK", "16"))
+    acsa_alpha_init = float(os.environ.get("ACSA_ALPHA_INIT", "0.05"))
+    acsa_tau_init = float(os.environ.get("ACSA_TAU_INIT", "0.01"))
+    acsa_lr = float(os.environ.get("ACSA_LR", os.environ.get("TTT_LORA_LR", "0.01")))
+    acsa_shrink_mode = os.environ.get("ACSA_SHRINK_MODE", "topk").strip().lower()
+    acsa_targets = tuple(
+        target.strip().lower()
+        for target in os.environ.get("ACSA_TARGETS", "postblock").split(",")
+        if target.strip()
+    )
+
+
+def resolve_model_dtype(args: Hyperparameters) -> torch.dtype:
+    if args.autocast_dtype == "bf16":
+        return torch.bfloat16
+    if args.autocast_dtype == "fp16":
+        return torch.float16
+    raise ValueError(f"Unsupported AUTOCAST_DTYPE={args.autocast_dtype!r}; expected bf16 or fp16")
+
+
+def autocast_context(args: Hyperparameters):
+    return torch.autocast(device_type="cuda", dtype=resolve_model_dtype(args), enabled=True)
+
+
+def fwht(x: Tensor) -> Tensor:
+    n = x.size(-1)
+    if n <= 0 or n & (n - 1):
+        raise ValueError(f"FWHT requires a power-of-two last dimension, got {n}")
+    y = x
+    h = 1
+    while h < n:
+        y = y.reshape(*y.shape[:-1], -1, 2 * h)
+        a, b = y[..., :h], y[..., h:]
+        y = torch.cat((a + b, a - b), dim=-1)
+        y = y.reshape(*x.shape[:-1], n)
+        h *= 2
+    return y * (n ** -0.5)
+
+
+class BatchedActivationCSA(nn.Module):
+    def __init__(self, bsz: int, model: "ACSAGPT", args: Hyperparameters):
+        super().__init__()
+        self.bsz = bsz
+        self.dim = model.tok_emb.embedding_dim
+        self.num_layers = len(model.blocks)
+        self.use_postblock = "postblock" in args.acsa_targets
+        self.use_prehead = "prehead" in args.acsa_targets
+        self.measure_dim = min(max(args.acsa_dim, 1), self.dim)
+        self.topk = min(max(args.acsa_topk, 1), self.measure_dim)
+        self.alpha_init = args.acsa_alpha_init
+        self.tau_init = args.acsa_tau_init
+        self.shrink_mode = args.acsa_shrink_mode
+        self.num_targets = (self.num_layers if self.use_postblock else 0) + (1 if self.use_prehead else 0)
+        if self.num_targets <= 0:
+            raise ValueError("ACSA_TARGETS must include postblock and/or prehead")
+        if self.dim & (self.dim - 1):
+            raise ValueError(f"ACSA currently requires power-of-two model_dim, got {self.dim}")
+        gen = torch.Generator(device="cpu")
+        gen.manual_seed(1337)
+        perm = torch.randperm(self.dim, generator=gen)
+        inv_perm = torch.empty_like(perm)
+        inv_perm[perm] = torch.arange(self.dim)
+        signs = torch.where(torch.rand(self.dim, generator=gen) > 0.5, 1.0, -1.0)
+        self.register_buffer("perm", perm, persistent=False)
+        self.register_buffer("inv_perm", inv_perm, persistent=False)
+        self.register_buffer("signs", signs, persistent=False)
+        self.gates = nn.Parameter(torch.empty(bsz, self.num_targets, self.measure_dim))
+        self.alpha = nn.Parameter(torch.empty(bsz, self.num_targets, 1))
+        self.tau = nn.Parameter(torch.empty(bsz, self.num_targets, 1))
+        self.reset()
+
+    def reset(self) -> None:
+        with torch.no_grad():
+            self.gates.fill_(1.0)
+            self.alpha.fill_(self.alpha_init)
+            self.tau.fill_(self.tau_init)
+
+    def num_trainable_params(self) -> int:
+        return sum(int(p.numel()) for p in self.parameters())
+
+    def _sense(self, x: Tensor) -> Tensor:
+        y = x * self.signs.to(dtype=x.dtype)[None, None, :]
+        y = y.index_select(-1, self.perm)
+        y = fwht(y)
+        return y[..., : self.measure_dim]
+
+    def _reconstruct(self, z: Tensor) -> Tensor:
+        full = torch.zeros(*z.shape[:-1], self.dim, dtype=z.dtype, device=z.device)
+        full[..., : self.measure_dim] = z
+        y = fwht(full)
+        y = y.index_select(-1, self.inv_perm)
+        return y * self.signs.to(dtype=y.dtype)[None, None, :]
+
+    def _shrink(self, z: Tensor, target_idx: int) -> Tensor:
+        gate = self.gates[:, target_idx].to(dtype=z.dtype)[:, None, :]
+        alpha = self.alpha[:, target_idx].to(dtype=z.dtype)[:, None, :]
+        tau = self.tau[:, target_idx].to(dtype=z.dtype).abs()[:, None, :]
+        gated = gate * z
+        if self.shrink_mode == "threshold":
+            sparse = gated.sign() * F.relu(gated.abs() - tau)
+            return alpha * sparse
+        topk = min(self.topk, gated.size(-1))
+        if topk >= gated.size(-1):
+            sparse = gated
+        else:
+            idx = gated.abs().topk(topk, dim=-1).indices
+            mask = torch.zeros_like(gated)
+            mask.scatter_(-1, idx, 1.0)
+            sparse = torch.where((mask > 0) & (gated.abs() >= tau), gated, torch.zeros_like(gated))
+        return alpha * sparse
+
+    def _delta(self, x: Tensor, target_idx: int) -> Tensor:
+        return self._reconstruct(self._shrink(self._sense(x), target_idx))
+
+    def apply_postblock(self, layer_idx: int, x: Tensor) -> Tensor:
+        if not self.use_postblock:
+            return x
+        return x + self._delta(x, layer_idx)
+
+    def apply_prehead(self, x: Tensor) -> Tensor:
+        if not self.use_prehead:
+            return x
+        idx = self.num_layers if self.use_postblock else 0
+        return x + self._delta(x, idx)
+
+
+class ACSAGPT(base.GPT):
+    def forward(self, input_ids: Tensor, target_ids: Tensor, acsa: BatchedActivationCSA | None = None) -> Tensor:
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            if acsa is not None:
+                x = acsa.apply_postblock(i, x)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[bi](x, x0)
+            if acsa is not None:
+                x = acsa.apply_postblock(bi, x)
+        x = self.final_norm(x)
+        if acsa is not None:
+            x = acsa.apply_prehead(x)
+        if self.tie_embeddings:
+            logits = F.linear(x, self.tok_emb.weight)
+        else:
+            logits = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        if acsa is not None:
+            bsz, sl, vocab = logits.shape
+            return F.cross_entropy(
+                logits.float().reshape(-1, vocab),
+                target_ids.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, sl)
+        return F.cross_entropy(logits.float().reshape(-1, logits.size(-1)), target_ids.reshape(-1), reduction="mean")
+
+
+def _reset_acsa_optimizer(opt: torch.optim.Optimizer) -> None:
+    for group in opt.param_groups:
+        for p in group["params"]:
+            state = opt.state.get(p)
+            if not state:
+                continue
+            state["exp_avg"].zero_()
+            state["exp_avg_sq"].zero_()
+            state["step"].fill_(0)
+
+
+def _build_acsa_optimizer(acsa: BatchedActivationCSA, args: Hyperparameters) -> torch.optim.Optimizer:
+    return torch.optim.Adam(acsa.parameters(), lr=args.acsa_lr, betas=(args.beta1, args.beta2), eps=1e-10)
+
+
+def load_debug_validation_tokens(args: Hyperparameters) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(args.val_files))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {args.val_files}")
+    tokens = torch.cat([base.load_data_shard(file) for file in files]).contiguous()
+    if args.debug_val_docs > 0:
+        docs = base._find_docs(tokens, include_next_bos=False)
+        limit = min(args.debug_val_docs, len(docs))
+        cutoff = docs[limit - 1][0] + docs[limit - 1][1]
+        tokens = tokens[:cutoff].contiguous()
+    usable = ((tokens.numel() - 1) // args.train_seq_len) * args.train_seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={args.train_seq_len}")
+    return tokens[: usable + 1]
+
+
+def load_eval_document_tokens(args: Hyperparameters) -> Tensor:
+    files = sorted(glob.glob(args.val_files))
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {args.val_files}")
+    tokens = torch.cat([base.load_data_shard(Path(path)) for path in files]).contiguous()
+    if args.debug_val_docs > 0:
+        docs = base._find_docs(tokens, include_next_bos=False)
+        limit = min(args.debug_val_docs, len(docs))
+        cutoff = docs[limit - 1][0] + docs[limit - 1][1]
+        tokens = tokens[:cutoff].contiguous()
+    return tokens
+
+
+def eval_val_ttt_acsa(
+    args: Hyperparameters,
+    base_model: ACSAGPT,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    log0,
+) -> tuple[float, float]:
+    def _format_duration(seconds: float) -> str:
+        seconds = max(float(seconds), 0.0)
+        minutes, secs = divmod(int(round(seconds)), 60)
+        hours, minutes = divmod(minutes, 60)
+        if hours > 0:
+            return f"{hours:d}h{minutes:02d}m{secs:02d}s"
+        if minutes > 0:
+            return f"{minutes:d}m{secs:02d}s"
+        return f"{secs:d}s"
+
+    all_tokens = load_eval_document_tokens(args)
+    docs = base._find_docs(all_tokens)
+    rank_docs = docs[(len(docs) * rank) // world_size : (len(docs) * (rank + 1)) // world_size]
+    chunk_size = args.ttt_chunk_size
+    eval_seq_len = args.ttt_eval_seq_len
+    batch_size = args.ttt_batch_size
+    rank_docs.sort(key=lambda d: (d[1] - 2) // chunk_size)
+    base_model.eval()
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+    acsa = BatchedActivationCSA(batch_size, base_model, args).to(device)
+    opt = _build_acsa_optimizer(acsa, args)
+    log0(
+        f"acsa_eval:targets={','.join(args.acsa_targets)} dim:{args.acsa_dim} "
+        f"topk:{args.acsa_topk} shrink:{args.acsa_shrink_mode} params:{acsa.num_trainable_params()}"
+    )
+    eval_start_time = time.perf_counter()
+    last_progress_time = eval_start_time
+    local_total_docs = len(rank_docs)
+    local_total_batches = (local_total_docs + batch_size - 1) // batch_size if local_total_docs > 0 else 0
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    for bi in range(0, len(rank_docs), batch_size):
+        batch = rank_docs[bi : bi + batch_size]
+        bsz = len(batch)
+        batch_index = bi // batch_size + 1
+        if bsz == batch_size:
+            cur_acsa, cur_opt = acsa, opt
+            cur_acsa.reset()
+            _reset_acsa_optimizer(cur_opt)
+        else:
+            cur_acsa = BatchedActivationCSA(bsz, base_model, args).to(device)
+            cur_opt = _build_acsa_optimizer(cur_acsa, args)
+        pred_lens = [doc_len - 1 for _, doc_len in batch]
+        num_chunks = [(pred_len + chunk_size - 1) // chunk_size for pred_len in pred_lens]
+        max_nc = max(num_chunks)
+        for ci in range(max_nc):
+            _, context_size, chunk_offset, _ = base._compute_chunk_window(ci, (ci + 1) * chunk_size, ci + 1, chunk_size, eval_seq_len)
+            active = [ci < nc for nc in num_chunks]
+            needs_train = any(ci < nc - 1 for nc in num_chunks)
+            x = torch.zeros(bsz, context_size, dtype=torch.int64, device=device)
+            y = torch.zeros(bsz, context_size, dtype=torch.int64, device=device)
+            doc_info: list[tuple[int, int]] = []
+            for b in range(bsz):
+                if not active[b]:
+                    doc_info.append((0, 0))
+                    continue
+                ds, dl = batch[b]
+                ws, wl, co, cl = base._compute_chunk_window(ci, pred_lens[b], num_chunks[b], chunk_size, eval_seq_len)
+                chunk = all_tokens[ds + ws : ds + ws + wl + 1]
+                toks = chunk.to(dtype=torch.int64, device=device)
+                x[b, :wl] = toks[:-1]
+                y[b, :wl] = toks[1:]
+                doc_info.append((co, cl))
+            if needs_train:
+                with autocast_context(args):
+                    ptl = base_model(x, y, acsa=cur_acsa)
+            else:
+                with torch.no_grad(), autocast_context(args):
+                    ptl = base_model(x, y, acsa=cur_acsa)
+            with torch.no_grad():
+                for b in range(bsz):
+                    if not active[b]:
+                        continue
+                    co, cl = doc_info[b]
+                    base._accumulate_bpb(
+                        ptl,
+                        x,
+                        y,
+                        b,
+                        co,
+                        cl,
+                        base_bytes_lut,
+                        has_leading_space_lut,
+                        is_boundary_token_lut,
+                        loss_sum,
+                        byte_sum,
+                        token_count,
+                    )
+            if needs_train:
+                mask = torch.tensor([float(ci < num_chunks[b] - 1) for b in range(bsz)], device=device)
+                per_doc = ptl[:, chunk_offset : chunk_offset + chunk_size].mean(dim=-1)
+                cur_opt.zero_grad()
+                (per_doc * mask).sum().backward()
+                cur_opt.step()
+        if rank == 0 and local_total_docs > 0:
+            now = time.perf_counter()
+            processed_docs = min(bi + bsz, local_total_docs)
+            should_log_progress = args.acsa_progress_every_seconds <= 0 or processed_docs == local_total_docs
+            if not should_log_progress:
+                should_log_progress = now - last_progress_time >= args.acsa_progress_every_seconds
+            if should_log_progress:
+                elapsed = now - eval_start_time
+                docs_per_second = processed_docs / max(elapsed, 1e-9)
+                remaining_docs = max(local_total_docs - processed_docs, 0)
+                eta_seconds = remaining_docs / max(docs_per_second, 1e-9)
+                log0(
+                    f"acsa_eval_progress rank0_local_docs:{processed_docs}/{local_total_docs} "
+                    f"batch:{batch_index}/{local_total_batches} "
+                    f"elapsed:{_format_duration(elapsed)} eta:{_format_duration(eta_seconds)} "
+                    f"docs_per_s:{docs_per_second:.2f}"
+                )
+                last_progress_time = now
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+    val_loss = float(loss_sum.item() / token_count.item())
+    val_bpb = float((loss_sum.item() / math.log(2.0)) / byte_sum.item())
+    return val_loss, val_bpb
+
+
+def maybe_compile(module: nn.Module, args: Hyperparameters) -> nn.Module:
+    if args.compile_model:
+        return torch.compile(module, dynamic=False, fullgraph=True)
+    return module
+
+
+def main() -> None:
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    model_dtype = resolve_model_dtype(args)
+    if args.compile_model:
+        base.zeropower_via_newtonschulz5 = torch.compile(base.zeropower_via_newtonschulz5)
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        if args.log_filename:
+            logfile = str(output_dir / args.log_filename)
+        else:
+            logs_dir = output_dir / "logs"
+            logs_dir.mkdir(parents=True, exist_ok=True)
+            logfile = str(logs_dir / f"{args.run_id}.txt")
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+            for line in str(msg).splitlines() or [""]:
+                print(f"{timestamp} {line}")
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only supports SentencePiece .model files: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}")
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_debug_validation_tokens(args)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = base.build_sentencepiece_luts(
+        sp,
+        args.vocab_size,
+        device,
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1} debug_val_docs:{args.debug_val_docs}")
+
+    base_model = ACSAGPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+    ).to(device).to(dtype=model_dtype)
+    for module in base_model.modules():
+        if isinstance(module, base.CastedLinear):
+            module.float()
+        if isinstance(module, base.Rotary):
+            module.inv_freq.data = module.inv_freq.data.float()
+    base.restore_low_dim_params_to_fp32(base_model)
+    compiled_model = maybe_compile(base_model, args)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in base.CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in base.CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizer_muon = base.Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"compile_model:{int(args.compile_model)} autocast_dtype:{args.autocast_dtype}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    train_loader = base.DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            if warmdown_start <= step < args.iterations:
+                return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0)
+            return 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with autocast_context(args):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = base.DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    training_time_ms = 0.0
+    pre_quant_val_loss: float | None = None
+    pre_quant_val_bpb: float | None = None
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = base.eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            pre_quant_val_loss = float(val_loss)
+            pre_quant_val_bpb = float(val_bpb)
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with autocast_context(args):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = args.train_log_every > 0 and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    model_path = output_dir / "final_model.pt"
+    quant_path = output_dir / "final_model.int8.ptz"
+    submission_path = output_dir / args.submission_filename
+
+    model_bytes = None
+    code_bytes = len(code.encode("utf-8"))
+    total_submission_bytes = None
+    quant_file_bytes = None
+    total_quant_submission_bytes = None
+
+    if master_process:
+        torch.save(base_model.state_dict(), model_path)
+        model_bytes = model_path.stat().st_size
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+        total_submission_bytes = model_bytes + code_bytes
+
+    quant_obj, quant_stats = base.quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    quant_file_bytes = len(quant_blob)
+    total_quant_submission_bytes = quant_file_bytes + code_bytes
+    if master_process:
+        with open(quant_path, "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = quant_path.stat().st_size
+        total_quant_submission_bytes = quant_file_bytes + code_bytes
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open(quant_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(base.dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = base.eval_val(
+        args,
+        model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+    qeval_ms = 1000.0 * (time.perf_counter() - t_qeval)
+
+    acsa_val_loss = None
+    acsa_val_bpb = None
+    acsa_ms = 0.0
+    if args.enable_acsa_eval:
+        if hasattr(torch, "_dynamo"):
+            torch._dynamo.reset()
+        torch.cuda.synchronize()
+        t_acsa = time.perf_counter()
+        acsa_val_loss, acsa_val_bpb = eval_val_ttt_acsa(
+            args,
+            base_model,
+            rank,
+            world_size,
+            device,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            log0,
+        )
+        torch.cuda.synchronize()
+        acsa_ms = 1000.0 * (time.perf_counter() - t_acsa)
+        log0(
+            f"final_int8_ttt_acsa val_loss:{acsa_val_loss:.4f} val_bpb:{acsa_val_bpb:.4f} "
+            f"eval_time:{acsa_ms:.0f}ms"
+        )
+
+    total_eval_ms = qeval_ms + acsa_ms
+    artifact_under_limit = total_quant_submission_bytes is not None and total_quant_submission_bytes <= args.submission_max_bytes
+    eval_under_limit = total_eval_ms <= 1000.0 * args.eval_max_seconds
+    train_under_limit = args.max_wallclock_seconds <= 0 or training_time_ms <= 1000.0 * args.max_wallclock_seconds
+    log0(
+        f"compliance artifact_under_limit:{int(bool(artifact_under_limit))} "
+        f"eval_under_limit:{int(bool(eval_under_limit))} "
+        f"train_under_limit:{int(bool(train_under_limit))} "
+        f"artifact_bytes:{total_quant_submission_bytes if total_quant_submission_bytes is not None else -1} "
+        f"eval_time_ms:{total_eval_ms:.0f}"
+    )
+
+    if master_process and args.write_submission_json:
+        final_val_loss = acsa_val_loss if acsa_val_loss is not None else q_val_loss
+        final_val_bpb = acsa_val_bpb if acsa_val_bpb is not None else q_val_bpb
+        payload = {
+            "author": args.submission_author,
+            "github_id": args.submission_github_id,
+            "name": args.submission_name,
+            "blurb": args.submission_blurb,
+            "date": time.strftime("%Y-%m-%dT00:00:00Z"),
+            "track": args.submission_track,
+            "val_loss": round(float(final_val_loss), 8),
+            "val_bpb": round(float(final_val_bpb), 8),
+            "pre_quant_val_loss": round(float(pre_quant_val_loss), 8) if pre_quant_val_loss is not None else None,
+            "pre_quant_val_bpb": round(float(pre_quant_val_bpb), 8) if pre_quant_val_bpb is not None else None,
+            "step_stop": int(step),
+            "wallclock_seconds": int(round(training_time_ms / 1000.0)),
+            "bytes_total": int(total_quant_submission_bytes if total_quant_submission_bytes is not None else -1),
+            "artifact_bytes": int(total_quant_submission_bytes if total_quant_submission_bytes is not None else -1),
+            "bytes_model_int8_zlib": int(quant_file_bytes) if quant_file_bytes is not None else None,
+            "bytes_code": int(code_bytes),
+            "artifact_file": quant_path.name,
+            "gpu": args.submission_hardware,
+            "hardware": args.submission_hardware,
+            "compliance": {
+                "train_under_limit": bool(train_under_limit),
+                "artifact_under_limit": bool(artifact_under_limit),
+                "eval_under_limit": bool(eval_under_limit),
+                "score_first_ttt": True,
+                "debug_val_docs": int(args.debug_val_docs),
+                "eval_time_ms": int(round(total_eval_ms)),
+            },
+        }
+        submission_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        log0(f"wrote_submission_json:{submission_path}")
+
+    if args.enforce_artifact_limit and not artifact_under_limit:
+        raise SystemExit(
+            f"artifact limit exceeded: bytes_total={total_quant_submission_bytes} limit={args.submission_max_bytes}"
+        )
+    if args.enforce_eval_limit and not eval_under_limit:
+        raise SystemExit(f"eval time limit exceeded: eval_time_ms={total_eval_ms:.0f} limit_ms={1000.0 * args.eval_max_seconds:.0f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100/training.log
+++ b/records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100/training.log
@@ -1,0 +1,1310 @@
+"""
+Local pilot for Activation-Space Compressed-Sensing Adapters (ACSA).
+
+This script is intentionally derived from the LoRA TTT reference run instead of
+starting from the current SOTA stack. The goal is to validate the adapter
+mechanism and the score-before-update evaluation loop on a smaller, cheaper
+pilot before porting the idea to stronger SP4096 / SP8192 stacks.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import glob
+import importlib.util
+import io
+import json
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BASE_SCRIPT = REPO_ROOT / "records" / "track_10min_16mb" / "2026-03-17_LoRA_TTT" / "train_gpt.py"
+if not BASE_SCRIPT.exists():
+    raise FileNotFoundError(f"Base script not found: {BASE_SCRIPT}")
+_spec = importlib.util.spec_from_file_location("lora_ttt_base", BASE_SCRIPT)
+if _spec is None or _spec.loader is None:
+    raise ImportError(f"Could not load base script: {BASE_SCRIPT}")
+base = importlib.util.module_from_spec(_spec)
+# TorchDynamo may later try to re-import this module by name during compilation.
+sys.modules[_spec.name] = base
+_spec.loader.exec_module(base)
+
+
+class Hyperparameters(base.Hyperparameters):
+    compile_model = bool(int(os.environ.get("COMPILE_MODEL", "0")))
+    autocast_dtype = os.environ.get("AUTOCAST_DTYPE", "bf16").strip().lower()
+    debug_val_docs = int(os.environ.get("DEBUG_VAL_DOCS", "0"))
+    output_dir = os.environ.get("OUTPUT_DIR", ".").strip() or "."
+    log_filename = os.environ.get("LOG_FILENAME", "").strip()
+    write_submission_json = bool(int(os.environ.get("WRITE_SUBMISSION_JSON", "0")))
+    submission_filename = os.environ.get("SUBMISSION_FILENAME", "submission.json").strip() or "submission.json"
+    submission_author = os.environ.get("SUBMISSION_AUTHOR", "").strip()
+    submission_github_id = os.environ.get("SUBMISSION_GITHUB_ID", "").strip()
+    submission_name = os.environ.get("SUBMISSION_NAME", "Activation-Space Compressed-Sensing Adapters").strip()
+    submission_blurb = os.environ.get("SUBMISSION_BLURB", "").strip()
+    submission_track = os.environ.get("SUBMISSION_TRACK", "non-record-16mb").strip()
+    submission_hardware = os.environ.get("SUBMISSION_HARDWARE", "").strip()
+    enforce_artifact_limit = bool(int(os.environ.get("ENFORCE_ARTIFACT_LIMIT", "0")))
+    submission_max_bytes = int(os.environ.get("SUBMISSION_MAX_BYTES", "16000000"))
+    enforce_eval_limit = bool(int(os.environ.get("ENFORCE_EVAL_LIMIT", "0")))
+    eval_max_seconds = float(os.environ.get("EVAL_MAX_SECONDS", "600"))
+    enable_acsa_eval = bool(int(os.environ.get("ENABLE_ACSA_EVAL", "1")))
+    acsa_progress_every_seconds = float(os.environ.get("ACSA_PROGRESS_EVERY_SECONDS", "15"))
+    acsa_dim = int(os.environ.get("ACSA_DIM", "64"))
+    acsa_topk = int(os.environ.get("ACSA_TOPK", "16"))
+    acsa_alpha_init = float(os.environ.get("ACSA_ALPHA_INIT", "0.05"))
+    acsa_tau_init = float(os.environ.get("ACSA_TAU_INIT", "0.01"))
+    acsa_lr = float(os.environ.get("ACSA_LR", os.environ.get("TTT_LORA_LR", "0.01")))
+    acsa_shrink_mode = os.environ.get("ACSA_SHRINK_MODE", "topk").strip().lower()
+    acsa_targets = tuple(
+        target.strip().lower()
+        for target in os.environ.get("ACSA_TARGETS", "postblock").split(",")
+        if target.strip()
+    )
+
+
+def resolve_model_dtype(args: Hyperparameters) -> torch.dtype:
+    if args.autocast_dtype == "bf16":
+        return torch.bfloat16
+    if args.autocast_dtype == "fp16":
+        return torch.float16
+    raise ValueError(f"Unsupported AUTOCAST_DTYPE={args.autocast_dtype!r}; expected bf16 or fp16")
+
+
+def autocast_context(args: Hyperparameters):
+    return torch.autocast(device_type="cuda", dtype=resolve_model_dtype(args), enabled=True)
+
+
+def fwht(x: Tensor) -> Tensor:
+    n = x.size(-1)
+    if n <= 0 or n & (n - 1):
+        raise ValueError(f"FWHT requires a power-of-two last dimension, got {n}")
+    y = x
+    h = 1
+    while h < n:
+        y = y.reshape(*y.shape[:-1], -1, 2 * h)
+        a, b = y[..., :h], y[..., h:]
+        y = torch.cat((a + b, a - b), dim=-1)
+        y = y.reshape(*x.shape[:-1], n)
+        h *= 2
+    return y * (n ** -0.5)
+
+
+class BatchedActivationCSA(nn.Module):
+    def __init__(self, bsz: int, model: "ACSAGPT", args: Hyperparameters):
+        super().__init__()
+        self.bsz = bsz
+        self.dim = model.tok_emb.embedding_dim
+        self.num_layers = len(model.blocks)
+        self.use_postblock = "postblock" in args.acsa_targets
+        self.use_prehead = "prehead" in args.acsa_targets
+        self.measure_dim = min(max(args.acsa_dim, 1), self.dim)
+        self.topk = min(max(args.acsa_topk, 1), self.measure_dim)
+        self.alpha_init = args.acsa_alpha_init
+        self.tau_init = args.acsa_tau_init
+        self.shrink_mode = args.acsa_shrink_mode
+        self.num_targets = (self.num_layers if self.use_postblock else 0) + (1 if self.use_prehead else 0)
+        if self.num_targets <= 0:
+            raise ValueError("ACSA_TARGETS must include postblock and/or prehead")
+        if self.dim & (self.dim - 1):
+            raise ValueError(f"ACSA currently requires power-of-two model_dim, got {self.dim}")
+        gen = torch.Generator(device="cpu")
+        gen.manual_seed(1337)
+        perm = torch.randperm(self.dim, generator=gen)
+        inv_perm = torch.empty_like(perm)
+        inv_perm[perm] = torch.arange(self.dim)
+        signs = torch.where(torch.rand(self.dim, generator=gen) > 0.5, 1.0, -1.0)
+        self.register_buffer("perm", perm, persistent=False)
+        self.register_buffer("inv_perm", inv_perm, persistent=False)
+        self.register_buffer("signs", signs, persistent=False)
+        self.gates = nn.Parameter(torch.empty(bsz, self.num_targets, self.measure_dim))
+        self.alpha = nn.Parameter(torch.empty(bsz, self.num_targets, 1))
+        self.tau = nn.Parameter(torch.empty(bsz, self.num_targets, 1))
+        self.reset()
+
+    def reset(self) -> None:
+        with torch.no_grad():
+            self.gates.fill_(1.0)
+            self.alpha.fill_(self.alpha_init)
+            self.tau.fill_(self.tau_init)
+
+    def num_trainable_params(self) -> int:
+        return sum(int(p.numel()) for p in self.parameters())
+
+    def _sense(self, x: Tensor) -> Tensor:
+        y = x * self.signs.to(dtype=x.dtype)[None, None, :]
+        y = y.index_select(-1, self.perm)
+        y = fwht(y)
+        return y[..., : self.measure_dim]
+
+    def _reconstruct(self, z: Tensor) -> Tensor:
+        full = torch.zeros(*z.shape[:-1], self.dim, dtype=z.dtype, device=z.device)
+        full[..., : self.measure_dim] = z
+        y = fwht(full)
+        y = y.index_select(-1, self.inv_perm)
+        return y * self.signs.to(dtype=y.dtype)[None, None, :]
+
+    def _shrink(self, z: Tensor, target_idx: int) -> Tensor:
+        gate = self.gates[:, target_idx].to(dtype=z.dtype)[:, None, :]
+        alpha = self.alpha[:, target_idx].to(dtype=z.dtype)[:, None, :]
+        tau = self.tau[:, target_idx].to(dtype=z.dtype).abs()[:, None, :]
+        gated = gate * z
+        if self.shrink_mode == "threshold":
+            sparse = gated.sign() * F.relu(gated.abs() - tau)
+            return alpha * sparse
+        topk = min(self.topk, gated.size(-1))
+        if topk >= gated.size(-1):
+            sparse = gated
+        else:
+            idx = gated.abs().topk(topk, dim=-1).indices
+            mask = torch.zeros_like(gated)
+            mask.scatter_(-1, idx, 1.0)
+            sparse = torch.where((mask > 0) & (gated.abs() >= tau), gated, torch.zeros_like(gated))
+        return alpha * sparse
+
+    def _delta(self, x: Tensor, target_idx: int) -> Tensor:
+        return self._reconstruct(self._shrink(self._sense(x), target_idx))
+
+    def apply_postblock(self, layer_idx: int, x: Tensor) -> Tensor:
+        if not self.use_postblock:
+            return x
+        return x + self._delta(x, layer_idx)
+
+    def apply_prehead(self, x: Tensor) -> Tensor:
+        if not self.use_prehead:
+            return x
+        idx = self.num_layers if self.use_postblock else 0
+        return x + self._delta(x, idx)
+
+
+class ACSAGPT(base.GPT):
+    def forward(self, input_ids: Tensor, target_ids: Tensor, acsa: BatchedActivationCSA | None = None) -> Tensor:
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            if acsa is not None:
+                x = acsa.apply_postblock(i, x)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            bi = self.num_encoder_layers + i
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[bi](x, x0)
+            if acsa is not None:
+                x = acsa.apply_postblock(bi, x)
+        x = self.final_norm(x)
+        if acsa is not None:
+            x = acsa.apply_prehead(x)
+        if self.tie_embeddings:
+            logits = F.linear(x, self.tok_emb.weight)
+        else:
+            logits = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        if acsa is not None:
+            bsz, sl, vocab = logits.shape
+            return F.cross_entropy(
+                logits.float().reshape(-1, vocab),
+                target_ids.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, sl)
+        return F.cross_entropy(logits.float().reshape(-1, logits.size(-1)), target_ids.reshape(-1), reduction="mean")
+
+
+def _reset_acsa_optimizer(opt: torch.optim.Optimizer) -> None:
+    for group in opt.param_groups:
+        for p in group["params"]:
+            state = opt.state.get(p)
+            if not state:
+                continue
+            state["exp_avg"].zero_()
+            state["exp_avg_sq"].zero_()
+            state["step"].fill_(0)
+
+
+def _build_acsa_optimizer(acsa: BatchedActivationCSA, args: Hyperparameters) -> torch.optim.Optimizer:
+    return torch.optim.Adam(acsa.parameters(), lr=args.acsa_lr, betas=(args.beta1, args.beta2), eps=1e-10)
+
+
+def load_debug_validation_tokens(args: Hyperparameters) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(args.val_files))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {args.val_files}")
+    tokens = torch.cat([base.load_data_shard(file) for file in files]).contiguous()
+    if args.debug_val_docs > 0:
+        docs = base._find_docs(tokens, include_next_bos=False)
+        limit = min(args.debug_val_docs, len(docs))
+        cutoff = docs[limit - 1][0] + docs[limit - 1][1]
+        tokens = tokens[:cutoff].contiguous()
+    usable = ((tokens.numel() - 1) // args.train_seq_len) * args.train_seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={args.train_seq_len}")
+    return tokens[: usable + 1]
+
+
+def load_eval_document_tokens(args: Hyperparameters) -> Tensor:
+    files = sorted(glob.glob(args.val_files))
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {args.val_files}")
+    tokens = torch.cat([base.load_data_shard(Path(path)) for path in files]).contiguous()
+    if args.debug_val_docs > 0:
+        docs = base._find_docs(tokens, include_next_bos=False)
+        limit = min(args.debug_val_docs, len(docs))
+        cutoff = docs[limit - 1][0] + docs[limit - 1][1]
+        tokens = tokens[:cutoff].contiguous()
+    return tokens
+
+
+def eval_val_ttt_acsa(
+    args: Hyperparameters,
+    base_model: ACSAGPT,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    log0,
+) -> tuple[float, float]:
+    def _format_duration(seconds: float) -> str:
+        seconds = max(float(seconds), 0.0)
+        minutes, secs = divmod(int(round(seconds)), 60)
+        hours, minutes = divmod(minutes, 60)
+        if hours > 0:
+            return f"{hours:d}h{minutes:02d}m{secs:02d}s"
+        if minutes > 0:
+            return f"{minutes:d}m{secs:02d}s"
+        return f"{secs:d}s"
+
+    all_tokens = load_eval_document_tokens(args)
+    docs = base._find_docs(all_tokens)
+    rank_docs = docs[(len(docs) * rank) // world_size : (len(docs) * (rank + 1)) // world_size]
+    chunk_size = args.ttt_chunk_size
+    eval_seq_len = args.ttt_eval_seq_len
+    batch_size = args.ttt_batch_size
+    rank_docs.sort(key=lambda d: (d[1] - 2) // chunk_size)
+    base_model.eval()
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+    acsa = BatchedActivationCSA(batch_size, base_model, args).to(device)
+    opt = _build_acsa_optimizer(acsa, args)
+    log0(
+        f"acsa_eval:targets={','.join(args.acsa_targets)} dim:{args.acsa_dim} "
+        f"topk:{args.acsa_topk} shrink:{args.acsa_shrink_mode} params:{acsa.num_trainable_params()}"
+    )
+    eval_start_time = time.perf_counter()
+    last_progress_time = eval_start_time
+    local_total_docs = len(rank_docs)
+    local_total_batches = (local_total_docs + batch_size - 1) // batch_size if local_total_docs > 0 else 0
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    for bi in range(0, len(rank_docs), batch_size):
+        batch = rank_docs[bi : bi + batch_size]
+        bsz = len(batch)
+        batch_index = bi // batch_size + 1
+        if bsz == batch_size:
+            cur_acsa, cur_opt = acsa, opt
+            cur_acsa.reset()
+            _reset_acsa_optimizer(cur_opt)
+        else:
+            cur_acsa = BatchedActivationCSA(bsz, base_model, args).to(device)
+            cur_opt = _build_acsa_optimizer(cur_acsa, args)
+        pred_lens = [doc_len - 1 for _, doc_len in batch]
+        num_chunks = [(pred_len + chunk_size - 1) // chunk_size for pred_len in pred_lens]
+        max_nc = max(num_chunks)
+        for ci in range(max_nc):
+            _, context_size, chunk_offset, _ = base._compute_chunk_window(ci, (ci + 1) * chunk_size, ci + 1, chunk_size, eval_seq_len)
+            active = [ci < nc for nc in num_chunks]
+            needs_train = any(ci < nc - 1 for nc in num_chunks)
+            x = torch.zeros(bsz, context_size, dtype=torch.int64, device=device)
+            y = torch.zeros(bsz, context_size, dtype=torch.int64, device=device)
+            doc_info: list[tuple[int, int]] = []
+            for b in range(bsz):
+                if not active[b]:
+                    doc_info.append((0, 0))
+                    continue
+                ds, dl = batch[b]
+                ws, wl, co, cl = base._compute_chunk_window(ci, pred_lens[b], num_chunks[b], chunk_size, eval_seq_len)
+                chunk = all_tokens[ds + ws : ds + ws + wl + 1]
+                toks = chunk.to(dtype=torch.int64, device=device)
+                x[b, :wl] = toks[:-1]
+                y[b, :wl] = toks[1:]
+                doc_info.append((co, cl))
+            if needs_train:
+                with autocast_context(args):
+                    ptl = base_model(x, y, acsa=cur_acsa)
+            else:
+                with torch.no_grad(), autocast_context(args):
+                    ptl = base_model(x, y, acsa=cur_acsa)
+            with torch.no_grad():
+                for b in range(bsz):
+                    if not active[b]:
+                        continue
+                    co, cl = doc_info[b]
+                    base._accumulate_bpb(
+                        ptl,
+                        x,
+                        y,
+                        b,
+                        co,
+                        cl,
+                        base_bytes_lut,
+                        has_leading_space_lut,
+                        is_boundary_token_lut,
+                        loss_sum,
+                        byte_sum,
+                        token_count,
+                    )
+            if needs_train:
+                mask = torch.tensor([float(ci < num_chunks[b] - 1) for b in range(bsz)], device=device)
+                per_doc = ptl[:, chunk_offset : chunk_offset + chunk_size].mean(dim=-1)
+                cur_opt.zero_grad()
+                (per_doc * mask).sum().backward()
+                cur_opt.step()
+        if rank == 0 and local_total_docs > 0:
+            now = time.perf_counter()
+            processed_docs = min(bi + bsz, local_total_docs)
+            should_log_progress = args.acsa_progress_every_seconds <= 0 or processed_docs == local_total_docs
+            if not should_log_progress:
+                should_log_progress = now - last_progress_time >= args.acsa_progress_every_seconds
+            if should_log_progress:
+                elapsed = now - eval_start_time
+                docs_per_second = processed_docs / max(elapsed, 1e-9)
+                remaining_docs = max(local_total_docs - processed_docs, 0)
+                eta_seconds = remaining_docs / max(docs_per_second, 1e-9)
+                log0(
+                    f"acsa_eval_progress rank0_local_docs:{processed_docs}/{local_total_docs} "
+                    f"batch:{batch_index}/{local_total_batches} "
+                    f"elapsed:{_format_duration(elapsed)} eta:{_format_duration(eta_seconds)} "
+                    f"docs_per_s:{docs_per_second:.2f}"
+                )
+                last_progress_time = now
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+    val_loss = float(loss_sum.item() / token_count.item())
+    val_bpb = float((loss_sum.item() / math.log(2.0)) / byte_sum.item())
+    return val_loss, val_bpb
+
+
+def maybe_compile(module: nn.Module, args: Hyperparameters) -> nn.Module:
+    if args.compile_model:
+        return torch.compile(module, dynamic=False, fullgraph=True)
+    return module
+
+
+def main() -> None:
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    model_dtype = resolve_model_dtype(args)
+    if args.compile_model:
+        base.zeropower_via_newtonschulz5 = torch.compile(base.zeropower_via_newtonschulz5)
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        if args.log_filename:
+            logfile = str(output_dir / args.log_filename)
+        else:
+            logs_dir = output_dir / "logs"
+            logs_dir.mkdir(parents=True, exist_ok=True)
+            logfile = str(logs_dir / f"{args.run_id}.txt")
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+            for line in str(msg).splitlines() or [""]:
+                print(f"{timestamp} {line}")
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only supports SentencePiece .model files: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}")
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_debug_validation_tokens(args)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = base.build_sentencepiece_luts(
+        sp,
+        args.vocab_size,
+        device,
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1} debug_val_docs:{args.debug_val_docs}")
+
+    base_model = ACSAGPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+    ).to(device).to(dtype=model_dtype)
+    for module in base_model.modules():
+        if isinstance(module, base.CastedLinear):
+            module.float()
+        if isinstance(module, base.Rotary):
+            module.inv_freq.data = module.inv_freq.data.float()
+    base.restore_low_dim_params_to_fp32(base_model)
+    compiled_model = maybe_compile(base_model, args)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in base.CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in base.CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizer_muon = base.Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(f"compile_model:{int(args.compile_model)} autocast_dtype:{args.autocast_dtype}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    train_loader = base.DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            if warmdown_start <= step < args.iterations:
+                return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0)
+            return 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with autocast_context(args):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = base.DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    training_time_ms = 0.0
+    pre_quant_val_loss: float | None = None
+    pre_quant_val_bpb: float | None = None
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = base.eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            pre_quant_val_loss = float(val_loss)
+            pre_quant_val_bpb = float(val_bpb)
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with autocast_context(args):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = args.train_log_every > 0 and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    model_path = output_dir / "final_model.pt"
+    quant_path = output_dir / "final_model.int8.ptz"
+    submission_path = output_dir / args.submission_filename
+
+    model_bytes = None
+    code_bytes = len(code.encode("utf-8"))
+    total_submission_bytes = None
+    quant_file_bytes = None
+    total_quant_submission_bytes = None
+
+    if master_process:
+        torch.save(base_model.state_dict(), model_path)
+        model_bytes = model_path.stat().st_size
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+        total_submission_bytes = model_bytes + code_bytes
+
+    quant_obj, quant_stats = base.quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    quant_file_bytes = len(quant_blob)
+    total_quant_submission_bytes = quant_file_bytes + code_bytes
+    if master_process:
+        with open(quant_path, "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = quant_path.stat().st_size
+        total_quant_submission_bytes = quant_file_bytes + code_bytes
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open(quant_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(base.dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = base.eval_val(
+        args,
+        model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+    qeval_ms = 1000.0 * (time.perf_counter() - t_qeval)
+
+    acsa_val_loss = None
+    acsa_val_bpb = None
+    acsa_ms = 0.0
+    if args.enable_acsa_eval:
+        if hasattr(torch, "_dynamo"):
+            torch._dynamo.reset()
+        torch.cuda.synchronize()
+        t_acsa = time.perf_counter()
+        acsa_val_loss, acsa_val_bpb = eval_val_ttt_acsa(
+            args,
+            base_model,
+            rank,
+            world_size,
+            device,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            log0,
+        )
+        torch.cuda.synchronize()
+        acsa_ms = 1000.0 * (time.perf_counter() - t_acsa)
+        log0(
+            f"final_int8_ttt_acsa val_loss:{acsa_val_loss:.4f} val_bpb:{acsa_val_bpb:.4f} "
+            f"eval_time:{acsa_ms:.0f}ms"
+        )
+
+    total_eval_ms = qeval_ms + acsa_ms
+    artifact_under_limit = total_quant_submission_bytes is not None and total_quant_submission_bytes <= args.submission_max_bytes
+    eval_under_limit = total_eval_ms <= 1000.0 * args.eval_max_seconds
+    train_under_limit = args.max_wallclock_seconds <= 0 or training_time_ms <= 1000.0 * args.max_wallclock_seconds
+    log0(
+        f"compliance artifact_under_limit:{int(bool(artifact_under_limit))} "
+        f"eval_under_limit:{int(bool(eval_under_limit))} "
+        f"train_under_limit:{int(bool(train_under_limit))} "
+        f"artifact_bytes:{total_quant_submission_bytes if total_quant_submission_bytes is not None else -1} "
+        f"eval_time_ms:{total_eval_ms:.0f}"
+    )
+
+    if master_process and args.write_submission_json:
+        final_val_loss = acsa_val_loss if acsa_val_loss is not None else q_val_loss
+        final_val_bpb = acsa_val_bpb if acsa_val_bpb is not None else q_val_bpb
+        payload = {
+            "author": args.submission_author,
+            "github_id": args.submission_github_id,
+            "name": args.submission_name,
+            "blurb": args.submission_blurb,
+            "date": time.strftime("%Y-%m-%dT00:00:00Z"),
+            "track": args.submission_track,
+            "val_loss": round(float(final_val_loss), 8),
+            "val_bpb": round(float(final_val_bpb), 8),
+            "pre_quant_val_loss": round(float(pre_quant_val_loss), 8) if pre_quant_val_loss is not None else None,
+            "pre_quant_val_bpb": round(float(pre_quant_val_bpb), 8) if pre_quant_val_bpb is not None else None,
+            "step_stop": int(step),
+            "wallclock_seconds": int(round(training_time_ms / 1000.0)),
+            "bytes_total": int(total_quant_submission_bytes if total_quant_submission_bytes is not None else -1),
+            "artifact_bytes": int(total_quant_submission_bytes if total_quant_submission_bytes is not None else -1),
+            "bytes_model_int8_zlib": int(quant_file_bytes) if quant_file_bytes is not None else None,
+            "bytes_code": int(code_bytes),
+            "artifact_file": quant_path.name,
+            "gpu": args.submission_hardware,
+            "hardware": args.submission_hardware,
+            "compliance": {
+                "train_under_limit": bool(train_under_limit),
+                "artifact_under_limit": bool(artifact_under_limit),
+                "eval_under_limit": bool(eval_under_limit),
+                "score_first_ttt": True,
+                "debug_val_docs": int(args.debug_val_docs),
+                "eval_time_ms": int(round(total_eval_ms)),
+            },
+        }
+        submission_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        log0(f"wrote_submission_json:{submission_path}")
+
+    if args.enforce_artifact_limit and not artifact_under_limit:
+        raise SystemExit(
+            f"artifact limit exceeded: bytes_total={total_quant_submission_bytes} limit={args.submission_max_bytes}"
+        )
+    if args.enforce_eval_limit and not eval_under_limit:
+        raise SystemExit(f"eval time limit exceeded: eval_time_ms={total_eval_ms:.0f} limit_ms={1000.0 * args.eval_max_seconds:.0f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+
+====================================================================================================
+Running Python 3.11.10 (main, Sep  7 2024, 18:35:41) [GCC 11.4.0]
+Running PyTorch 2.11.0+cu130
+Tue Apr 28 16:19:31 2026       
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
++-----------------------------------------+------------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
+|                                         |                        |               MIG M. |
+|=========================================+========================+======================|
+|   0  NVIDIA H100 80GB HBM3          On  |   00000000:19:00.0 Off |                    0 |
+| N/A   35C    P0            118W /  700W |    1505MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   1  NVIDIA H100 80GB HBM3          On  |   00000000:3B:00.0 Off |                    0 |
+| N/A   34C    P0            117W /  700W |    1505MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   2  NVIDIA H100 80GB HBM3          On  |   00000000:4C:00.0 Off |                    0 |
+| N/A   32C    P0            121W /  700W |    1505MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   3  NVIDIA H100 80GB HBM3          On  |   00000000:5D:00.0 Off |                    0 |
+| N/A   34C    P0            118W /  700W |    1505MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   4  NVIDIA H100 80GB HBM3          On  |   00000000:9B:00.0 Off |                    0 |
+| N/A   36C    P0            119W /  700W |    1505MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   5  NVIDIA H100 80GB HBM3          On  |   00000000:BB:00.0 Off |                    0 |
+| N/A   33C    P0            118W /  700W |    1505MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   6  NVIDIA H100 80GB HBM3          On  |   00000000:CB:00.0 Off |                    0 |
+| N/A   33C    P0            115W /  700W |    1505MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+|   7  NVIDIA H100 80GB HBM3          On  |   00000000:DB:00.0 Off |                    0 |
+| N/A   32C    P0            118W /  700W |    1505MiB /  81559MiB |      0%      Default |
+|                                         |                        |             Disabled |
++-----------------------------------------+------------------------+----------------------+
+
++-----------------------------------------------------------------------------------------+
+| Processes:                                                                              |
+|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
+|        ID   ID                                                               Usage      |
+|=========================================================================================|
+|  No running processes found                                                             |
++-----------------------------------------------------------------------------------------+
+
+====================================================================================================
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:10
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632 debug_val_docs:0
+model_params:17059912
+world_size:8 grad_accum_steps:1
+compile_model:1 autocast_dtype:bf16
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:65536 train_seq_len:1024 iterations:50000 warmup_steps:50 max_wallclock_seconds:590.000
+seed:1337
+warmup_step:10/50
+warmup_step:20/50
+warmup_step:30/50
+warmup_step:40/50
+warmup_step:50/50
+step:1/50000 train_loss:6.9447 train_time:39ms step_avg:39.15ms
+step:2/50000 train_loss:17.3338 train_time:67ms step_avg:33.50ms
+step:3/50000 train_loss:9.3007 train_time:96ms step_avg:31.89ms
+step:4/50000 train_loss:6.8477 train_time:125ms step_avg:31.34ms
+step:5/50000 train_loss:6.6315 train_time:154ms step_avg:30.76ms
+step:6/50000 train_loss:7.1507 train_time:184ms step_avg:30.62ms
+step:7/50000 train_loss:6.3054 train_time:212ms step_avg:30.26ms
+step:8/50000 train_loss:6.1907 train_time:239ms step_avg:29.86ms
+step:9/50000 train_loss:6.2508 train_time:267ms step_avg:29.65ms
+step:10/50000 train_loss:6.0383 train_time:294ms step_avg:29.39ms
+step:50/50000 train_loss:3.9579 train_time:1577ms step_avg:31.53ms
+step:100/50000 train_loss:3.7349 train_time:3273ms step_avg:32.73ms
+step:150/50000 train_loss:3.4376 train_time:4970ms step_avg:33.13ms
+step:200/50000 train_loss:3.4228 train_time:6660ms step_avg:33.30ms
+step:250/50000 train_loss:3.1227 train_time:8357ms step_avg:33.43ms
+step:300/50000 train_loss:2.9730 train_time:10079ms step_avg:33.60ms
+step:350/50000 train_loss:3.0275 train_time:11795ms step_avg:33.70ms
+step:400/50000 train_loss:2.9144 train_time:13506ms step_avg:33.76ms
+step:450/50000 train_loss:3.0691 train_time:15253ms step_avg:33.90ms
+step:500/50000 train_loss:2.7419 train_time:16920ms step_avg:33.84ms
+step:550/50000 train_loss:2.9194 train_time:18603ms step_avg:33.82ms
+step:600/50000 train_loss:2.6145 train_time:20312ms step_avg:33.85ms
+step:650/50000 train_loss:2.7704 train_time:22066ms step_avg:33.95ms
+step:700/50000 train_loss:2.6482 train_time:23782ms step_avg:33.97ms
+step:750/50000 train_loss:2.6089 train_time:25484ms step_avg:33.98ms
+step:800/50000 train_loss:2.5845 train_time:27192ms step_avg:33.99ms
+step:850/50000 train_loss:2.6301 train_time:28898ms step_avg:34.00ms
+step:900/50000 train_loss:2.7112 train_time:30609ms step_avg:34.01ms
+step:950/50000 train_loss:2.6446 train_time:32389ms step_avg:34.09ms
+step:1000/50000 train_loss:2.6837 train_time:34169ms step_avg:34.17ms
+step:1050/50000 train_loss:2.7034 train_time:35937ms step_avg:34.23ms
+step:1100/50000 train_loss:2.6503 train_time:37642ms step_avg:34.22ms
+step:1150/50000 train_loss:2.6947 train_time:39353ms step_avg:34.22ms
+step:1200/50000 train_loss:2.4608 train_time:41059ms step_avg:34.22ms
+step:1250/50000 train_loss:2.3788 train_time:42768ms step_avg:34.21ms
+step:1300/50000 train_loss:2.8192 train_time:44472ms step_avg:34.21ms
+step:1350/50000 train_loss:2.6747 train_time:46185ms step_avg:34.21ms
+step:1400/50000 train_loss:1.8754 train_time:47891ms step_avg:34.21ms
+step:1450/50000 train_loss:3.0612 train_time:49600ms step_avg:34.21ms
+step:1500/50000 train_loss:2.5470 train_time:51318ms step_avg:34.21ms
+step:1550/50000 train_loss:2.5713 train_time:52971ms step_avg:34.17ms
+step:1600/50000 train_loss:2.5141 train_time:54651ms step_avg:34.16ms
+step:1650/50000 train_loss:2.6031 train_time:56395ms step_avg:34.18ms
+step:1700/50000 train_loss:2.3892 train_time:58153ms step_avg:34.21ms
+step:1750/50000 train_loss:2.4395 train_time:59745ms step_avg:34.14ms
+step:1800/50000 train_loss:2.6741 train_time:61486ms step_avg:34.16ms
+step:1850/50000 train_loss:2.4523 train_time:63281ms step_avg:34.21ms
+step:1900/50000 train_loss:2.5371 train_time:64999ms step_avg:34.21ms
+step:1950/50000 train_loss:2.4825 train_time:66708ms step_avg:34.21ms
+step:2000/50000 train_loss:2.3975 train_time:68411ms step_avg:34.21ms
+step:2050/50000 train_loss:2.2961 train_time:70115ms step_avg:34.20ms
+step:2100/50000 train_loss:2.5295 train_time:71823ms step_avg:34.20ms
+step:2150/50000 train_loss:2.2977 train_time:73529ms step_avg:34.20ms
+step:2200/50000 train_loss:2.3426 train_time:75234ms step_avg:34.20ms
+step:2250/50000 train_loss:2.5125 train_time:76752ms step_avg:34.11ms
+step:2300/50000 train_loss:2.1224 train_time:78473ms step_avg:34.12ms
+step:2350/50000 train_loss:2.9858 train_time:80211ms step_avg:34.13ms
+step:2400/50000 train_loss:2.4564 train_time:82045ms step_avg:34.19ms
+step:2450/50000 train_loss:2.2521 train_time:83875ms step_avg:34.23ms
+step:2500/50000 train_loss:2.5030 train_time:85714ms step_avg:34.29ms
+step:2550/50000 train_loss:2.4245 train_time:87548ms step_avg:34.33ms
+step:2600/50000 train_loss:2.3175 train_time:89355ms step_avg:34.37ms
+step:2650/50000 train_loss:2.4784 train_time:91143ms step_avg:34.39ms
+step:2700/50000 train_loss:2.4878 train_time:92910ms step_avg:34.41ms
+step:2750/50000 train_loss:2.2816 train_time:94678ms step_avg:34.43ms
+step:2800/50000 train_loss:2.4135 train_time:96461ms step_avg:34.45ms
+step:2850/50000 train_loss:2.5719 train_time:98239ms step_avg:34.47ms
+step:2900/50000 train_loss:2.3631 train_time:99969ms step_avg:34.47ms
+step:2950/50000 train_loss:2.1621 train_time:101755ms step_avg:34.49ms
+step:3000/50000 train_loss:2.5218 train_time:103541ms step_avg:34.51ms
+step:3050/50000 train_loss:2.4524 train_time:105348ms step_avg:34.54ms
+step:3100/50000 train_loss:2.5239 train_time:107004ms step_avg:34.52ms
+step:3150/50000 train_loss:2.4867 train_time:108779ms step_avg:34.53ms
+step:3200/50000 train_loss:2.3341 train_time:110560ms step_avg:34.55ms
+step:3250/50000 train_loss:2.3931 train_time:112329ms step_avg:34.56ms
+step:3300/50000 train_loss:2.4175 train_time:114097ms step_avg:34.57ms
+step:3350/50000 train_loss:2.4598 train_time:115880ms step_avg:34.59ms
+step:3400/50000 train_loss:2.3536 train_time:117665ms step_avg:34.61ms
+step:3450/50000 train_loss:2.1810 train_time:119433ms step_avg:34.62ms
+step:3500/50000 train_loss:2.3501 train_time:121221ms step_avg:34.63ms
+step:3550/50000 train_loss:2.4198 train_time:123014ms step_avg:34.65ms
+step:3600/50000 train_loss:2.1820 train_time:124799ms step_avg:34.67ms
+step:3650/50000 train_loss:2.0051 train_time:126570ms step_avg:34.68ms
+step:3700/50000 train_loss:2.3530 train_time:128358ms step_avg:34.69ms
+step:3750/50000 train_loss:2.6209 train_time:130141ms step_avg:34.70ms
+step:3800/50000 train_loss:2.2885 train_time:131919ms step_avg:34.72ms
+step:3850/50000 train_loss:2.5179 train_time:133712ms step_avg:34.73ms
+step:3900/50000 train_loss:2.3780 train_time:135500ms step_avg:34.74ms
+step:3950/50000 train_loss:2.5449 train_time:137297ms step_avg:34.76ms
+step:4000/50000 train_loss:2.2261 train_time:139083ms step_avg:34.77ms
+step:4050/50000 train_loss:2.4583 train_time:140897ms step_avg:34.79ms
+step:4100/50000 train_loss:2.4503 train_time:142697ms step_avg:34.80ms
+step:4150/50000 train_loss:2.3286 train_time:144493ms step_avg:34.82ms
+step:4200/50000 train_loss:2.3499 train_time:146288ms step_avg:34.83ms
+step:4250/50000 train_loss:2.4415 train_time:148038ms step_avg:34.83ms
+step:4300/50000 train_loss:2.2698 train_time:149814ms step_avg:34.84ms
+step:4350/50000 train_loss:2.4189 train_time:151581ms step_avg:34.85ms
+step:4400/50000 train_loss:2.3829 train_time:153297ms step_avg:34.84ms
+step:4450/50000 train_loss:2.6112 train_time:155041ms step_avg:34.84ms
+step:4500/50000 train_loss:2.2955 train_time:156798ms step_avg:34.84ms
+step:4550/50000 train_loss:2.2823 train_time:158465ms step_avg:34.83ms
+step:4600/50000 train_loss:2.1027 train_time:160172ms step_avg:34.82ms
+step:4650/50000 train_loss:2.3055 train_time:161956ms step_avg:34.83ms
+step:4700/50000 train_loss:2.2311 train_time:163690ms step_avg:34.83ms
+step:4750/50000 train_loss:1.8949 train_time:165460ms step_avg:34.83ms
+step:4800/50000 train_loss:2.4798 train_time:167246ms step_avg:34.84ms
+step:4850/50000 train_loss:2.2962 train_time:169034ms step_avg:34.85ms
+step:4900/50000 train_loss:2.4945 train_time:170774ms step_avg:34.85ms
+step:4950/50000 train_loss:2.2642 train_time:172558ms step_avg:34.86ms
+step:5000/50000 train_loss:2.3878 train_time:174295ms step_avg:34.86ms
+step:5050/50000 train_loss:2.4549 train_time:176042ms step_avg:34.86ms
+step:5100/50000 train_loss:2.4286 train_time:177822ms step_avg:34.87ms
+step:5150/50000 train_loss:2.3257 train_time:179591ms step_avg:34.87ms
+step:5200/50000 train_loss:2.1825 train_time:181280ms step_avg:34.86ms
+step:5250/50000 train_loss:2.3261 train_time:183050ms step_avg:34.87ms
+step:5300/50000 train_loss:2.2914 train_time:184849ms step_avg:34.88ms
+step:5350/50000 train_loss:2.0892 train_time:186651ms step_avg:34.89ms
+step:5400/50000 train_loss:2.2968 train_time:188433ms step_avg:34.89ms
+step:5450/50000 train_loss:2.3586 train_time:190230ms step_avg:34.90ms
+step:5500/50000 train_loss:2.0183 train_time:192023ms step_avg:34.91ms
+step:5550/50000 train_loss:2.3920 train_time:193782ms step_avg:34.92ms
+step:5600/50000 train_loss:2.6710 train_time:195536ms step_avg:34.92ms
+step:5650/50000 train_loss:2.1558 train_time:197324ms step_avg:34.92ms
+step:5700/50000 train_loss:2.3212 train_time:199087ms step_avg:34.93ms
+step:5750/50000 train_loss:2.4647 train_time:200860ms step_avg:34.93ms
+step:5800/50000 train_loss:2.5578 train_time:202623ms step_avg:34.93ms
+step:5850/50000 train_loss:2.1787 train_time:204325ms step_avg:34.93ms
+step:5900/50000 train_loss:2.5204 train_time:206180ms step_avg:34.95ms
+step:5950/50000 train_loss:1.8480 train_time:207967ms step_avg:34.95ms
+step:6000/50000 train_loss:2.0018 train_time:209767ms step_avg:34.96ms
+step:6050/50000 train_loss:2.4145 train_time:211554ms step_avg:34.97ms
+step:6100/50000 train_loss:2.2097 train_time:213345ms step_avg:34.97ms
+step:6150/50000 train_loss:1.9795 train_time:215043ms step_avg:34.97ms
+step:6200/50000 train_loss:2.4351 train_time:216785ms step_avg:34.97ms
+step:6250/50000 train_loss:2.3304 train_time:218539ms step_avg:34.97ms
+step:6300/50000 train_loss:2.1524 train_time:220305ms step_avg:34.97ms
+step:6350/50000 train_loss:2.2344 train_time:222070ms step_avg:34.97ms
+step:6400/50000 train_loss:2.1541 train_time:223813ms step_avg:34.97ms
+step:6450/50000 train_loss:2.0030 train_time:225592ms step_avg:34.98ms
+step:6500/50000 train_loss:2.2072 train_time:227273ms step_avg:34.97ms
+step:6550/50000 train_loss:2.2549 train_time:229049ms step_avg:34.97ms
+step:6600/50000 train_loss:2.5753 train_time:230749ms step_avg:34.96ms
+step:6650/50000 train_loss:2.3333 train_time:232490ms step_avg:34.96ms
+step:6700/50000 train_loss:2.3822 train_time:234260ms step_avg:34.96ms
+step:6750/50000 train_loss:2.3464 train_time:236026ms step_avg:34.97ms
+step:6800/50000 train_loss:2.3189 train_time:237767ms step_avg:34.97ms
+step:6850/50000 train_loss:2.2281 train_time:239461ms step_avg:34.96ms
+step:6900/50000 train_loss:2.1075 train_time:241160ms step_avg:34.95ms
+step:6950/50000 train_loss:2.1866 train_time:242899ms step_avg:34.95ms
+step:7000/50000 train_loss:2.0753 train_time:244655ms step_avg:34.95ms
+step:7050/50000 train_loss:2.3312 train_time:246435ms step_avg:34.96ms
+step:7100/50000 train_loss:2.3485 train_time:248235ms step_avg:34.96ms
+step:7150/50000 train_loss:2.5377 train_time:249983ms step_avg:34.96ms
+step:7200/50000 train_loss:2.3715 train_time:251734ms step_avg:34.96ms
+step:7250/50000 train_loss:2.3286 train_time:253510ms step_avg:34.97ms
+step:7300/50000 train_loss:2.1651 train_time:255188ms step_avg:34.96ms
+step:7350/50000 train_loss:2.1580 train_time:256908ms step_avg:34.95ms
+step:7400/50000 train_loss:2.2635 train_time:258626ms step_avg:34.95ms
+step:7450/50000 train_loss:2.9607 train_time:260421ms step_avg:34.96ms
+step:7500/50000 train_loss:2.0415 train_time:262191ms step_avg:34.96ms
+step:7550/50000 train_loss:2.2457 train_time:263975ms step_avg:34.96ms
+step:7600/50000 train_loss:2.2502 train_time:265765ms step_avg:34.97ms
+step:7650/50000 train_loss:2.5802 train_time:267474ms step_avg:34.96ms
+step:7700/50000 train_loss:2.2023 train_time:269151ms step_avg:34.95ms
+step:7750/50000 train_loss:2.3564 train_time:270848ms step_avg:34.95ms
+step:7800/50000 train_loss:2.1574 train_time:272548ms step_avg:34.94ms
+step:7850/50000 train_loss:2.3822 train_time:274298ms step_avg:34.94ms
+step:7900/50000 train_loss:2.2395 train_time:276060ms step_avg:34.94ms
+step:7950/50000 train_loss:2.3867 train_time:277827ms step_avg:34.95ms
+step:8000/50000 train_loss:2.6100 train_time:279529ms step_avg:34.94ms
+step:8050/50000 train_loss:2.1747 train_time:281224ms step_avg:34.93ms
+step:8100/50000 train_loss:2.1640 train_time:282929ms step_avg:34.93ms
+step:8150/50000 train_loss:2.3094 train_time:284629ms step_avg:34.92ms
+step:8200/50000 train_loss:2.3907 train_time:286320ms step_avg:34.92ms
+step:8250/50000 train_loss:2.3010 train_time:288063ms step_avg:34.92ms
+step:8300/50000 train_loss:2.5006 train_time:289861ms step_avg:34.92ms
+step:8350/50000 train_loss:2.1718 train_time:291680ms step_avg:34.93ms
+step:8400/50000 train_loss:2.4256 train_time:293473ms step_avg:34.94ms
+step:8450/50000 train_loss:2.1831 train_time:295247ms step_avg:34.94ms
+step:8500/50000 train_loss:2.1570 train_time:297030ms step_avg:34.94ms
+step:8550/50000 train_loss:2.2844 train_time:298792ms step_avg:34.95ms
+step:8600/50000 train_loss:2.3148 train_time:300588ms step_avg:34.95ms
+step:8650/50000 train_loss:2.0317 train_time:302391ms step_avg:34.96ms
+step:8700/50000 train_loss:2.2875 train_time:304181ms step_avg:34.96ms
+step:8750/50000 train_loss:2.3576 train_time:305958ms step_avg:34.97ms
+step:8800/50000 train_loss:2.1607 train_time:307735ms step_avg:34.97ms
+step:8850/50000 train_loss:2.3101 train_time:309514ms step_avg:34.97ms
+step:8900/50000 train_loss:2.3656 train_time:311305ms step_avg:34.98ms
+step:8950/50000 train_loss:2.1843 train_time:313019ms step_avg:34.97ms
+step:9000/50000 train_loss:2.3415 train_time:314723ms step_avg:34.97ms
+step:9050/50000 train_loss:2.1358 train_time:316480ms step_avg:34.97ms
+step:9100/50000 train_loss:2.5386 train_time:318242ms step_avg:34.97ms
+step:9150/50000 train_loss:2.2194 train_time:319941ms step_avg:34.97ms
+step:9200/50000 train_loss:2.1892 train_time:321602ms step_avg:34.96ms
+step:9250/50000 train_loss:2.2388 train_time:323343ms step_avg:34.96ms
+step:9300/50000 train_loss:2.3901 train_time:325124ms step_avg:34.96ms
+step:9350/50000 train_loss:2.2688 train_time:326933ms step_avg:34.97ms
+step:9400/50000 train_loss:2.2736 train_time:328714ms step_avg:34.97ms
+step:9450/50000 train_loss:2.3254 train_time:330472ms step_avg:34.97ms
+step:9500/50000 train_loss:2.3169 train_time:332190ms step_avg:34.97ms
+step:9550/50000 train_loss:2.3975 train_time:333891ms step_avg:34.96ms
+step:9600/50000 train_loss:2.2781 train_time:335600ms step_avg:34.96ms
+step:9650/50000 train_loss:2.2074 train_time:337309ms step_avg:34.95ms
+step:9700/50000 train_loss:1.9904 train_time:339016ms step_avg:34.95ms
+step:9750/50000 train_loss:2.3648 train_time:340733ms step_avg:34.95ms
+step:9800/50000 train_loss:1.6635 train_time:342501ms step_avg:34.95ms
+step:9850/50000 train_loss:1.9906 train_time:344271ms step_avg:34.95ms
+step:9900/50000 train_loss:2.1640 train_time:346048ms step_avg:34.95ms
+step:9950/50000 train_loss:2.2434 train_time:347830ms step_avg:34.96ms
+step:10000/50000 train_loss:2.2322 train_time:349611ms step_avg:34.96ms
+step:10050/50000 train_loss:2.2401 train_time:351395ms step_avg:34.96ms
+step:10100/50000 train_loss:2.2390 train_time:353175ms step_avg:34.97ms
+step:10150/50000 train_loss:2.2327 train_time:354957ms step_avg:34.97ms
+step:10200/50000 train_loss:2.0367 train_time:356732ms step_avg:34.97ms
+step:10250/50000 train_loss:2.0424 train_time:358514ms step_avg:34.98ms
+step:10300/50000 train_loss:2.0431 train_time:360319ms step_avg:34.98ms
+step:10350/50000 train_loss:2.2205 train_time:362110ms step_avg:34.99ms
+step:10400/50000 train_loss:2.2244 train_time:363888ms step_avg:34.99ms
+step:10450/50000 train_loss:2.1810 train_time:365667ms step_avg:34.99ms
+step:10500/50000 train_loss:2.3601 train_time:367444ms step_avg:34.99ms
+step:10550/50000 train_loss:2.3151 train_time:369226ms step_avg:35.00ms
+step:10600/50000 train_loss:2.0470 train_time:371009ms step_avg:35.00ms
+step:10650/50000 train_loss:2.1344 train_time:372731ms step_avg:35.00ms
+step:10700/50000 train_loss:2.0137 train_time:374391ms step_avg:34.99ms
+step:10750/50000 train_loss:2.3075 train_time:376075ms step_avg:34.98ms
+step:10800/50000 train_loss:2.0624 train_time:377774ms step_avg:34.98ms
+step:10850/50000 train_loss:2.0419 train_time:379476ms step_avg:34.97ms
+step:10900/50000 train_loss:2.4390 train_time:381181ms step_avg:34.97ms
+step:10950/50000 train_loss:2.2559 train_time:382881ms step_avg:34.97ms
+step:11000/50000 train_loss:2.2951 train_time:384581ms step_avg:34.96ms
+step:11050/50000 train_loss:2.2968 train_time:386285ms step_avg:34.96ms
+step:11100/50000 train_loss:2.3249 train_time:388057ms step_avg:34.96ms
+step:11150/50000 train_loss:2.2465 train_time:389833ms step_avg:34.96ms
+step:11200/50000 train_loss:2.3557 train_time:391631ms step_avg:34.97ms
+step:11250/50000 train_loss:2.3806 train_time:393439ms step_avg:34.97ms
+step:11300/50000 train_loss:2.0738 train_time:395245ms step_avg:34.98ms
+step:11350/50000 train_loss:2.3109 train_time:397051ms step_avg:34.98ms
+step:11400/50000 train_loss:2.2638 train_time:398856ms step_avg:34.99ms
+step:11450/50000 train_loss:2.1450 train_time:400658ms step_avg:34.99ms
+step:11500/50000 train_loss:2.0903 train_time:402464ms step_avg:35.00ms
+step:11550/50000 train_loss:2.3458 train_time:404163ms step_avg:34.99ms
+step:11600/50000 train_loss:1.9832 train_time:405865ms step_avg:34.99ms
+step:11650/50000 train_loss:2.1829 train_time:407568ms step_avg:34.98ms
+step:11700/50000 train_loss:2.2723 train_time:409272ms step_avg:34.98ms
+step:11750/50000 train_loss:2.2348 train_time:410998ms step_avg:34.98ms
+step:11800/50000 train_loss:2.1736 train_time:412775ms step_avg:34.98ms
+step:11850/50000 train_loss:2.2375 train_time:414561ms step_avg:34.98ms
+step:11900/50000 train_loss:2.3841 train_time:416350ms step_avg:34.99ms
+step:11950/50000 train_loss:2.1683 train_time:418130ms step_avg:34.99ms
+step:12000/50000 train_loss:2.1431 train_time:419866ms step_avg:34.99ms
+step:12050/50000 train_loss:1.8059 train_time:421571ms step_avg:34.99ms
+step:12100/50000 train_loss:2.2814 train_time:423330ms step_avg:34.99ms
+step:12150/50000 train_loss:2.2835 train_time:425106ms step_avg:34.99ms
+step:12200/50000 train_loss:2.2930 train_time:426892ms step_avg:34.99ms
+step:12250/50000 train_loss:2.3541 train_time:428550ms step_avg:34.98ms
+step:12300/50000 train_loss:2.3667 train_time:430292ms step_avg:34.98ms
+step:12350/50000 train_loss:2.3606 train_time:432070ms step_avg:34.99ms
+step:12400/50000 train_loss:2.4089 train_time:433849ms step_avg:34.99ms
+step:12450/50000 train_loss:2.2784 train_time:435629ms step_avg:34.99ms
+step:12500/50000 train_loss:2.3140 train_time:437411ms step_avg:34.99ms
+step:12550/50000 train_loss:2.2015 train_time:439192ms step_avg:35.00ms
+step:12600/50000 train_loss:2.4235 train_time:440974ms step_avg:35.00ms
+step:12650/50000 train_loss:1.9358 train_time:442779ms step_avg:35.00ms
+step:12700/50000 train_loss:2.2638 train_time:444571ms step_avg:35.01ms
+step:12750/50000 train_loss:2.2016 train_time:446357ms step_avg:35.01ms
+step:12800/50000 train_loss:2.2740 train_time:448144ms step_avg:35.01ms
+step:12850/50000 train_loss:2.3640 train_time:449937ms step_avg:35.01ms
+step:12900/50000 train_loss:1.9129 train_time:451727ms step_avg:35.02ms
+step:12950/50000 train_loss:2.2476 train_time:453511ms step_avg:35.02ms
+step:13000/50000 train_loss:2.2352 train_time:455292ms step_avg:35.02ms
+step:13050/50000 train_loss:2.2938 train_time:457072ms step_avg:35.02ms
+step:13100/50000 train_loss:2.4015 train_time:458821ms step_avg:35.02ms
+step:13150/50000 train_loss:2.2461 train_time:460520ms step_avg:35.02ms
+step:13200/50000 train_loss:2.0895 train_time:462215ms step_avg:35.02ms
+step:13250/50000 train_loss:2.1653 train_time:463925ms step_avg:35.01ms
+step:13300/50000 train_loss:2.2116 train_time:465670ms step_avg:35.01ms
+step:13350/50000 train_loss:2.0972 train_time:467444ms step_avg:35.01ms
+step:13400/50000 train_loss:2.2813 train_time:469211ms step_avg:35.02ms
+step:13450/50000 train_loss:2.5665 train_time:470980ms step_avg:35.02ms
+step:13500/50000 train_loss:2.3144 train_time:472763ms step_avg:35.02ms
+step:13550/50000 train_loss:2.8226 train_time:474561ms step_avg:35.02ms
+step:13600/50000 train_loss:2.2424 train_time:476329ms step_avg:35.02ms
+step:13650/50000 train_loss:2.2265 train_time:478114ms step_avg:35.03ms
+step:13700/50000 train_loss:2.2459 train_time:479912ms step_avg:35.03ms
+step:13750/50000 train_loss:2.0682 train_time:481659ms step_avg:35.03ms
+step:13800/50000 train_loss:2.3335 train_time:483339ms step_avg:35.02ms
+step:13850/50000 train_loss:2.2597 train_time:485043ms step_avg:35.02ms
+step:13900/50000 train_loss:2.2211 train_time:486744ms step_avg:35.02ms
+step:13950/50000 train_loss:1.7927 train_time:488448ms step_avg:35.01ms
+step:14000/50000 train_loss:2.1944 train_time:490183ms step_avg:35.01ms
+step:14050/50000 train_loss:2.1782 train_time:491948ms step_avg:35.01ms
+step:14100/50000 train_loss:2.0331 train_time:493703ms step_avg:35.01ms
+step:14150/50000 train_loss:2.5710 train_time:495404ms step_avg:35.01ms
+step:14200/50000 train_loss:2.0438 train_time:497119ms step_avg:35.01ms
+step:14250/50000 train_loss:2.6737 train_time:498891ms step_avg:35.01ms
+step:14300/50000 train_loss:3.4563 train_time:500660ms step_avg:35.01ms
+step:14350/50000 train_loss:2.4062 train_time:502446ms step_avg:35.01ms
+step:14400/50000 train_loss:2.2745 train_time:504230ms step_avg:35.02ms
+step:14450/50000 train_loss:2.1246 train_time:506016ms step_avg:35.02ms
+step:14500/50000 train_loss:2.5472 train_time:507800ms step_avg:35.02ms
+step:14550/50000 train_loss:2.1101 train_time:509551ms step_avg:35.02ms
+step:14600/50000 train_loss:1.9845 train_time:511327ms step_avg:35.02ms
+step:14650/50000 train_loss:2.1668 train_time:513128ms step_avg:35.03ms
+step:14700/50000 train_loss:2.1590 train_time:514929ms step_avg:35.03ms
+step:14750/50000 train_loss:2.1702 train_time:516716ms step_avg:35.03ms
+step:14800/50000 train_loss:2.2087 train_time:518459ms step_avg:35.03ms
+step:14850/50000 train_loss:2.3352 train_time:520164ms step_avg:35.03ms
+step:14900/50000 train_loss:2.2265 train_time:521865ms step_avg:35.02ms
+step:14950/50000 train_loss:2.3255 train_time:523568ms step_avg:35.02ms
+step:15000/50000 train_loss:2.2696 train_time:525276ms step_avg:35.02ms
+step:15050/50000 train_loss:2.5744 train_time:526984ms step_avg:35.02ms
+step:15100/50000 train_loss:2.0539 train_time:528747ms step_avg:35.02ms
+step:15150/50000 train_loss:2.2671 train_time:530523ms step_avg:35.02ms
+step:15200/50000 train_loss:2.1236 train_time:532316ms step_avg:35.02ms
+step:15250/50000 train_loss:1.9980 train_time:534115ms step_avg:35.02ms
+step:15300/50000 train_loss:2.1633 train_time:535784ms step_avg:35.02ms
+step:15350/50000 train_loss:2.3963 train_time:537483ms step_avg:35.02ms
+step:15400/50000 train_loss:2.1539 train_time:539201ms step_avg:35.01ms
+step:15450/50000 train_loss:2.2988 train_time:540966ms step_avg:35.01ms
+step:15500/50000 train_loss:2.1471 train_time:542736ms step_avg:35.02ms
+step:15550/50000 train_loss:2.1022 train_time:544504ms step_avg:35.02ms
+step:15600/50000 train_loss:2.1430 train_time:546266ms step_avg:35.02ms
+step:15650/50000 train_loss:2.3859 train_time:548033ms step_avg:35.02ms
+step:15700/50000 train_loss:2.0890 train_time:549798ms step_avg:35.02ms
+step:15750/50000 train_loss:2.2255 train_time:551572ms step_avg:35.02ms
+step:15800/50000 train_loss:2.0634 train_time:553414ms step_avg:35.03ms
+step:15850/50000 train_loss:2.1517 train_time:555181ms step_avg:35.03ms
+step:15900/50000 train_loss:2.2375 train_time:556977ms step_avg:35.03ms
+step:15950/50000 train_loss:2.2951 train_time:558762ms step_avg:35.03ms
+step:16000/50000 train_loss:2.0855 train_time:560543ms step_avg:35.03ms
+step:16050/50000 train_loss:2.4331 train_time:562332ms step_avg:35.04ms
+step:16100/50000 train_loss:2.2599 train_time:564116ms step_avg:35.04ms
+step:16150/50000 train_loss:2.1074 train_time:565906ms step_avg:35.04ms
+step:16200/50000 train_loss:2.4727 train_time:567695ms step_avg:35.04ms
+step:16250/50000 train_loss:2.1525 train_time:569488ms step_avg:35.05ms
+step:16300/50000 train_loss:2.3136 train_time:571277ms step_avg:35.05ms
+step:16350/50000 train_loss:2.1466 train_time:573064ms step_avg:35.05ms
+step:16400/50000 train_loss:2.2164 train_time:574856ms step_avg:35.05ms
+step:16450/50000 train_loss:2.2248 train_time:576458ms step_avg:35.04ms
+step:16500/50000 train_loss:2.1285 train_time:578058ms step_avg:35.03ms
+step:16550/50000 train_loss:2.0227 train_time:579748ms step_avg:35.03ms
+step:16600/50000 train_loss:2.2005 train_time:581506ms step_avg:35.03ms
+step:16650/50000 train_loss:2.1436 train_time:583055ms step_avg:35.02ms
+step:16700/50000 train_loss:2.2271 train_time:584631ms step_avg:35.01ms
+step:16750/50000 train_loss:2.0956 train_time:586343ms step_avg:35.01ms
+step:16800/50000 train_loss:2.2904 train_time:588056ms step_avg:35.00ms
+step:16850/50000 train_loss:2.1203 train_time:589745ms step_avg:35.00ms
+step:16858/50000 val_loss:2.1666 val_bpb:1.2832 train_time:590039ms step_avg:35.00ms
+stopping_early: wallclock_cap train_time:590039ms step:16858/50000
+peak memory allocated: 1506 MiB reserved: 1588 MiB
+Serialized model: 67224983 bytes
+Code size: 38830 bytes
+Total submission size: 67263813 bytes
+Serialized model int8+zlib: 15790377 bytes (payload:17178912 raw_torch:17224025 payload_ratio:3.91x)
+Total submission size int8+zlib: 15829207 bytes
+final_int8_zlib_roundtrip val_loss:2.1740 val_bpb:1.2875 eval_time:2829ms
+final_int8_zlib_roundtrip_exact val_loss:2.17395389 val_bpb:1.28753794
+acsa_eval:targets=postblock,prehead dim:160 topk:40 shrink:topk params:103680
+acsa_eval_progress rank0_local_docs:4416/6250 batch:69/98 elapsed:16s eta:6s docs_per_s:284.80
+acsa_eval_progress rank0_local_docs:5376/6250 batch:84/98 elapsed:31s eta:5s docs_per_s:175.32
+acsa_eval_progress rank0_local_docs:5952/6250 batch:93/98 elapsed:48s eta:2s docs_per_s:124.62
+acsa_eval_progress rank0_local_docs:6208/6250 batch:97/98 elapsed:1m10s eta:0s docs_per_s:88.99
+acsa_eval_progress rank0_local_docs:6250/6250 batch:98/98 elapsed:1m36s eta:0s docs_per_s:65.07
+final_int8_ttt_acsa val_loss:2.1240 val_bpb:1.2580 eval_time:141662ms
+compliance artifact_under_limit:1 eval_under_limit:1 train_under_limit:0 artifact_bytes:15829207 eval_time_ms:144491
+wrote_submission_json:/root/parameter-golf/records/track_non_record_16mb/2026-04-27_ActivationSpaceCSA_SP1024_RTX3060_Pilot/submission.json


### PR DESCRIPTION
## Summary

This PR adds a non-record submission under:

`records/track_non_record_16mb/2026-04-28_ActivationSpaceCSA_SP1024_8xH100/`

The submission explores **Activation-Space Compressed-Sensing Adapters (ACSA)** as an alternative to LoRA-based evaluation-time adaptation on the `2026-03-17_LoRA_TTT` lineage.

Instead of attaching trainable low-rank weight deltas, ACSA adapts the model through a small sparse code in activation space while preserving the legal **score-before-update** evaluation protocol and resetting adapter state between documents.

## Main Result

From the committed `8xH100 SXM 80GB` run:

- Pre-ACSA quantized roundtrip: `1.2875 bpb`
- Final quantized eval with ACSA: `1.2580 bpb`
- Compressed artifact size: `15,829,207` bytes
- Total ACSA eval time: `144,491 ms`

So the current ACSA path stays under the `16 MB` artifact cap and improves the compressed model relative to its own no-adaptation quantized evaluation.

## Comparison To The Starting Baseline

The starting baseline for this experiment lineage is the `2026-03-17_LoRA_TTT` record, which reports `1.1928 bpb`.

Relative to that baseline:

- `LoRA_TTT` baseline: `1.1928 bpb`
- Current ACSA non-record result: `1.2580 bpb`
- Delta vs baseline: `+0.0652 bpb`

So this submission does **not** claim a leaderboard improvement. It is being submitted as a **non-record** result because the mechanism is novel in this repo context and produces a real improvement over its own quantized no-ACSA evaluation.

## Included Files

This PR only adds files inside the submission folder:

- `README.md`
- `requirements.txt`
- `submission.json`
- `train_gpt.py`
- `training.log`
- `final_model.int8.ptz`

## Note on Follow-Up Work

Further progress on this line is currently gated by compute credits. I am waiting for additional credits to continue with more seed runs, parameter sweeps, implementation cleanup, and follow-up ideas that are not yet tested in this submission.

## Notes

- This is a non-record submission, not a leaderboard claim.
- No multi-seed statistical package is included.
- The stack is still `SP1024`.
- One preserved line in `training.log` still references the earlier `RTX3060_Pilot` folder label because the run log was kept as originally generated and the folder was renamed only during final packaging.
