### PR TITLE
Attempted H200 run: learned pipeline bottlenecks

### DIFF
--- a/records/track_10min_16mb/2026-04-30_Attempted_H200_Learnings/README.md
+++ b/records/track_10min_16mb/2026-04-30_Attempted_H200_Learnings/README.md
@@ -1,0 +1,7 @@
+# Attempted H200 Learnings
+
+This submission records an attempted final run under severe time pressure.
+
+I tried to reproduce and extend the current SP8192/CaseOps/TTT frontier, but the practical bottleneck became data preparation and environment stability rather than model code. The main lesson was that CPU preprocessing, FA3 compilation, and final torchrun need to be staged as a pipeline before the expensive GPU window starts.
+
+No new score is claimed here. This is a small record of the attempt and what I learned.


### PR DESCRIPTION
This is a no-score attempt record. I tried to reproduce and extend the SP8192/CaseOps/TTT frontier under a short GPU window, but the useful result was operational: data preprocessing, FA3 compilation, and final torchrun need to be staged before the expensive GPU window. No new val_bpb is claimed.