### PR TITLE
Record candidate: PR #1855 + Adaptive Hessian-Sensitivity GPTQ Clip — val_bpb 1.06310 (3-seed mean)

### DIFF
--- a/records/track_10min_16mb/2026-04-30_AdaptiveHessianClip_PR1855_1.0631/README.md
+++ b/records/track_10min_16mb/2026-04-30_AdaptiveHessianClip_PR1855_1.0631/README.md
@@ -1,0 +1,357 @@
+# Record candidate: PR #1855 stack + Adaptive Hessian-Sensitivity GPTQ Clip + TTT_LORA_RANK=56
+
+**val_bpb: 1.06310** (3-seed mean, std 0.00102) | ~15.9 MB | 8×H100 SXM, 600s wallclock | phased TTT eval
+
+**Comparison vs current leaderboard (PR #1855, 1.06108):** **+0.00203 BPB / +0.00444 nats**.
+
+This is a follow-up to **PR [#1689](https://github.com/openai/parameter-golf/pull/1689)**
+by the same author, which introduced adaptive Hessian-sensitivity GPTQ
+clipping at 1.0822 BPB on the PR #1394 base. The leaderboard has since
+advanced through ~20 PRs to PR #1855 at 1.06108. This submission ports the
+adaptive-clip technique onto PR #1855's stack to test whether the
+sensitivity-driven per-tensor approach holds up against LQER asymmetric
+quantization, the heavily-tuned 9-hparam greedy stack, and the rest of
+the modern pipeline.
+
+The adaptive Hessian-sensitivity GPTQ clipping technique **eliminates three
+hand-tuned hyperparameters** (`MLP_CLIP_SIGMAS=11.5`, `ATTN_CLIP_SIGMAS=13.0`,
+`MATRIX_CLIP_SIGMAS=12.85`) from the search space and replaces them with one
+automated per-tensor selection driven by the Hessian diagonal magnitude. On
+PR #1855's heavily-tuned base it reproduces the hand-tuned result within ~2σ
+(t≈2.0 across our 3 seeds vs theirs) at +0.00203 BPB; on a stack that has not
+had per-group sigmas tuned, it saves both the search cost and the risk of
+overfitting the validation distribution.
+
+A **second technique** — Hessian-sensitivity-driven mixed-precision GPTQ
+(int5/int6/int7) — was tested in the same codebase under `MIXED_PRECISION_HESSIAN=1`
+and is documented below as a negative result.
+
+## Results
+
+| Seed     | Steps     | ms/step   | Pre-quant val_bpb | Post-quant val_bpb | **Post-TTT val_bpb** | Artifact bytes | Eval time |
+|----------|-----------|-----------|-------------------|--------------------|----------------------|----------------|-----------|
+| 42       | 4,835     | 123.3     | 1.06498           | 1.07480            | **1.06214**          | 15,905,000     | 592.9 s   |
+| 1337     | 4,807     | 124.0     | 1.06711           | 1.07696            | **1.06417**          | 15,918,827     | 521.1 s   |
+| 999      | 4,805     | 124.1     | 1.06611           | 1.07570            | **1.06300**          | 15,901,152     | 456.5 s   |
+| **Mean** | **4,816** | **123.8** | 1.06607           | 1.07582            | **1.06310**          | 15,908,326     | 523.5 s   |
+
+3-seed std: 0.00102 BPB / 0.00224 nats. All artifacts under 16,000,000 bytes;
+all runs stopped at the 600 s wallclock cap.
+
+## Architecture
+
+Inherited from PR #1855 unless marked **new**.
+
+| Component                         | Setting                                                 | Source                                                                                                                                                                                                                                                                         |
+|-----------------------------------|---------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Layers                            | 11 (512d, 8 GQA heads, 4 KV heads)                      | Baseline                                                                                                                                                                                                                                                                       |
+| MLP                               | 4× (2048) with LeakyReLU(0.5)²                          | [#493](https://github.com/openai/parameter-golf/pull/493)                                                                                                                                                                                                                      |
+| Fused MLP kernel                  | LeakyReLU-square Triton                                 | [#1530](https://github.com/openai/parameter-golf/pull/1530)                                                                                                                                                                                                                    |
+| Attention                         | Standard FA3, GQA 2:1                                   | Baseline                                                                                                                                                                                                                                                                       |
+| XSA                               | All 11 layers                                           | [#478](https://github.com/openai/parameter-golf/pull/478)                                                                                                                                                                                                                      |
+| RoPE                              | Partial (16/64 dims) + YaRN                             | [#315](https://github.com/openai/parameter-golf/pull/315)                                                                                                                                                                                                                      |
+| LN Scale                          | 1/√(layer+1)                                            | [#315](https://github.com/openai/parameter-golf/pull/315)                                                                                                                                                                                                                      |
+| QK Gain init                      | 5.0 (per-head learned)                                  | [#1276](https://github.com/openai/parameter-golf/pull/1276)                                                                                                                                                                                                                    |
+| U-Net skips                       | Encoder-decoder skip + skip gates                       | [#289](https://github.com/openai/parameter-golf/pull/289)                                                                                                                                                                                                                      |
+| Parallel decoder                  | 2-lane parallel from layer 8+, lane mix learned         | [#1530](https://github.com/openai/parameter-golf/pull/1530)                                                                                                                                                                                                                    |
+| Depth recurrence                  | Loop layers 3–5, run 3× once frac ≥ 0.35                | [#1344](https://github.com/openai/parameter-golf/pull/1344)                                                                                                                                                                                                                    |
+| Logit softcap                     | 30                                                      | Gemma2-style                                                                                                                                                                                                                                                                   |
+| Sparse attention gate             | Narrow head-output gate, gate_window=12                 | [#1787](https://github.com/openai/parameter-golf/pull/1787)                                                                                                                                                                                                                    |
+| SmearGate (BOS-fixed)             | Position-mixing gate with `not_bos` mask                | [#1667](https://github.com/openai/parameter-golf/pull/1667) + [#1851](https://github.com/openai/parameter-golf/pull/1851)                                                                                                                                                      |
+| Polar-Express Newton-Schulz       | Muon, 5 steps, per-iter minimax tuples                  | [#1344](https://github.com/openai/parameter-golf/pull/1344) → [#1787](https://github.com/openai/parameter-golf/pull/1787)                                                                                                                                                      |
+| MIN_LR floor                      | 0.10 (warmdown LR floor)                                | [#1787](https://github.com/openai/parameter-golf/pull/1787)                                                                                                                                                                                                                    |
+| Fused softcapped CE Triton kernel | Single-pass training-only                               | [#1787](https://github.com/openai/parameter-golf/pull/1787)                                                                                                                                                                                                                    |
+| LQER asymmetric int4              | Rank-4 quant-error correction on top-3 tensors          | [#1797](https://github.com/openai/parameter-golf/pull/1797)                                                                                                                                                                                                                    |
+| Per-group compression             | lrzip zpaq + L1 simsort + brotli remainder              | [#1855](https://github.com/openai/parameter-golf/pull/1855)                                                                                                                                                                                                                    |
+| Quantization base                 | GPTQ int6 + int7 embed + int8-per-row attn-gate         | [#1394](https://github.com/openai/parameter-golf/pull/1394), [#1586](https://github.com/openai/parameter-golf/pull/1586), [#1736](https://github.com/openai/parameter-golf/pull/1736)                                                                                          |
+| Phased TTT                        | 3 cumulative phases, LoRA rank 80→**56**, per-doc reset | concept [#1610](https://github.com/openai/parameter-golf/pull/1610) → [#1626](https://github.com/openai/parameter-golf/pull/1626) → [#1736](https://github.com/openai/parameter-golf/pull/1736); rank 56 from open [#1935](https://github.com/openai/parameter-golf/pull/1935) |
+| **GPTQ clip selection**           | **Per-tensor adaptive σ ∈ [6, 24] from H_diag·row_var** | **[#1689](https://github.com/openai/parameter-golf/pull/1689) (this submitter), ported to PR #1855 stack**                                                                                                                                                                    |
+| Tokenizer                         | sp8192 lossless caps caseops v1 reserved                | [#1729](https://github.com/openai/parameter-golf/pull/1729)                                                                                                                                                                                                                    |
+
+## Adaptive Hessian-Sensitivity GPTQ Clipping
+
+**Setting up the problem.** GPTQ rounds floating-point weights to a small
+integer range (here `bits=6`, range `[-31, 31]`). Each row of each matrix is
+scaled by a single fp16 factor `s_row` such that `q_row = round(W_row / s_row)`.
+The choice of `s_row` is a tradeoff: tight scales waste bits on outlier rows
+(more clipping); loose scales dilute precision in the bulk (more roundoff).
+The standard heuristic — used by SDClip in PR #1394 and tuned per-group in PR
+#1855 — is `s_row = (clip_sigmas · std(W_row)) / clip_range`, where
+`clip_sigmas` is a hyperparameter usually in [3, 20].
+
+PR #1855's 9-hparam greedy search settled on **three** per-group `clip_sigmas`
+values:
+
+| Group          | clip_sigmas | Tensor count                              |
+|----------------|-------------|-------------------------------------------|
+| MLP            | 11.5        | 22 (mlp.fc + mlp.proj)                    |
+| Attention      | 13.0        | 44 (c_q, c_k, c_v, proj across 11 layers) |
+| Matrix (other) | 12.85       | a few non-bank tensors                    |
+
+These three numbers are themselves an averaging of the per-tensor optimum
+under a constrained search. Different stacks (different recurrence patterns,
+different LR schedules, different Hessian distributions from training data)
+would shift the optimum.
+
+**Adaptive replacement.** This submission replaces the three constants with one
+**per-tensor** clip-sigma chosen from each tensor's Hessian sensitivity:
+
+```
+sens(name) = max( H_diag(name).mean() · row_var(W(name)),  ε )
+log_raw(name) = -0.15 · log(sens(name))
+σ(name) = clamp( exp(log_raw(name) + offset),  6.0,  24.0 )
+```
+
+The `offset` is determined by binary search such that the numel-weighted
+log-average of σ across all matrix tensors equals PR #1855's hand-tuned
+log-average:
+
+```
+target = (Σ_n  numel(n) · log(base_cs(n)))  /  Σ_n  numel(n)
+```
+
+where `base_cs(n)` is the appropriate hand-tuned per-group sigma for tensor
+`n`. This guarantees that **the overall compression budget is preserved** —
+the average sigma across the model is unchanged from PR #1855, only the
+per-tensor distribution shifts according to sensitivity.
+
+**Why `H_diag.mean() × row_var`?** GPTQ minimises the layer-wise output error
+`||(W − Ŵ) X||_F²` where `X` is calibration activations. To leading order
+this scales with `tr(H · ΔW · ΔW^T)` for a tensor with Hessian `H = X X^T`.
+Allocating clip-aggressiveness inversely to `H_diag.mean() · row_var` (hence
+the `-0.15 · log` above; the 0.15 coefficient is empirical, originally tuned
+in PR [#1689](https://github.com/openai/parameter-golf/pull/1689)) approximates
+the optimal sensitivity-budgeted clip allocation. Tensors with high effective sensitivity (high Hessian magnitude,
+high weight variance) get smaller σ — finer integer granularity at the cost
+of more outlier clipping. Tensors with low sensitivity get larger σ — accept
+roundoff in the bulk to preserve outliers.
+
+**Per-tensor allocation (seed 42).** All 66 matrix tensors, sorted by canonical
+order:
+
+```
+                  c_q     c_k     c_v    proj    fc     proj
+blocks.0:        8.74    8.60    8.37   11.39   8.39    9.25
+blocks.1:        9.73    9.46    9.19   14.52   9.24   11.26
+blocks.2:       10.37   10.17   10.00   14.48   9.80   12.28
+blocks.3:        9.21    8.94    8.79   13.82   8.75   11.08
+blocks.4:        9.55    9.39    9.17   12.94   9.02   12.22
+blocks.5:        9.86    9.48    9.35   14.52   9.27   12.41
+blocks.6:       11.75   11.47   11.21   18.13  11.11   14.83
+blocks.7:       12.02   11.66   11.51   19.61  11.35   16.79
+blocks.8:       12.31   12.04   11.57   15.51  11.60   17.67
+blocks.9:       12.66   12.18   11.55   24.00  11.80   17.89
+blocks.10:      12.75   12.36   11.75   24.00  12.09   19.58
+```
+
+The pattern reflects two robust intuitions:
+
+1. **Output projections (`attn.proj`, `mlp.proj`) systematically receive larger σ**
+   than input projections at the same depth — their inputs are post-attention /
+   post-activation residual streams with smaller variance, so their per-row
+   Hessians scale smaller, so the sensitivity-divided budget allocates them
+   more clip-room.
+2. **Sigmas widen with depth**. Deeper layers' attn.proj and mlp.proj weights
+   are processing increasingly low-variance signals (after many residual
+   additions); their Hessian diagonals are small in absolute terms; they get
+   the most permissive clipping. Layers 9-10 attn.proj hit the upper clamp at
+   24.00 — the technique would prefer even less precision there but is bounded.
+
+The pattern is **stable across seeds** (per-tensor σ matches to within 0.05 across
+all three runs), confirming the technique is responding to the model architecture
+and training-data distribution, not seed-specific noise.
+
+**Composability with LQER.** PR #1855's LQER asymmetric int4 picks the top-3
+highest-error tensors after GPTQ for rank-4 correction. Across all three
+seeds, our adaptive-clip pipeline converges on the same LQER selection as
+PR #1855's hand-tuned pipeline (top-3 are mlp.fc layers, plus tok_emb at
+int7 by default). The adaptive technique does not destabilise LQER's
+selection.
+
+**Composability with phased TTT.** TTT recovery dynamics under the adaptive
+clip pipeline match PR #1855's hand-tuned pipeline exactly (-0.01272 mean
+across all three seeds in both submissions, four decimals identical). The
+technique only modifies the GPTQ clip-sigma stage; the phased TTT eval
+sees an identically-shaped quantization error distribution and recovers
+the same amount.
+
+## Mixed-precision GPTQ ablation (gated, negative result)
+
+A second technique was implemented in the same codebase under
+`MIXED_PRECISION_HESSIAN=1` (off by default). Same Hessian-sensitivity ranking
+is used to allocate **bit width** rather than clip σ:
+
+- Bottom 25% by sensitivity → int5
+- Middle 50% → int6
+- Top 25% → int7
+
+Average bits-per-weight is conserved at 6.0 (same as all-int6).
+
+Single-seed test on the same PR #1855 stack:
+
+| Configuration                                | Pre-quant | Post-quant | Quant penalty |
+|----------------------------------------------|-----------|------------|---------------|
+| PR #1855 baseline (all int6 + LQER)          | 1.06396   | 1.07254    | +0.00858      |
+| This work (adaptive σ + all int6 + LQER)     | 1.06498   | 1.07480    | +0.00982      |
+| **+ Hessian mixed-precision (5/6/7) + LQER** | 1.07155   | 1.08465    | **+0.01310**  |
+
+The 16 int5 tensors lose more precision than the 16 int7 tensors gain. Net
++0.0045 quant penalty vs all-int6. Different from PR #1908's AWQ-lite mixed
+precision (which uses **activation-magnitude** sensitivity rather than
+Hessian-diagonal sensitivity), but the negative result is symmetric: an
+aggressive int5 floor on a heavily-tuned stack with LQER on top is too
+costly. Disabled in this submission. Reported as an honest ablation; the
+codebase ships with the gate so reviewers can reproduce.
+
+## Hyperparameter stack
+
+PR #1855's full 9-hparam greedy stack is preserved with one change:
+
+| hparam                 | value  | source            |
+|------------------------|--------|-------------------|
+| MLP_CLIP_SIGMAS        | 11.5   | PR #1855          |
+| EMBED_CLIP_SIGMAS      | 14.0   | PR #1855          |
+| ATTN_CLIP_SIGMAS       | 13.0   | PR #1855          |
+| WARMDOWN_FRAC          | 0.85   | PR #1855          |
+| BETA2                  | 0.99   | PR #1855          |
+| TTT_BETA2              | 0.99   | PR #1855          |
+| TTT_WEIGHT_DECAY       | 0.5    | PR #1855          |
+| **TTT_LORA_RANK**      | **56** | **open PR #1935** |
+| SPARSE_ATTN_GATE_SCALE | 0.5    | PR #1855          |
+| PHASED_TTT_PREFIX_DOCS | 2500   | PR #1855          |
+
+The CLIP_SIGMAS values still appear in the env-var list because they define
+the **target compression budget** that the adaptive offset binary search
+matches. They no longer directly determine per-tensor σ; the adaptive
+mapping does.
+
+## Training & evaluation
+
+|                  |                                                                                                                                                    |
+|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| Training         | 4,816 ± 14 steps in 600 s on 8×H100 SXM (123.8 ms/step mean), warmup=20, warmdown_frac=0.85, MIN_LR=0.10, MATRIX_LR=0.026, GRAD_CLIP_NORM=0.3      |
+| Optimizer        | Polar-Express Muon (5 steps) on matrix params; Adam (β₁=0.9, β₂=0.99) on tied embeddings (lr=0.03) and scalars (lr=0.02)                           |
+| EMA              | decay = 0.9965                                                                                                                                     |
+| Quantization     | GPTQ int6 (matrix, adaptive σ) + int7 (tied embed, fixed σ=14) + int8-per-row attn-gate, with LQER asym int4 rank-4 correction on top-3 tensors    |
+| Compression      | per-group lrzip ZPAQ + L1 simsort on hot tensors + brotli on remainder + brotli code wrapper                                                       |
+| TTT              | Phased, 3 cumulative phases at doc-boundaries 833 / 1666 / 2500; LoRA rank=56 on Q/K/V/O/MLP + lm_head, per-doc reset, lr=5e-5 cosine within phase |
+| Eval time (mean) | 523.5 s of 600 s budget                                                                                                                            |
+
+## Reproduction
+
+```bash
+# Deps (RunPod runpod/parameter-golf:latest base; PEP-668 image)
+pip install --break-system-packages brotli huggingface_hub python-minifier sentencepiece
+pip install --break-system-packages --no-deps flash_attn_3 \
+  --find-links https://windreamer.github.io/flash-attention3-wheels/cu128_torch291/
+apt-get update && apt-get install -y lrzip
+
+# CaseOps tokenized FineWeb (HF, ~16 GB; set HF_TOKEN to skip rate limits)
+export HF_TOKEN=<your_hf_read_token>
+python3 -c "
+from huggingface_hub import snapshot_download
+snapshot_download('romeerp/parameter-golf-caseops-v1',
+                  repo_type='dataset',
+                  local_dir='/workspace/parameter-golf/data/datasets')
+"
+
+# 3-seed run
+for SEED in 42 1337 999; do
+  SEED=$SEED MAX_WALLCLOCK_SECONDS=600 \
+    ADAPTIVE_HESSIAN_CLIP=1 MIXED_PRECISION_HESSIAN=0 TTT_LORA_RANK=56 \
+    CASEOPS_ENABLED=1 SPARSE_ATTN_GATE_ENABLED=1 SMEAR_GATE_ENABLED=1 \
+    LQER_ENABLED=1 LQER_ASYM_ENABLED=1 \
+    MIN_LR=0.1 PHASED_TTT_NUM_PHASES=3 PHASED_TTT_PREFIX_DOCS=2500 \
+    MLP_CLIP_SIGMAS=11.5 EMBED_CLIP_SIGMAS=14.0 EMBED_BITS=7 \
+    WARMDOWN_FRAC=0.85 BETA2=0.99 TTT_BETA2=0.99 TTT_WEIGHT_DECAY=0.5 \
+    SPARSE_ATTN_GATE_SCALE=0.5 \
+    COMPRESSOR=pergroup NCCL_NET=Socket \
+    DATA_PATH=/workspace/parameter-golf/data/datasets/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved \
+    TOKENIZER_PATH=/workspace/parameter-golf/data/datasets/datasets/tokenizers/fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model \
+    PYTHONUNBUFFERED=1 \
+    torchrun --standalone --nproc_per_node=8 train_gpt.py 2>&1 \
+    | tee train_seed${SEED}.log
+done
+```
+
+To reproduce **with** the mixed-precision ablation (negative result), set
+`MIXED_PRECISION_HESSIAN=1`. To reproduce **without** the adaptive technique
+(i.e. PR #1855 verbatim), set `ADAPTIVE_HESSIAN_CLIP=0`.
+
+## Files
+
+- `train_gpt.py` — full training script (~3,750 lines, identical to PR #1855
+  except for ~80 lines of new env-var-gated code: adaptive clip computation
+  in `gptq_mixed_quantize` and the optional mixed-precision bit-allocation
+  block).
+- `train_seed42.log`, `train_seed1337.log`, `train_seed999.log` — full
+  per-seed run logs including the adaptive σ allocation table for each seed.
+- `submission.json` — structured metadata (per-seed val_bpb, std, comparison,
+  technique summary).
+
+## Compliance (track_10min_16mb)
+
+- **Training under 600 s:** ✅ All seeds stopped at the wallclock cap (596 s mean).
+- **Artifact under 16,000,000 bytes:** ✅ All seeds 15.90–15.92 MB.
+- **Eval under 600 s:** ✅ Seeds 456–593 s (median 521 s).
+- **No pre-quant TTT:** ✅ TTT runs post-quantization only.
+- **Score-first TTT:** ✅ Phased TTT scores before each update.
+- **No SLOT / no ETLB / no n-gram cache:** ✅
+- **3 seeds:** ✅ Seeds 42, 1337, 999.
+
+## Credits
+
+The novel contribution — adaptive Hessian-sensitivity GPTQ clipping — was
+first introduced in **PR [#1689](https://github.com/openai/parameter-golf/pull/1689)**
+by this submitter on a different base. This submission ports it to PR #1855's
+stack and shows the technique generalises across architectures.
+
+Implementation lineage of the inherited components stacks decisions from the
+established community PR chain. Direct ancestors:
+
+- **PR [#1855](https://github.com/openai/parameter-golf/pull/1855)** by
+  @codemath3000 — the entire architectural and quantization stack used here:
+  11L XSA, LQER asymmetric, SparseAttnGate, BOS-fixed SmearGate, Polar-Express
+  Muon, MIN_LR, FusedCE, per-group lrzip, 9-hparam greedy. This submission
+  is PR #1855 with the three hand-tuned per-group clip sigmas replaced by
+  one Hessian-driven adaptive selection. Everything else is preserved.
+- **PR [#1851](https://github.com/openai/parameter-golf/pull/1851)** by
+  @aquariouseworkman — SmearGate BOS leak fix, LQER asymmetric int4, 3-phase
+  phased TTT framework that PR #1855 builds on.
+- **PR [#1797](https://github.com/openai/parameter-golf/pull/1797)** by
+  @dexhunter — SmearGate + LQER asymmetric implementation.
+- **PR [#1787](https://github.com/openai/parameter-golf/pull/1787)** by
+  @nprime06 — Polar-Express Newton-Schulz Muon, MIN_LR floor, sparse attention
+  gate, fused softcapped CE.
+- **PR [#1736](https://github.com/openai/parameter-golf/pull/1736)** —
+  CaseOps + GatedAttn + QuantGate + Loop3-5 + phased TTT integration.
+- **PR [#1729](https://github.com/openai/parameter-golf/pull/1729)** by
+  @romeerp — sp8192 lossless caps caseops v1 reserved tokenizer + dataset
+  hosting on HuggingFace as `romeerp/parameter-golf-caseops-v1`.
+- **PR [#1626](https://github.com/openai/parameter-golf/pull/1626)** by
+  @dexhunter — Multi-phase global SGD phased-TTT.
+- **PR [#1530](https://github.com/openai/parameter-golf/pull/1530)** by
+  @samacqua — Variable-length attention, fused LeakyReLU² MLP Triton kernel,
+  parallel residuals, doc-based LoRA TTT.
+- **PR [#1493](https://github.com/openai/parameter-golf/pull/1493)** by
+  @bigbag — 3-layer recurrence, parallel residuals, QK-Gain 5.25 on PR #1394.
+- **PR [#1394](https://github.com/openai/parameter-golf/pull/1394)** by
+  @clarkkev — SP8192 + GPTQ embeddings + SDClip base. The original GPTQ
+  pipeline our adaptive σ replaces.
+- **PR [#1344](https://github.com/openai/parameter-golf/pull/1344)** —
+  Polar-Express Newton-Schulz coefficients + depth recurrence.
+- **PR [#1276](https://github.com/openai/parameter-golf/pull/1276)** —
+  QK-Gain 5.0.
+- **PR [#1586](https://github.com/openai/parameter-golf/pull/1586)** —
+  Per-Layer Adaptive GPTQ Clip + int7 embeddings + MATRIX_LR=0.026.
+- Open **PR [#1935](https://github.com/openai/parameter-golf/pull/1935)**
+  by @vimeto — `TTT_LORA_RANK=56` tweak adopted here.
+- **PR [#493](https://github.com/openai/parameter-golf/pull/493)** —
+  LeakyReLU² activation.
+- **PR [#478](https://github.com/openai/parameter-golf/pull/478)** by
+  @gowtham0992 — XSA on all layers.
+- **PR [#315](https://github.com/openai/parameter-golf/pull/315)** —
+  Partial RoPE + LN Scale.
+- **PR [#289](https://github.com/openai/parameter-golf/pull/289)** —
+  U-Net skip connections.
+

--- a/records/track_10min_16mb/2026-04-30_AdaptiveHessianClip_PR1855_1.0631/submission.json
+++ b/records/track_10min_16mb/2026-04-30_AdaptiveHessianClip_PR1855_1.0631/submission.json
@@ -1,0 +1,61 @@
+{
+  "author": "Chris Colinsky",
+  "github_id": "chris-colinsky",
+  "name": "PR #1855 stack + Adaptive Hessian-Sensitivity GPTQ Clip + TTT_LORA_RANK=56",
+  "blurb": "PR #1855's full architecture (11L XSA + LQER asym int4 rank-4 + SparseAttnGate + BOS-fixed SmearGate + Polar-Express Muon + per-group lrzip + CaseOps tokenizer + phased TTT) with two changes: (1) the three hand-tuned per-group GPTQ clip sigmas (MLP_CLIP_SIGMAS=11.5, ATTN_CLIP_SIGMAS=13.0, MATRIX_CLIP_SIGMAS=12.85) replaced by a per-tensor Hessian-sensitivity-driven adaptive selection that auto-chooses each tensor's clip sigma in [6.0, 24.0] from H_diag.mean()*row_var, with a binary-search offset that preserves PR #1855's numel-weighted log-average compression budget; (2) TTT_LORA_RANK=80 → 56 (PR #1935 tweak). 3-seed mean: 1.06310 BPB (seeds 42/1337/999), std 0.00102. Sub-SOTA vs PR #1855's 1.06108 by +0.00203 nats; submitted as a documented ablation showing the adaptive technique reproduces hand-tuned sigmas within ~2σ while eliminating 3 hyperparameters from the search space.",
+  "date": "2026-04-30",
+  "track": "10min_16mb",
+  "val_loss": 2.32646441,
+  "val_bpb": 1.06310345,
+  "val_loss_std": 0.00224,
+  "val_bpb_std": 0.00102,
+  "seeds": [42, 1337, 999],
+  "seed_results": {
+    "42": {
+      "val_loss": 2.32435698,
+      "val_bpb": 1.06214044,
+      "artifact_bytes": 15905000,
+      "steps": 4835,
+      "step_avg_ms": 123.3,
+      "eval_time_s": 592.9,
+      "pre_quant_val_bpb": 1.06498069,
+      "post_quant_val_bpb": 1.07479764
+    },
+    "1337": {
+      "val_loss": 2.32878891,
+      "val_bpb": 1.06416566,
+      "artifact_bytes": 15918827,
+      "steps": 4807,
+      "step_avg_ms": 124.0,
+      "eval_time_s": 521.1,
+      "pre_quant_val_bpb": 1.06710520,
+      "post_quant_val_bpb": 1.07695614
+    },
+    "999": {
+      "val_loss": 2.32624735,
+      "val_bpb": 1.06300426,
+      "artifact_bytes": 15901152,
+      "steps": 4805,
+      "step_avg_ms": 124.1,
+      "eval_time_s": 456.5,
+      "pre_quant_val_bpb": 1.06611260,
+      "post_quant_val_bpb": 1.07570206
+    }
+  },
+  "comparison_baseline_bpb": 1.06108,
+  "comparison_baseline_pr": "openai/parameter-golf#1855",
+  "delta_vs_leaderboard_bpb": 0.00203,
+  "delta_vs_leaderboard_nats": 0.00444,
+  "artifact_bytes_mean": 15908326,
+  "artifact_bytes_max": 15918827,
+  "bytes_total": 15918827,
+  "train_steps_mean": 4815.67,
+  "step_avg_ms_mean": 123.8,
+  "hardware": "8xH100 80GB SXM",
+  "pytorch_version": "2.9.1+cu128",
+  "cuda_version": "12.8",
+  "flash_attn_version": "FA3 (cu128_torch291 wheel)",
+  "tokenizer": "fineweb_8192_bpe_lossless_caps_caseops_v1_reserved (CaseOps, romeerp/parameter-golf-caseops-v1 on HF)",
+  "technique_summary": "PR #1855 base + adaptive Hessian-sensitivity GPTQ clip (per-tensor sigma in [6,24] from H_diag.mean()*row_var, budget-preserving binary-search offset) + TTT_LORA_RANK=56. The clip technique replaces three hand-tuned hyperparameters (MLP_CLIP_SIGMAS, ATTN_CLIP_SIGMAS, MATRIX_CLIP_SIGMAS) with one automated per-tensor selection. Mixed-precision GPTQ (also Hessian-sensitivity-driven, 25/50/25 int5/int6/int7) was tested in the same codebase but disabled in this submission — ablation finding showed it added +0.0045 quant penalty vs all-int6 + LQER on this stack and is documented as a negative result (gated by MIXED_PRECISION_HESSIAN env var).",
+  "novel_contribution": "Adaptive Hessian-sensitivity GPTQ clipping. Per-tensor clip sigma is chosen from sensitivity = H_diag.mean() * row_var, with a binary-search log-space offset that preserves PR #1855's numel-weighted log-average of (mlp_clip_sigmas, attn_clip_sigmas, matrix_clip_sigmas). Per-tensor sigma is clamped to [6.0, 24.0]. tok_emb is excluded (kept at fixed embed_clip_sigmas=14.0); attn_gate_w uses its own int8-per-row path. Composes mechanically with PR #1855's LQER asymmetric rank-4 correction — LQER picks top-3 highest-error tensors after the adaptive clip is applied. Eliminates 3 hyperparameters from the search space at the cost of ~+0.002 BPB on this heavily-tuned stack."
+}

--- a/records/track_10min_16mb/2026-04-30_AdaptiveHessianClip_PR1855_1.0631/train_gpt.py
+++ b/records/track_10min_16mb/2026-04-30_AdaptiveHessianClip_PR1855_1.0631/train_gpt.py
@@ -1,0 +1,3868 @@
+import base64, collections, copy, fcntl, glob, io, lzma, math, os
+from pathlib import Path
+import random, re, subprocess, sys, time, uuid, numpy as np, sentencepiece as spm, torch, torch.distributed as dist, torch.nn.functional as F
+from torch import Tensor, nn
+from flash_attn_interface import (
+    flash_attn_func as flash_attn_3_func,
+    flash_attn_varlen_func,
+)
+from concurrent.futures import ThreadPoolExecutor
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+# ===== Fused softcapped cross-entropy (Triton) — training-only path =====
+# Replaces the eager
+#     logits_softcap = softcap * tanh(logits / softcap)
+#     F.cross_entropy(logits_softcap.float(), targets, reduction="mean")
+# sequence with a single fused kernel that reads logits_proj once, applies
+# softcap in-register, and computes (LSE, loss) in one streaming pass. The
+# backward kernel mirrors the forward so there's no stored softcapped logits.
+# Numerically identical to the eager path up to fp32 accumulation differences.
+_FUSED_CE_LIBRARY = "pgsubmission1draft7fusedce"
+_FUSED_CE_BLOCK_SIZE = 1024
+_FUSED_CE_NUM_WARPS = 4
+
+
+@triton.jit
+def _softcapped_ce_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, softcap,
+    block_size: tl.constexpr,
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    max_val = -float("inf")
+    sum_exp = 0.0
+    A = 2.0 * softcap
+    inv_C = 2.0 / softcap
+    for off in range(0, n_cols, block_size):
+        cols = off + tl.arange(0, block_size)
+        mask = cols < n_cols
+        val = tl.load(
+            logits_row_ptr + cols * stride_logits_v,
+            mask=mask, other=-float("inf"),
+        ).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C)
+        z = tl.where(mask, z, -float("inf"))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    target = tl.load(targets_ptr + row_idx).to(tl.int32)
+    target_val = tl.load(logits_row_ptr + target * stride_logits_v).to(tl.float32)
+    target_z = A * tl.sigmoid(target_val * inv_C)
+    tl.store(losses_ptr + row_idx, lse - target_z)
+
+
+@triton.jit
+def _softcapped_ce_bwd_kernel(
+    grad_logits_ptr, grad_losses_ptr, lse_ptr, logits_ptr, targets_ptr,
+    stride_logits_n, stride_logits_v,
+    stride_grad_n, stride_grad_v,
+    n_rows, n_cols, softcap,
+    block_size: tl.constexpr,
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_logits_ptr + row_idx * stride_grad_n
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_losses_ptr + row_idx).to(tl.float32)
+    target = tl.load(targets_ptr + row_idx).to(tl.int32)
+    A = 2.0 * softcap
+    inv_C = 2.0 / softcap
+    dz_dx_scale = A * inv_C
+    for off in range(0, n_cols, block_size):
+        cols = off + tl.arange(0, block_size)
+        mask = cols < n_cols
+        val = tl.load(
+            logits_row_ptr + cols * stride_logits_v,
+            mask=mask, other=0.0,
+        ).to(tl.float32)
+        sigmoid_u = tl.sigmoid(val * inv_C)
+        z = A * sigmoid_u
+        probs = tl.exp(z - lse)
+        grad_z = grad_loss * (probs - tl.where(cols == target, 1.0, 0.0))
+        grad_x = grad_z * (dz_dx_scale * sigmoid_u * (1.0 - sigmoid_u))
+        tl.store(grad_row_ptr + cols * stride_grad_v, grad_x, mask=mask)
+
+
+def _validate_softcapped_ce_inputs(
+    logits: Tensor, targets: Tensor, softcap: float,
+) -> tuple[Tensor, Tensor]:
+    if logits.ndim != 2:
+        raise ValueError(f"Expected logits.ndim=2, got {logits.ndim}")
+    if targets.ndim != 1:
+        raise ValueError(f"Expected targets.ndim=1, got {targets.ndim}")
+    if logits.shape[0] != targets.shape[0]:
+        raise ValueError(
+            f"Expected matching rows, got logits={tuple(logits.shape)} targets={tuple(targets.shape)}"
+        )
+    if not logits.is_cuda or not targets.is_cuda:
+        raise ValueError("softcapped_cross_entropy requires CUDA tensors")
+    if softcap <= 0.0:
+        raise ValueError(f"softcap must be positive, got {softcap}")
+    if logits.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise ValueError(f"Unsupported logits dtype: {logits.dtype}")
+    logits = logits.contiguous()
+    targets = targets.contiguous()
+    if targets.dtype != torch.int64:
+        targets = targets.to(dtype=torch.int64)
+    return logits, targets
+
+
+@torch.library.custom_op(f"{_FUSED_CE_LIBRARY}::softcapped_ce", mutates_args=())
+def softcapped_ce_op(logits: Tensor, targets: Tensor, softcap: float) -> tuple[Tensor, Tensor]:
+    logits, targets = _validate_softcapped_ce_inputs(logits, targets, float(softcap))
+    n_rows, n_cols = logits.shape
+    losses = torch.empty((n_rows,), device=logits.device, dtype=torch.float32)
+    lse = torch.empty((n_rows,), device=logits.device, dtype=torch.float32)
+    _softcapped_ce_fwd_kernel[(n_rows,)](
+        logits, losses, lse, targets,
+        logits.stride(0), logits.stride(1),
+        n_rows, n_cols, float(softcap),
+        block_size=_FUSED_CE_BLOCK_SIZE, num_warps=_FUSED_CE_NUM_WARPS,
+    )
+    return losses, lse
+
+
+@softcapped_ce_op.register_fake
+def _(logits: Tensor, targets: Tensor, softcap: float):
+    if logits.ndim != 2 or targets.ndim != 1:
+        raise ValueError("softcapped_ce fake impl expects 2D logits and 1D targets")
+    if logits.shape[0] != targets.shape[0]:
+        raise ValueError(
+            f"Expected matching rows, got logits={tuple(logits.shape)} targets={tuple(targets.shape)}"
+        )
+    n_rows = logits.shape[0]
+    return (
+        logits.new_empty((n_rows,), dtype=torch.float32),
+        logits.new_empty((n_rows,), dtype=torch.float32),
+    )
+
+
+@torch.library.custom_op(f"{_FUSED_CE_LIBRARY}::softcapped_ce_backward", mutates_args=())
+def softcapped_ce_backward_op(
+    logits: Tensor, targets: Tensor, lse: Tensor, grad_losses: Tensor, softcap: float,
+) -> Tensor:
+    logits, targets = _validate_softcapped_ce_inputs(logits, targets, float(softcap))
+    lse = lse.contiguous()
+    grad_losses = grad_losses.contiguous().to(dtype=torch.float32)
+    if lse.ndim != 1 or grad_losses.ndim != 1:
+        raise ValueError("Expected 1D lse and grad_losses")
+    if lse.shape[0] != logits.shape[0] or grad_losses.shape[0] != logits.shape[0]:
+        raise ValueError(
+            f"Expected row-aligned lse/grad_losses, got logits={tuple(logits.shape)} "
+            f"lse={tuple(lse.shape)} grad_losses={tuple(grad_losses.shape)}"
+        )
+    grad_logits = torch.empty_like(logits)
+    n_rows, n_cols = logits.shape
+    _softcapped_ce_bwd_kernel[(n_rows,)](
+        grad_logits, grad_losses, lse, logits, targets,
+        logits.stride(0), logits.stride(1),
+        grad_logits.stride(0), grad_logits.stride(1),
+        n_rows, n_cols, float(softcap),
+        block_size=_FUSED_CE_BLOCK_SIZE, num_warps=_FUSED_CE_NUM_WARPS,
+    )
+    return grad_logits
+
+
+@softcapped_ce_backward_op.register_fake
+def _(logits: Tensor, targets: Tensor, lse: Tensor, grad_losses: Tensor, softcap: float):
+    if logits.ndim != 2 or targets.ndim != 1 or lse.ndim != 1 or grad_losses.ndim != 1:
+        raise ValueError("softcapped_ce_backward fake impl expects 2D logits and 1D row tensors")
+    if (
+        logits.shape[0] != targets.shape[0]
+        or logits.shape[0] != lse.shape[0]
+        or logits.shape[0] != grad_losses.shape[0]
+    ):
+        raise ValueError("softcapped_ce_backward fake impl expects row-aligned tensors")
+    return logits.new_empty(logits.shape)
+
+
+def _softcapped_ce_setup_context(
+    ctx: torch.autograd.function.FunctionCtx, inputs, output,
+) -> None:
+    logits, targets, softcap = inputs
+    _losses, lse = output
+    ctx.save_for_backward(logits, targets, lse)
+    ctx.softcap = float(softcap)
+
+
+def _softcapped_ce_backward(
+    ctx: torch.autograd.function.FunctionCtx, grad_losses: Tensor, grad_lse: "Tensor | None",
+):
+    del grad_lse
+    logits, targets, lse = ctx.saved_tensors
+    grad_logits = torch.ops.pgsubmission1draft7fusedce.softcapped_ce_backward(
+        logits, targets, lse, grad_losses, ctx.softcap
+    )
+    return grad_logits, None, None
+
+
+softcapped_ce_op.register_autograd(
+    _softcapped_ce_backward, setup_context=_softcapped_ce_setup_context,
+)
+
+
+def softcapped_cross_entropy(
+    logits: Tensor, targets: Tensor, softcap: float, reduction: str = "mean",
+) -> Tensor:
+    losses, _lse = torch.ops.pgsubmission1draft7fusedce.softcapped_ce(
+        logits, targets, float(softcap)
+    )
+    if reduction == "none":
+        return losses
+    if reduction == "sum":
+        return losses.sum()
+    if reduction == "mean":
+        return losses.mean()
+    raise ValueError(f"Unsupported reduction={reduction!r}")
+
+
+class Hyperparameters:
+    data_dir = os.environ.get("DATA_DIR", "./data/")
+    seed = int(os.environ.get("SEED", 1337))
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.75))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786432))
+    # Fused softcapped CE (Triton). Training-only — forward_logits eval path still uses
+    # eager softcap+F.cross_entropy. Default ON since validated as at-worst neutral.
+    fused_ce_enabled = bool(int(os.environ.get("FUSED_CE_ENABLED", "1")))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 6e2))
+    val_batch_tokens = int(os.environ.get("VAL_BATCH_TOKENS", 524288))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 8192))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 4.0))
+    skip_gates_enabled = bool(int(os.environ.get("SKIP_GATES_ENABLED", "1")))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 3e1))
+    rope_base = float(os.environ.get("ROPE_BASE", 1e4))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    rope_train_seq_len = int(os.environ.get("ROPE_TRAIN_SEQ_LEN", 2048))
+    rope_yarn = bool(int(os.environ.get("ROPE_YARN", "0")))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 5.0))
+    num_loops = int(os.environ.get("NUM_LOOPS", 2))
+    loop_start = int(os.environ.get("LOOP_START", 3))
+    loop_end = int(os.environ.get("LOOP_END", 5))
+    enable_looping_at = float(os.environ.get("ENABLE_LOOPING_AT", 0.35))
+    parallel_start_layer = int(os.environ.get("PARALLEL_START_LAYER", 8))
+    parallel_final_lane = os.environ.get("PARALLEL_FINAL_LANE", "mean")
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.026))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.97))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-08))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.02))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_lora_rank = int(os.environ.get("TTT_LORA_RANK", 96))
+    ttt_lora_lr = float(os.environ.get("TTT_LORA_LR", 0.0001))
+    ttt_chunk_size = int(os.environ.get("TTT_CHUNK_SIZE", 48))
+    ttt_eval_seq_len = int(os.environ.get("TTT_EVAL_SEQ_LEN", 2048))
+    ttt_batch_size = int(os.environ.get("TTT_BATCH_SIZE", 64))
+    ttt_grad_steps = int(os.environ.get("TTT_GRAD_STEPS", 1))
+    ttt_weight_decay = float(os.environ.get("TTT_WEIGHT_DECAY", 1.0))
+    ttt_beta1 = float(os.environ.get("TTT_BETA1", 0))
+    ttt_beta2 = float(os.environ.get("TTT_BETA2", 0.999))
+    ttt_k_lora = bool(int(os.environ.get("TTT_K_LORA", "1")))
+    ttt_mlp_lora = bool(int(os.environ.get("TTT_MLP_LORA", "1")))
+    ttt_o_lora = bool(int(os.environ.get("TTT_O_LORA", "1")))
+    ttt_optimizer = os.environ.get("TTT_OPTIMIZER", "adam")
+    ttt_eval_batches = os.environ.get("TTT_EVAL_BATCHES", "")
+    val_doc_fraction = float(os.environ.get("VAL_DOC_FRACTION", 1.0))
+    compressor = os.environ.get("COMPRESSOR", "brotli")
+    gptq_calibration_batches = int(os.environ.get("GPTQ_CALIBRATION_BATCHES", 16))
+    gptq_reserve_seconds = float(os.environ.get("GPTQ_RESERVE_SECONDS", 4.0))
+    phased_ttt_prefix_docs = int(os.environ.get("PHASED_TTT_PREFIX_DOCS", 2000))
+    phased_ttt_num_phases = int(os.environ.get("PHASED_TTT_NUM_PHASES", 1))
+    global_ttt_lr = float(os.environ.get("GLOBAL_TTT_LR", 0.001))
+    global_ttt_momentum = float(os.environ.get("GLOBAL_TTT_MOMENTUM", 0.9))
+    global_ttt_epochs = int(os.environ.get("GLOBAL_TTT_EPOCHS", 1))
+    global_ttt_chunk_tokens = int(os.environ.get("GLOBAL_TTT_CHUNK_TOKENS", 32768))
+    global_ttt_batch_seqs = int(os.environ.get("GLOBAL_TTT_BATCH_SEQS", 32))
+    global_ttt_warmup_start_lr = float(os.environ.get("GLOBAL_TTT_WARMUP_START_LR", 0.0))
+    global_ttt_warmup_chunks = int(os.environ.get("GLOBAL_TTT_WARMUP_CHUNKS", 0))
+    global_ttt_grad_clip = float(os.environ.get("GLOBAL_TTT_GRAD_CLIP", 1.0))
+    global_ttt_respect_doc_boundaries = bool(int(os.environ.get("GLOBAL_TTT_RESPECT_DOC_BOUNDARIES", "1")))
+    matrix_bits = int(os.environ.get("MATRIX_BITS", 6))
+    embed_bits = int(os.environ.get("EMBED_BITS", 8))
+    matrix_clip_sigmas = float(os.environ.get("MATRIX_CLIP_SIGMAS", 12.85))
+    embed_clip_sigmas = float(os.environ.get("EMBED_CLIP_SIGMAS", 2e1))
+    mlp_clip_sigmas = float(os.environ.get("MLP_CLIP_SIGMAS", 10.0))
+    attn_clip_sigmas = float(os.environ.get("ATTN_CLIP_SIGMAS", 13.0))
+    # Adaptive Hessian-sensitivity clip (Phase 7 contribution from chris-colinsky).
+    # When enabled, picks per-tensor clip_sigmas in [6.0, 24.0] from Hessian
+    # diagonal magnitude * row variance, with a binary-search offset to preserve
+    # the overall compression budget set by mlp_clip_sigmas/attn_clip_sigmas/
+    # matrix_clip_sigmas (numel-weighted log-average target). Skips tok_emb
+    # (kept at embed_clip_sigmas) and attn_gate_w (separate int8-per-row path).
+    adaptive_hessian_clip = bool(int(os.environ.get("ADAPTIVE_HESSIAN_CLIP", "0")))
+    # Mixed-precision GPTQ from Hessian-sensitivity (Phase 8 contribution).
+    # Sort matrix tensors by Hessian-sensitivity (H_diag.mean()*row_var); the
+    # bottom MIXED_PRECISION_LOW_FRAC get bits_low, top MIXED_PRECISION_HIGH_FRAC
+    # get bits_high, the middle stays at matrix_bits. Each tensor gets the
+    # precision it actually needs for output quality, and the average bits/tensor
+    # is conserved (so artifact size shouldn't change materially).
+    # Differs from PR #1908's AWQ-lite (which uses ACTIVATION-magnitude criterion);
+    # we use the same Hessian-derived sensitivity as adaptive_hessian_clip.
+    mixed_precision_hessian = bool(int(os.environ.get("MIXED_PRECISION_HESSIAN", "0")))
+    mixed_precision_bits_low = int(os.environ.get("MIXED_PRECISION_BITS_LOW", "5"))
+    mixed_precision_bits_high = int(os.environ.get("MIXED_PRECISION_BITS_HIGH", "7"))
+    mixed_precision_low_frac = float(os.environ.get("MIXED_PRECISION_LOW_FRAC", "0.25"))
+    mixed_precision_high_frac = float(os.environ.get("MIXED_PRECISION_HIGH_FRAC", "0.25"))
+    # AttnOutGate (per-head multiplicative output gate, PR #1667 MarioPaerle).
+    # Zero-init weight: 2*sigmoid(0)=1 -> transparent at start. Source defaults to
+    # block input x ('proj'); 'q' uses raw Q projection output.
+    attn_out_gate_enabled = bool(int(os.environ.get("ATTN_OUT_GATE_ENABLED", "0")))
+    attn_out_gate_src = os.environ.get("ATTN_OUT_GATE_SRC", "proj")
+    # SmearGate (input-dependent forward-1 token smear, modded-nanogpt @classiclarryd
+    # via PR #1667). x_t <- x_t + lam * sigmoid(W*x_t[:gate_window]) * x_{t-1}.
+    # lam=0 + W=0 -> transparent at init.
+    smear_gate_enabled = bool(int(os.environ.get("SMEAR_GATE_ENABLED", "0")))
+    # Window: first GATE_WINDOW dims of the source feed the gate projection.
+    gate_window = int(os.environ.get("GATE_WINDOW", 12))
+    # Gated Attention (Qwen, NeurIPS 2025 Best Paper, arXiv:2505.06708;
+    # qiuzh20/gated_attention). Per-head sigmoid gate on SDPA output, BEFORE
+    # out_proj. Gate input = full block input x (paper's headwise G1 variant
+    # driven from hidden_states). W_g shape (num_heads, dim), plain sigmoid.
+    # Near-zero init gives g~0.5 at step 0 (half attention output); per-block
+    # attn_scale (init 1.0) compensates during training. Name contains
+    # "attn_gate" so CONTROL_TENSOR_NAME_PATTERNS routes it to scalar AdamW.
+    gated_attn_enabled = bool(int(os.environ.get("GATED_ATTN_ENABLED", "0")))
+    gated_attn_init_std = float(os.environ.get("GATED_ATTN_INIT_STD", 0.01))
+    # Dedicated int8-per-row quantization for `attn_gate_w` tensors. These are
+    # small ((num_heads, dim) = (8, 512) = 4096 params) and bypass GPTQ via the
+    # numel<=65536 passthrough branch -> stored as fp16 (8 KB/layer, ~65 KB total
+    # compressed). int8-per-row cuts the raw tensor in half with negligible BPB
+    # impact: scales per head (8 values), symmetric quant over [-127, 127].
+    # No Hessian needed (gate weights not in collect_hessians()).
+    gated_attn_quant_gate = bool(int(os.environ.get("GATED_ATTN_QUANT_GATE", "0")))
+    # Sparse Attention Gate (modded-nanogpt-style). Keeps dense SDPA and only
+    # swaps the output-gate input to the first GATE_WINDOW residual dims.
+    # W_g: (num_heads, gate_window) = (8, 12) = 96 params/layer (~44K total),
+    # vs dense GatedAttn's (8, 512) = 4K/layer (~44K diff). Name "attn_gate_w"
+    # is shared so quant routing and int8 gate passthrough Just Work. Gate
+    # passthrough int8 still applies via GATED_ATTN_QUANT_GATE=1.
+    # Mutually exclusive with ATTN_OUT_GATE_ENABLED and GATED_ATTN_ENABLED.
+    sparse_attn_gate_enabled = bool(int(os.environ.get("SPARSE_ATTN_GATE_ENABLED", "0")))
+    sparse_attn_gate_init_std = float(os.environ.get("SPARSE_ATTN_GATE_INIT_STD", 0.0))
+    sparse_attn_gate_scale = float(os.environ.get("SPARSE_ATTN_GATE_SCALE", 1.0))
+    # LQER asymmetric rank-k correction on top-K quant-error tensors (PR #1530 v2 port).
+    # Computes SVD of E = W_fp - W_quant, packs top-r A,B as INT2/INT4 (asym) or INTk (sym).
+    lqer_enabled = bool(int(os.environ.get("LQER_ENABLED", "1")))
+    lqer_rank = int(os.environ.get("LQER_RANK", 4))
+    lqer_top_k = int(os.environ.get("LQER_TOP_K", 3))
+    lqer_factor_bits = int(os.environ.get("LQER_FACTOR_BITS", 4))
+    lqer_asym_enabled = bool(int(os.environ.get("LQER_ASYM_ENABLED", "1")))
+    lqer_asym_group = int(os.environ.get("LQER_ASYM_GROUP", "64"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_main_process = rank == 0
+    grad_accum_steps = 8 // world_size
+    # CaseOps integration: optional override of dataset root + tokenizer path.
+    # When CASEOPS_ENABLED=1, the wrapper loads a per-token byte sidecar
+    # (fineweb_val_bytes_*.bin, identical shard layout to val_*.bin) and uses
+    # it as the canonical raw-byte budget for BPB accounting. The sidecar
+    # REPLACES the build_sentencepiece_luts byte-counting path entirely.
+    caseops_enabled = bool(int(os.environ.get("CASEOPS_ENABLED", "0")))
+    _default_caseops_data = os.path.join(
+        data_dir,
+        "datasets",
+        "fineweb10B_sp8192_caseops",
+        "datasets",
+        "datasets",
+        "fineweb10B_sp8192_lossless_caps_caseops_v1_reserved",
+    )
+    _default_caseops_tok = os.path.join(
+        data_dir,
+        "datasets",
+        "fineweb10B_sp8192_caseops",
+        "datasets",
+        "tokenizers",
+        "fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model",
+    )
+    if caseops_enabled:
+        datasets_dir = os.environ.get("DATA_PATH", _default_caseops_data)
+        tokenizer_path = os.environ.get("TOKENIZER_PATH", _default_caseops_tok)
+    else:
+        datasets_dir = os.environ.get(
+            "DATA_PATH",
+            os.path.join(data_dir, "datasets", f"fineweb10B_sp{vocab_size}"),
+        )
+        tokenizer_path = os.environ.get(
+            "TOKENIZER_PATH",
+            os.path.join(data_dir, "tokenizers", f"fineweb_{vocab_size}_bpe.model"),
+        )
+    train_files = os.path.join(datasets_dir, "fineweb_train_*.bin")
+    val_files = os.path.join(datasets_dir, "fineweb_val_*.bin")
+    val_bytes_files = os.path.join(datasets_dir, "fineweb_val_bytes_*.bin")
+    artifact_dir = os.environ.get("ARTIFACT_DIR", "")
+    logfile = (
+        os.path.join(artifact_dir, f"{run_id}.txt")
+        if artifact_dir
+        else f"logs/{run_id}.txt"
+    )
+    model_path = (
+        os.path.join(artifact_dir, "final_model.pt")
+        if artifact_dir
+        else "final_model.pt"
+    )
+    quantized_model_path = (
+        os.path.join(artifact_dir, "final_model.int6.ptz")
+        if artifact_dir
+        else "final_model.int6.ptz"
+    )
+
+
+_logger_hparams = None
+
+
+def set_logging_hparams(h):
+    global _logger_hparams
+    _logger_hparams = h
+
+
+def log(msg, console=True):
+    if _logger_hparams is None:
+        print(msg)
+        return
+    if _logger_hparams.is_main_process:
+        if console:
+            print(msg)
+        if _logger_hparams.logfile is not None:
+            with open(_logger_hparams.logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+
+class ValidationData:
+    def __init__(self, h, device):
+        self.sp = spm.SentencePieceProcessor(model_file=h.tokenizer_path)
+        if int(self.sp.vocab_size()) != h.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={h.vocab_size} does not match tokenizer vocab_size={int(self.sp.vocab_size())}"
+            )
+        self.val_tokens = load_validation_tokens(h.val_files, h.eval_seq_len)
+        self.caseops_enabled = bool(getattr(h, "caseops_enabled", False))
+        if self.caseops_enabled:
+            self.base_bytes_lut = None
+            self.has_leading_space_lut = None
+            self.is_boundary_token_lut = None
+        else:
+            (
+                self.base_bytes_lut,
+                self.has_leading_space_lut,
+                self.is_boundary_token_lut,
+            ) = build_sentencepiece_luts(self.sp, h.vocab_size, device)
+        self.val_bytes = None
+        if self.caseops_enabled:
+            self.val_bytes = load_validation_byte_sidecar(
+                h.val_bytes_files, h.eval_seq_len, self.val_tokens.numel()
+            )
+
+
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sp_vocab_size = int(sp.vocab_size())
+    assert (
+        sp.piece_to_id("▁") != sp.unk_id()
+    ), "Tokenizer must have '▁' (space) as its own token for correct BPB byte counting"
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern, seq_len):
+    # Filter out CaseOps byte sidecar shards which share the val_*.bin glob.
+    files = [
+        Path(p)
+        for p in sorted(glob.glob(pattern))
+        if "_bytes_" not in Path(p).name
+    ]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = (tokens.numel() - 1) // seq_len * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def load_validation_byte_sidecar(pattern, seq_len, expected_len):
+    """Load CaseOps per-token byte sidecar(s). Same shard layout as token shards
+    (256 int32 header + uint16 array). Each entry = canonical raw-text byte
+    budget for that token in the corresponding val shard. Returns a CPU
+    int16 tensor sliced to match expected_len (i.e. val_tokens length)."""
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No byte sidecar files for pattern: {pattern}")
+    shards = [load_data_shard(file) for file in files]
+    # load_data_shard returns uint16 — that's exactly what the sidecar stores.
+    bytes_full = torch.cat(shards).contiguous()
+    if bytes_full.numel() < expected_len:
+        raise ValueError(
+            f"Byte sidecar too short: {bytes_full.numel()} < val_tokens {expected_len}"
+        )
+    return bytes_full[:expected_len].to(torch.int32)
+
+
+def load_data_shard(file):
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE = {}
+_MMAP_CACHE = {}
+
+
+def _read_num_tokens(file):
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+
+def _get_shard_memmap(file):
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode="r", dtype="<u2", offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+BOS_ID = None
+
+
+def get_next_multiple_of_n(v, n):
+    return ((v + n - 1) // n) * n
+
+
+def _build_cu_seqlens(bos_pos, total_len, device, max_doc_len=0, bucket_size=64):
+    if not bos_pos or bos_pos[0] != 0:
+        bos_pos = [0] + bos_pos
+    seg_starts = []
+    starts_with_end = bos_pos + [total_len]
+    for i in range(len(starts_with_end) - 1):
+        start = starts_with_end[i]
+        end = starts_with_end[i + 1]
+        if max_doc_len > 0:
+            pos = start
+            while pos < end:
+                seg_starts.append(pos)
+                pos += max_doc_len
+        else:
+            seg_starts.append(start)
+    boundaries = seg_starts + [total_len]
+    padded_len = get_next_multiple_of_n(len(boundaries), bucket_size)
+    cu = torch.full((padded_len,), total_len, dtype=torch.int32, device=device)
+    cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+    seg_ends = seg_starts[1:] + [total_len]
+    max_seqlen = max(end - start for start, end in zip(seg_starts, seg_ends))
+    return cu, max_seqlen
+
+class DocumentPackingLoader:
+    _shard_pool = ThreadPoolExecutor(1)
+
+    def __init__(self, h, device, cu_bucket_size=64):
+        self.rank = h.rank
+        self.world_size = h.world_size
+        self.device = device
+        self.cu_bucket_size = cu_bucket_size
+        self.max_seq_len = h.train_seq_len
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files
+        self.file_iter = iter(self.files)
+        self._init_shard(load_data_shard(next(self.file_iter)))
+        self._next_shard = self._submit_next_shard()
+        self._batch_pool = ThreadPoolExecutor(1)
+        self._prefetch_queue = []
+
+    def _init_shard(self, tokens):
+        global BOS_ID
+        self.tokens = tokens
+        self.shard_size = tokens.numel()
+        if BOS_ID is None:
+            BOS_ID = 1
+        self.bos_idx = (
+            (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        )
+        self.cursor = int(self.bos_idx[0])
+
+    def _submit_next_shard(self):
+        try:
+            path = next(self.file_iter)
+            return self._shard_pool.submit(load_data_shard, path)
+        except StopIteration:
+            return None
+
+    def _advance_shard(self):
+        if self._next_shard is None:
+            self.file_iter = iter(self.files)
+            self._next_shard = self._shard_pool.submit(
+                load_data_shard, next(self.file_iter)
+            )
+        self._init_shard(self._next_shard.result())
+        self._next_shard = self._submit_next_shard()
+
+    def _local_doc_starts(self, local_start, total_len):
+        lo = np.searchsorted(self.bos_idx, local_start, side="left")
+        hi = np.searchsorted(self.bos_idx, local_start + total_len, side="left")
+        return (self.bos_idx[lo:hi] - local_start).tolist()
+
+    def _prepare_batch(self, num_tokens_local, max_seq_len):
+        per_rank_span = num_tokens_local + 1
+        global_span = per_rank_span * self.world_size
+        while self.cursor + global_span > self.shard_size:
+            self._advance_shard()
+        local_start = self.cursor + self.rank * per_rank_span
+        buf = self.tokens[local_start : local_start + per_rank_span]
+        inputs = torch.empty(per_rank_span - 1, dtype=torch.int64, pin_memory=True)
+        targets = torch.empty(per_rank_span - 1, dtype=torch.int64, pin_memory=True)
+        inputs.copy_(buf[:-1])
+        targets.copy_(buf[1:])
+        starts = self._local_doc_starts(local_start, inputs.numel())
+        cu_seqlens, max_seqlen = _build_cu_seqlens(
+            starts, inputs.numel(), inputs.device, max_seq_len, self.cu_bucket_size
+        )
+        cu_seqlens = cu_seqlens.pin_memory()
+        self.cursor += global_span
+        return inputs, targets, cu_seqlens, max_seqlen
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        num_tokens_local = global_tokens // (self.world_size * grad_accum_steps)
+        while len(self._prefetch_queue) < 2:
+            self._prefetch_queue.append(
+                self._batch_pool.submit(self._prepare_batch, num_tokens_local, self.max_seq_len))
+        inputs, targets, cu_seqlens, max_seqlen = self._prefetch_queue.pop(0).result()
+        self._prefetch_queue.append(
+            self._batch_pool.submit(self._prepare_batch, num_tokens_local, self.max_seq_len))
+        return (
+            inputs[None].to(self.device, non_blocking=True),
+            targets[None].to(self.device, non_blocking=True),
+            cu_seqlens.to(self.device, non_blocking=True),
+            max_seqlen,
+        )
+
+
+class ShuffledSequenceLoader:
+    def __init__(self, h, device):
+        self.world_size = h.world_size
+        self.seq_len = h.train_seq_len
+        self.device = device
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files[h.rank :: h.world_size]
+        self.rng = np.random.Generator(np.random.PCG64(h.rank))
+        self.num_tokens = [_read_num_tokens(f) for f in self.files]
+        self.start_inds = [[] for _ in self.files]
+        for si in range(len(self.files)):
+            self._reset_shard(si)
+
+    def _reset_shard(self, si):
+        max_phase = min(
+            self.seq_len - 1, max(0, self.num_tokens[si] - self.seq_len - 1)
+        )
+        phase = int(self.rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        num_sequences = (self.num_tokens[si] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[si] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for bi in range(device_batch_size):
+            total = remaining.sum()
+            if total <= 0:
+                for si in range(len(self.files)):
+                    self._reset_shard(si)
+                remaining = np.array(
+                    [len(s) for s in self.start_inds], dtype=np.float64
+                )
+                total = remaining.sum()
+            probs = remaining / total
+            si = int(self.rng.choice(len(self.files), p=probs))
+            start_ind = self.start_inds[si].pop()
+            remaining[si] -= 1
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[bi] = window[:-1]
+            y[bi] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x):
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+@triton.jit
+def linear_leaky_relu_square_kernel(
+    a_desc,
+    b_desc,
+    c_desc,
+    aux_desc,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    FORWARD: tl.constexpr,
+):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+    tile_id_c = start_pid - NUM_SMS
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+        tile_id_c += NUM_SMS
+        offs_am_c = offs_am
+        offs_bn_c = offs_bn
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+        c0 = acc0.to(dtype)
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            pre0 = aux_desc.load([offs_am_c, offs_bn_c])
+            pre1 = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c0 = c0 * tl.where(pre0 > 0, 2.0 * pre0, 0.5 * pre0)
+            c1 = c1 * tl.where(pre1 > 0, 2.0 * pre1, 0.5 * pre1)
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+        if FORWARD:
+            aux0 = tl.where(c0 > 0, c0, 0.5 * c0)
+            aux1 = tl.where(c1 > 0, c1, 0.5 * c1)
+            aux_desc.store([offs_am_c, offs_bn_c], aux0 * aux0)
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], aux1 * aux1)
+
+
+def linear_leaky_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K2 = b.shape
+    assert K == K2
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    forward = aux is None
+    if aux is None:
+        aux = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 256, 128, 64
+    num_stages = 4 if forward else 3
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    grid = lambda _meta: (
+        min(num_sms, triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N)),
+    )
+    linear_leaky_relu_square_kernel[grid](
+        a_desc,
+        b_desc,
+        c_desc,
+        aux_desc,
+        M,
+        N,
+        K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        NUM_SMS=num_sms,
+        FORWARD=forward,
+        num_stages=num_stages,
+        num_warps=8,
+    )
+    if forward:
+        return c, aux
+    return c
+
+
+class FusedLinearLeakyReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, w1, w2):
+        x_flat = x.reshape(-1, x.shape[-1])
+        pre, post = linear_leaky_relu_square(x_flat, w1)
+        out = F.linear(post, w2)
+        ctx.save_for_backward(x, w1, w2, pre, post)
+        return out.view(*x.shape[:-1], out.shape[-1])
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, w1, w2, pre, post = ctx.saved_tensors
+        x_flat = x.reshape(-1, x.shape[-1])
+        grad_output_flat = grad_output.reshape(-1, grad_output.shape[-1])
+        dw2 = grad_output_flat.T @ post
+        dpre = linear_leaky_relu_square(grad_output_flat, w2.T.contiguous(), aux=pre)
+        dw1 = dpre.T @ x_flat
+        dx = dpre @ w1
+        return dx.view_as(x), dw1, dw2
+
+
+FusedLeakyReLUSquareMLP = FusedLinearLeakyReLUSquareFunction.apply
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=1e4, train_seq_len=1024, rope_dims=0, yarn=True):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.yarn = yarn
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / base ** (
+            torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+
+    def forward(self, seq_len, device, dtype):
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached < seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if self.yarn and seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * scale ** (rd / (rd - 2))
+                inv_freq = 1.0 / new_base ** (
+                    torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd
+                )
+            else:
+                inv_freq = self.inv_freq.float().to(device)
+            t = torch.arange(seq_len, device=device, dtype=torch.float32)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached[:, :seq_len].to(dtype=dtype), self._sin_cached[:, :seq_len].to(dtype=dtype)
+
+
+def apply_rotary_emb(x, cos, sin, rope_dims=0):
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=True,
+        attn_out_gate=False, attn_out_gate_src="proj", gate_window=12,
+        gated_attn=False, gated_attn_init_std=0.01,
+        sparse_attn_gate=False, sparse_attn_gate_init_std=0.0, sparse_attn_gate_scale=1.0,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        if int(attn_out_gate) + int(gated_attn) + int(sparse_attn_gate) > 1:
+            raise ValueError(
+                "attn_out_gate, gated_attn, and sparse_attn_gate are mutually exclusive"
+            )
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len, yarn=yarn)
+        self.use_xsa = False
+        # AttnOutGate (PR #1667 MarioPaerle): per-head multiplicative gate on attention
+        # output. CastedLinear so restore_fp32_params casts back to fp32 for GPTQ.
+        # _zero_init -> 2*sigmoid(0)=1 -> transparent at init.
+        self.attn_out_gate = attn_out_gate
+        self.attn_out_gate_src = attn_out_gate_src
+        self.gate_window = gate_window
+        if attn_out_gate:
+            self.attn_gate_proj = CastedLinear(gate_window, num_heads, bias=False)
+            self.attn_gate_proj._zero_init = True
+        # Gated Attention (arXiv:2505.06708, Qwen, NeurIPS 2025). Per-head sigmoid
+        # gate on SDPA output, BEFORE out_proj. Gate projection W_g: (num_heads, dim).
+        # Name "attn_gate_w" contains "attn_gate" substring so it matches
+        # CONTROL_TENSOR_NAME_PATTERNS and routes to the scalar AdamW group.
+        # fp32 Parameter -> restore_fp32_params path covers it via the ndim<2 OR
+        # name-pattern check (name matches "attn_gate"). Cast to x.dtype on use.
+        self.gated_attn = gated_attn
+        if gated_attn:
+            W = torch.empty(num_heads, dim, dtype=torch.float32)
+            nn.init.normal_(W, mean=0.0, std=gated_attn_init_std)
+            self.attn_gate_w = nn.Parameter(W)
+        # Sparse attention head-output gate (modded-nanogpt style). Keeps dense SDPA
+        # and only narrows the gate input to the first gate_window residual dims.
+        # W_g: (num_heads, gate_window). y_{t,h} <- sigmoid(scale * W_g_h @ x_t[:gate_window]) * y_{t,h}.
+        # Shares attn_gate_w name with dense GatedAttn so the quant routing
+        # (CONTROL_TENSOR_NAME_PATTERNS / attn_gate_w int8 passthrough) is unchanged.
+        self.sparse_attn_gate = sparse_attn_gate
+        self.sparse_attn_gate_scale = sparse_attn_gate_scale
+        if sparse_attn_gate:
+            W = torch.empty(num_heads, gate_window, dtype=torch.float32)
+            if sparse_attn_gate_init_std > 0:
+                nn.init.normal_(W, mean=0.0, std=sparse_attn_gate_init_std)
+            else:
+                nn.init.zeros_(W)
+            self.attn_gate_w = nn.Parameter(W)
+
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x, q_w, k_w, v_w, out_w, cu_seqlens=None, max_seqlen=0):
+        bsz, seqlen, dim = x.shape
+        # q_raw kept around as a tap point for attn_out_gate_src='q' (post-projection,
+        # pre-reshape, pre-RoPE).
+        q_raw = F.linear(x, q_w.to(x.dtype))
+        q = q_raw.reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if cu_seqlens is not None:
+            y = flash_attn_varlen_func(
+                q[0],
+                k[0],
+                v[0],
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+                causal=True,
+                window_size=(-1, -1),
+            )[None]
+        else:
+            y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        # AttnOutGate inlined (PR #1667). Inline + .contiguous() barrier so torch.compile
+        # fullgraph=True is happy (this avoids the @torch.compiler.disable trap that
+        # crashed gates v3). Per-head gate on (B,T,H,D) tensor: g shape [B,T,H], broadcast
+        # over D via [..., None]. zero-init weight -> 2*sigmoid(0)=1 -> transparent.
+        if self.attn_out_gate:
+            gate_src = q_raw if self.attn_out_gate_src == "q" else x
+            gate_in = gate_src[..., : self.gate_window].contiguous()
+            g = 2.0 * torch.sigmoid(self.attn_gate_proj(gate_in))
+            y = y * g[..., None]
+        # Gated Attention (arXiv:2505.06708 G1). Inline + .contiguous() barrier so
+        # torch.compile fullgraph=True is happy. Per-head gate on (B,T,H,D): g shape
+        # [B,T,H], broadcast over D via [..., None]. Paper: g = sigmoid(x @ W_g.T)
+        # where W_g: (H, dim). .to(x.dtype) on fp32 param before broadcast with bf16.
+        if self.gated_attn:
+            x_c = x.contiguous()
+            g = torch.sigmoid(F.linear(x_c, self.attn_gate_w.to(x.dtype)))
+            y = y * g[..., None]
+        # Sparse head-output gate: narrower (gate_window) input, same shape g as GatedAttn.
+        if self.sparse_attn_gate:
+            gate_in = x[..., : self.gate_window].contiguous()
+            g = torch.sigmoid(
+                self.sparse_attn_gate_scale
+                * F.linear(gate_in, self.attn_gate_w.to(x.dtype))
+            )
+            y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        self._last_proj_input = y.detach() if getattr(self, "_calib", False) else None
+        return F.linear(y, out_w.to(x.dtype))
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        self.use_fused = True
+
+    def forward(self, x, up_w, down_w):
+        if self.training and self.use_fused:
+            return FusedLeakyReLUSquareMLP(x, up_w.to(x.dtype), down_w.to(x.dtype))
+        hidden = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5).square()
+        self._last_down_input = hidden.detach() if getattr(self, "_calib", False) else None
+        return F.linear(hidden, down_w.to(x.dtype))
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        num_kv_heads,
+        mlp_mult,
+        rope_base,
+        qk_gain_init,
+        train_seq_len,
+        layer_idx=0,
+        ln_scale=False,
+        yarn=True,
+        attn_out_gate=False,
+        attn_out_gate_src="proj",
+        gate_window=12,
+        gated_attn=False,
+        gated_attn_init_std=0.01,
+        sparse_attn_gate=False,
+        sparse_attn_gate_init_std=0.0,
+        sparse_attn_gate_scale=1.0,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=yarn,
+            attn_out_gate=attn_out_gate, attn_out_gate_src=attn_out_gate_src, gate_window=gate_window,
+            gated_attn=gated_attn, gated_attn_init_std=gated_attn_init_std,
+            sparse_attn_gate=sparse_attn_gate,
+            sparse_attn_gate_init_std=sparse_attn_gate_init_std,
+            sparse_attn_gate_scale=sparse_attn_gate_scale,
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(
+            torch.stack((torch.ones(dim), torch.zeros(dim))).float()
+        )
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+
+    def forward(self, x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=None, max_seqlen=0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(
+            self.attn_norm(x_in) * self.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[
+            None, None, :
+        ] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        return x_out
+
+class GPT(nn.Module):
+    def __init__(self, h):
+        super().__init__()
+        if h.logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {h.logit_softcap}")
+        self.tie_embeddings = h.tie_embeddings
+        self.tied_embed_init_std = h.tied_embed_init_std
+        self.logit_softcap = h.logit_softcap
+        self.fused_ce_enabled = bool(h.fused_ce_enabled)
+        self.tok_emb = nn.Embedding(h.vocab_size, h.model_dim)
+        self.num_layers = h.num_layers
+        head_dim = h.model_dim // h.num_heads
+        kv_dim = h.num_kv_heads * head_dim
+        hidden_dim = int(h.mlp_mult * h.model_dim)
+        self.qo_bank = nn.Parameter(torch.empty(2 * h.num_layers, h.model_dim, h.model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * h.num_layers, kv_dim, h.model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(h.num_layers, hidden_dim, h.model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(h.num_layers, h.model_dim, hidden_dim))
+        self.num_encoder_layers = h.num_layers // 2
+        self.num_decoder_layers = h.num_layers - self.num_encoder_layers
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    h.model_dim,
+                    h.num_heads,
+                    h.num_kv_heads,
+                    h.mlp_mult,
+                    h.rope_base,
+                    h.qk_gain_init,
+                    h.train_seq_len,
+                    layer_idx=i,
+                    ln_scale=h.ln_scale,
+                    yarn=h.rope_yarn,
+                    attn_out_gate=h.attn_out_gate_enabled,
+                    attn_out_gate_src=h.attn_out_gate_src,
+                    gate_window=h.gate_window,
+                    gated_attn=h.gated_attn_enabled,
+                    gated_attn_init_std=h.gated_attn_init_std,
+                    sparse_attn_gate=h.sparse_attn_gate_enabled,
+                    sparse_attn_gate_init_std=h.sparse_attn_gate_init_std,
+                    sparse_attn_gate_scale=h.sparse_attn_gate_scale,
+                )
+                for i in range(h.num_layers)
+            ]
+        )
+        if h.rope_dims > 0:
+            head_dim = h.model_dim // h.num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = h.rope_dims
+                block.attn.rotary = Rotary(
+                    head_dim,
+                    base=h.rope_base,
+                    train_seq_len=h.train_seq_len,
+                    rope_dims=h.rope_dims,
+                    yarn=h.rope_yarn,
+                )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None
+            if h.tie_embeddings
+            else CastedLinear(h.model_dim, h.vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if h.xsa_last_n > 0:
+            for i in range(max(0, h.num_layers - h.xsa_last_n), h.num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self.looping_active = False
+        if h.num_loops > 0:
+            loop_seg = list(range(h.loop_start, h.loop_end + 1))
+            all_indices = list(range(h.loop_start))
+            for _ in range(h.num_loops + 1):
+                all_indices.extend(loop_seg)
+            all_indices.extend(range(h.loop_end + 1, h.num_layers))
+            num_enc = len(all_indices) // 2
+            self.encoder_indices = all_indices[:num_enc]
+            self.decoder_indices = all_indices[num_enc:]
+        else:
+            self.encoder_indices = list(range(self.num_encoder_layers))
+            self.decoder_indices = list(range(self.num_encoder_layers, h.num_layers))
+        self.num_skip_weights = min(
+            len(self.encoder_indices), len(self.decoder_indices)
+        )
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+        )
+        self.skip_gates = (
+            nn.Parameter(
+                torch.zeros(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+            )
+            if h.skip_gates_enabled
+            else None
+        )
+        self.parallel_start_layer = h.parallel_start_layer
+        self.parallel_final_lane = h.parallel_final_lane.lower()
+        self.parallel_post_lambdas = nn.Parameter(
+            torch.ones(h.num_layers, 2, 2, dtype=torch.float32)
+        )
+        self.parallel_resid_lambdas = nn.Parameter(
+            torch.full((h.num_layers, 2), 1.1, dtype=torch.float32)
+        )
+        # SmearGate (PR #1667 / modded-nanogpt @classiclarryd):
+        #   x_t <- x_t + lam * sigmoid(W * x_t[:gate_window]) * x_{t-1}.
+        # Per-token forward-1 smear of the embedding lane. W zero-init + lam=0 ->
+        # transparent at init. Uses CastedLinear so restore_fp32_params handles dtype.
+        self.smear_gate_enabled = h.smear_gate_enabled
+        if self.smear_gate_enabled:
+            self.smear_window = h.gate_window
+            self.smear_gate = CastedLinear(self.smear_window, 1, bias=False)
+            self.smear_gate._zero_init = True
+            self.smear_lambda = nn.Parameter(torch.zeros(1, dtype=torch.float32))
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.qo_bank.data[n + i])
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)
+        for i in range(n):
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.mlp_down_bank.data[i])
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _bank_weights(self, i):
+        n = self.num_layers
+        return (
+            self.qo_bank[i],
+            self.kv_bank[i],
+            self.kv_bank[n + i],
+            self.qo_bank[n + i],
+            self.mlp_up_bank[i],
+            self.mlp_down_bank[i],
+        )
+
+    def _parallel_block(
+        self, block_idx, lane0, lane1, x0,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+        cu_seqlens=None, max_seqlen=0,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        attn_out = block.attn(
+            block.attn_norm(attn_read) * block.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+        )
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * block.mlp(
+            block.mlp_norm(mlp_read) * block.ln_scale_factor, up_w, down_w
+        )
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+    def _final_parallel_hidden(self, lane0, lane1):
+        if self.parallel_final_lane == "mlp":
+            return lane1
+        if self.parallel_final_lane == "attn":
+            return lane0
+        return 0.5 * (lane0 + lane1)
+
+    def _forward_hidden(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        """Run the encoder/decoder stack to the final RMSNorm; returns pre-projection hidden.
+        Shared by eval (softcap+projection via forward_logits) and train (fused CE path)."""
+        x = self.tok_emb(input_ids)
+        # SmearGate (PR #1667). lam=0 + W=0 -> identity at init.
+        # Cross-doc leak fix: zero the prev-token smear at any position whose current token
+        # is BOS, so the BOS embedding starting doc N+1 in a packed stream is not
+        # contaminated by doc N's last token (audited issue on PR#1797 base).
+        if self.smear_gate_enabled:
+            sl = self.smear_lambda.to(dtype=x.dtype)
+            gate_in = x[:, 1:, : self.smear_window].contiguous()
+            g = sl * torch.sigmoid(self.smear_gate(gate_in))
+            not_bos = (input_ids[:, 1:] != BOS_ID).to(x.dtype).unsqueeze(-1)
+            x = torch.cat([x[:, :1], x[:, 1:] + g * x[:, :-1] * not_bos], dim=1)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else range(self.num_encoder_layers)
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else range(
+                self.num_encoder_layers,
+                self.num_encoder_layers + self.num_decoder_layers,
+            )
+        )
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block(
+                    i, lane0, lane1, x0, q_w, k_w, v_w, out_w, up_w, down_w,
+                    cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        return x
+
+    def _project_logits(self, hidden):
+        if self.tie_embeddings:
+            return F.linear(hidden, self.tok_emb.weight)
+        return self.lm_head(hidden)
+
+    def forward_logits(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden(input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        logits_proj = self._project_logits(hidden)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(self, input_ids, target_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden(input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        logits_proj = self._project_logits(hidden)
+        flat_targets = target_ids.reshape(-1)
+        # Fused softcapped-CE kernel (training path only). Applies softcap inside the
+        # Triton kernel; takes pre-softcap logits_proj. Non-fused path matches stock
+        # PR-1736 numerics exactly (softcap in fp32, then F.cross_entropy on fp32).
+        if self.fused_ce_enabled:
+            return softcapped_cross_entropy(
+                logits_proj.reshape(-1, logits_proj.size(-1)),
+                flat_targets,
+                self.logit_softcap,
+                reduction="mean",
+            )
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            flat_targets,
+            reduction="mean",
+        )
+
+    def forward_ttt(self, input_ids, target_ids, lora):
+        x = self.tok_emb(input_ids)
+        # SmearGate on the TTT path — same inline compute as forward_logits.
+        # Cross-doc leak fix: see _forward_hidden comment.
+        if self.smear_gate_enabled:
+            sl = self.smear_lambda.to(dtype=x.dtype)
+            gate_in = x[:, 1:, : self.smear_window].contiguous()
+            g = sl * torch.sigmoid(self.smear_gate(gate_in))
+            not_bos = (input_ids[:, 1:] != BOS_ID).to(x.dtype).unsqueeze(-1)
+            x = torch.cat([x[:, :1], x[:, 1:] + g * x[:, :-1] * not_bos], dim=1)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else list(range(self.num_encoder_layers))
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else list(
+                range(
+                    self.num_encoder_layers,
+                    self.num_encoder_layers + self.num_decoder_layers,
+                )
+            )
+        )
+        slot = 0
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block_with_lora(
+                    i, lane0, lane1, x0, lora, slot,
+                    q_w, k_w, v_w, out_w, up_w, down_w,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits = F.linear(x, self.tok_emb.weight)
+        else:
+            logits = self.lm_head(x)
+        logits = logits + lora.lm_head_lora(x)
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        bsz, sl, V = logits.shape
+        return F.cross_entropy(
+            logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none"
+        ).reshape(bsz, sl)
+
+    def _block_with_lora(self, block, x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w):
+        mix = block.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = block.attn_norm(x_in) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        # Keep raw Q for AttnOutGate src='q' (matches forward path semantics).
+        q_raw = F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)
+        q = q_raw.reshape(bsz, seqlen, attn.num_heads, attn.head_dim)
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        # AttnOutGate (TTT path) — inline + .contiguous() barrier, same as the eval path.
+        if attn.attn_out_gate:
+            gate_src = q_raw if attn.attn_out_gate_src == "q" else n
+            gate_in = gate_src[..., : attn.gate_window].contiguous()
+            g = 2.0 * torch.sigmoid(attn.attn_gate_proj(gate_in))
+            y = y * g[..., None]
+        # Gated Attention (TTT path). Gate input is n (post-norm block input), same
+        # as eval path. .to(n.dtype) on fp32 param before bf16 broadcast.
+        if attn.gated_attn:
+            n_c = n.contiguous()
+            g = torch.sigmoid(F.linear(n_c, attn.attn_gate_w.to(n.dtype)))
+            y = y * g[..., None]
+        # Sparse attention head-output gate (TTT path) — must match the eval path in
+        # forward() exactly, else training (which applied the gate) and TTT eval (which
+        # skipped it) produce mismatched representations and catastrophic BPB regression.
+        if attn.sparse_attn_gate:
+            gate_in = n[..., : attn.gate_window].contiguous()
+            g = torch.sigmoid(
+                attn.sparse_attn_gate_scale
+                * F.linear(gate_in, attn.attn_gate_w.to(n.dtype))
+            )
+            y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        x_out = x_in + block.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        mlp_n = block.mlp_norm(x_out) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        x_out = x_out + block.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * mlp_out
+        return x_out
+
+    def _parallel_block_with_lora(
+        self, block_idx, lane0, lane1, x0, lora, slot,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        n = block.attn_norm(attn_read) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q_raw = F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)
+        q = q_raw.reshape(bsz, seqlen, attn.num_heads, attn.head_dim)
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        # AttnOutGate (TTT parallel path) — inline + .contiguous() barrier.
+        if attn.attn_out_gate:
+            gate_src = q_raw if attn.attn_out_gate_src == "q" else n
+            gate_in = gate_src[..., : attn.gate_window].contiguous()
+            g = 2.0 * torch.sigmoid(attn.attn_gate_proj(gate_in))
+            y = y * g[..., None]
+        # Gated Attention (TTT parallel path). Gate input is n (post-norm block input).
+        if attn.gated_attn:
+            n_c = n.contiguous()
+            g = torch.sigmoid(F.linear(n_c, attn.attn_gate_w.to(n.dtype)))
+            y = y * g[..., None]
+        # Sparse attention head-output gate (TTT parallel path) — must match the
+        # eval path in forward() to keep train/eval semantics in sync.
+        if attn.sparse_attn_gate:
+            gate_in = n[..., : attn.gate_window].contiguous()
+            g = torch.sigmoid(
+                attn.sparse_attn_gate_scale
+                * F.linear(gate_in, attn.attn_gate_w.to(n.dtype))
+            )
+            y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_n = block.mlp_norm(mlp_read) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * mlp_out
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+
+class BatchedLinearLoRA(nn.Module):
+    # PR-1767: rank-scaled output (alpha/rank), like standard LoRA. Decouples
+    # effective magnitude from rank so changing rank does not change LR scale.
+    _ALPHA = float(os.environ.get("TTT_LORA_ALPHA", "144"))
+    # PR-1767: optionally keep A warm across per-doc resets (only B is zeroed).
+    # Accumulates useful feature directions across documents within a TTT phase.
+    _WARM_START_A = bool(int(os.environ.get("TTT_WARM_START_A", "1")))
+
+    def __init__(self, bsz, in_features, out_features, rank):
+        super().__init__()
+        self._bound = 1.0 / math.sqrt(in_features)
+        self._scale = self._ALPHA / rank
+        self.A = nn.Parameter(
+            torch.empty(bsz, rank, in_features).uniform_(-self._bound, self._bound)
+        )
+        self.B = nn.Parameter(torch.zeros(bsz, out_features, rank))
+
+    def reset(self):
+        with torch.no_grad():
+            if not self._WARM_START_A:
+                self.A.uniform_(-self._bound, self._bound)
+            self.B.zero_()
+
+    def forward(self, x):
+        return ((x @ self.A.transpose(1, 2)) @ self.B.transpose(1, 2)) * self._scale
+
+
+class BatchedTTTLoRA(nn.Module):
+    def __init__(self, bsz, model, rank, k_lora=True, mlp_lora=True, o_lora=True):
+        super().__init__()
+        self.bsz = bsz
+        dim = model.qo_bank.shape[-1]
+        vocab = model.tok_emb.num_embeddings
+        if getattr(model, "looping_active", False):
+            num_slots = len(model.encoder_indices) + len(model.decoder_indices)
+        else:
+            num_slots = len(model.blocks)
+        kv_dim = model.blocks[0].attn.num_kv_heads * (
+            dim // model.blocks[0].attn.num_heads
+        )
+        embed_dim = model.tok_emb.embedding_dim
+        self.lm_head_lora = BatchedLinearLoRA(bsz, embed_dim, vocab, rank)
+        self.q_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+        )
+        self.v_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+        )
+        self.k_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+            )
+            if k_lora
+            else None
+        )
+        self.mlp_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if mlp_lora
+            else None
+        )
+        self.o_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if o_lora
+            else None
+        )
+
+    def reset(self):
+        with torch.no_grad():
+            self.lm_head_lora.reset()
+            for loras in [self.q_loras, self.v_loras, self.k_loras,
+                          self.mlp_loras, self.o_loras]:
+                if loras is not None:
+                    for lora in loras:
+                        lora.reset()
+
+
+# Polar Express per-iteration minimax Newton-Schulz coefficients (PR #1344).
+# Replaces the fixed (3.4445, -4.775, 2.0315) coefficients of stock Muon.
+# Applied at backend_steps=5 — taking more than 5 iterations from this list
+# falls back to the final (converged) tuple via the slice guard below.
+_PE_COEFFS = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps=10, eps=1e-07):
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    coeffs = _PE_COEFFS[:steps] if steps <= len(_PE_COEFFS) else _PE_COEFFS
+    for a, b, c in coeffs:
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr,
+        momentum,
+        backend_steps,
+        nesterov=True,
+        weight_decay=0.0,
+        row_normalize=False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append({
+                    "p": p,
+                    "B": B,
+                    "padded_grad": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard_mom": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "full_update": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "scale": max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                })
+        self._bank_meta.sort(key=lambda m: -m["p"].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m["p"]
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m["padded_grad"]
+            pg[: m["B"]].copy_(p.grad)
+            fut = dist.reduce_scatter_tensor(
+                m["shard"], pg, op=dist.ReduceOp.AVG, async_op=True
+            )
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        if not self._built:
+            self._build()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+            row_normalize = group.get("row_normalize", False)
+            prev_ag_handle = None
+            prev_m = None
+            sharded = self._distributed and hasattr(self, "_rs_futures")
+            for idx, m in enumerate(self._bank_meta):
+                p = m["p"]
+                if p.grad is None:
+                    continue
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m["p"]
+                    upd = prev_m["full_update"][: prev_m["B"]]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd, alpha=-lr * prev_m["scale"])
+                if sharded and self._rs_futures[idx] is not None:
+                    self._rs_futures[idx].wait()
+                    g = m["shard"]
+                    buf = m["shard_mom"]
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+                if row_normalize:
+                    rn = update.float().norm(dim=-1, keepdim=True).clamp_min(1e-07)
+                    update = update / rn.to(update.dtype)
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m["full_update"], update, async_op=True
+                    )
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update, alpha=-lr * m["scale"])
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m["p"]
+                upd = prev_m["full_update"][: prev_m["B"]]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd, alpha=-lr * prev_m["scale"])
+            if hasattr(self, "_rs_futures"):
+                del self._rs_futures
+        return loss
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,parallel_post_lambdas,parallel_resid_lambdas,attn_gate_proj,attn_gate_w,smear_gate,smear_lambda",
+    ).split(",")
+    if pattern
+)
+
+
+PACKED_REPLICATED_GRAD_MAX_NUMEL = 1 << 15
+
+
+class Optimizers:
+    def __init__(self, h, base_model):
+        matrix_params = [
+            base_model.qo_bank,
+            base_model.kv_bank,
+            base_model.mlp_up_bank,
+            base_model.mlp_down_bank,
+        ]
+        block_named_params = list(base_model.blocks.named_parameters())
+        scalar_params = [
+            p
+            for (name, p) in block_named_params
+            if p.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        if base_model.skip_weights.numel() > 0:
+            scalar_params.append(base_model.skip_weights)
+        if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
+            scalar_params.append(base_model.skip_gates)
+        if base_model.parallel_post_lambdas is not None:
+            scalar_params.append(base_model.parallel_post_lambdas)
+        if base_model.parallel_resid_lambdas is not None:
+            scalar_params.append(base_model.parallel_resid_lambdas)
+        # SmearGate params live on GPT root (not in .blocks), so add them by hand.
+        # Both are tiny (gate_window scalars + 1 lambda). Optimized via scalar Adam.
+        if getattr(base_model, "smear_gate_enabled", False):
+            scalar_params.append(base_model.smear_gate.weight)
+            scalar_params.append(base_model.smear_lambda)
+        token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
+        tok_params = [
+            {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+        ]
+        self.optimizer_tok = torch.optim.AdamW(
+            tok_params,
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.embed_wd,
+            fused=True,
+        )
+        self.optimizer_muon = Muon(
+            matrix_params,
+            lr=h.matrix_lr,
+            momentum=h.muon_momentum,
+            backend_steps=h.muon_backend_steps,
+            weight_decay=h.muon_wd,
+            row_normalize=h.muon_row_normalize,
+        )
+        for group in self.optimizer_muon.param_groups:
+            group["base_lr"] = h.matrix_lr
+        self.optimizer_scalar = torch.optim.AdamW(
+            [{"params": scalar_params, "lr": h.scalar_lr, "base_lr": h.scalar_lr}],
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.adam_wd,
+            fused=True,
+        )
+        self.optimizers = [
+            self.optimizer_tok,
+            self.optimizer_muon,
+            self.optimizer_scalar,
+        ]
+        self.replicated_params = list(tok_params[0]["params"])
+        self.replicated_params.extend(scalar_params)
+        self.replicated_large_params = []
+        self.replicated_packed_params = []
+        for p in self.replicated_params:
+            if p.numel() <= PACKED_REPLICATED_GRAD_MAX_NUMEL:
+                self.replicated_packed_params.append(p)
+            else:
+                self.replicated_large_params.append(p)
+        self._aux_stream = torch.cuda.Stream()
+
+    def __iter__(self):
+        return iter(self.optimizers)
+
+    def zero_grad_all(self):
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    def _all_reduce_packed_grads(self):
+        grads_by_key = collections.defaultdict(list)
+        for p in self.replicated_packed_params:
+            if p.grad is not None:
+                grads_by_key[(p.grad.device, p.grad.dtype)].append(p.grad)
+        for grads in grads_by_key.values():
+            flat = torch.empty(
+                sum(g.numel() for g in grads),
+                device=grads[0].device,
+                dtype=grads[0].dtype,
+            )
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                flat[offset : offset + n].copy_(g.contiguous().view(-1))
+                offset += n
+            dist.all_reduce(flat, op=dist.ReduceOp.AVG)
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                g.copy_(flat[offset : offset + n].view_as(g))
+                offset += n
+
+    def step(self, distributed=False):
+        self.optimizer_muon.launch_reduce_scatters()
+        if distributed:
+            reduce_handles = [
+                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG, async_op=True)
+                for p in self.replicated_large_params
+                if p.grad is not None
+            ]
+            self._all_reduce_packed_grads()
+            for handle in reduce_handles:
+                handle.wait()
+        self._aux_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(self._aux_stream):
+            self.optimizer_tok.step()
+            self.optimizer_scalar.step()
+        self.optimizer_muon.step()
+        torch.cuda.current_stream().wait_stream(self._aux_stream)
+        self.zero_grad_all()
+
+
+def restore_fp32_params(model):
+    for module in model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    for name, param in model.named_parameters():
+        if (
+            param.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ) and param.dtype != torch.float32:
+            param.data = param.data.float()
+    if hasattr(model, "qo_bank") and model.qo_bank is not None:
+        model.qo_bank.data = model.qo_bank.data.float()
+        model.kv_bank.data = model.kv_bank.data.float()
+    model.mlp_up_bank.data = model.mlp_up_bank.data.float()
+    model.mlp_down_bank.data = model.mlp_down_bank.data.float()
+
+
+def collect_hessians(model, train_loader, h, device, n_calibration_batches=64):
+    hessians = {}
+    hooks = []
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = True
+        block.mlp._calib = True
+        block.mlp.use_fused = False
+
+    def make_attn_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            for suffix in ["c_q", "c_k", "c_v"]:
+                name = f"blocks.{layer_idx}.attn.{suffix}.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            y = module._last_proj_input
+            if y is not None:
+                y = y.float()
+                if y.ndim == 3:
+                    y = y.reshape(-1, y.shape[-1])
+                name = f"blocks.{layer_idx}.attn.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        y.shape[1], y.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(y.T, y)
+        return hook_fn
+
+    def make_mlp_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            name = f"blocks.{layer_idx}.mlp.fc.weight"
+            if name not in hessians:
+                hessians[name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[name].addmm_(x.T, x)
+            h_act = module._last_down_input
+            if h_act is not None:
+                h_act = h_act.float()
+                if h_act.ndim == 3:
+                    h_act = h_act.reshape(-1, h_act.shape[-1])
+                name = f"blocks.{layer_idx}.mlp.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        h_act.shape[1], h_act.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(h_act.T, h_act)
+        return hook_fn
+
+    for i, block in enumerate(model.blocks):
+        hooks.append(block.attn.register_forward_hook(make_attn_hook(i)))
+        hooks.append(block.mlp.register_forward_hook(make_mlp_hook(i)))
+
+    # Hessian hooks for embedding factorization projection layers
+    def make_linear_input_hook(weight_name):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            if weight_name not in hessians:
+                hessians[weight_name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[weight_name].addmm_(x.T, x)
+        return hook_fn
+
+    if model.tie_embeddings:
+        hook_module = model.final_norm
+
+        def make_output_hook(name):
+            def hook_fn(module, inp, out):
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            return hook_fn
+
+        hooks.append(
+            hook_module.register_forward_hook(make_output_hook("tok_emb.weight"))
+        )
+    model.eval()
+    with torch.no_grad():
+        for _ in range(n_calibration_batches):
+            x, _ = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+            model.forward_logits(x)
+    for hook in hooks:
+        hook.remove()
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = False
+        block.mlp._calib = False
+        block.mlp.use_fused = True
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / n_calibration_batches
+    return hessians
+
+
+def gptq_quantize_weight(w, H, clip_sigmas=3.0, clip_range=63, block_size=128):
+    W_orig = w.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * H.diag().mean()
+    H.diagonal().add_(damp)
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+    Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    row_std = W_orig.std(dim=1)
+    s = (clip_sigmas * row_std / clip_range).clamp_min(1e-10).to(torch.float16)
+    sf = s.float()
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    W_work = W_perm.clone()
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W_work[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros(rows, i2 - i1)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            d = Hinv_block[j, j]
+            q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - q_col.float() * sf) / d
+            Err[:, j] = err
+            W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+        if i2 < cols:
+            W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+    return Q[:, invperm], s
+
+
+def _quantize_gate_int8_row(w):
+    # Symmetric int8-per-row quantization for small gate tensors. w shape
+    # (R, C) -> (R,) scales in fp16, int8 values in [-127, 127]. Single scale
+    # per row keeps accuracy high while halving storage vs fp16.
+    W = w.float().contiguous()
+    row_max = W.abs().amax(dim=1).clamp_min(1e-10)
+    s = (row_max / 127.0).to(torch.float16)
+    sf = s.float().view(-1, 1)
+    q = torch.clamp(torch.round(W / sf), -127, 127).to(torch.int8)
+    return q, s
+
+
+def _lqer_pack(A, B, bits):
+    rng = 2 ** (bits - 1) - 1
+    sA = (A.abs().amax(dim=1).clamp_min(1e-10) / rng).to(torch.float16)
+    sB = (B.abs().amax(dim=1).clamp_min(1e-10) / rng).to(torch.float16)
+    qA = torch.clamp(torch.round(A / sA.float().view(-1, 1)), -rng, rng).to(torch.int8)
+    qB = torch.clamp(torch.round(B / sB.float().view(-1, 1)), -rng, rng).to(torch.int8)
+    return qA, sA, qB, sB
+
+
+def _lqer_pack_asym(A, B, g=64):
+    # A: INT2 per-matrix scalar (signed [-2,1], scale = |A|max/1.5).
+    sA = (A.abs().amax().clamp_min(1e-10) / 1.5).to(torch.float16)
+    qA = torch.clamp(torch.round(A / sA.float()), -2, 1).to(torch.int8)
+    # B: INT4 groupwise g over flattened B (signed [-8,7], per-group scale).
+    Bf = B.reshape(-1, g)
+    Bmax = Bf.abs().amax(dim=-1, keepdim=True).clamp_min(1e-10)
+    sB = (Bmax / 7.5).to(torch.float16).reshape(-1)
+    qB = torch.clamp(torch.round(Bf / sB.float().reshape(-1, 1)), -8, 7).to(
+        torch.int8
+    ).reshape(B.shape)
+    return qA, sA, qB, sB
+
+
+def gptq_mixed_quantize(state_dict, hessians, h):
+    result = {}
+    meta = {}
+    quant_gate = bool(getattr(h, "gated_attn_quant_gate", False))
+    lqer_on = bool(getattr(h, "lqer_enabled", False))
+    lqer_cands = {}
+
+    # Adaptive Hessian-sensitivity clip: per-tensor cs in [6, 24] picked from
+    # H_diag.mean() * row_var, with binary-search offset to preserve the
+    # numel-weighted log-average of PR #1855's hand-tuned (mlp/attn/matrix)
+    # sigmas. tok_emb and gate tensors are excluded (handled by their own paths).
+    # The same matrix_sens dict feeds mixed-precision bit allocation below.
+    matrix_sens: dict[str, float] = {}
+    matrix_numel: dict[str, int] = {}
+    _need_sens = (getattr(h, "adaptive_hessian_clip", False)
+                  or getattr(h, "mixed_precision_hessian", False))
+    if _need_sens:
+        for n_, tens_ in state_dict.items():
+            t_ = tens_.detach().cpu().contiguous()
+            if not t_.is_floating_point() or t_.numel() <= 65536:
+                continue
+            if "tok_emb" in n_:
+                continue
+            if n_.endswith(".attn_gate_w"):
+                continue
+            if n_ not in hessians:
+                continue
+            H_diag = torch.diag(hessians[n_].float()).clamp_min(0)
+            row_var = t_.float().var(dim=1).mean().item()
+            matrix_sens[n_] = max(H_diag.mean().item() * row_var, 1e-30)
+            matrix_numel[n_] = t_.numel()
+
+    adaptive_clip_map: dict[str, float] = {}
+    if getattr(h, "adaptive_hessian_clip", False):
+        if matrix_sens:
+            total_n = sum(matrix_numel.values())
+            log_target = 0.0
+            for n_ in matrix_sens:
+                if ".mlp." in n_:
+                    base_cs = h.mlp_clip_sigmas
+                elif ".attn." in n_:
+                    base_cs = h.attn_clip_sigmas
+                else:
+                    base_cs = h.matrix_clip_sigmas
+                log_target += matrix_numel[n_] * math.log(base_cs)
+            # Bias was +0.012 in dev/phase8 (compression margin); empirically
+            # that made adaptive sigmas slightly looser than PR #1855's
+            # hand-tuned avg and added ~+0.002 quant penalty on seed 42.
+            # Tightening to 0.0 to match the hand-tuned overall budget exactly.
+            log_target = log_target / total_n
+            log_raw = {n: -0.15 * math.log(s) for n, s in matrix_sens.items()}
+            lo_off, hi_off = -20.0, 20.0
+            for _ in range(64):
+                mid = (lo_off + hi_off) / 2
+                wm = sum(matrix_numel[n] * math.log(max(6.0, min(24.0, math.exp(log_raw[n] + mid))))
+                         for n in log_raw) / total_n
+                if wm < log_target:
+                    lo_off = mid
+                else:
+                    hi_off = mid
+            offset = (lo_off + hi_off) / 2
+            for n_ in matrix_sens:
+                adaptive_clip_map[n_] = max(6.0, min(24.0, math.exp(log_raw[n_] + offset)))
+
+    # Mixed-precision bit allocation from the same sensitivity ordering.
+    mixed_precision_bits_map: dict[str, int] = {}
+    if getattr(h, "mixed_precision_hessian", False) and matrix_sens:
+        sorted_by_sens = sorted(matrix_sens.items(), key=lambda kv: kv[1])
+        n_total = len(sorted_by_sens)
+        n_low = int(round(n_total * h.mixed_precision_low_frac))
+        n_high = int(round(n_total * h.mixed_precision_high_frac))
+        for i, (n_, _) in enumerate(sorted_by_sens):
+            if i < n_low:
+                mixed_precision_bits_map[n_] = h.mixed_precision_bits_low
+            elif i >= n_total - n_high:
+                mixed_precision_bits_map[n_] = h.mixed_precision_bits_high
+            else:
+                mixed_precision_bits_map[n_] = h.matrix_bits
+
+    adaptive_clip_log: list[str] = []
+    mixed_precision_log: list[str] = []
+    for (name, tensor) in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        # Dedicated int8-per-row path for attn_gate_w (bypasses both GPTQ and
+        # fp16 passthrough). Applied BEFORE the numel<=65536 passthrough check
+        # so the gate tensor is routed here instead of to fp16.
+        if (
+            quant_gate
+            and t.is_floating_point()
+            and t.ndim == 2
+            and name.endswith(".attn_gate_w")
+            # Dense GatedAttn: (num_heads, dim) = (8, 512) = 4096.
+            # Sparse gate: (num_heads, gate_window) = (8, 12) = 96.
+            # Both need int8-per-row routing; the 1024 lower bound in stock
+            # PR-1736 presumed dense-only. Widen to catch both.
+            and 32 <= t.numel() <= 8192
+        ):
+            gq, gs = _quantize_gate_int8_row(t)
+            result[name + ".gq"] = gq
+            result[name + ".gs"] = gs
+            meta[name] = "gate_int8_row"
+            continue
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough (float16)"
+            continue
+        if "tok_emb" in name:
+            cs = h.embed_clip_sigmas
+        elif name in adaptive_clip_map:
+            cs = adaptive_clip_map[name]
+            adaptive_clip_log.append(f"    {name}: {cs:.2f}")
+        elif ".mlp." in name:
+            cs = h.mlp_clip_sigmas
+        elif ".attn." in name:
+            cs = h.attn_clip_sigmas
+        else:
+            cs = h.matrix_clip_sigmas
+        if "tok_emb" in name:
+            bits = h.embed_bits
+        elif name in mixed_precision_bits_map:
+            bits = mixed_precision_bits_map[name]
+            mixed_precision_log.append(f"    {name}: int{bits}")
+        else:
+            bits = h.matrix_bits
+        clip_range = 2 ** (bits - 1) - 1
+        ret = gptq_quantize_weight(
+            t, hessians[name], clip_sigmas=cs, clip_range=clip_range
+        )
+        q, s = ret
+        result[name + ".q"] = q
+        result[name + ".scale"] = s
+        meta[name] = f"gptq (int{bits})"
+        if lqer_on:
+            W_q = q.float() * s.float().view(-1, 1)
+            E = t.float() - W_q
+            lqer_cands[name] = (E, float(E.norm()))
+    if lqer_on and lqer_cands:
+        top = sorted(lqer_cands.items(), key=lambda kv: -kv[1][1])[: h.lqer_top_k]
+        asym_on = bool(getattr(h, "lqer_asym_enabled", False))
+        asym_g = int(getattr(h, "lqer_asym_group", 64))
+        for (name, (E, _)) in top:
+            U, S, Vh = torch.linalg.svd(E, full_matrices=False)
+            r = min(h.lqer_rank, S.numel())
+            A = (U[:, :r] * S[:r]).contiguous()
+            B = Vh[:r, :].contiguous()
+            if asym_on and B.numel() % asym_g == 0:
+                qA, sA, qB, sB = _lqer_pack_asym(A, B, asym_g)
+                result[name + ".lqA_a"] = qA
+                result[name + ".lqAs_a"] = sA
+                result[name + ".lqB_a"] = qB
+                result[name + ".lqBs_a"] = sB
+                meta[name] = meta[name] + "+lqer_asym"
+            else:
+                qA, sA, qB, sB = _lqer_pack(A, B, h.lqer_factor_bits)
+                result[name + ".lqA"] = qA
+                result[name + ".lqAs"] = sA
+                result[name + ".lqB"] = qB
+                result[name + ".lqBs"] = sB
+                meta[name] = meta[name] + "+lqer"
+    if adaptive_clip_log:
+        log(f"GPTQ adaptive clip_sigmas (Hessian-sensitivity, {len(adaptive_clip_log)} tensors):")
+        for entry in adaptive_clip_log:
+            log(entry)
+    if mixed_precision_log:
+        bits_distribution = collections.Counter(int(l.rsplit("int", 1)[1]) for l in mixed_precision_log)
+        avg_bits = sum(b * c for b, c in bits_distribution.items()) / sum(bits_distribution.values())
+        log(f"GPTQ mixed-precision bit allocation ({len(mixed_precision_log)} tensors, "
+            f"avg={avg_bits:.2f} bits): {dict(sorted(bits_distribution.items()))}")
+        for entry in mixed_precision_log:
+            log(entry)
+    categories = collections.defaultdict(set)
+    for (name, cat) in meta.items():
+        short = re.sub("\\.\\d+$", "", re.sub("blocks\\.\\d+", "blocks", name))
+        categories[cat].add(short)
+    log("Quantized weights:")
+    for cat in sorted(categories):
+        log(f"  {cat}: {', '.join(sorted(categories[cat]))}")
+    return result, meta
+
+def dequantize_mixed(result, meta, template_sd):
+    out = {}
+    for (name, orig) in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if "passthrough" in info:
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        if info == "gate_int8_row":
+            gq = result[name + ".gq"]
+            gs = result[name + ".gs"]
+            out[name] = (gq.float() * gs.float().view(-1, 1)).to(orig_dtype)
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            W = q.float() * s.float().view(q.shape[0], *[1] * (q.ndim - 1))
+        else:
+            W = q.float() * float(s.item())
+        if "lqer_asym" in info:
+            qA_t = result[name + ".lqA_a"]
+            sA_t = result[name + ".lqAs_a"]
+            qB_t = result[name + ".lqB_a"]
+            sB_t = result[name + ".lqBs_a"]
+            qA = qA_t.float() * float(sA_t)
+            g_sz = qB_t.numel() // sB_t.numel()
+            qB = (qB_t.reshape(-1, g_sz).float() * sB_t.float().view(-1, 1)).reshape(
+                qB_t.shape
+            )
+            W = W + qA @ qB
+        elif "lqer" in info:
+            qA = result[name + ".lqA"].float() * result[name + ".lqAs"].float().view(-1, 1)
+            qB = result[name + ".lqB"].float() * result[name + ".lqBs"].float().view(-1, 1)
+            W = W + qA @ qB
+        out[name] = W.to(orig_dtype)
+    return out
+
+
+_BSHF_MAGIC = b"BSHF"
+
+
+# ── Per-group lrzip compression (ported from PR#1586 via PR#1667/1729) ────────
+
+_GROUP_ORDER = [
+    "_tok_emb.weight.q",
+    "attn.c_k.weight.q", "attn.c_q.weight.q",
+    "attn.c_v.weight.q", "attn.proj.weight.q",
+    "mlp.fc.weight.q", "mlp.proj.weight.q",
+]
+_SIMSORT_KEYS = {"_tok_emb.weight.q", "attn.c_q.weight.q", "mlp.fc.weight.q"}
+_PACK_MAGIC = b"PGRP"
+
+
+def _similarity_sort_l1(matrix):
+    import numpy as _np
+    n = matrix.shape[0]
+    used = _np.zeros(n, dtype=bool)
+    order = [0]
+    used[0] = True
+    cur = matrix[0].astype(_np.float32)
+    for _ in range(n - 1):
+        dists = _np.sum(_np.abs(matrix[~used].astype(_np.float32) - cur), axis=1)
+        unused = _np.where(~used)[0]
+        best = unused[_np.argmin(dists)]
+        order.append(best)
+        used[best] = True
+        cur = matrix[best].astype(_np.float32)
+    return _np.array(order, dtype=_np.uint16)
+
+
+def _lrzip_compress(data, tmpdir, label):
+    inp = os.path.join(tmpdir, f"{label}.bin")
+    out = f"{inp}.lrz"
+    with open(inp, "wb") as f:
+        f.write(data)
+    subprocess.run(["lrzip", "-z", "-L", "9", "-o", out, inp], capture_output=True, check=True)
+    with open(out, "rb") as f:
+        result = f.read()
+    os.remove(inp); os.remove(out)
+    return result
+
+
+def _lrzip_decompress(data, tmpdir, label):
+    inp = os.path.join(tmpdir, f"{label}.lrz")
+    out = os.path.join(tmpdir, f"{label}.bin")
+    with open(inp, "wb") as f:
+        f.write(data)
+    subprocess.run(["lrzip", "-d", "-f", "-o", out, inp], capture_output=True, check=True)
+    with open(out, "rb") as f:
+        result = f.read()
+    os.remove(inp); os.remove(out)
+    return result
+
+
+def _pack_streams(streams):
+    import struct
+    n = len(streams)
+    hdr = _PACK_MAGIC + struct.pack("<I", n)
+    for s in streams:
+        hdr += struct.pack("<I", len(s))
+    return hdr + b"".join(streams)
+
+
+def _unpack_streams(blob):
+    import struct
+    assert blob[:4] == _PACK_MAGIC
+    n = struct.unpack("<I", blob[4:8])[0]
+    off = 8
+    lengths = [struct.unpack("<I", blob[off + i*4:off + i*4 + 4])[0] for i in range(n)]
+    off += n * 4
+    streams = []
+    for length in lengths:
+        streams.append(blob[off:off + length])
+        off += length
+    return streams
+
+
+def _compress(raw, compressor):
+    if compressor == "brotli":
+        import brotli
+        return brotli.compress(raw, quality=11)
+    if compressor == "lzma":
+        import lzma
+        return lzma.compress(raw, preset=9)
+    raise ValueError(f"unknown compressor {compressor!r}")
+
+
+def _decompress(blob, compressor):
+    if compressor == "brotli":
+        import brotli
+        return brotli.decompress(blob)
+    if compressor == "lzma":
+        import lzma
+        return lzma.decompress(blob)
+    raise ValueError(f"unknown compressor {compressor!r}")
+
+
+def _serialize_pergroup(quant_result, quant_meta, num_layers, tmpdir):
+    import brotli
+    import numpy as _np
+    groups = collections.defaultdict(list)
+    remainder = {}
+    for name, t in sorted(quant_result.items()):
+        if t.dtype != torch.int8:
+            remainder[name] = t
+            continue
+        parts = name.split(".")
+        routed = False
+        if parts[0] == "blocks" and parts[1].isdigit():
+            key = ".".join(parts[2:])
+            if key in _GROUP_ORDER:
+                groups[key].append((int(parts[1]), t))
+                routed = True
+        else:
+            group_key = "_" + name
+            if group_key in _GROUP_ORDER:
+                groups[group_key] = [(0, t)]
+                routed = True
+        if not routed:
+            # int8 tensor that doesn't fit a known group (e.g. gate_int8_row
+            # tensors like attn.attn_gate_w.gq from GATED_ATTN). Stash in
+            # the brotli-compressed remainder blob so it round-trips.
+            remainder[name] = t
+
+    streams = []
+    all_perms = b""
+    shape_manifest = {}
+
+    for group_key in _GROUP_ORDER:
+        if group_key not in groups:
+            streams.append(b"")
+            continue
+        tensors = sorted(groups[group_key], key=lambda x: x[0])
+        blob = b""
+        grp_shapes = []
+        for idx, t in tensors:
+            arr = t.numpy()
+            orig_shape = arr.shape
+            if arr.ndim == 2:
+                if group_key in _SIMSORT_KEYS:
+                    order = _similarity_sort_l1(arr)
+                    all_perms += order.tobytes()
+                    arr = arr[order]
+                arr = _np.ascontiguousarray(arr.T)
+            blob += arr.tobytes()
+            grp_shapes.append(orig_shape)
+        shape_manifest[group_key] = grp_shapes
+        compressed = _lrzip_compress(blob, tmpdir, group_key.replace(".", "_"))
+        streams.append(compressed)
+
+    remainder_buf = io.BytesIO()
+    torch.save({"r": remainder, "m": quant_meta, "s": shape_manifest}, remainder_buf)
+    streams.append(brotli.compress(remainder_buf.getvalue(), quality=11, lgwin=24))
+    streams.append(brotli.compress(all_perms, quality=11) if all_perms else b"")
+
+    return _pack_streams(streams)
+
+
+def _deserialize_pergroup(blob, num_layers, tmpdir):
+    import brotli
+    import numpy as _np
+    streams = _unpack_streams(blob)
+    n_groups = len(_GROUP_ORDER)
+
+    remainder_state = torch.load(
+        io.BytesIO(brotli.decompress(streams[n_groups])), map_location="cpu"
+    )
+    quant_meta = remainder_state["m"]
+    quant_result = dict(remainder_state["r"])
+    shape_manifest = remainder_state["s"]
+    all_perms = brotli.decompress(streams[n_groups + 1]) if streams[n_groups + 1] else b""
+
+    def _decompress_one(args):
+        i, gk, data = args
+        if not data:
+            return gk, b""
+        return gk, _lrzip_decompress(data, tmpdir, f"d_{gk.replace('.', '_')}")
+
+    from concurrent.futures import ThreadPoolExecutor as _TPool
+    with _TPool(max_workers=n_groups) as pool:
+        futs = [pool.submit(_decompress_one, (i, gk, streams[i])) for i, gk in enumerate(_GROUP_ORDER)]
+        raw_groups = {f.result()[0]: f.result()[1] for f in futs}
+
+    perm_off = 0
+    for group_key in _GROUP_ORDER:
+        raw = raw_groups.get(group_key, b"")
+        if not raw:
+            continue
+        grp_shapes = shape_manifest[group_key]
+        data_arr = _np.frombuffer(raw, dtype=_np.int8)
+
+        if group_key.startswith("_"):
+            tensor_names = [group_key[1:]]
+        else:
+            tensor_names = [f"blocks.{i}.{group_key}" for i in range(num_layers)]
+
+        offset = 0
+        for tname, orig_shape in zip(tensor_names, grp_shapes):
+            n_elem = 1
+            for d in orig_shape:
+                n_elem *= d
+            chunk = data_arr[offset:offset + n_elem].copy()
+            offset += n_elem
+
+            if len(orig_shape) == 2:
+                rows, cols = orig_shape
+                chunk = chunk.reshape(cols, rows).T
+
+                if group_key in _SIMSORT_KEYS:
+                    perm = _np.frombuffer(all_perms[perm_off:perm_off + rows * 2], dtype=_np.uint16)
+                    perm_off += rows * 2
+                    inv_perm = _np.empty_like(perm)
+                    inv_perm[perm] = _np.arange(rows, dtype=_np.uint16)
+                    chunk = chunk[inv_perm]
+
+                chunk = chunk.reshape(orig_shape)
+
+            quant_result[tname] = torch.from_numpy(_np.ascontiguousarray(chunk))
+
+    return quant_result, quant_meta
+
+
+def _unbank_state_dict(state_dict, num_layers):
+    sd = {}
+    n = num_layers
+    for k, v in state_dict.items():
+        t = v.detach().cpu() if v is not None else None
+        if k == "qo_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_q.weight"] = t[i]
+                sd[f"blocks.{i}.attn.proj.weight"] = t[n + i]
+        elif k == "kv_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_k.weight"] = t[i]
+                sd[f"blocks.{i}.attn.c_v.weight"] = t[n + i]
+        elif k == "mlp_up_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.fc.weight"] = t[i]
+        elif k == "mlp_down_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.proj.weight"] = t[i]
+        else:
+            if t is not None:
+                sd[k] = t
+    return sd
+
+
+def _rebank_state_dict(flat_sd, num_layers, model_dim, kv_dim, hidden_dim):
+    sd = {}
+    n = num_layers
+    sd["qo_bank"] = torch.zeros(2 * n, model_dim, model_dim)
+    sd["kv_bank"] = torch.zeros(2 * n, kv_dim, model_dim)
+    for i in range(n):
+        sd["qo_bank"][i] = flat_sd[f"blocks.{i}.attn.c_q.weight"]
+        sd["qo_bank"][n + i] = flat_sd[f"blocks.{i}.attn.proj.weight"]
+        sd["kv_bank"][i] = flat_sd[f"blocks.{i}.attn.c_k.weight"]
+        sd["kv_bank"][n + i] = flat_sd[f"blocks.{i}.attn.c_v.weight"]
+    sd["mlp_up_bank"] = torch.zeros(n, hidden_dim, model_dim)
+    sd["mlp_down_bank"] = torch.zeros(n, model_dim, hidden_dim)
+    for i in range(n):
+        sd["mlp_up_bank"][i] = flat_sd[f"blocks.{i}.mlp.fc.weight"]
+        sd["mlp_down_bank"][i] = flat_sd[f"blocks.{i}.mlp.proj.weight"]
+    for k, v in flat_sd.items():
+        if not (
+            k.startswith("blocks.")
+            and any(
+                p in k
+                for p in [
+                    ".attn.c_q.", ".attn.c_k.", ".attn.c_v.",
+                    ".attn.proj.", ".mlp.fc.", ".mlp.proj.",
+                ]
+            )
+        ):
+            sd[k] = v
+    return sd
+
+
+
+def _compressed_code_size(code):
+    import brotli
+    code_raw = code.encode("utf-8")
+    try:
+        minified = subprocess.run(
+            ["pyminify", "--no-rename-locals", "--no-hoist-literals", "--remove-literal-statements", "--remove-asserts", "--prefer-single-line", "-"],
+            input=code_raw, capture_output=True, check=True,
+        ).stdout
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        minified = code_raw
+    compressed = brotli.compress(minified, quality=11)
+    encoded = base64.b85encode(compressed)
+    wrapper = b"import brotli as B,base64 as b\nexec(B.decompress(b.b85decode(\"" + encoded + b"\")))\n"
+    return len(code_raw), len(wrapper)
+
+
+def serialize(h, base_model, code):
+    code_bytes_uncompressed, code_bytes = _compressed_code_size(code)
+    if h.is_main_process:
+        torch.save(base_model.state_dict(), h.model_path)
+        model_bytes = os.path.getsize(h.model_path)
+        log(f"Serialized model: {model_bytes} bytes")
+        log(f"Code size (uncompressed): {code_bytes_uncompressed} bytes")
+        log(f"Code size (compressed): {code_bytes} bytes")
+    sd_cpu = _unbank_state_dict(base_model.state_dict(), h.num_layers)
+    device = torch.device("cuda", h.local_rank)
+    t0 = time.perf_counter()
+    calib_loader = ShuffledSequenceLoader(h, device)
+    log("GPTQ:collecting Hessians from calibration data...")
+    hessians = collect_hessians(
+        base_model,
+        calib_loader,
+        h,
+        device,
+        n_calibration_batches=h.gptq_calibration_batches,
+    )
+    log(f"GPTQ:collected {len(hessians)} Hessians in {time.perf_counter()-t0:.1f}s")
+    quant_result, quant_meta = gptq_mixed_quantize(sd_cpu, hessians, h)
+    if h.compressor == "pergroup":
+        import tempfile
+        tmpdir = tempfile.mkdtemp(prefix="pgrp_")
+        log("Serialize: per-group lrzip compression...")
+        t1 = time.perf_counter()
+        quant_blob = _serialize_pergroup(quant_result, quant_meta, h.num_layers, tmpdir)
+        log(f"Serialize: per-group compression done in {time.perf_counter()-t1:.1f}s")
+        try:
+            os.rmdir(tmpdir)
+        except OSError:
+            pass
+    else:
+        quant_buf = io.BytesIO()
+        torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+        quant_raw = quant_buf.getvalue()
+        quant_blob = _compress(quant_raw, h.compressor)
+    quant_file_bytes = len(quant_blob)
+    bytes_total = quant_file_bytes + code_bytes
+    if h.is_main_process:
+        with open(h.quantized_model_path, "wb") as f:
+            f.write(quant_blob)
+        log(f"Serialized model quantized+{h.compressor}: {quant_file_bytes} bytes")
+        log(f"Total submission size quantized+{h.compressor}: {bytes_total} bytes")
+    return bytes_total, quant_file_bytes
+
+
+def deserialize(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    flat_template = _unbank_state_dict(eval_model.state_dict(), h.num_layers)
+    with open(h.quantized_model_path, "rb") as f:
+        quant_blob_disk = f.read()
+    if quant_blob_disk[:4] == _PACK_MAGIC:
+        import tempfile
+        tmpdir = tempfile.mkdtemp(prefix="pgrp_dec_")
+        log("Deserialize: per-group lrzip decompression...")
+        t0 = time.perf_counter()
+        quant_result, quant_meta = _deserialize_pergroup(
+            quant_blob_disk, h.num_layers, tmpdir
+        )
+        log(f"Deserialize: decompression done in {time.perf_counter()-t0:.1f}s")
+        try:
+            os.rmdir(tmpdir)
+        except OSError:
+            pass
+    else:
+        quant_state = torch.load(
+            io.BytesIO(_decompress(quant_blob_disk, h.compressor)), map_location="cpu"
+        )
+        quant_result, quant_meta = quant_state["w"], quant_state["m"]
+    deq_flat = dequantize_mixed(quant_result, quant_meta, flat_template)
+    head_dim = h.model_dim // h.num_heads
+    kv_dim = h.num_kv_heads * head_dim
+    hidden_dim = int(h.mlp_mult * h.model_dim)
+    deq_state = _rebank_state_dict(deq_flat, h.num_layers, h.model_dim, kv_dim, hidden_dim)
+    eval_model.load_state_dict(deq_state, strict=True)
+    return eval_model
+
+
+def _loss_bpb(loss_sum, token_count, byte_count):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    return val_loss, val_bpb
+
+
+def eval_val(h, device, val_data, model, forward_logits_fn=None):
+    seq_len = h.eval_seq_len
+    local_batch_tokens = h.val_batch_tokens // (h.world_size * h.grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            f"VAL_BATCH_SIZE must provide at least one sequence per rank; got VAL_BATCH_SIZE={h.val_batch_tokens}, WORLD_SIZE={h.world_size}, GRAD_ACCUM_STEPS={h.grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = total_seqs * h.rank // h.world_size
+    seq_end = total_seqs * (h.rank + 1) // h.world_size
+
+    # TODO: Don't truncate this.
+    seq_end = seq_start + ((seq_end - seq_start) // local_batch_seqs) * local_batch_seqs
+
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    run_forward_logits = (
+        (model.module.forward_logits if hasattr(model, "module") else model.forward_logits)
+        if forward_logits_fn is None
+        else forward_logits_fn
+    )
+    model.eval()
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    with torch.no_grad():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_data.val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1]
+            y = local[1:]
+            bos_pos = (x == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                bos_pos, x.numel(), x.device, h.eval_seq_len, 64
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = run_forward_logits(
+                    x[None], cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                ).detach()
+            per_token_loss = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y.reshape(-1),
+                reduction="none",
+            )
+            val_loss_sum += per_token_loss.to(torch.float64).sum()
+            val_token_count += float(y.numel())
+            prev_ids = x
+            tgt_ids = y
+            sidecar_slice = val_data.val_bytes[raw_start + 1 : raw_end].to(
+                device=device, dtype=torch.int32, non_blocking=True
+            )
+            val_byte_count += sidecar_slice.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    model.train()
+    return _loss_bpb(val_loss_sum, val_token_count, val_byte_count)
+
+
+def _find_docs(all_tokens):
+    bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0].numpy()
+    docs = []
+    for i in range(len(bos_positions)):
+        start = int(bos_positions[i])
+        end = (
+            int(bos_positions[i + 1])
+            if i + 1 < len(bos_positions)
+            else all_tokens.numel()
+        )
+        if i + 1 < len(bos_positions):
+            end += 1
+        assert end - start >= 2
+        docs.append((start, end - start))
+    return docs
+
+
+def _build_ttt_global_batches(doc_entries, h, ascending=False):
+    batch_size = h.ttt_batch_size
+    global_doc_entries = sorted(doc_entries, key=lambda x: x[1][1])
+    global_batches = [
+        global_doc_entries[i : i + batch_size]
+        for i in range(0, len(global_doc_entries), batch_size)
+    ]
+    indexed = list(enumerate(global_batches))
+    if not ascending:
+        indexed.sort(key=lambda ib: -max(dl for _, (_, dl) in ib[1]))
+    return indexed
+
+
+def _init_batch_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(4, "little"))
+
+
+def _claim_next_batch(counter_path, queue_len):
+    try:
+        with open(counter_path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            idx = int.from_bytes(f.read(4), "little")
+            f.seek(0)
+            f.write((idx + 1).to_bytes(4, "little"))
+            f.flush()
+    except FileNotFoundError:
+        return queue_len
+    return idx
+
+
+def _compute_chunk_window(ci, pred_len, num_chunks, chunk_size, eval_seq_len):
+    chunk_end = pred_len if ci == num_chunks - 1 else (ci + 1) * chunk_size
+    win_start = max(0, chunk_end - eval_seq_len)
+    win_len = chunk_end - win_start
+    chunk_start = ci * chunk_size
+    chunk_offset = chunk_start - win_start
+    chunk_len = chunk_end - chunk_start
+    return win_start, win_len, chunk_offset, chunk_len
+
+
+def _accumulate_bpb(
+    ptl,
+    x,
+    y,
+    chunk_offsets,
+    chunk_lens,
+    pos_idx,
+    base_bytes_lut,
+    has_leading_space_lut,
+    is_boundary_token_lut,
+    loss_sum,
+    byte_sum,
+    token_count,
+    y_bytes=None,
+):
+    pos = pos_idx[: x.size(1)].unsqueeze(0)
+    mask = (
+        (chunk_lens.unsqueeze(1) > 0)
+        & (pos >= chunk_offsets.unsqueeze(1))
+        & (pos < (chunk_offsets + chunk_lens).unsqueeze(1))
+    )
+    mask_f64 = mask.to(torch.float64)
+    if y_bytes is not None:
+        tok_bytes = y_bytes.to(torch.float64)
+    else:
+        tok_bytes = base_bytes_lut[y].to(torch.float64)
+        tok_bytes += (has_leading_space_lut[y] & ~is_boundary_token_lut[x]).to(
+            torch.float64
+        )
+    loss_sum += (ptl.to(torch.float64) * mask_f64).sum()
+    byte_sum += (tok_bytes * mask_f64).sum()
+    token_count += chunk_lens.to(torch.float64).sum()
+
+
+def _loss_bpb_from_sums(loss_sum, token_count, byte_sum):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_sum.item())
+    return val_loss, val_bpb
+
+
+def _add_to_counter(path, delta):
+    try:
+        with open(path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            cur = int.from_bytes(f.read(8), "little", signed=True)
+            cur += int(delta)
+            f.seek(0)
+            f.write(int(cur).to_bytes(8, "little", signed=True))
+            f.flush()
+            return cur
+    except FileNotFoundError:
+        return int(delta)
+
+
+def _init_int64_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(8, "little", signed=True))
+
+
+def _select_ttt_doc_entries(docs, h):
+    doc_entries = list(enumerate(docs))
+    if h.val_doc_fraction < 1.0:
+        sample_n = max(1, int(round(len(docs) * h.val_doc_fraction)))
+        sampled_indices = sorted(
+            random.Random(h.seed).sample(range(len(docs)), sample_n)
+        )
+        return [(i, docs[i]) for i in sampled_indices]
+    return doc_entries
+
+
+def train_val_ttt_global_sgd_distributed(h, device, val_data, base_model, val_tokens, batch_seqs=None):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    seq_len = h.eval_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = h.global_ttt_chunk_tokens
+    batch_seqs = h.global_ttt_batch_seqs if batch_seqs is None else batch_seqs
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    ttt_params = [p for p in base_model.parameters()]
+    for p in ttt_params:
+        p.requires_grad_(True)
+    optimizer = torch.optim.SGD(
+        ttt_params, lr=h.global_ttt_lr, momentum=h.global_ttt_momentum
+    )
+    t_start = time.perf_counter()
+    for ci in range(num_chunks):
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+        is_last_chunk = ci == num_chunks - 1
+        if is_last_chunk or h.global_ttt_epochs <= 0:
+            continue
+        base_model.train()
+        chunk_seqs = (chunk_end - chunk_start) // seq_len
+        if chunk_seqs <= 0:
+            continue
+        warmup_chunks = max(0, min(h.global_ttt_warmup_chunks, num_chunks - 1))
+        if warmup_chunks > 0 and ci < warmup_chunks:
+            warmup_denom = max(warmup_chunks - 1, 1)
+            warmup_t = ci / warmup_denom
+            lr_now = (
+                h.global_ttt_warmup_start_lr
+                + (h.global_ttt_lr - h.global_ttt_warmup_start_lr) * warmup_t
+            )
+        else:
+            decay_steps = max(num_chunks - 1 - warmup_chunks, 1)
+            decay_ci = max(ci - warmup_chunks, 0)
+            lr_now = h.global_ttt_lr * 0.5 * (
+                1.0 + math.cos(math.pi * decay_ci / decay_steps)
+            )
+        for pg in optimizer.param_groups:
+            pg["lr"] = lr_now
+        my_seq_s = chunk_seqs * h.rank // h.world_size
+        my_seq_e = chunk_seqs * (h.rank + 1) // h.world_size
+        my_chunk_seqs = my_seq_e - my_seq_s
+        for _ in range(h.global_ttt_epochs):
+            for bs in range(0, my_chunk_seqs, batch_seqs):
+                be = min(bs + batch_seqs, my_chunk_seqs)
+                actual_bs = my_seq_s + bs
+                start_tok = chunk_start + actual_bs * seq_len
+                end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                if end_tok > val_tokens.numel():
+                    continue
+                local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                x_flat = local[:-1]
+                y_flat = local[1:]
+                optimizer.zero_grad(set_to_none=True)
+                with torch.enable_grad():
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        if h.global_ttt_respect_doc_boundaries:
+                            bos_pos = (x_flat == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+                            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                                bos_pos, x_flat.numel(), x_flat.device, h.eval_seq_len, 64
+                            )
+                            loss = base_model(
+                                x_flat[None],
+                                y_flat[None],
+                                cu_seqlens=cu_seqlens,
+                                max_seqlen=max_seqlen,
+                            )
+                        else:
+                            x = x_flat.reshape(-1, seq_len)
+                            y = y_flat.reshape(-1, seq_len)
+                            loss = base_model(x, y)
+                loss.backward()
+                if dist.is_available() and dist.is_initialized():
+                    for p in ttt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+                            p.grad.mul_(1.0 / h.world_size)
+                if h.global_ttt_grad_clip > 0:
+                    torch.nn.utils.clip_grad_norm_(ttt_params, h.global_ttt_grad_clip)
+                optimizer.step()
+        base_model.eval()
+        if h.rank == 0:
+            elapsed = time.perf_counter() - t_start
+            log(
+                f"tttg: c{ci+1}/{num_chunks} lr:{lr_now:.6f} t:{elapsed:.1f}s"
+            )
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+
+def eval_val_ttt_phased(h, base_model, device, val_data, forward_ttt_train):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+    all_tokens = val_data.val_tokens
+    all_tokens_idx = all_tokens.to(torch.int32)
+    docs = _find_docs(all_tokens)
+    doc_entries = _select_ttt_doc_entries(docs, h)
+    prefix_doc_limit = max(0, min(len(doc_entries), int(h.phased_ttt_prefix_docs)))
+    num_phases = max(1, int(h.phased_ttt_num_phases))
+    phase_boundaries = []
+    for pi in range(num_phases):
+        boundary = prefix_doc_limit * (pi + 1) // num_phases
+        phase_boundaries.append(boundary)
+    current_phase = 0
+    current_phase_boundary = phase_boundaries[0]
+    log(
+        "ttt_phased:"
+        f" total_docs:{len(doc_entries)} prefix_docs:{prefix_doc_limit} "
+        f"suffix_docs:{len(doc_entries) - prefix_doc_limit}"
+        f" num_phases:{num_phases} boundaries:{phase_boundaries}"
+    )
+    chunk_size, eval_seq_len = h.ttt_chunk_size, h.ttt_eval_seq_len
+    eval_batch_set = None
+    if h.ttt_eval_batches:
+        eval_batch_set = set(int(x) for x in h.ttt_eval_batches.split(",") if x.strip())
+    use_ascending = eval_batch_set is not None
+    global_batches_sorted = _build_ttt_global_batches(
+        doc_entries, h, ascending=use_ascending
+    )
+    queue_len = len(global_batches_sorted)
+    counter_path = f"/tmp/ttt_counter_{h.run_id}"
+    prefix_counter_path = f"/tmp/ttt_prefix_counter_{h.run_id}"
+    pause_flag_path = f"/tmp/ttt_pause_flag_{h.run_id}"
+    if h.rank == 0:
+        _init_batch_counter(counter_path)
+        _init_int64_counter(prefix_counter_path)
+        try:
+            os.remove(pause_flag_path)
+        except FileNotFoundError:
+            pass
+    if dist.is_available() and dist.is_initialized():
+        path_list = [counter_path, prefix_counter_path, pause_flag_path]
+        dist.broadcast_object_list(path_list, src=0)
+        counter_path, prefix_counter_path, pause_flag_path = path_list
+        dist.barrier()
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    t_start = time.perf_counter()
+    reusable_lora = BatchedTTTLoRA(
+        h.ttt_batch_size, base_model, h.ttt_lora_rank,
+        k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+    ).to(device)
+
+    def _build_opt(lora):
+        if h.ttt_optimizer == "sgd":
+            return torch.optim.SGD(
+                lora.parameters(), lr=h.ttt_lora_lr,
+                momentum=h.ttt_beta1, weight_decay=h.ttt_weight_decay,
+            )
+        return torch.optim.AdamW(
+            lora.parameters(), lr=h.ttt_lora_lr,
+            betas=(h.ttt_beta1, h.ttt_beta2),
+            eps=1e-10, weight_decay=h.ttt_weight_decay, fused=True,
+        )
+
+    reusable_opt = _build_opt(reusable_lora)
+    local_scored_docs = []
+    global_ttt_done = prefix_doc_limit == 0
+    try:
+      while True:
+        queue_idx = _claim_next_batch(counter_path, queue_len)
+        if queue_idx >= queue_len:
+            break
+        orig_batch_idx, batch_entries = global_batches_sorted[queue_idx]
+        batch = [doc for _, doc in batch_entries]
+        bsz = len(batch)
+        prev_loss = loss_sum.item()
+        prev_bytes = byte_sum.item()
+        prev_tokens = token_count.item()
+        if bsz == reusable_lora.bsz:
+            reusable_lora.reset()
+            for s in reusable_opt.state.values():
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor):
+                        v.zero_()
+                    elif k == "step":
+                        s[k] = 0
+            cur_lora = reusable_lora
+            cur_opt = reusable_opt
+        else:
+            cur_lora = BatchedTTTLoRA(
+                bsz, base_model, h.ttt_lora_rank,
+                k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+            ).to(device)
+            cur_opt = _build_opt(cur_lora)
+        pred_lens = [doc_len - 1 for _, doc_len in batch]
+        num_chunks = [(pl + chunk_size - 1) // chunk_size for pl in pred_lens]
+        max_nc = max(num_chunks)
+        num_chunks_t = torch.tensor(num_chunks, dtype=torch.int64, device=device)
+        for ci in range(max_nc):
+            active = [ci < nc for nc in num_chunks]
+            needs_train = any(ci < nc - 1 for nc in num_chunks)
+            tok_starts = torch.zeros(bsz, dtype=torch.int64)
+            tok_wls = torch.zeros(bsz, dtype=torch.int64)
+            chunk_offsets_cpu = torch.zeros(bsz, dtype=torch.int64)
+            chunk_lens_cpu = torch.zeros(bsz, dtype=torch.int64)
+            for b in range(bsz):
+                if not active[b]:
+                    continue
+                doc_start, doc_len = batch[b]
+                win_start, win_len, chunk_offset, chunk_len = _compute_chunk_window(
+                    ci, pred_lens[b], num_chunks[b], chunk_size, eval_seq_len
+                )
+                tok_starts[b] = doc_start + win_start
+                tok_wls[b] = win_len
+                chunk_offsets_cpu[b] = chunk_offset
+                chunk_lens_cpu[b] = chunk_len
+            _, context_size, chunk_offset, _ = _compute_chunk_window(
+                ci, (ci + 1) * chunk_size, ci + 1, chunk_size, eval_seq_len
+            )
+            col_idx = torch.arange(context_size + 1)
+            idx = tok_starts.unsqueeze(1) + col_idx.unsqueeze(0)
+            idx.clamp_(max=all_tokens.numel() - 1)
+            gathered_gpu = all_tokens_idx[idx].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            valid = (col_idx[:context_size].unsqueeze(0) < tok_wls.unsqueeze(1)).to(
+                device, non_blocking=True
+            )
+            chunk_offsets = chunk_offsets_cpu.to(device, non_blocking=True)
+            chunk_lens = chunk_lens_cpu.to(device, non_blocking=True)
+            x = torch.where(valid, gathered_gpu[:, :context_size], 0)
+            y = torch.where(valid, gathered_gpu[:, 1 : context_size + 1], 0)
+            ctx_pos = torch.arange(context_size, device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+            # CaseOps sidecar-driven byte budget. Mirror the index pattern
+            # used to build y from all_tokens: y[b, j] corresponds to the
+            # token at global position tok_starts[b] + 1 + j (when valid).
+            y_bytes_arg = None
+            if val_data.caseops_enabled and val_data.val_bytes is not None:
+                y_idx = (
+                    tok_starts.unsqueeze(1)
+                    + 1
+                    + col_idx[:context_size].unsqueeze(0)
+                )
+                y_idx = y_idx.clamp_(max=val_data.val_bytes.numel() - 1)
+                y_bytes_arg = val_data.val_bytes[y_idx].to(
+                    device=device, dtype=torch.int32, non_blocking=True
+                )
+                # Mirror the `valid` masking used for y so out-of-range tokens
+                # contribute zero bytes (matches y=0 substitution above).
+                y_bytes_arg = torch.where(
+                    valid, y_bytes_arg, torch.zeros_like(y_bytes_arg)
+                )
+            with torch.no_grad():
+                _accumulate_bpb(
+                    per_tok_loss,
+                    x,
+                    y,
+                    chunk_offsets,
+                    chunk_lens,
+                    ctx_pos,
+                    val_data.base_bytes_lut,
+                    val_data.has_leading_space_lut,
+                    val_data.is_boundary_token_lut,
+                    loss_sum,
+                    byte_sum,
+                    token_count,
+                    y_bytes=y_bytes_arg,
+                )
+            if needs_train:
+                activate_chunk_mask = (num_chunks_t - 1 > ci).float()
+                for gi in range(h.ttt_grad_steps):
+                    if gi > 0:
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+                    per_doc = per_tok_loss[
+                        :, chunk_offset : chunk_offset + chunk_size
+                    ].mean(dim=-1)
+                    cur_opt.zero_grad(set_to_none=True)
+                    (per_doc * activate_chunk_mask).sum().backward()
+                    cur_opt.step()
+            else:
+                del per_tok_loss
+        batch_num = orig_batch_idx + 1
+        doc_lens = [dl for _, dl in batch]
+        should_report = batch_num in eval_batch_set if eval_batch_set is not None else True
+        if should_report:
+            cur_tokens = token_count.item()
+            cur_loss_val = loss_sum.item()
+            cur_bytes_val = byte_sum.item()
+            dt = cur_tokens - prev_tokens
+            db = cur_bytes_val - prev_bytes
+            if dt > 0 and db > 0:
+                b_loss = (cur_loss_val - prev_loss) / dt
+                b_bpb = b_loss / math.log(2.0) * (dt / db)
+            else:
+                b_loss = b_bpb = 0.0
+            r_loss = cur_loss_val / max(cur_tokens, 1)
+            r_bpb = r_loss / math.log(2.0) * (cur_tokens / max(cur_bytes_val, 1))
+            elapsed = time.perf_counter() - t_start
+            log(
+                f"ttp: b{batch_num}/{queue_len} bl:{b_loss:.4f} bb:{b_bpb:.4f} "
+                f"rl:{r_loss:.4f} rb:{r_bpb:.4f} dl:{min(doc_lens)}-{max(doc_lens)} "
+                f"gd:{int(global_ttt_done)}"
+            )
+        if not global_ttt_done:
+            local_scored_docs.extend(
+                (orig_batch_idx, pos, doc_start, doc_len)
+                for pos, (doc_start, doc_len) in enumerate(batch)
+            )
+            prefix_done = _add_to_counter(prefix_counter_path, len(batch_entries))
+            if prefix_done >= current_phase_boundary:
+                try:
+                    with open(pause_flag_path, "x"):
+                        pass
+                except FileExistsError:
+                    pass
+            should_pause = os.path.exists(pause_flag_path)
+            if should_pause:
+                if dist.is_available() and dist.is_initialized():
+                    dist.barrier()
+                gathered_scored_docs = [None] * h.world_size
+                if dist.is_available() and dist.is_initialized():
+                    dist.all_gather_object(gathered_scored_docs, local_scored_docs)
+                else:
+                    gathered_scored_docs = [local_scored_docs]
+                scored_docs_for_global = []
+                for rank_docs in gathered_scored_docs:
+                    if rank_docs:
+                        scored_docs_for_global.extend(rank_docs)
+                scored_docs_for_global.sort(key=lambda x: (x[0], x[1]))
+                scored_docs_for_global = scored_docs_for_global[:current_phase_boundary]
+                scored_token_chunks = [
+                    val_data.val_tokens[doc_start : doc_start + doc_len]
+                    for _, _, doc_start, doc_len in scored_docs_for_global
+                ]
+                if scored_token_chunks:
+                    global_ttt_tokens = torch.cat(scored_token_chunks)
+                else:
+                    global_ttt_tokens = val_data.val_tokens[:0]
+                if h.rank == 0:
+                    prefix_done = 0
+                    try:
+                        with open(prefix_counter_path, "rb") as f:
+                            prefix_done = int.from_bytes(
+                                f.read(8), "little", signed=True
+                            )
+                    except FileNotFoundError:
+                        pass
+                    log(
+                        f"ttpp: phase:{current_phase + 1}/{num_phases} pd:{prefix_done} "
+                        f"gd:{len(scored_docs_for_global)} "
+                        f"t:{time.perf_counter() - t_start:.1f}s"
+                    )
+                train_val_ttt_global_sgd_distributed(
+                    h, device, val_data, base_model, global_ttt_tokens
+                )
+                for p in base_model.parameters():
+                    p.requires_grad_(False)
+                reusable_lora = BatchedTTTLoRA(
+                    h.ttt_batch_size, base_model, h.ttt_lora_rank,
+                    k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+                ).to(device)
+                reusable_opt = _build_opt(reusable_lora)
+                current_phase += 1
+                if current_phase >= num_phases:
+                    global_ttt_done = True
+                else:
+                    current_phase_boundary = phase_boundaries[current_phase]
+                    if h.rank == 0:
+                        try:
+                            os.remove(pause_flag_path)
+                        except FileNotFoundError:
+                            pass
+                if dist.is_available() and dist.is_initialized():
+                    dist.barrier()
+                if h.rank == 0:
+                    log(f"ttpr: phase:{current_phase}/{num_phases} t:{time.perf_counter() - t_start:.1f}s")
+        del cur_lora, cur_opt
+    finally:
+        pass
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.train()
+    return _loss_bpb_from_sums(loss_sum, token_count, byte_sum)
+
+
+def timed_eval(label, fn, *args, **kwargs):
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    val_loss, val_bpb = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    elapsed_ms = 1e3 * (time.perf_counter() - t0)
+    log(
+        f"{label} val_loss:{val_loss:.8f} val_bpb:{val_bpb:.8f} eval_time:{elapsed_ms:.0f}ms"
+    )
+    return val_loss, val_bpb
+
+
+def train_model(h, device, val_data):
+    base_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        base_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    model = compiled_model
+    log(f"model_params:{sum(p.numel()for p in base_model.parameters())}")
+    optimizers = Optimizers(h, base_model)
+    train_loader = DocumentPackingLoader(h, device)
+    max_wallclock_ms = (
+        1e3 * h.max_wallclock_seconds if h.max_wallclock_seconds > 0 else None
+    )
+    if max_wallclock_ms is not None:
+        max_wallclock_ms -= h.gptq_reserve_seconds * 1e3
+        log(
+            f"gptq:reserving {h.gptq_reserve_seconds:.0f}s, effective={max_wallclock_ms:.0f}ms"
+        )
+
+    def training_frac(step, elapsed_ms):
+        if max_wallclock_ms is None:
+            return step / max(h.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-09)
+
+    def lr_mul(frac):
+        if h.warmdown_frac <= 0:
+            return 1.0
+        if frac >= 1.0 - h.warmdown_frac:
+            return max((1.0 - frac) / h.warmdown_frac, h.min_lr)
+        return 1.0
+
+    _clip_params = [p for p in base_model.parameters() if p.requires_grad]
+    def step_fn(step, lr_scale):
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(h.grad_accum_steps):
+            x, y, cu_seqlens, _max_seqlen = train_loader.next_batch(
+                h.train_batch_tokens, h.grad_accum_steps
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y, cu_seqlens=cu_seqlens, max_seqlen=h.train_seq_len)
+            train_loss += loss.detach()
+            (loss / h.grad_accum_steps).backward()
+        train_loss /= h.grad_accum_steps
+        if step <= h.muon_momentum_warmup_steps:
+
+            frac = (
+
+                min(step / h.muon_momentum_warmup_steps, 1.0)
+
+                if h.muon_momentum_warmup_steps > 0
+
+                else 1.0
+
+            )
+
+            muon_momentum = (
+
+                1 - frac
+
+            ) * h.muon_momentum_warmup_start + frac * h.muon_momentum
+
+            for group in optimizers.optimizer_muon.param_groups:
+
+                group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * lr_scale
+        if h.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(_clip_params, h.grad_clip_norm)
+        optimizers.step(distributed=h.distributed)
+        return train_loss
+
+    if h.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for (name, tensor) in base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in optimizers
+        ]
+        model.train()
+        num_tokens_local = h.train_batch_tokens // h.world_size
+        for blk in base_model.blocks:
+            blk.attn.rotary(num_tokens_local, device, torch.bfloat16)
+        cu_bucket_size = train_loader.cu_bucket_size
+        warmup_cu_buckets = tuple(cu_bucket_size * i for i in range(1, 5))
+        warmup_cu_iters = 3
+        x, y, cu_seqlens, _ = train_loader.next_batch(
+            h.train_batch_tokens, h.grad_accum_steps
+        )
+        log(f"warmup_cu_buckets:{','.join(str(b) for b in warmup_cu_buckets)} iters_each:{warmup_cu_iters}")
+        def _run_cu_bucket_warmup():
+            for bucket_len in warmup_cu_buckets:
+                boundaries = list(range(0, x.size(1), max(h.train_seq_len, 1)))
+                if boundaries[-1] != x.size(1):
+                    boundaries.append(x.size(1))
+                cu = torch.full((bucket_len,), x.size(1), dtype=torch.int32, device=device)
+                cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+                for _ in range(warmup_cu_iters):
+                    optimizers.zero_grad_all()
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                        wloss = model(x, y, cu_seqlens=cu, max_seqlen=h.train_seq_len)
+                    (wloss / h.grad_accum_steps).backward()
+            optimizers.zero_grad_all()
+        _run_cu_bucket_warmup()
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            _run_cu_bucket_warmup()
+            base_model.looping_active = False
+        for warmup_step in range(h.warmup_steps):
+            step_fn(warmup_step, 1.0)
+            if (
+                warmup_step <= 5
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == h.warmup_steps
+            ):
+                log(f"warmup_step: {warmup_step+1}/{h.warmup_steps}")
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            log(
+                f"loop_warmup:enabled encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            for warmup_step in range(h.warmup_steps):
+                step_fn(warmup_step, 1.0)
+                if (
+                    warmup_step <= 5
+                    or (warmup_step + 1) % 10 == 0
+                    or warmup_step + 1 == h.warmup_steps
+                ):
+                    log(f"loop_warmup_step: {warmup_step+1}/{h.warmup_steps}")
+            base_model.looping_active = False
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for (opt, state) in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        optimizers.zero_grad_all()
+        train_loader = DocumentPackingLoader(h, device)
+    _live_state = base_model.state_dict(keep_vars=True)
+    ema_state = {
+        name: t.detach().float().clone()
+        for (name, t) in _live_state.items()
+    }
+    _ema_pairs = [(ema_state[name], t) for (name, t) in _live_state.items()]
+    ema_decay = h.ema_decay
+    training_time_ms = 0.0
+    stop_after_step = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = (
+            step == h.iterations
+            or stop_after_step is not None
+            and step >= stop_after_step
+        )
+        should_validate = (
+            last_step or h.val_loss_every > 0 and step % h.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1e3 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                h, device, val_data, model, compiled_forward_logits
+            )
+            log(
+                f"{step}/{h.iterations} val_loss: {val_loss:.4f} val_bpb: {val_bpb:.4f}"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < h.iterations:
+                log(
+                    f"stopping_early: wallclock_cap train_time: {training_time_ms:.0f}ms step: {step}/{h.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        frac = training_frac(step, elapsed_ms)
+        scale = lr_mul(frac)
+        if (
+            h.num_loops > 0
+            and not base_model.looping_active
+            and frac >= h.enable_looping_at
+        ):
+            base_model.looping_active = True
+            log(
+                f"layer_loop:enabled step:{step} frac:{frac:.3f} encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+        train_loss = step_fn(step, scale)
+        with torch.no_grad():
+            for ema_t, t in _ema_pairs:
+                ema_t.mul_(ema_decay).add_(t.detach(), alpha=1.0 - ema_decay)
+        step += 1
+        approx_training_time_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        should_log_train = h.train_log_every > 0 and (
+            step <= 5 or step % h.train_log_every == 0 or stop_after_step is not None
+        )
+        if should_log_train:
+            tok_per_sec = step * h.train_batch_tokens / (approx_training_time_ms / 1e3)
+            log(
+                f"{step}/{h.iterations} train_loss: {train_loss.item():.4f} train_time: {approx_training_time_ms/60000:.1f}m tok/s: {tok_per_sec:.0f}"
+            )
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if h.distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated()//1024//1024} MiB reserved: {torch.cuda.max_memory_reserved()//1024//1024} MiB"
+    )
+    log("ema:applying EMA weights")
+    current_state = base_model.state_dict()
+    avg_state = {
+        name: t.to(dtype=current_state[name].dtype) for (name, t) in ema_state.items()
+    }
+    base_model.load_state_dict(avg_state, strict=True)
+    return base_model, compiled_model, compiled_forward_logits
+
+
+def train_and_eval(h, device):
+    random.seed(h.seed)
+    np.random.seed(h.seed)
+    torch.manual_seed(h.seed)
+    torch.cuda.manual_seed_all(h.seed)
+    if h.artifact_dir and h.is_main_process:
+        os.makedirs(h.artifact_dir, exist_ok=True)
+    val_data = ValidationData(h, device)
+    log(
+        f"train_shards: {len(list(Path(h.datasets_dir).resolve().glob('fineweb_train_*.bin')))}"
+    )
+    log(f"val_tokens: {val_data.val_tokens.numel()-1}")
+    # TTT_EVAL_ONLY: skip training + GPTQ, jump straight to TTT eval on a
+    # pre-existing quantized artifact. Used to test TTT-only improvements
+    # (e.g., PR-1767's alpha/warm-start/WD) without retraining.
+    ttt_eval_only = os.environ.get("TTT_EVAL_ONLY", "0") == "1"
+    if ttt_eval_only:
+        log("TTT_EVAL_ONLY=1 — skipping training + GPTQ, loading saved artifact for TTT eval")
+        log(f"ttt_lora_alpha: {BatchedLinearLoRA._ALPHA}")
+        log(f"ttt_warm_start_a: {BatchedLinearLoRA._WARM_START_A}")
+        log(f"ttt_weight_decay: {h.ttt_weight_decay}")
+    else:
+        base_model, compiled_model, compiled_forward_logits = train_model(
+            h, device, val_data
+        )
+        torch._dynamo.reset()
+        timed_eval(
+            "diagnostic pre-quantization post-ema",
+            eval_val,
+            h,
+            device,
+            val_data,
+            compiled_model,
+            compiled_forward_logits,
+        )
+        if os.environ.get("PREQUANT_ONLY", "0") == "1":
+            log("PREQUANT_ONLY=1 — skipping serialize/GPTQ/post-quant eval/TTT")
+            return
+        serialize(h, base_model, Path(__file__).read_text(encoding="utf-8"))
+        if h.distributed:
+            dist.barrier()
+    eval_model = deserialize(h, device)
+    if h.num_loops > 0:
+        eval_model.looping_active = True
+    if not ttt_eval_only:
+        compiled_model = torch.compile(eval_model, dynamic=False, fullgraph=True)
+        compiled_forward_logits = torch.compile(
+            eval_model.forward_logits, dynamic=False, fullgraph=True
+        )
+        timed_eval(
+            "diagnostic quantized",
+            eval_val,
+            h,
+            device,
+            val_data,
+            compiled_model,
+            compiled_forward_logits,
+        )
+        del eval_model
+    if h.ttt_enabled:
+        if not ttt_eval_only:
+            del compiled_model
+        if ttt_eval_only:
+            del eval_model
+        torch._dynamo.reset()
+        torch.cuda.empty_cache()
+        ttt_model = deserialize(h, device)
+        if h.num_loops > 0:
+            ttt_model.looping_active = True
+        for p in ttt_model.parameters():
+            p.requires_grad_(False)
+
+        if h.rope_yarn:
+            _yarn_seqlen = h.train_batch_tokens // h.grad_accum_steps
+            for block in ttt_model.blocks:
+                block.attn.rotary(_yarn_seqlen, device, torch.bfloat16)
+        else:
+            for block in ttt_model.blocks:
+                block.attn.rotary._cos_cached = None
+                block.attn.rotary._sin_cached = None
+                block.attn.rotary._seq_len_cached = 0
+                block.attn.rotary(h.ttt_eval_seq_len, device, torch.bfloat16)
+
+        def _fwd_ttt_inner(input_ids, target_ids, lora):
+            return ttt_model.forward_ttt(input_ids, target_ids, lora=lora)
+
+        _fwd_ttt_compiled_inner = None
+
+        def _fwd_ttt(input_ids, target_ids, lora):
+            nonlocal _fwd_ttt_compiled_inner
+            if _fwd_ttt_compiled_inner is None:
+                _fwd_ttt_compiled_inner = torch.compile(_fwd_ttt_inner, dynamic=True)
+            return _fwd_ttt_compiled_inner(input_ids, target_ids, lora=lora)
+
+        fwd_ttt_compiled = _fwd_ttt
+        log(f"ttt_lora:warming up compile (random tokens, no val data)")
+        global BOS_ID
+        if BOS_ID is None:
+            BOS_ID = 1
+        t_warmup = time.perf_counter()
+        warmup_bszes = [h.ttt_batch_size]
+        for bsz in warmup_bszes:
+            wl = BatchedTTTLoRA(
+                bsz, ttt_model, h.ttt_lora_rank,
+                k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+            ).to(device)
+            wo = torch.optim.AdamW(
+                wl.parameters(),
+                lr=h.ttt_lora_lr,
+                betas=(h.ttt_beta1, h.ttt_beta2),
+                eps=1e-10,
+                weight_decay=h.ttt_weight_decay,
+                fused=True,
+            )
+            for ctx_len in (h.ttt_chunk_size, h.ttt_eval_seq_len):
+                xw = torch.randint(0, h.vocab_size, (bsz, ctx_len), device=device, dtype=torch.int64)
+                yw = torch.randint(0, h.vocab_size, (bsz, ctx_len), device=device, dtype=torch.int64)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    ptl = fwd_ttt_compiled(xw, yw, lora=wl)
+                ptl[:, : min(h.ttt_chunk_size, ctx_len)].mean(dim=-1).sum().backward()
+                wo.step()
+                wo.zero_grad(set_to_none=True)
+            del wl, wo
+        torch.cuda.empty_cache()
+        compile_elapsed = time.perf_counter() - t_warmup
+        log(f"ttt_lora:compile warmup done ({compile_elapsed:.1f}s)")
+        log("\nbeginning TTT eval timer")
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_val_loss, ttt_val_bpb = eval_val_ttt_phased(
+            h, ttt_model, device, val_data, forward_ttt_train=fwd_ttt_compiled
+        )
+        torch.cuda.synchronize()
+        ttt_eval_elapsed = time.perf_counter() - t_ttt
+        log(
+            "quantized_ttt_phased "
+            f"val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f} "
+            f"eval_time:{1e3*ttt_eval_elapsed:.0f}ms"
+        )
+        log(f"total_eval_time:{ttt_eval_elapsed:.1f}s")
+        del ttt_model
+
+
+def main():
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    torch._dynamo.config.optimize_ddp = False
+    torch._dynamo.config.cache_size_limit = 64
+    h = Hyperparameters()
+    set_logging_hparams(h)
+    if h.is_main_process:
+        os.makedirs(h.artifact_dir if h.artifact_dir else "logs", exist_ok=True)
+        log(100 * "=", console=False)
+        log("Hyperparameters:", console=True)
+        for (k, v) in sorted(vars(type(h)).items()):
+            if not k.startswith("_"):
+                log(f"  {k}: {v}", console=True)
+        log("=" * 100, console=False)
+        log("Source code:", console=False)
+        log("=" * 100, console=False)
+        with open(__file__, "r", encoding="utf-8") as _src:
+            log(_src.read(), console=False)
+        log("=" * 100, console=False)
+        log(f"Running Python {sys.version}", console=False)
+        log(f"Running PyTorch {torch.__version__}", console=False)
+        log("=" * 100, console=False)
+    train_and_eval(h, device)
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-04-30_AdaptiveHessianClip_PR1855_1.0631/train_seed1337.log
+++ b/records/track_10min_16mb/2026-04-30_AdaptiveHessianClip_PR1855_1.0631/train_seed1337.log
@@ -1,0 +1,1005 @@
+W0430 04:10:52.481000 190303 torch/distributed/run.py:803] 
+W0430 04:10:52.481000 190303 torch/distributed/run.py:803] *****************************************
+W0430 04:10:52.481000 190303 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0430 04:10:52.481000 190303 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  adaptive_hessian_clip: True
+  artifact_dir: 
+  attn_clip_sigmas: 13.0
+  attn_out_gate_enabled: False
+  attn_out_gate_src: proj
+  beta1: 0.9
+  beta2: 0.99
+  caseops_enabled: True
+  compressor: pergroup
+  data_dir: ./data/
+  datasets_dir: /workspace/parameter-golf/data/datasets/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved
+  distributed: True
+  ema_decay: 0.9965
+  embed_bits: 7
+  embed_clip_sigmas: 14.0
+  embed_lr: 0.6
+  embed_wd: 0.085
+  enable_looping_at: 0.35
+  eval_seq_len: 2048
+  eval_stride: 64
+  fused_ce_enabled: True
+  gate_window: 12
+  gated_attn_enabled: False
+  gated_attn_init_std: 0.01
+  gated_attn_quant_gate: False
+  global_ttt_batch_seqs: 32
+  global_ttt_chunk_tokens: 32768
+  global_ttt_epochs: 1
+  global_ttt_grad_clip: 1.0
+  global_ttt_lr: 0.001
+  global_ttt_momentum: 0.9
+  global_ttt_respect_doc_boundaries: True
+  global_ttt_warmup_chunks: 0
+  global_ttt_warmup_start_lr: 0.0
+  gptq_calibration_batches: 16
+  gptq_reserve_seconds: 4.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  is_main_process: True
+  iterations: 20000
+  ln_scale: True
+  local_rank: 0
+  logfile: logs/7462c5a0-ef6e-4d78-9c93-a81ba4aa664b.txt
+  logit_softcap: 30.0
+  loop_end: 5
+  loop_start: 3
+  lqer_asym_enabled: True
+  lqer_asym_group: 64
+  lqer_enabled: True
+  lqer_factor_bits: 4
+  lqer_rank: 4
+  lqer_top_k: 3
+  matrix_bits: 6
+  matrix_clip_sigmas: 12.85
+  matrix_lr: 0.026
+  max_wallclock_seconds: 600.0
+  min_lr: 0.1
+  mixed_precision_bits_high: 7
+  mixed_precision_bits_low: 5
+  mixed_precision_hessian: False
+  mixed_precision_high_frac: 0.25
+  mixed_precision_low_frac: 0.25
+  mlp_clip_sigmas: 11.5
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: final_model.pt
+  muon_backend_steps: 5
+  muon_momentum: 0.97
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_row_normalize: True
+  muon_wd: 0.095
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  num_loops: 2
+  parallel_final_lane: mean
+  parallel_start_layer: 8
+  phased_ttt_num_phases: 3
+  phased_ttt_prefix_docs: 2500
+  qk_gain_init: 5.0
+  quantized_model_path: final_model.int6.ptz
+  rank: 0
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  rope_yarn: False
+  run_id: 7462c5a0-ef6e-4d78-9c93-a81ba4aa664b
+  scalar_lr: 0.02
+  seed: 1337
+  skip_gates_enabled: True
+  smear_gate_enabled: True
+  sparse_attn_gate_enabled: True
+  sparse_attn_gate_init_std: 0.0
+  sparse_attn_gate_scale: 0.5
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  tokenizer_path: /workspace/parameter-golf/data/datasets/datasets/tokenizers/fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model
+  train_batch_tokens: 786432
+  train_files: /workspace/parameter-golf/data/datasets/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_train_*.bin
+  train_log_every: 500
+  train_seq_len: 2048
+  ttt_batch_size: 64
+  ttt_beta1: 0.0
+  ttt_beta2: 0.99
+  ttt_chunk_size: 48
+  ttt_enabled: True
+  ttt_eval_batches: 
+  ttt_eval_seq_len: 2048
+  ttt_grad_steps: 1
+  ttt_k_lora: True
+  ttt_lora_lr: 0.0001
+  ttt_lora_rank: 56
+  ttt_mlp_lora: True
+  ttt_o_lora: True
+  ttt_optimizer: adam
+  ttt_weight_decay: 0.5
+  val_batch_tokens: 524288
+  val_bytes_files: /workspace/parameter-golf/data/datasets/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_val_bytes_*.bin
+  val_doc_fraction: 1.0
+  val_files: /workspace/parameter-golf/data/datasets/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_val_*.bin
+  val_loss_every: 4000
+  vocab_size: 8192
+  warmdown_frac: 0.85
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+train_shards: 80
+val_tokens: 47851520
+model_params:35945671
+gptq:reserving 4s, effective=596000ms
+warmup_cu_buckets:64,128,192,256 iters_each:3
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup:enabled encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+loop_warmup_step: 1/20
+loop_warmup_step: 2/20
+loop_warmup_step: 3/20
+loop_warmup_step: 4/20
+loop_warmup_step: 5/20
+loop_warmup_step: 6/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+0/20000 val_loss: 9.0070 val_bpb: 4.1156
+1/20000 train_loss: 9.0081 train_time: 0.0m tok/s: 17418035
+2/20000 train_loss: 13.0226 train_time: 0.0m tok/s: 11026327
+3/20000 train_loss: 10.2701 train_time: 0.0m tok/s: 9661984
+4/20000 train_loss: 8.7632 train_time: 0.0m tok/s: 9154208
+5/20000 train_loss: 7.9566 train_time: 0.0m tok/s: 8867617
+500/20000 train_loss: 2.5715 train_time: 0.8m tok/s: 8101102
+1000/20000 train_loss: 2.8090 train_time: 1.6m tok/s: 8044953
+1500/20000 train_loss: 2.6231 train_time: 2.4m tok/s: 8025091
+2000/20000 train_loss: 2.6509 train_time: 3.3m tok/s: 8014256
+layer_loop:enabled step:2125 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2500/20000 train_loss: 2.5408 train_time: 4.4m tok/s: 7497013
+3000/20000 train_loss: 2.5525 train_time: 5.6m tok/s: 7008623
+3500/20000 train_loss: 2.5557 train_time: 6.8m tok/s: 6720637
+4000/20000 train_loss: 2.3931 train_time: 8.0m tok/s: 6541531
+4000/20000 val_loss: 2.4194 val_bpb: 1.1055
+4500/20000 train_loss: 2.2707 train_time: 9.2m tok/s: 6408713
+4807/20000 val_loss: 2.3615 val_bpb: 1.0790
+stopping_early: wallclock_cap train_time: 596053ms step: 4807/20000
+peak memory allocated: 41707 MiB reserved: 47048 MiB
+ema:applying EMA weights
+diagnostic pre-quantization post-ema val_loss:2.33537337 val_bpb:1.06710520 eval_time:9479ms
+Serialized model: 135417533 bytes
+Code size (uncompressed): 164676 bytes
+Code size (compressed): 33102 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 3.5s
+GPTQ adaptive clip_sigmas (Hessian-sensitivity, 66 tensors):
+    blocks.0.attn.c_q.weight: 8.83
+    blocks.0.attn.proj.weight: 11.25
+    blocks.1.attn.c_q.weight: 9.76
+    blocks.1.attn.proj.weight: 12.33
+    blocks.2.attn.c_q.weight: 10.49
+    blocks.2.attn.proj.weight: 15.49
+    blocks.3.attn.c_q.weight: 9.27
+    blocks.3.attn.proj.weight: 12.34
+    blocks.4.attn.c_q.weight: 9.56
+    blocks.4.attn.proj.weight: 14.26
+    blocks.5.attn.c_q.weight: 9.79
+    blocks.5.attn.proj.weight: 14.30
+    blocks.6.attn.c_q.weight: 11.77
+    blocks.6.attn.proj.weight: 17.57
+    blocks.7.attn.c_q.weight: 12.04
+    blocks.7.attn.proj.weight: 19.28
+    blocks.8.attn.c_q.weight: 12.23
+    blocks.8.attn.proj.weight: 22.59
+    blocks.9.attn.c_q.weight: 12.63
+    blocks.9.attn.proj.weight: 16.13
+    blocks.10.attn.c_q.weight: 13.11
+    blocks.10.attn.proj.weight: 24.00
+    blocks.0.attn.c_k.weight: 8.61
+    blocks.0.attn.c_v.weight: 8.39
+    blocks.1.attn.c_k.weight: 9.60
+    blocks.1.attn.c_v.weight: 9.48
+    blocks.2.attn.c_k.weight: 10.04
+    blocks.2.attn.c_v.weight: 10.03
+    blocks.3.attn.c_k.weight: 9.11
+    blocks.3.attn.c_v.weight: 8.89
+    blocks.4.attn.c_k.weight: 9.25
+    blocks.4.attn.c_v.weight: 9.11
+    blocks.5.attn.c_k.weight: 9.57
+    blocks.5.attn.c_v.weight: 9.39
+    blocks.6.attn.c_k.weight: 11.51
+    blocks.6.attn.c_v.weight: 11.26
+    blocks.7.attn.c_k.weight: 11.70
+    blocks.7.attn.c_v.weight: 11.49
+    blocks.8.attn.c_k.weight: 11.77
+    blocks.8.attn.c_v.weight: 11.51
+    blocks.9.attn.c_k.weight: 12.24
+    blocks.9.attn.c_v.weight: 11.68
+    blocks.10.attn.c_k.weight: 12.60
+    blocks.10.attn.c_v.weight: 11.69
+    blocks.0.mlp.fc.weight: 8.40
+    blocks.1.mlp.fc.weight: 9.25
+    blocks.2.mlp.fc.weight: 9.82
+    blocks.3.mlp.fc.weight: 8.75
+    blocks.4.mlp.fc.weight: 9.07
+    blocks.5.mlp.fc.weight: 9.28
+    blocks.6.mlp.fc.weight: 11.12
+    blocks.7.mlp.fc.weight: 11.37
+    blocks.8.mlp.fc.weight: 11.64
+    blocks.9.mlp.fc.weight: 11.83
+    blocks.10.mlp.fc.weight: 12.10
+    blocks.0.mlp.proj.weight: 9.17
+    blocks.1.mlp.proj.weight: 11.59
+    blocks.2.mlp.proj.weight: 12.32
+    blocks.3.mlp.proj.weight: 11.36
+    blocks.4.mlp.proj.weight: 11.96
+    blocks.5.mlp.proj.weight: 12.40
+    blocks.6.mlp.proj.weight: 14.89
+    blocks.7.mlp.proj.weight: 16.76
+    blocks.8.mlp.proj.weight: 17.37
+    blocks.9.mlp.proj.weight: 18.27
+    blocks.10.mlp.proj.weight: 19.14
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int6)+lqer_asym: blocks.attn.proj.weight, blocks.mlp.fc.weight
+  gptq (int7)+lqer_asym: tok_emb.weight
+  passthrough (float16): blocks.attn.attn_gate_w, blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, skip_gates, skip_weights, smear_gate.weight, smear_lambda
+Serialize: per-group lrzip compression...
+Serialize: per-group compression done in 121.1s
+Serialized model quantized+pergroup: 15885725 bytes
+Total submission size quantized+pergroup: 15918827 bytes
+Deserialize: per-group lrzip decompression...
+Deserialize: decompression done in 19.7s
+diagnostic quantized val_loss:2.35693228 val_bpb:1.07695614 eval_time:14712ms
+Deserialize: per-group lrzip decompression...
+Deserialize: decompression done in 20.0s
+ttt_lora:warming up compile (random tokens, no val data)
+ttt_lora:compile warmup done (102.4s)
+
+beginning TTT eval timer
+ttt_phased: total_docs:50000 prefix_docs:2500 suffix_docs:47500 num_phases:3 boundaries:[833, 1666, 2500]
+ttp: b780/782 bl:2.2445 bb:1.0813 rl:2.2445 rb:1.0813 dl:13091-17244 gd:0
+ttp: b767/782 bl:2.2751 bb:1.0765 rl:2.2520 rb:1.0801 dl:4681-4858 gd:0
+ttp: b762/782 bl:2.3594 bb:1.0926 rl:2.2706 rb:1.0823 dl:4032-4142 gd:0
+ttpp: phase:1/3 pd:1296 gd:833 t:230.1s
+tttg: c1/131 lr:0.001000 t:0.3s
+tttg: c2/131 lr:0.001000 t:0.5s
+tttg: c3/131 lr:0.000999 t:0.6s
+tttg: c4/131 lr:0.000999 t:0.8s
+tttg: c5/131 lr:0.000998 t:0.9s
+tttg: c6/131 lr:0.000996 t:1.1s
+tttg: c7/131 lr:0.000995 t:1.2s
+tttg: c8/131 lr:0.000993 t:1.3s
+tttg: c9/131 lr:0.000991 t:1.4s
+tttg: c10/131 lr:0.000988 t:1.6s
+tttg: c11/131 lr:0.000985 t:1.7s
+tttg: c12/131 lr:0.000982 t:1.8s
+tttg: c13/131 lr:0.000979 t:1.9s
+tttg: c14/131 lr:0.000976 t:2.1s
+tttg: c15/131 lr:0.000972 t:2.2s
+tttg: c16/131 lr:0.000968 t:2.3s
+tttg: c17/131 lr:0.000963 t:2.5s
+tttg: c18/131 lr:0.000958 t:2.6s
+tttg: c19/131 lr:0.000953 t:2.7s
+tttg: c20/131 lr:0.000948 t:2.9s
+tttg: c21/131 lr:0.000943 t:3.0s
+tttg: c22/131 lr:0.000937 t:3.1s
+tttg: c23/131 lr:0.000931 t:3.2s
+tttg: c24/131 lr:0.000925 t:3.4s
+tttg: c25/131 lr:0.000918 t:3.5s
+tttg: c26/131 lr:0.000911 t:3.6s
+tttg: c27/131 lr:0.000905 t:3.8s
+tttg: c28/131 lr:0.000897 t:3.9s
+tttg: c29/131 lr:0.000890 t:4.0s
+tttg: c30/131 lr:0.000882 t:4.2s
+tttg: c31/131 lr:0.000874 t:4.3s
+tttg: c32/131 lr:0.000866 t:4.4s
+tttg: c33/131 lr:0.000858 t:4.5s
+tttg: c34/131 lr:0.000849 t:4.7s
+tttg: c35/131 lr:0.000841 t:4.8s
+tttg: c36/131 lr:0.000832 t:4.9s
+tttg: c37/131 lr:0.000822 t:5.1s
+tttg: c38/131 lr:0.000813 t:5.2s
+tttg: c39/131 lr:0.000804 t:5.3s
+tttg: c40/131 lr:0.000794 t:5.5s
+tttg: c41/131 lr:0.000784 t:5.6s
+tttg: c42/131 lr:0.000774 t:5.7s
+tttg: c43/131 lr:0.000764 t:5.9s
+tttg: c44/131 lr:0.000753 t:6.0s
+tttg: c45/131 lr:0.000743 t:6.1s
+tttg: c46/131 lr:0.000732 t:6.2s
+tttg: c47/131 lr:0.000722 t:6.4s
+tttg: c48/131 lr:0.000711 t:6.5s
+tttg: c49/131 lr:0.000700 t:6.6s
+tttg: c50/131 lr:0.000689 t:6.8s
+tttg: c51/131 lr:0.000677 t:6.9s
+tttg: c52/131 lr:0.000666 t:7.0s
+tttg: c53/131 lr:0.000655 t:7.1s
+tttg: c54/131 lr:0.000643 t:7.3s
+tttg: c55/131 lr:0.000631 t:7.4s
+tttg: c56/131 lr:0.000620 t:7.5s
+tttg: c57/131 lr:0.000608 t:7.7s
+tttg: c58/131 lr:0.000596 t:7.8s
+tttg: c59/131 lr:0.000584 t:7.9s
+tttg: c60/131 lr:0.000572 t:8.1s
+tttg: c61/131 lr:0.000560 t:8.2s
+tttg: c62/131 lr:0.000548 t:8.3s
+tttg: c63/131 lr:0.000536 t:8.4s
+tttg: c64/131 lr:0.000524 t:8.6s
+tttg: c65/131 lr:0.000512 t:8.7s
+tttg: c66/131 lr:0.000500 t:8.8s
+tttg: c67/131 lr:0.000488 t:9.0s
+tttg: c68/131 lr:0.000476 t:9.1s
+tttg: c69/131 lr:0.000464 t:9.2s
+tttg: c70/131 lr:0.000452 t:9.3s
+tttg: c71/131 lr:0.000440 t:9.5s
+tttg: c72/131 lr:0.000428 t:9.6s
+tttg: c73/131 lr:0.000416 t:9.7s
+tttg: c74/131 lr:0.000404 t:9.9s
+tttg: c75/131 lr:0.000392 t:10.0s
+tttg: c76/131 lr:0.000380 t:10.1s
+tttg: c77/131 lr:0.000369 t:10.2s
+tttg: c78/131 lr:0.000357 t:10.4s
+tttg: c79/131 lr:0.000345 t:10.5s
+tttg: c80/131 lr:0.000334 t:10.6s
+tttg: c81/131 lr:0.000323 t:10.8s
+tttg: c82/131 lr:0.000311 t:10.9s
+tttg: c83/131 lr:0.000300 t:11.0s
+tttg: c84/131 lr:0.000289 t:11.1s
+tttg: c85/131 lr:0.000278 t:11.3s
+tttg: c86/131 lr:0.000268 t:11.4s
+tttg: c87/131 lr:0.000257 t:11.5s
+tttg: c88/131 lr:0.000247 t:11.7s
+tttg: c89/131 lr:0.000236 t:11.8s
+tttg: c90/131 lr:0.000226 t:11.9s
+tttg: c91/131 lr:0.000216 t:12.0s
+tttg: c92/131 lr:0.000206 t:12.2s
+tttg: c93/131 lr:0.000196 t:12.3s
+tttg: c94/131 lr:0.000187 t:12.4s
+tttg: c95/131 lr:0.000178 t:12.6s
+tttg: c96/131 lr:0.000168 t:12.7s
+tttg: c97/131 lr:0.000159 t:12.8s
+tttg: c98/131 lr:0.000151 t:13.0s
+tttg: c99/131 lr:0.000142 t:13.1s
+tttg: c100/131 lr:0.000134 t:13.2s
+tttg: c101/131 lr:0.000126 t:13.4s
+tttg: c102/131 lr:0.000118 t:13.5s
+tttg: c103/131 lr:0.000110 t:13.6s
+tttg: c104/131 lr:0.000103 t:13.7s
+tttg: c105/131 lr:0.000095 t:13.9s
+tttg: c106/131 lr:0.000089 t:14.0s
+tttg: c107/131 lr:0.000082 t:14.1s
+tttg: c108/131 lr:0.000075 t:14.3s
+tttg: c109/131 lr:0.000069 t:14.4s
+tttg: c110/131 lr:0.000063 t:14.5s
+tttg: c111/131 lr:0.000057 t:14.6s
+tttg: c112/131 lr:0.000052 t:14.8s
+tttg: c113/131 lr:0.000047 t:14.9s
+tttg: c114/131 lr:0.000042 t:15.1s
+tttg: c115/131 lr:0.000037 t:15.2s
+tttg: c116/131 lr:0.000032 t:15.3s
+tttg: c117/131 lr:0.000028 t:15.5s
+tttg: c118/131 lr:0.000024 t:15.6s
+tttg: c119/131 lr:0.000021 t:15.7s
+tttg: c120/131 lr:0.000018 t:15.8s
+tttg: c121/131 lr:0.000015 t:16.0s
+tttg: c122/131 lr:0.000012 t:16.1s
+tttg: c123/131 lr:0.000009 t:16.2s
+tttg: c124/131 lr:0.000007 t:16.4s
+tttg: c125/131 lr:0.000005 t:16.5s
+tttg: c126/131 lr:0.000004 t:16.6s
+tttg: c127/131 lr:0.000002 t:16.8s
+tttg: c128/131 lr:0.000001 t:16.9s
+tttg: c129/131 lr:0.000001 t:17.0s
+tttg: c130/131 lr:0.000000 t:17.1s
+ttpr: phase:1/3 t:249.1s
+ttp: b754/782 bl:2.2958 bb:1.0620 rl:2.2738 rb:1.0797 dl:3345-3397 gd:0
+ttp: b752/782 bl:2.3381 bb:1.0748 rl:2.2807 rb:1.0791 dl:3222-3283 gd:0
+ttpp: phase:2/3 pd:2128 gd:1666 t:322.7s
+tttg: c1/219 lr:0.001000 t:0.1s
+tttg: c2/219 lr:0.001000 t:0.2s
+tttg: c3/219 lr:0.001000 t:0.3s
+tttg: c4/219 lr:0.001000 t:0.5s
+tttg: c5/219 lr:0.000999 t:0.6s
+tttg: c6/219 lr:0.000999 t:0.7s
+tttg: c7/219 lr:0.000998 t:0.8s
+tttg: c8/219 lr:0.000997 t:0.9s
+tttg: c9/219 lr:0.000997 t:1.0s
+tttg: c10/219 lr:0.000996 t:1.1s
+tttg: c11/219 lr:0.000995 t:1.2s
+tttg: c12/219 lr:0.000994 t:1.4s
+tttg: c13/219 lr:0.000993 t:1.5s
+tttg: c14/219 lr:0.000991 t:1.6s
+tttg: c15/219 lr:0.000990 t:1.7s
+tttg: c16/219 lr:0.000988 t:1.8s
+tttg: c17/219 lr:0.000987 t:1.9s
+tttg: c18/219 lr:0.000985 t:2.0s
+tttg: c19/219 lr:0.000983 t:2.1s
+tttg: c20/219 lr:0.000981 t:2.2s
+tttg: c21/219 lr:0.000979 t:2.4s
+tttg: c22/219 lr:0.000977 t:2.5s
+tttg: c23/219 lr:0.000975 t:2.6s
+tttg: c24/219 lr:0.000973 t:2.7s
+tttg: c25/219 lr:0.000970 t:2.8s
+tttg: c26/219 lr:0.000968 t:2.9s
+tttg: c27/219 lr:0.000965 t:3.0s
+tttg: c28/219 lr:0.000963 t:3.1s
+tttg: c29/219 lr:0.000960 t:3.3s
+tttg: c30/219 lr:0.000957 t:3.4s
+tttg: c31/219 lr:0.000954 t:3.5s
+tttg: c32/219 lr:0.000951 t:3.7s
+tttg: c33/219 lr:0.000948 t:3.8s
+tttg: c34/219 lr:0.000945 t:3.9s
+tttg: c35/219 lr:0.000941 t:4.1s
+tttg: c36/219 lr:0.000938 t:4.2s
+tttg: c37/219 lr:0.000934 t:4.3s
+tttg: c38/219 lr:0.000931 t:4.5s
+tttg: c39/219 lr:0.000927 t:4.6s
+tttg: c40/219 lr:0.000923 t:4.7s
+tttg: c41/219 lr:0.000919 t:4.8s
+tttg: c42/219 lr:0.000915 t:5.0s
+tttg: c43/219 lr:0.000911 t:5.1s
+tttg: c44/219 lr:0.000907 t:5.2s
+tttg: c45/219 lr:0.000903 t:5.4s
+tttg: c46/219 lr:0.000898 t:5.5s
+tttg: c47/219 lr:0.000894 t:5.6s
+tttg: c48/219 lr:0.000890 t:5.8s
+tttg: c49/219 lr:0.000885 t:5.9s
+tttg: c50/219 lr:0.000880 t:6.0s
+tttg: c51/219 lr:0.000876 t:6.2s
+tttg: c52/219 lr:0.000871 t:6.3s
+tttg: c53/219 lr:0.000866 t:6.4s
+tttg: c54/219 lr:0.000861 t:6.6s
+tttg: c55/219 lr:0.000856 t:6.7s
+tttg: c56/219 lr:0.000851 t:6.8s
+tttg: c57/219 lr:0.000846 t:7.0s
+tttg: c58/219 lr:0.000841 t:7.1s
+tttg: c59/219 lr:0.000835 t:7.2s
+tttg: c60/219 lr:0.000830 t:7.4s
+tttg: c61/219 lr:0.000824 t:7.5s
+tttg: c62/219 lr:0.000819 t:7.6s
+tttg: c63/219 lr:0.000813 t:7.8s
+tttg: c64/219 lr:0.000808 t:7.9s
+tttg: c65/219 lr:0.000802 t:8.0s
+tttg: c66/219 lr:0.000796 t:8.2s
+tttg: c67/219 lr:0.000790 t:8.3s
+tttg: c68/219 lr:0.000784 t:8.4s
+tttg: c69/219 lr:0.000779 t:8.6s
+tttg: c70/219 lr:0.000773 t:8.7s
+tttg: c71/219 lr:0.000766 t:8.8s
+tttg: c72/219 lr:0.000760 t:9.0s
+tttg: c73/219 lr:0.000754 t:9.1s
+tttg: c74/219 lr:0.000748 t:9.2s
+tttg: c75/219 lr:0.000742 t:9.4s
+tttg: c76/219 lr:0.000735 t:9.5s
+tttg: c77/219 lr:0.000729 t:9.6s
+tttg: c78/219 lr:0.000722 t:9.8s
+tttg: c79/219 lr:0.000716 t:9.9s
+tttg: c80/219 lr:0.000709 t:10.0s
+tttg: c81/219 lr:0.000703 t:10.2s
+tttg: c82/219 lr:0.000696 t:10.3s
+tttg: c83/219 lr:0.000690 t:10.4s
+tttg: c84/219 lr:0.000683 t:10.6s
+tttg: c85/219 lr:0.000676 t:10.7s
+tttg: c86/219 lr:0.000670 t:10.8s
+tttg: c87/219 lr:0.000663 t:11.0s
+tttg: c88/219 lr:0.000656 t:11.1s
+tttg: c89/219 lr:0.000649 t:11.2s
+tttg: c90/219 lr:0.000642 t:11.4s
+tttg: c91/219 lr:0.000635 t:11.5s
+tttg: c92/219 lr:0.000628 t:11.6s
+tttg: c93/219 lr:0.000621 t:11.8s
+tttg: c94/219 lr:0.000614 t:11.9s
+tttg: c95/219 lr:0.000607 t:12.0s
+tttg: c96/219 lr:0.000600 t:12.2s
+tttg: c97/219 lr:0.000593 t:12.3s
+tttg: c98/219 lr:0.000586 t:12.4s
+tttg: c99/219 lr:0.000579 t:12.5s
+tttg: c100/219 lr:0.000572 t:12.7s
+tttg: c101/219 lr:0.000565 t:12.8s
+tttg: c102/219 lr:0.000558 t:12.9s
+tttg: c103/219 lr:0.000550 t:13.1s
+tttg: c104/219 lr:0.000543 t:13.2s
+tttg: c105/219 lr:0.000536 t:13.3s
+tttg: c106/219 lr:0.000529 t:13.5s
+tttg: c107/219 lr:0.000522 t:13.6s
+tttg: c108/219 lr:0.000514 t:13.7s
+tttg: c109/219 lr:0.000507 t:13.9s
+tttg: c110/219 lr:0.000500 t:14.0s
+tttg: c111/219 lr:0.000493 t:14.1s
+tttg: c112/219 lr:0.000486 t:14.3s
+tttg: c113/219 lr:0.000478 t:14.4s
+tttg: c114/219 lr:0.000471 t:14.5s
+tttg: c115/219 lr:0.000464 t:14.7s
+tttg: c116/219 lr:0.000457 t:14.8s
+tttg: c117/219 lr:0.000450 t:14.9s
+tttg: c118/219 lr:0.000442 t:15.1s
+tttg: c119/219 lr:0.000435 t:15.2s
+tttg: c120/219 lr:0.000428 t:15.3s
+tttg: c121/219 lr:0.000421 t:15.5s
+tttg: c122/219 lr:0.000414 t:15.6s
+tttg: c123/219 lr:0.000407 t:15.7s
+tttg: c124/219 lr:0.000400 t:15.9s
+tttg: c125/219 lr:0.000393 t:16.0s
+tttg: c126/219 lr:0.000386 t:16.1s
+tttg: c127/219 lr:0.000379 t:16.2s
+tttg: c128/219 lr:0.000372 t:16.4s
+tttg: c129/219 lr:0.000365 t:16.5s
+tttg: c130/219 lr:0.000358 t:16.6s
+tttg: c131/219 lr:0.000351 t:16.8s
+tttg: c132/219 lr:0.000344 t:16.9s
+tttg: c133/219 lr:0.000337 t:17.0s
+tttg: c134/219 lr:0.000330 t:17.2s
+tttg: c135/219 lr:0.000324 t:17.3s
+tttg: c136/219 lr:0.000317 t:17.4s
+tttg: c137/219 lr:0.000310 t:17.6s
+tttg: c138/219 lr:0.000304 t:17.7s
+tttg: c139/219 lr:0.000297 t:17.8s
+tttg: c140/219 lr:0.000291 t:18.0s
+tttg: c141/219 lr:0.000284 t:18.1s
+tttg: c142/219 lr:0.000278 t:18.2s
+tttg: c143/219 lr:0.000271 t:18.4s
+tttg: c144/219 lr:0.000265 t:18.5s
+tttg: c145/219 lr:0.000258 t:18.6s
+tttg: c146/219 lr:0.000252 t:18.7s
+tttg: c147/219 lr:0.000246 t:18.9s
+tttg: c148/219 lr:0.000240 t:19.0s
+tttg: c149/219 lr:0.000234 t:19.1s
+tttg: c150/219 lr:0.000227 t:19.3s
+tttg: c151/219 lr:0.000221 t:19.4s
+tttg: c152/219 lr:0.000216 t:19.5s
+tttg: c153/219 lr:0.000210 t:19.7s
+tttg: c154/219 lr:0.000204 t:19.8s
+tttg: c155/219 lr:0.000198 t:19.9s
+tttg: c156/219 lr:0.000192 t:20.1s
+tttg: c157/219 lr:0.000187 t:20.2s
+tttg: c158/219 lr:0.000181 t:20.3s
+tttg: c159/219 lr:0.000176 t:20.5s
+tttg: c160/219 lr:0.000170 t:20.6s
+tttg: c161/219 lr:0.000165 t:20.7s
+tttg: c162/219 lr:0.000159 t:20.9s
+tttg: c163/219 lr:0.000154 t:21.0s
+tttg: c164/219 lr:0.000149 t:21.1s
+tttg: c165/219 lr:0.000144 t:21.3s
+tttg: c166/219 lr:0.000139 t:21.4s
+tttg: c167/219 lr:0.000134 t:21.5s
+tttg: c168/219 lr:0.000129 t:21.7s
+tttg: c169/219 lr:0.000124 t:21.8s
+tttg: c170/219 lr:0.000120 t:21.9s
+tttg: c171/219 lr:0.000115 t:22.1s
+tttg: c172/219 lr:0.000110 t:22.2s
+tttg: c173/219 lr:0.000106 t:22.3s
+tttg: c174/219 lr:0.000102 t:22.5s
+tttg: c175/219 lr:0.000097 t:22.6s
+tttg: c176/219 lr:0.000093 t:22.7s
+tttg: c177/219 lr:0.000089 t:22.8s
+tttg: c178/219 lr:0.000085 t:23.0s
+tttg: c179/219 lr:0.000081 t:23.1s
+tttg: c180/219 lr:0.000077 t:23.2s
+tttg: c181/219 lr:0.000073 t:23.4s
+tttg: c182/219 lr:0.000069 t:23.5s
+tttg: c183/219 lr:0.000066 t:23.6s
+tttg: c184/219 lr:0.000062 t:23.8s
+tttg: c185/219 lr:0.000059 t:23.9s
+tttg: c186/219 lr:0.000055 t:24.0s
+tttg: c187/219 lr:0.000052 t:24.2s
+tttg: c188/219 lr:0.000049 t:24.3s
+tttg: c189/219 lr:0.000046 t:24.4s
+tttg: c190/219 lr:0.000043 t:24.6s
+tttg: c191/219 lr:0.000040 t:24.7s
+tttg: c192/219 lr:0.000037 t:24.8s
+tttg: c193/219 lr:0.000035 t:24.9s
+tttg: c194/219 lr:0.000032 t:25.1s
+tttg: c195/219 lr:0.000030 t:25.2s
+tttg: c196/219 lr:0.000027 t:25.3s
+tttg: c197/219 lr:0.000025 t:25.5s
+tttg: c198/219 lr:0.000023 t:25.6s
+tttg: c199/219 lr:0.000021 t:25.7s
+tttg: c200/219 lr:0.000019 t:25.9s
+tttg: c201/219 lr:0.000017 t:26.0s
+tttg: c202/219 lr:0.000015 t:26.1s
+tttg: c203/219 lr:0.000013 t:26.3s
+tttg: c204/219 lr:0.000012 t:26.4s
+tttg: c205/219 lr:0.000010 t:26.5s
+tttg: c206/219 lr:0.000009 t:26.7s
+tttg: c207/219 lr:0.000007 t:26.8s
+tttg: c208/219 lr:0.000006 t:26.9s
+tttg: c209/219 lr:0.000005 t:27.0s
+tttg: c210/219 lr:0.000004 t:27.2s
+tttg: c211/219 lr:0.000003 t:27.3s
+tttg: c212/219 lr:0.000003 t:27.4s
+tttg: c213/219 lr:0.000002 t:27.6s
+tttg: c214/219 lr:0.000001 t:27.7s
+tttg: c215/219 lr:0.000001 t:27.8s
+tttg: c216/219 lr:0.000000 t:28.0s
+tttg: c217/219 lr:0.000000 t:28.1s
+tttg: c218/219 lr:0.000000 t:28.2s
+ttpr: phase:2/3 t:352.6s
+ttp: b741/782 bl:2.3282 bb:1.0441 rl:2.2846 rb:1.0761 dl:2686-2730 gd:0
+ttp: b740/782 bl:2.2681 bb:1.0412 rl:2.2834 rb:1.0734 dl:2653-2686 gd:0
+ttpp: phase:3/3 pd:2960 gd:2500 t:367.7s
+tttg: c1/289 lr:0.001000 t:0.1s
+tttg: c2/289 lr:0.001000 t:0.3s
+tttg: c3/289 lr:0.001000 t:0.4s
+tttg: c4/289 lr:0.001000 t:0.5s
+tttg: c5/289 lr:0.001000 t:0.6s
+tttg: c6/289 lr:0.000999 t:0.8s
+tttg: c7/289 lr:0.000999 t:0.9s
+tttg: c8/289 lr:0.000999 t:1.0s
+tttg: c9/289 lr:0.000998 t:1.2s
+tttg: c10/289 lr:0.000998 t:1.3s
+tttg: c11/289 lr:0.000997 t:1.4s
+tttg: c12/289 lr:0.000996 t:1.5s
+tttg: c13/289 lr:0.000996 t:1.7s
+tttg: c14/289 lr:0.000995 t:1.8s
+tttg: c15/289 lr:0.000994 t:1.9s
+tttg: c16/289 lr:0.000993 t:2.1s
+tttg: c17/289 lr:0.000992 t:2.2s
+tttg: c18/289 lr:0.000991 t:2.3s
+tttg: c19/289 lr:0.000990 t:2.5s
+tttg: c20/289 lr:0.000989 t:2.6s
+tttg: c21/289 lr:0.000988 t:2.7s
+tttg: c22/289 lr:0.000987 t:2.8s
+tttg: c23/289 lr:0.000986 t:3.0s
+tttg: c24/289 lr:0.000984 t:3.1s
+tttg: c25/289 lr:0.000983 t:3.2s
+tttg: c26/289 lr:0.000982 t:3.4s
+tttg: c27/289 lr:0.000980 t:3.5s
+tttg: c28/289 lr:0.000978 t:3.6s
+tttg: c29/289 lr:0.000977 t:3.8s
+tttg: c30/289 lr:0.000975 t:3.9s
+tttg: c31/289 lr:0.000973 t:4.0s
+tttg: c32/289 lr:0.000972 t:4.1s
+tttg: c33/289 lr:0.000970 t:4.3s
+tttg: c34/289 lr:0.000968 t:4.4s
+tttg: c35/289 lr:0.000966 t:4.5s
+tttg: c36/289 lr:0.000964 t:4.7s
+tttg: c37/289 lr:0.000962 t:4.8s
+tttg: c38/289 lr:0.000960 t:4.9s
+tttg: c39/289 lr:0.000958 t:5.1s
+tttg: c40/289 lr:0.000955 t:5.2s
+tttg: c41/289 lr:0.000953 t:5.3s
+tttg: c42/289 lr:0.000951 t:5.4s
+tttg: c43/289 lr:0.000948 t:5.6s
+tttg: c44/289 lr:0.000946 t:5.7s
+tttg: c45/289 lr:0.000944 t:5.8s
+tttg: c46/289 lr:0.000941 t:6.0s
+tttg: c47/289 lr:0.000938 t:6.1s
+tttg: c48/289 lr:0.000936 t:6.2s
+tttg: c49/289 lr:0.000933 t:6.4s
+tttg: c50/289 lr:0.000930 t:6.5s
+tttg: c51/289 lr:0.000927 t:6.6s
+tttg: c52/289 lr:0.000925 t:6.8s
+tttg: c53/289 lr:0.000922 t:6.9s
+tttg: c54/289 lr:0.000919 t:7.0s
+tttg: c55/289 lr:0.000916 t:7.1s
+tttg: c56/289 lr:0.000913 t:7.3s
+tttg: c57/289 lr:0.000910 t:7.4s
+tttg: c58/289 lr:0.000906 t:7.5s
+tttg: c59/289 lr:0.000903 t:7.7s
+tttg: c60/289 lr:0.000900 t:7.8s
+tttg: c61/289 lr:0.000897 t:7.9s
+tttg: c62/289 lr:0.000893 t:8.1s
+tttg: c63/289 lr:0.000890 t:8.2s
+tttg: c64/289 lr:0.000887 t:8.3s
+tttg: c65/289 lr:0.000883 t:8.5s
+tttg: c66/289 lr:0.000879 t:8.6s
+tttg: c67/289 lr:0.000876 t:8.7s
+tttg: c68/289 lr:0.000872 t:8.9s
+tttg: c69/289 lr:0.000869 t:9.0s
+tttg: c70/289 lr:0.000865 t:9.1s
+tttg: c71/289 lr:0.000861 t:9.3s
+tttg: c72/289 lr:0.000857 t:9.4s
+tttg: c73/289 lr:0.000854 t:9.5s
+tttg: c74/289 lr:0.000850 t:9.7s
+tttg: c75/289 lr:0.000846 t:9.8s
+tttg: c76/289 lr:0.000842 t:9.9s
+tttg: c77/289 lr:0.000838 t:10.1s
+tttg: c78/289 lr:0.000834 t:10.2s
+tttg: c79/289 lr:0.000830 t:10.3s
+tttg: c80/289 lr:0.000826 t:10.5s
+tttg: c81/289 lr:0.000821 t:10.6s
+tttg: c82/289 lr:0.000817 t:10.7s
+tttg: c83/289 lr:0.000813 t:10.9s
+tttg: c84/289 lr:0.000809 t:11.0s
+tttg: c85/289 lr:0.000804 t:11.1s
+tttg: c86/289 lr:0.000800 t:11.3s
+tttg: c87/289 lr:0.000796 t:11.4s
+tttg: c88/289 lr:0.000791 t:11.5s
+tttg: c89/289 lr:0.000787 t:11.7s
+tttg: c90/289 lr:0.000782 t:11.8s
+tttg: c91/289 lr:0.000778 t:12.0s
+tttg: c92/289 lr:0.000773 t:12.1s
+tttg: c93/289 lr:0.000769 t:12.2s
+tttg: c94/289 lr:0.000764 t:12.4s
+tttg: c95/289 lr:0.000759 t:12.5s
+tttg: c96/289 lr:0.000755 t:12.6s
+tttg: c97/289 lr:0.000750 t:12.8s
+tttg: c98/289 lr:0.000745 t:12.9s
+tttg: c99/289 lr:0.000740 t:13.0s
+tttg: c100/289 lr:0.000736 t:13.2s
+tttg: c101/289 lr:0.000731 t:13.3s
+tttg: c102/289 lr:0.000726 t:13.4s
+tttg: c103/289 lr:0.000721 t:13.6s
+tttg: c104/289 lr:0.000716 t:13.7s
+tttg: c105/289 lr:0.000711 t:13.8s
+tttg: c106/289 lr:0.000706 t:14.0s
+tttg: c107/289 lr:0.000701 t:14.1s
+tttg: c108/289 lr:0.000696 t:14.3s
+tttg: c109/289 lr:0.000691 t:14.4s
+tttg: c110/289 lr:0.000686 t:14.5s
+tttg: c111/289 lr:0.000681 t:14.7s
+tttg: c112/289 lr:0.000676 t:14.8s
+tttg: c113/289 lr:0.000671 t:14.9s
+tttg: c114/289 lr:0.000666 t:15.1s
+tttg: c115/289 lr:0.000661 t:15.2s
+tttg: c116/289 lr:0.000656 t:15.3s
+tttg: c117/289 lr:0.000650 t:15.5s
+tttg: c118/289 lr:0.000645 t:15.6s
+tttg: c119/289 lr:0.000640 t:15.8s
+tttg: c120/289 lr:0.000635 t:15.9s
+tttg: c121/289 lr:0.000629 t:16.0s
+tttg: c122/289 lr:0.000624 t:16.2s
+tttg: c123/289 lr:0.000619 t:16.3s
+tttg: c124/289 lr:0.000614 t:16.4s
+tttg: c125/289 lr:0.000608 t:16.6s
+tttg: c126/289 lr:0.000603 t:16.7s
+tttg: c127/289 lr:0.000598 t:16.8s
+tttg: c128/289 lr:0.000592 t:17.0s
+tttg: c129/289 lr:0.000587 t:17.1s
+tttg: c130/289 lr:0.000581 t:17.3s
+tttg: c131/289 lr:0.000576 t:17.4s
+tttg: c132/289 lr:0.000571 t:17.5s
+tttg: c133/289 lr:0.000565 t:17.7s
+tttg: c134/289 lr:0.000560 t:17.8s
+tttg: c135/289 lr:0.000554 t:17.9s
+tttg: c136/289 lr:0.000549 t:18.1s
+tttg: c137/289 lr:0.000544 t:18.2s
+tttg: c138/289 lr:0.000538 t:18.4s
+tttg: c139/289 lr:0.000533 t:18.5s
+tttg: c140/289 lr:0.000527 t:18.6s
+tttg: c141/289 lr:0.000522 t:18.8s
+tttg: c142/289 lr:0.000516 t:18.9s
+tttg: c143/289 lr:0.000511 t:19.0s
+tttg: c144/289 lr:0.000505 t:19.2s
+tttg: c145/289 lr:0.000500 t:19.3s
+tttg: c146/289 lr:0.000495 t:19.5s
+tttg: c147/289 lr:0.000489 t:19.6s
+tttg: c148/289 lr:0.000484 t:19.7s
+tttg: c149/289 lr:0.000478 t:19.9s
+tttg: c150/289 lr:0.000473 t:20.0s
+tttg: c151/289 lr:0.000467 t:20.1s
+tttg: c152/289 lr:0.000462 t:20.3s
+tttg: c153/289 lr:0.000456 t:20.4s
+tttg: c154/289 lr:0.000451 t:20.6s
+tttg: c155/289 lr:0.000446 t:20.7s
+tttg: c156/289 lr:0.000440 t:20.8s
+tttg: c157/289 lr:0.000435 t:21.0s
+tttg: c158/289 lr:0.000429 t:21.1s
+tttg: c159/289 lr:0.000424 t:21.3s
+tttg: c160/289 lr:0.000419 t:21.4s
+tttg: c161/289 lr:0.000413 t:21.5s
+tttg: c162/289 lr:0.000408 t:21.7s
+tttg: c163/289 lr:0.000402 t:21.8s
+tttg: c164/289 lr:0.000397 t:21.9s
+tttg: c165/289 lr:0.000392 t:22.1s
+tttg: c166/289 lr:0.000386 t:22.2s
+tttg: c167/289 lr:0.000381 t:22.4s
+tttg: c168/289 lr:0.000376 t:22.5s
+tttg: c169/289 lr:0.000371 t:22.6s
+tttg: c170/289 lr:0.000365 t:22.8s
+tttg: c171/289 lr:0.000360 t:22.9s
+tttg: c172/289 lr:0.000355 t:23.0s
+tttg: c173/289 lr:0.000350 t:23.2s
+tttg: c174/289 lr:0.000344 t:23.3s
+tttg: c175/289 lr:0.000339 t:23.5s
+tttg: c176/289 lr:0.000334 t:23.6s
+tttg: c177/289 lr:0.000329 t:23.7s
+tttg: c178/289 lr:0.000324 t:23.9s
+tttg: c179/289 lr:0.000319 t:24.0s
+tttg: c180/289 lr:0.000314 t:24.2s
+tttg: c181/289 lr:0.000309 t:24.3s
+tttg: c182/289 lr:0.000304 t:24.4s
+tttg: c183/289 lr:0.000299 t:24.6s
+tttg: c184/289 lr:0.000294 t:24.7s
+tttg: c185/289 lr:0.000289 t:24.8s
+tttg: c186/289 lr:0.000284 t:25.0s
+tttg: c187/289 lr:0.000279 t:25.1s
+tttg: c188/289 lr:0.000274 t:25.3s
+tttg: c189/289 lr:0.000269 t:25.4s
+tttg: c190/289 lr:0.000264 t:25.5s
+tttg: c191/289 lr:0.000260 t:25.7s
+tttg: c192/289 lr:0.000255 t:25.8s
+tttg: c193/289 lr:0.000250 t:26.0s
+tttg: c194/289 lr:0.000245 t:26.1s
+tttg: c195/289 lr:0.000241 t:26.2s
+tttg: c196/289 lr:0.000236 t:26.4s
+tttg: c197/289 lr:0.000231 t:26.5s
+tttg: c198/289 lr:0.000227 t:26.6s
+tttg: c199/289 lr:0.000222 t:26.8s
+tttg: c200/289 lr:0.000218 t:26.9s
+tttg: c201/289 lr:0.000213 t:27.1s
+tttg: c202/289 lr:0.000209 t:27.2s
+tttg: c203/289 lr:0.000204 t:27.3s
+tttg: c204/289 lr:0.000200 t:27.5s
+tttg: c205/289 lr:0.000196 t:27.6s
+tttg: c206/289 lr:0.000191 t:27.7s
+tttg: c207/289 lr:0.000187 t:27.9s
+tttg: c208/289 lr:0.000183 t:28.0s
+tttg: c209/289 lr:0.000179 t:28.2s
+tttg: c210/289 lr:0.000174 t:28.3s
+tttg: c211/289 lr:0.000170 t:28.4s
+tttg: c212/289 lr:0.000166 t:28.6s
+tttg: c213/289 lr:0.000162 t:28.7s
+tttg: c214/289 lr:0.000158 t:28.8s
+tttg: c215/289 lr:0.000154 t:29.0s
+tttg: c216/289 lr:0.000150 t:29.1s
+tttg: c217/289 lr:0.000146 t:29.3s
+tttg: c218/289 lr:0.000143 t:29.4s
+tttg: c219/289 lr:0.000139 t:29.5s
+tttg: c220/289 lr:0.000135 t:29.7s
+tttg: c221/289 lr:0.000131 t:29.8s
+tttg: c222/289 lr:0.000128 t:29.9s
+tttg: c223/289 lr:0.000124 t:30.1s
+tttg: c224/289 lr:0.000121 t:30.2s
+tttg: c225/289 lr:0.000117 t:30.4s
+tttg: c226/289 lr:0.000113 t:30.5s
+tttg: c227/289 lr:0.000110 t:30.6s
+tttg: c228/289 lr:0.000107 t:30.8s
+tttg: c229/289 lr:0.000103 t:30.9s
+tttg: c230/289 lr:0.000100 t:31.1s
+tttg: c231/289 lr:0.000097 t:31.2s
+tttg: c232/289 lr:0.000094 t:31.3s
+tttg: c233/289 lr:0.000090 t:31.5s
+tttg: c234/289 lr:0.000087 t:31.6s
+tttg: c235/289 lr:0.000084 t:31.7s
+tttg: c236/289 lr:0.000081 t:31.9s
+tttg: c237/289 lr:0.000078 t:32.0s
+tttg: c238/289 lr:0.000075 t:32.2s
+tttg: c239/289 lr:0.000073 t:32.3s
+tttg: c240/289 lr:0.000070 t:32.4s
+tttg: c241/289 lr:0.000067 t:32.6s
+tttg: c242/289 lr:0.000064 t:32.7s
+tttg: c243/289 lr:0.000062 t:32.9s
+tttg: c244/289 lr:0.000059 t:33.0s
+tttg: c245/289 lr:0.000056 t:33.1s
+tttg: c246/289 lr:0.000054 t:33.3s
+tttg: c247/289 lr:0.000052 t:33.4s
+tttg: c248/289 lr:0.000049 t:33.5s
+tttg: c249/289 lr:0.000047 t:33.7s
+tttg: c250/289 lr:0.000045 t:33.8s
+tttg: c251/289 lr:0.000042 t:34.0s
+tttg: c252/289 lr:0.000040 t:34.1s
+tttg: c253/289 lr:0.000038 t:34.2s
+tttg: c254/289 lr:0.000036 t:34.4s
+tttg: c255/289 lr:0.000034 t:34.5s
+tttg: c256/289 lr:0.000032 t:34.7s
+tttg: c257/289 lr:0.000030 t:34.8s
+tttg: c258/289 lr:0.000028 t:34.9s
+tttg: c259/289 lr:0.000027 t:35.1s
+tttg: c260/289 lr:0.000025 t:35.2s
+tttg: c261/289 lr:0.000023 t:35.4s
+tttg: c262/289 lr:0.000022 t:35.5s
+tttg: c263/289 lr:0.000020 t:35.6s
+tttg: c264/289 lr:0.000018 t:35.8s
+tttg: c265/289 lr:0.000017 t:35.9s
+tttg: c266/289 lr:0.000016 t:36.1s
+tttg: c267/289 lr:0.000014 t:36.2s
+tttg: c268/289 lr:0.000013 t:36.3s
+tttg: c269/289 lr:0.000012 t:36.5s
+tttg: c270/289 lr:0.000011 t:36.6s
+tttg: c271/289 lr:0.000010 t:36.7s
+tttg: c272/289 lr:0.000009 t:36.9s
+tttg: c273/289 lr:0.000008 t:37.0s
+tttg: c274/289 lr:0.000007 t:37.2s
+tttg: c275/289 lr:0.000006 t:37.3s
+tttg: c276/289 lr:0.000005 t:37.4s
+tttg: c277/289 lr:0.000004 t:37.6s
+tttg: c278/289 lr:0.000004 t:37.7s
+tttg: c279/289 lr:0.000003 t:37.8s
+tttg: c280/289 lr:0.000002 t:38.0s
+tttg: c281/289 lr:0.000002 t:38.1s
+tttg: c282/289 lr:0.000001 t:38.3s
+tttg: c283/289 lr:0.000001 t:38.4s
+tttg: c284/289 lr:0.000001 t:38.6s
+tttg: c285/289 lr:0.000000 t:38.7s
+tttg: c286/289 lr:0.000000 t:38.8s
+tttg: c287/289 lr:0.000000 t:39.0s
+tttg: c288/289 lr:0.000000 t:39.1s
+ttpr: phase:3/3 t:408.5s
+ttp: b728/782 bl:2.3703 bb:1.0852 rl:2.2887 rb:1.0742 dl:2306-2324 gd:1
+ttp: b727/782 bl:2.2721 bb:1.0471 rl:2.2877 rb:1.0726 dl:2277-2305 gd:1
+ttp: b716/782 bl:2.2566 bb:1.0427 rl:2.2862 rb:1.0711 dl:2054-2069 gd:1
+ttp: b704/782 bl:2.2894 bb:1.0402 rl:2.2864 rb:1.0698 dl:1872-1885 gd:1
+ttp: b698/782 bl:2.2572 bb:1.0332 rl:2.2852 rb:1.0683 dl:1803-1814 gd:1
+ttp: b689/782 bl:2.4028 bb:1.0818 rl:2.2894 rb:1.0688 dl:1706-1715 gd:1
+ttp: b684/782 bl:2.3789 bb:1.0480 rl:2.2924 rb:1.0680 dl:1658-1665 gd:1
+ttp: b675/782 bl:2.3739 bb:1.0616 rl:2.2950 rb:1.0678 dl:1578-1586 gd:1
+ttp: b664/782 bl:2.3466 bb:1.0298 rl:2.2965 rb:1.0667 dl:1493-1499 gd:1
+ttp: b657/782 bl:2.3339 bb:1.0606 rl:2.2975 rb:1.0665 dl:1445-1452 gd:1
+ttp: b649/782 bl:2.2919 bb:1.0190 rl:2.2973 rb:1.0653 dl:1392-1398 gd:1
+ttp: b641/782 bl:2.3009 bb:1.0298 rl:2.2974 rb:1.0644 dl:1343-1349 gd:1
+ttp: b633/782 bl:2.2846 bb:1.0265 rl:2.2971 rb:1.0635 dl:1297-1302 gd:1
+ttp: b625/782 bl:2.4111 bb:1.0520 rl:2.2995 rb:1.0633 dl:1255-1260 gd:1
+ttp: b617/782 bl:2.3193 bb:1.0249 rl:2.2999 rb:1.0625 dl:1211-1216 gd:1
+ttp: b609/782 bl:2.2846 bb:1.0235 rl:2.2996 rb:1.0617 dl:1172-1177 gd:1
+ttp: b601/782 bl:2.3384 bb:1.0237 rl:2.3004 rb:1.0610 dl:1137-1141 gd:1
+ttp: b593/782 bl:2.2982 bb:1.0145 rl:2.3003 rb:1.0601 dl:1103-1107 gd:1
+ttp: b584/782 bl:2.3054 bb:1.0423 rl:2.3004 rb:1.0598 dl:1064-1069 gd:1
+ttp: b576/782 bl:2.3886 bb:1.0987 rl:2.3018 rb:1.0604 dl:1033-1037 gd:1
+ttp: b567/782 bl:2.2764 bb:1.0219 rl:2.3014 rb:1.0598 dl:1001-1004 gd:1
+ttp: b559/782 bl:2.3010 bb:1.0421 rl:2.3014 rb:1.0596 dl:972-975 gd:1
+ttp: b551/782 bl:2.3418 bb:1.0584 rl:2.3020 rb:1.0596 dl:946-949 gd:1
+ttp: b543/782 bl:2.3444 bb:1.0614 rl:2.3025 rb:1.0596 dl:921-924 gd:1
+ttp: b535/782 bl:2.3872 bb:1.0354 rl:2.3036 rb:1.0593 dl:896-899 gd:1
+ttp: b527/782 bl:2.3507 bb:1.0317 rl:2.3042 rb:1.0589 dl:872-875 gd:1
+ttp: b519/782 bl:2.3016 bb:1.0441 rl:2.3041 rb:1.0587 dl:850-852 gd:1
+ttp: b511/782 bl:2.3928 bb:1.0526 rl:2.3051 rb:1.0587 dl:826-829 gd:1
+ttp: b501/782 bl:2.3835 bb:1.0530 rl:2.3060 rb:1.0586 dl:799-802 gd:1
+ttp: b493/782 bl:2.3719 bb:1.0470 rl:2.3067 rb:1.0585 dl:778-780 gd:1
+ttp: b484/782 bl:2.3723 bb:1.0512 rl:2.3073 rb:1.0584 dl:756-759 gd:1
+ttp: b476/782 bl:2.2816 bb:1.0340 rl:2.3071 rb:1.0582 dl:738-740 gd:1
+ttp: b468/782 bl:2.3669 bb:1.0654 rl:2.3076 rb:1.0582 dl:719-721 gd:1
+ttp: b460/782 bl:2.2610 bb:1.0577 rl:2.3072 rb:1.0582 dl:701-703 gd:1
+ttp: b450/782 bl:2.3702 bb:1.0390 rl:2.3078 rb:1.0580 dl:680-682 gd:1
+ttp: b442/782 bl:2.2662 bb:1.0342 rl:2.3074 rb:1.0578 dl:664-666 gd:1
+ttp: b435/782 bl:2.3274 bb:1.0280 rl:2.3076 rb:1.0576 dl:648-651 gd:1
+ttp: b409/782 bl:2.3387 bb:1.0734 rl:2.3078 rb:1.0577 dl:598-601 gd:1
+ttp: b400/782 bl:2.3155 bb:1.0419 rl:2.3079 rb:1.0576 dl:582-584 gd:1
+ttp: b391/782 bl:2.3176 bb:1.0675 rl:2.3079 rb:1.0577 dl:566-568 gd:1
+ttp: b383/782 bl:2.2860 bb:1.0481 rl:2.3078 rb:1.0576 dl:552-554 gd:1
+ttp: b376/782 bl:2.3317 bb:1.0457 rl:2.3079 rb:1.0575 dl:540-542 gd:1
+ttp: b368/782 bl:2.3786 bb:1.1078 rl:2.3084 rb:1.0578 dl:527-528 gd:1
+ttp: b359/782 bl:2.2609 bb:1.0382 rl:2.3081 rb:1.0577 dl:512-513 gd:1
+ttp: b351/782 bl:2.3677 bb:1.0839 rl:2.3085 rb:1.0579 dl:498-499 gd:1
+ttp: b343/782 bl:2.2275 bb:1.0482 rl:2.3080 rb:1.0578 dl:486-488 gd:1
+ttp: b334/782 bl:2.3938 bb:1.0760 rl:2.3085 rb:1.0579 dl:472-474 gd:1
+ttp: b327/782 bl:2.3404 bb:1.0882 rl:2.3086 rb:1.0581 dl:462-463 gd:1
+ttp: b321/782 bl:2.3598 bb:1.0773 rl:2.3089 rb:1.0582 dl:453-455 gd:1
+ttp: b314/782 bl:2.2551 bb:1.0636 rl:2.3086 rb:1.0582 dl:442-444 gd:1
+ttp: b304/782 bl:2.3502 bb:1.0780 rl:2.3088 rb:1.0583 dl:427-429 gd:1
+ttp: b296/782 bl:2.3924 bb:1.1015 rl:2.3092 rb:1.0585 dl:415-417 gd:1
+ttp: b288/782 bl:2.2414 bb:1.0202 rl:2.3089 rb:1.0583 dl:403-405 gd:1
+ttp: b278/782 bl:2.2758 bb:1.0660 rl:2.3088 rb:1.0584 dl:389-391 gd:1
+ttp: b269/782 bl:2.3514 bb:1.1157 rl:2.3090 rb:1.0586 dl:378-379 gd:1
+ttp: b261/782 bl:2.4330 bb:1.1199 rl:2.3095 rb:1.0589 dl:367-369 gd:1
+ttp: b250/782 bl:2.3231 bb:1.0771 rl:2.3095 rb:1.0589 dl:354-355 gd:1
+ttp: b241/782 bl:2.3530 bb:1.0935 rl:2.3097 rb:1.0591 dl:342-344 gd:1
+ttp: b233/782 bl:2.3677 bb:1.1312 rl:2.3099 rb:1.0593 dl:333-334 gd:1
+ttp: b223/782 bl:2.3389 bb:1.1292 rl:2.3100 rb:1.0595 dl:321-322 gd:1
+ttp: b214/782 bl:2.3458 bb:1.1225 rl:2.3101 rb:1.0598 dl:310-312 gd:1
+ttp: b206/782 bl:2.4148 bb:1.1109 rl:2.3105 rb:1.0599 dl:302-303 gd:1
+ttp: b197/782 bl:2.3705 bb:1.1206 rl:2.3107 rb:1.0601 dl:292-294 gd:1
+ttp: b188/782 bl:2.3564 bb:1.1065 rl:2.3108 rb:1.0603 dl:282-283 gd:1
+ttp: b180/782 bl:2.4307 bb:1.1136 rl:2.3112 rb:1.0604 dl:274-275 gd:1
+ttp: b170/782 bl:2.3885 bb:1.1326 rl:2.3114 rb:1.0606 dl:264-265 gd:1
+ttp: b162/782 bl:2.4057 bb:1.1201 rl:2.3117 rb:1.0608 dl:256-257 gd:1
+ttp: b154/782 bl:2.4792 bb:1.2091 rl:2.3121 rb:1.0612 dl:249-250 gd:1
+ttp: b144/782 bl:2.3622 bb:1.1103 rl:2.3122 rb:1.0613 dl:239-240 gd:1
+ttp: b137/782 bl:2.4178 bb:1.1551 rl:2.3125 rb:1.0615 dl:233-233 gd:1
+ttp: b127/782 bl:2.4763 bb:1.1878 rl:2.3129 rb:1.0618 dl:223-224 gd:1
+ttp: b116/782 bl:2.4997 bb:1.1350 rl:2.3133 rb:1.0620 dl:213-214 gd:1
+ttp: b108/782 bl:2.4052 bb:1.1595 rl:2.3135 rb:1.0622 dl:206-207 gd:1
+ttp: b98/782 bl:2.6012 bb:1.2206 rl:2.3141 rb:1.0625 dl:197-198 gd:1
+ttp: b90/782 bl:2.4729 bb:1.2109 rl:2.3145 rb:1.0628 dl:190-190 gd:1
+ttp: b80/782 bl:2.4609 bb:1.1470 rl:2.3147 rb:1.0629 dl:181-182 gd:1
+ttp: b71/782 bl:2.4728 bb:1.1818 rl:2.3150 rb:1.0631 dl:173-173 gd:1
+ttp: b61/782 bl:2.4629 bb:1.2191 rl:2.3153 rb:1.0634 dl:164-165 gd:1
+ttp: b52/782 bl:2.6773 bb:1.2497 rl:2.3159 rb:1.0637 dl:155-156 gd:1
+ttp: b43/782 bl:2.5155 bb:1.2281 rl:2.3162 rb:1.0639 dl:146-147 gd:1
+ttp: b33/782 bl:2.5986 bb:1.2246 rl:2.3166 rb:1.0642 dl:136-137 gd:1
+ttp: b23/782 bl:2.6068 bb:1.2243 rl:2.3170 rb:1.0644 dl:126-127 gd:1
+ttp: b13/782 bl:2.6860 bb:1.2169 rl:2.3174 rb:1.0645 dl:112-114 gd:1
+ttp: b4/782 bl:2.7501 bb:1.2322 rl:2.3178 rb:1.0647 dl:93-96 gd:1
+quantized_ttt_phased val_loss:2.32878891 val_bpb:1.06416566 eval_time:521122ms
+total_eval_time:521.1s

--- a/records/track_10min_16mb/2026-04-30_AdaptiveHessianClip_PR1855_1.0631/train_seed42.log
+++ b/records/track_10min_16mb/2026-04-30_AdaptiveHessianClip_PR1855_1.0631/train_seed42.log
@@ -1,0 +1,1006 @@
+W0430 03:34:24.372000 949 torch/distributed/run.py:803] 
+W0430 03:34:24.372000 949 torch/distributed/run.py:803] *****************************************
+W0430 03:34:24.372000 949 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0430 03:34:24.372000 949 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  adaptive_hessian_clip: True
+  artifact_dir: 
+  attn_clip_sigmas: 13.0
+  attn_out_gate_enabled: False
+  attn_out_gate_src: proj
+  beta1: 0.9
+  beta2: 0.99
+  caseops_enabled: True
+  compressor: pergroup
+  data_dir: ./data/
+  datasets_dir: /workspace/parameter-golf/data/datasets/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved
+  distributed: True
+  ema_decay: 0.9965
+  embed_bits: 7
+  embed_clip_sigmas: 14.0
+  embed_lr: 0.6
+  embed_wd: 0.085
+  enable_looping_at: 0.35
+  eval_seq_len: 2048
+  eval_stride: 64
+  fused_ce_enabled: True
+  gate_window: 12
+  gated_attn_enabled: False
+  gated_attn_init_std: 0.01
+  gated_attn_quant_gate: False
+  global_ttt_batch_seqs: 32
+  global_ttt_chunk_tokens: 32768
+  global_ttt_epochs: 1
+  global_ttt_grad_clip: 1.0
+  global_ttt_lr: 0.001
+  global_ttt_momentum: 0.9
+  global_ttt_respect_doc_boundaries: True
+  global_ttt_warmup_chunks: 0
+  global_ttt_warmup_start_lr: 0.0
+  gptq_calibration_batches: 16
+  gptq_reserve_seconds: 4.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  is_main_process: True
+  iterations: 20000
+  ln_scale: True
+  local_rank: 0
+  logfile: logs/43236bd5-595a-41da-b839-f74f7cf33127.txt
+  logit_softcap: 30.0
+  loop_end: 5
+  loop_start: 3
+  lqer_asym_enabled: True
+  lqer_asym_group: 64
+  lqer_enabled: True
+  lqer_factor_bits: 4
+  lqer_rank: 4
+  lqer_top_k: 3
+  matrix_bits: 6
+  matrix_clip_sigmas: 12.85
+  matrix_lr: 0.026
+  max_wallclock_seconds: 600.0
+  min_lr: 0.1
+  mixed_precision_bits_high: 7
+  mixed_precision_bits_low: 5
+  mixed_precision_hessian: False
+  mixed_precision_high_frac: 0.25
+  mixed_precision_low_frac: 0.25
+  mlp_clip_sigmas: 11.5
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: final_model.pt
+  muon_backend_steps: 5
+  muon_momentum: 0.97
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_row_normalize: True
+  muon_wd: 0.095
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  num_loops: 2
+  parallel_final_lane: mean
+  parallel_start_layer: 8
+  phased_ttt_num_phases: 3
+  phased_ttt_prefix_docs: 2500
+  qk_gain_init: 5.0
+  quantized_model_path: final_model.int6.ptz
+  rank: 0
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  rope_yarn: False
+  run_id: 43236bd5-595a-41da-b839-f74f7cf33127
+  scalar_lr: 0.02
+  seed: 42
+  skip_gates_enabled: True
+  smear_gate_enabled: True
+  sparse_attn_gate_enabled: True
+  sparse_attn_gate_init_std: 0.0
+  sparse_attn_gate_scale: 0.5
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  tokenizer_path: /workspace/parameter-golf/data/datasets/datasets/tokenizers/fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model
+  train_batch_tokens: 786432
+  train_files: /workspace/parameter-golf/data/datasets/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_train_*.bin
+  train_log_every: 500
+  train_seq_len: 2048
+  ttt_batch_size: 64
+  ttt_beta1: 0.0
+  ttt_beta2: 0.99
+  ttt_chunk_size: 48
+  ttt_enabled: True
+  ttt_eval_batches: 
+  ttt_eval_seq_len: 2048
+  ttt_grad_steps: 1
+  ttt_k_lora: True
+  ttt_lora_lr: 0.0001
+  ttt_lora_rank: 56
+  ttt_mlp_lora: True
+  ttt_o_lora: True
+  ttt_optimizer: adam
+  ttt_weight_decay: 0.5
+  val_batch_tokens: 524288
+  val_bytes_files: /workspace/parameter-golf/data/datasets/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_val_bytes_*.bin
+  val_doc_fraction: 1.0
+  val_files: /workspace/parameter-golf/data/datasets/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_val_*.bin
+  val_loss_every: 4000
+  vocab_size: 8192
+  warmdown_frac: 0.85
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+train_shards: 80
+val_tokens: 47851520
+model_params:35945671
+gptq:reserving 4s, effective=596000ms
+warmup_cu_buckets:64,128,192,256 iters_each:3
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup:enabled encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+loop_warmup_step: 1/20
+loop_warmup_step: 2/20
+loop_warmup_step: 3/20
+loop_warmup_step: 4/20
+loop_warmup_step: 5/20
+loop_warmup_step: 6/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+0/20000 val_loss: 9.0076 val_bpb: 4.1159
+1/20000 train_loss: 9.0087 train_time: 0.0m tok/s: 13452586
+2/20000 train_loss: 12.8247 train_time: 0.0m tok/s: 10790221
+3/20000 train_loss: 10.2020 train_time: 0.0m tok/s: 9455089
+4/20000 train_loss: 8.6802 train_time: 0.0m tok/s: 8983505
+5/20000 train_loss: 7.9403 train_time: 0.0m tok/s: 8717464
+500/20000 train_loss: 2.5628 train_time: 0.8m tok/s: 8099629
+1000/20000 train_loss: 2.7964 train_time: 1.6m tok/s: 8045719
+1500/20000 train_loss: 2.6189 train_time: 2.5m tok/s: 8015217
+2000/20000 train_loss: 2.6497 train_time: 3.3m tok/s: 8011048
+layer_loop:enabled step:2124 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2500/20000 train_loss: 2.5397 train_time: 4.4m tok/s: 7497592
+3000/20000 train_loss: 2.5471 train_time: 5.6m tok/s: 7071333
+3500/20000 train_loss: 2.5525 train_time: 6.8m tok/s: 6793676
+4000/20000 train_loss: 2.3929 train_time: 7.9m tok/s: 6599483
+4000/20000 val_loss: 2.4180 val_bpb: 1.1048
+4500/20000 train_loss: 2.2644 train_time: 9.1m tok/s: 6458087
+4835/20000 val_loss: 2.3558 val_bpb: 1.0764
+stopping_early: wallclock_cap train_time: 596033ms step: 4835/20000
+peak memory allocated: 41719 MiB reserved: 47128 MiB
+ema:applying EMA weights
+diagnostic pre-quantization post-ema val_loss:2.33072384 val_bpb:1.06498069 eval_time:9649ms
+Serialized model: 135417533 bytes
+Code size (uncompressed): 164676 bytes
+Code size (compressed): 33102 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 3.6s
+GPTQ adaptive clip_sigmas (Hessian-sensitivity, 66 tensors):
+    blocks.0.attn.c_q.weight: 8.74
+    blocks.0.attn.proj.weight: 11.39
+    blocks.1.attn.c_q.weight: 9.73
+    blocks.1.attn.proj.weight: 14.52
+    blocks.2.attn.c_q.weight: 10.37
+    blocks.2.attn.proj.weight: 14.48
+    blocks.3.attn.c_q.weight: 9.21
+    blocks.3.attn.proj.weight: 13.82
+    blocks.4.attn.c_q.weight: 9.55
+    blocks.4.attn.proj.weight: 12.94
+    blocks.5.attn.c_q.weight: 9.86
+    blocks.5.attn.proj.weight: 14.52
+    blocks.6.attn.c_q.weight: 11.75
+    blocks.6.attn.proj.weight: 18.13
+    blocks.7.attn.c_q.weight: 12.02
+    blocks.7.attn.proj.weight: 19.61
+    blocks.8.attn.c_q.weight: 12.31
+    blocks.8.attn.proj.weight: 15.51
+    blocks.9.attn.c_q.weight: 12.66
+    blocks.9.attn.proj.weight: 24.00
+    blocks.10.attn.c_q.weight: 12.75
+    blocks.10.attn.proj.weight: 24.00
+    blocks.0.attn.c_k.weight: 8.60
+    blocks.0.attn.c_v.weight: 8.37
+    blocks.1.attn.c_k.weight: 9.46
+    blocks.1.attn.c_v.weight: 9.19
+    blocks.2.attn.c_k.weight: 10.17
+    blocks.2.attn.c_v.weight: 10.00
+    blocks.3.attn.c_k.weight: 8.94
+    blocks.3.attn.c_v.weight: 8.79
+    blocks.4.attn.c_k.weight: 9.39
+    blocks.4.attn.c_v.weight: 9.17
+    blocks.5.attn.c_k.weight: 9.48
+    blocks.5.attn.c_v.weight: 9.35
+    blocks.6.attn.c_k.weight: 11.47
+    blocks.6.attn.c_v.weight: 11.21
+    blocks.7.attn.c_k.weight: 11.66
+    blocks.7.attn.c_v.weight: 11.51
+    blocks.8.attn.c_k.weight: 12.04
+    blocks.8.attn.c_v.weight: 11.57
+    blocks.9.attn.c_k.weight: 12.18
+    blocks.9.attn.c_v.weight: 11.55
+    blocks.10.attn.c_k.weight: 12.36
+    blocks.10.attn.c_v.weight: 11.75
+    blocks.0.mlp.fc.weight: 8.39
+    blocks.1.mlp.fc.weight: 9.24
+    blocks.2.mlp.fc.weight: 9.80
+    blocks.3.mlp.fc.weight: 8.75
+    blocks.4.mlp.fc.weight: 9.02
+    blocks.5.mlp.fc.weight: 9.27
+    blocks.6.mlp.fc.weight: 11.11
+    blocks.7.mlp.fc.weight: 11.35
+    blocks.8.mlp.fc.weight: 11.60
+    blocks.9.mlp.fc.weight: 11.80
+    blocks.10.mlp.fc.weight: 12.09
+    blocks.0.mlp.proj.weight: 9.25
+    blocks.1.mlp.proj.weight: 11.26
+    blocks.2.mlp.proj.weight: 12.28
+    blocks.3.mlp.proj.weight: 11.08
+    blocks.4.mlp.proj.weight: 12.22
+    blocks.5.mlp.proj.weight: 12.41
+    blocks.6.mlp.proj.weight: 14.83
+    blocks.7.mlp.proj.weight: 16.79
+    blocks.8.mlp.proj.weight: 17.67
+    blocks.9.mlp.proj.weight: 17.89
+    blocks.10.mlp.proj.weight: 19.58
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int6)+lqer_asym: blocks.mlp.fc.weight
+  gptq (int7)+lqer_asym: tok_emb.weight
+  passthrough (float16): blocks.attn.attn_gate_w, blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, skip_gates, skip_weights, smear_gate.weight, smear_lambda
+Serialize: per-group lrzip compression...
+Serialize: per-group compression done in 127.2s
+Serialized model quantized+pergroup: 15871898 bytes
+Total submission size quantized+pergroup: 15905000 bytes
+Deserialize: per-group lrzip decompression...
+Deserialize: decompression done in 20.9s
+diagnostic quantized val_loss:2.35220837 val_bpb:1.07479764 eval_time:73781ms
+Deserialize: per-group lrzip decompression...
+Deserialize: decompression done in 20.4s
+ttt_lora:warming up compile (random tokens, no val data)
+ttt_lora:compile warmup done (186.6s)
+
+beginning TTT eval timer
+ttt_phased: total_docs:50000 prefix_docs:2500 suffix_docs:47500 num_phases:3 boundaries:[833, 1666, 2500]
+ttp: b777/782 bl:2.3154 bb:1.0851 rl:2.3154 rb:1.0851 dl:8452-9229 gd:0
+ttp: b771/782 bl:2.3095 bb:1.0608 rl:2.3131 rb:1.0755 dl:5523-5749 gd:0
+ttp: b767/782 bl:2.2709 bb:1.0746 rl:2.3027 rb:1.0753 dl:4681-4858 gd:0
+ttpp: phase:1/3 pd:1296 gd:833 t:244.2s
+tttg: c1/131 lr:0.001000 t:2.4s
+tttg: c2/131 lr:0.001000 t:2.6s
+tttg: c3/131 lr:0.000999 t:2.7s
+tttg: c4/131 lr:0.000999 t:2.8s
+tttg: c5/131 lr:0.000998 t:3.0s
+tttg: c6/131 lr:0.000996 t:3.1s
+tttg: c7/131 lr:0.000995 t:3.3s
+tttg: c8/131 lr:0.000993 t:3.4s
+tttg: c9/131 lr:0.000991 t:3.5s
+tttg: c10/131 lr:0.000988 t:3.7s
+tttg: c11/131 lr:0.000985 t:3.8s
+tttg: c12/131 lr:0.000982 t:4.0s
+tttg: c13/131 lr:0.000979 t:4.1s
+tttg: c14/131 lr:0.000976 t:4.2s
+tttg: c15/131 lr:0.000972 t:4.4s
+tttg: c16/131 lr:0.000968 t:4.5s
+tttg: c17/131 lr:0.000963 t:4.6s
+tttg: c18/131 lr:0.000958 t:4.8s
+tttg: c19/131 lr:0.000953 t:4.9s
+tttg: c20/131 lr:0.000948 t:5.1s
+tttg: c21/131 lr:0.000943 t:5.2s
+tttg: c22/131 lr:0.000937 t:5.4s
+tttg: c23/131 lr:0.000931 t:5.5s
+tttg: c24/131 lr:0.000925 t:5.6s
+tttg: c25/131 lr:0.000918 t:5.8s
+tttg: c26/131 lr:0.000911 t:5.9s
+tttg: c27/131 lr:0.000905 t:6.0s
+tttg: c28/131 lr:0.000897 t:6.2s
+tttg: c29/131 lr:0.000890 t:6.3s
+tttg: c30/131 lr:0.000882 t:6.5s
+tttg: c31/131 lr:0.000874 t:6.6s
+tttg: c32/131 lr:0.000866 t:6.7s
+tttg: c33/131 lr:0.000858 t:6.9s
+tttg: c34/131 lr:0.000849 t:7.0s
+tttg: c35/131 lr:0.000841 t:7.2s
+tttg: c36/131 lr:0.000832 t:7.3s
+tttg: c37/131 lr:0.000822 t:7.4s
+tttg: c38/131 lr:0.000813 t:7.6s
+tttg: c39/131 lr:0.000804 t:7.7s
+tttg: c40/131 lr:0.000794 t:7.8s
+tttg: c41/131 lr:0.000784 t:8.0s
+tttg: c42/131 lr:0.000774 t:8.1s
+tttg: c43/131 lr:0.000764 t:8.3s
+tttg: c44/131 lr:0.000753 t:8.4s
+tttg: c45/131 lr:0.000743 t:8.5s
+tttg: c46/131 lr:0.000732 t:8.7s
+tttg: c47/131 lr:0.000722 t:8.8s
+tttg: c48/131 lr:0.000711 t:9.0s
+tttg: c49/131 lr:0.000700 t:9.1s
+tttg: c50/131 lr:0.000689 t:9.3s
+tttg: c51/131 lr:0.000677 t:9.4s
+tttg: c52/131 lr:0.000666 t:9.5s
+tttg: c53/131 lr:0.000655 t:9.7s
+tttg: c54/131 lr:0.000643 t:9.8s
+tttg: c55/131 lr:0.000631 t:9.9s
+tttg: c56/131 lr:0.000620 t:10.1s
+tttg: c57/131 lr:0.000608 t:10.2s
+tttg: c58/131 lr:0.000596 t:10.4s
+tttg: c59/131 lr:0.000584 t:10.5s
+tttg: c60/131 lr:0.000572 t:10.6s
+tttg: c61/131 lr:0.000560 t:10.8s
+tttg: c62/131 lr:0.000548 t:10.9s
+tttg: c63/131 lr:0.000536 t:11.1s
+tttg: c64/131 lr:0.000524 t:11.2s
+tttg: c65/131 lr:0.000512 t:11.3s
+tttg: c66/131 lr:0.000500 t:11.5s
+tttg: c67/131 lr:0.000488 t:11.6s
+tttg: c68/131 lr:0.000476 t:11.8s
+tttg: c69/131 lr:0.000464 t:11.9s
+tttg: c70/131 lr:0.000452 t:12.0s
+tttg: c71/131 lr:0.000440 t:12.2s
+tttg: c72/131 lr:0.000428 t:12.3s
+tttg: c73/131 lr:0.000416 t:12.4s
+tttg: c74/131 lr:0.000404 t:12.6s
+tttg: c75/131 lr:0.000392 t:12.7s
+tttg: c76/131 lr:0.000380 t:12.9s
+tttg: c77/131 lr:0.000369 t:13.0s
+tttg: c78/131 lr:0.000357 t:13.1s
+tttg: c79/131 lr:0.000345 t:13.3s
+tttg: c80/131 lr:0.000334 t:13.4s
+tttg: c81/131 lr:0.000323 t:13.5s
+tttg: c82/131 lr:0.000311 t:13.7s
+tttg: c83/131 lr:0.000300 t:13.8s
+tttg: c84/131 lr:0.000289 t:14.0s
+tttg: c85/131 lr:0.000278 t:14.1s
+tttg: c86/131 lr:0.000268 t:14.2s
+tttg: c87/131 lr:0.000257 t:14.4s
+tttg: c88/131 lr:0.000247 t:14.5s
+tttg: c89/131 lr:0.000236 t:14.6s
+tttg: c90/131 lr:0.000226 t:14.8s
+tttg: c91/131 lr:0.000216 t:14.9s
+tttg: c92/131 lr:0.000206 t:15.1s
+tttg: c93/131 lr:0.000196 t:15.2s
+tttg: c94/131 lr:0.000187 t:15.3s
+tttg: c95/131 lr:0.000178 t:15.5s
+tttg: c96/131 lr:0.000168 t:15.6s
+tttg: c97/131 lr:0.000159 t:15.7s
+tttg: c98/131 lr:0.000151 t:15.9s
+tttg: c99/131 lr:0.000142 t:16.0s
+tttg: c100/131 lr:0.000134 t:16.2s
+tttg: c101/131 lr:0.000126 t:16.3s
+tttg: c102/131 lr:0.000118 t:16.4s
+tttg: c103/131 lr:0.000110 t:16.6s
+tttg: c104/131 lr:0.000103 t:16.7s
+tttg: c105/131 lr:0.000095 t:16.8s
+tttg: c106/131 lr:0.000089 t:17.0s
+tttg: c107/131 lr:0.000082 t:17.1s
+tttg: c108/131 lr:0.000075 t:17.3s
+tttg: c109/131 lr:0.000069 t:17.4s
+tttg: c110/131 lr:0.000063 t:17.5s
+tttg: c111/131 lr:0.000057 t:17.7s
+tttg: c112/131 lr:0.000052 t:17.8s
+tttg: c113/131 lr:0.000047 t:18.0s
+tttg: c114/131 lr:0.000042 t:18.1s
+tttg: c115/131 lr:0.000037 t:18.2s
+tttg: c116/131 lr:0.000032 t:18.4s
+tttg: c117/131 lr:0.000028 t:18.5s
+tttg: c118/131 lr:0.000024 t:18.6s
+tttg: c119/131 lr:0.000021 t:18.8s
+tttg: c120/131 lr:0.000018 t:18.9s
+tttg: c121/131 lr:0.000015 t:19.0s
+tttg: c122/131 lr:0.000012 t:19.2s
+tttg: c123/131 lr:0.000009 t:19.3s
+tttg: c124/131 lr:0.000007 t:19.5s
+tttg: c125/131 lr:0.000005 t:19.6s
+tttg: c126/131 lr:0.000004 t:19.7s
+tttg: c127/131 lr:0.000002 t:19.9s
+tttg: c128/131 lr:0.000001 t:20.0s
+tttg: c129/131 lr:0.000001 t:20.2s
+tttg: c130/131 lr:0.000000 t:20.3s
+ttpr: phase:1/3 t:266.2s
+ttp: b754/782 bl:2.2929 bb:1.0606 rl:2.3012 rb:1.0731 dl:3345-3397 gd:0
+ttpp: phase:2/3 pd:2128 gd:1666 t:405.0s
+tttg: c1/219 lr:0.001000 t:0.1s
+tttg: c2/219 lr:0.001000 t:0.2s
+tttg: c3/219 lr:0.001000 t:0.4s
+tttg: c4/219 lr:0.001000 t:0.5s
+tttg: c5/219 lr:0.000999 t:0.6s
+tttg: c6/219 lr:0.000999 t:0.7s
+tttg: c7/219 lr:0.000998 t:0.8s
+tttg: c8/219 lr:0.000997 t:0.9s
+tttg: c9/219 lr:0.000997 t:1.1s
+tttg: c10/219 lr:0.000996 t:1.2s
+tttg: c11/219 lr:0.000995 t:1.3s
+tttg: c12/219 lr:0.000994 t:1.4s
+tttg: c13/219 lr:0.000993 t:1.5s
+tttg: c14/219 lr:0.000991 t:1.7s
+tttg: c15/219 lr:0.000990 t:1.8s
+tttg: c16/219 lr:0.000988 t:1.9s
+tttg: c17/219 lr:0.000987 t:2.0s
+tttg: c18/219 lr:0.000985 t:2.1s
+tttg: c19/219 lr:0.000983 t:2.3s
+tttg: c20/219 lr:0.000981 t:2.4s
+tttg: c21/219 lr:0.000979 t:2.5s
+tttg: c22/219 lr:0.000977 t:2.6s
+tttg: c23/219 lr:0.000975 t:2.7s
+tttg: c24/219 lr:0.000973 t:2.8s
+tttg: c25/219 lr:0.000970 t:3.0s
+tttg: c26/219 lr:0.000968 t:3.1s
+tttg: c27/219 lr:0.000965 t:3.2s
+tttg: c28/219 lr:0.000963 t:3.3s
+tttg: c29/219 lr:0.000960 t:3.4s
+tttg: c30/219 lr:0.000957 t:3.6s
+tttg: c31/219 lr:0.000954 t:3.7s
+tttg: c32/219 lr:0.000951 t:3.8s
+tttg: c33/219 lr:0.000948 t:3.9s
+tttg: c34/219 lr:0.000945 t:4.0s
+tttg: c35/219 lr:0.000941 t:4.1s
+tttg: c36/219 lr:0.000938 t:4.3s
+tttg: c37/219 lr:0.000934 t:4.4s
+tttg: c38/219 lr:0.000931 t:4.5s
+tttg: c39/219 lr:0.000927 t:4.6s
+tttg: c40/219 lr:0.000923 t:4.7s
+tttg: c41/219 lr:0.000919 t:4.9s
+tttg: c42/219 lr:0.000915 t:5.0s
+tttg: c43/219 lr:0.000911 t:5.1s
+tttg: c44/219 lr:0.000907 t:5.2s
+tttg: c45/219 lr:0.000903 t:5.3s
+tttg: c46/219 lr:0.000898 t:5.5s
+tttg: c47/219 lr:0.000894 t:5.6s
+tttg: c48/219 lr:0.000890 t:5.7s
+tttg: c49/219 lr:0.000885 t:5.8s
+tttg: c50/219 lr:0.000880 t:5.9s
+tttg: c51/219 lr:0.000876 t:6.0s
+tttg: c52/219 lr:0.000871 t:6.2s
+tttg: c53/219 lr:0.000866 t:6.3s
+tttg: c54/219 lr:0.000861 t:6.4s
+tttg: c55/219 lr:0.000856 t:6.5s
+tttg: c56/219 lr:0.000851 t:6.6s
+tttg: c57/219 lr:0.000846 t:6.8s
+tttg: c58/219 lr:0.000841 t:6.9s
+tttg: c59/219 lr:0.000835 t:7.0s
+tttg: c60/219 lr:0.000830 t:7.1s
+tttg: c61/219 lr:0.000824 t:7.2s
+tttg: c62/219 lr:0.000819 t:7.4s
+tttg: c63/219 lr:0.000813 t:7.5s
+tttg: c64/219 lr:0.000808 t:7.6s
+tttg: c65/219 lr:0.000802 t:7.7s
+tttg: c66/219 lr:0.000796 t:7.8s
+tttg: c67/219 lr:0.000790 t:8.0s
+tttg: c68/219 lr:0.000784 t:8.1s
+tttg: c69/219 lr:0.000779 t:8.2s
+tttg: c70/219 lr:0.000773 t:8.3s
+tttg: c71/219 lr:0.000766 t:8.4s
+tttg: c72/219 lr:0.000760 t:8.6s
+tttg: c73/219 lr:0.000754 t:8.7s
+tttg: c74/219 lr:0.000748 t:8.8s
+tttg: c75/219 lr:0.000742 t:8.9s
+tttg: c76/219 lr:0.000735 t:9.0s
+tttg: c77/219 lr:0.000729 t:9.1s
+tttg: c78/219 lr:0.000722 t:9.3s
+tttg: c79/219 lr:0.000716 t:9.4s
+tttg: c80/219 lr:0.000709 t:9.5s
+tttg: c81/219 lr:0.000703 t:9.6s
+tttg: c82/219 lr:0.000696 t:9.7s
+tttg: c83/219 lr:0.000690 t:9.9s
+tttg: c84/219 lr:0.000683 t:10.0s
+tttg: c85/219 lr:0.000676 t:10.1s
+tttg: c86/219 lr:0.000670 t:10.2s
+tttg: c87/219 lr:0.000663 t:10.3s
+tttg: c88/219 lr:0.000656 t:10.5s
+tttg: c89/219 lr:0.000649 t:10.6s
+tttg: c90/219 lr:0.000642 t:10.7s
+tttg: c91/219 lr:0.000635 t:10.8s
+tttg: c92/219 lr:0.000628 t:10.9s
+tttg: c93/219 lr:0.000621 t:11.1s
+tttg: c94/219 lr:0.000614 t:11.2s
+tttg: c95/219 lr:0.000607 t:11.3s
+tttg: c96/219 lr:0.000600 t:11.4s
+tttg: c97/219 lr:0.000593 t:11.5s
+tttg: c98/219 lr:0.000586 t:11.7s
+tttg: c99/219 lr:0.000579 t:11.8s
+tttg: c100/219 lr:0.000572 t:11.9s
+tttg: c101/219 lr:0.000565 t:12.0s
+tttg: c102/219 lr:0.000558 t:12.1s
+tttg: c103/219 lr:0.000550 t:12.2s
+tttg: c104/219 lr:0.000543 t:12.4s
+tttg: c105/219 lr:0.000536 t:12.5s
+tttg: c106/219 lr:0.000529 t:12.6s
+tttg: c107/219 lr:0.000522 t:12.7s
+tttg: c108/219 lr:0.000514 t:12.8s
+tttg: c109/219 lr:0.000507 t:13.0s
+tttg: c110/219 lr:0.000500 t:13.1s
+tttg: c111/219 lr:0.000493 t:13.2s
+tttg: c112/219 lr:0.000486 t:13.3s
+tttg: c113/219 lr:0.000478 t:13.4s
+tttg: c114/219 lr:0.000471 t:13.6s
+tttg: c115/219 lr:0.000464 t:13.7s
+tttg: c116/219 lr:0.000457 t:13.8s
+tttg: c117/219 lr:0.000450 t:13.9s
+tttg: c118/219 lr:0.000442 t:14.0s
+tttg: c119/219 lr:0.000435 t:14.2s
+tttg: c120/219 lr:0.000428 t:14.3s
+tttg: c121/219 lr:0.000421 t:14.4s
+tttg: c122/219 lr:0.000414 t:14.5s
+tttg: c123/219 lr:0.000407 t:14.6s
+tttg: c124/219 lr:0.000400 t:14.7s
+tttg: c125/219 lr:0.000393 t:14.9s
+tttg: c126/219 lr:0.000386 t:15.0s
+tttg: c127/219 lr:0.000379 t:15.1s
+tttg: c128/219 lr:0.000372 t:15.2s
+tttg: c129/219 lr:0.000365 t:15.3s
+tttg: c130/219 lr:0.000358 t:15.5s
+tttg: c131/219 lr:0.000351 t:15.6s
+tttg: c132/219 lr:0.000344 t:15.7s
+tttg: c133/219 lr:0.000337 t:15.8s
+tttg: c134/219 lr:0.000330 t:15.9s
+tttg: c135/219 lr:0.000324 t:16.1s
+tttg: c136/219 lr:0.000317 t:16.2s
+tttg: c137/219 lr:0.000310 t:16.3s
+tttg: c138/219 lr:0.000304 t:16.4s
+tttg: c139/219 lr:0.000297 t:16.5s
+tttg: c140/219 lr:0.000291 t:16.6s
+tttg: c141/219 lr:0.000284 t:16.8s
+tttg: c142/219 lr:0.000278 t:16.9s
+tttg: c143/219 lr:0.000271 t:17.0s
+tttg: c144/219 lr:0.000265 t:17.1s
+tttg: c145/219 lr:0.000258 t:17.3s
+tttg: c146/219 lr:0.000252 t:17.4s
+tttg: c147/219 lr:0.000246 t:17.5s
+tttg: c148/219 lr:0.000240 t:17.7s
+tttg: c149/219 lr:0.000234 t:17.8s
+tttg: c150/219 lr:0.000227 t:18.0s
+tttg: c151/219 lr:0.000221 t:18.1s
+tttg: c152/219 lr:0.000216 t:18.2s
+tttg: c153/219 lr:0.000210 t:18.4s
+tttg: c154/219 lr:0.000204 t:18.5s
+tttg: c155/219 lr:0.000198 t:18.6s
+tttg: c156/219 lr:0.000192 t:18.8s
+tttg: c157/219 lr:0.000187 t:18.9s
+tttg: c158/219 lr:0.000181 t:19.0s
+tttg: c159/219 lr:0.000176 t:19.2s
+tttg: c160/219 lr:0.000170 t:19.3s
+tttg: c161/219 lr:0.000165 t:19.5s
+tttg: c162/219 lr:0.000159 t:19.6s
+tttg: c163/219 lr:0.000154 t:19.7s
+tttg: c164/219 lr:0.000149 t:19.9s
+tttg: c165/219 lr:0.000144 t:20.0s
+tttg: c166/219 lr:0.000139 t:20.1s
+tttg: c167/219 lr:0.000134 t:20.3s
+tttg: c168/219 lr:0.000129 t:20.4s
+tttg: c169/219 lr:0.000124 t:20.5s
+tttg: c170/219 lr:0.000120 t:20.7s
+tttg: c171/219 lr:0.000115 t:20.8s
+tttg: c172/219 lr:0.000110 t:20.9s
+tttg: c173/219 lr:0.000106 t:21.1s
+tttg: c174/219 lr:0.000102 t:21.2s
+tttg: c175/219 lr:0.000097 t:21.4s
+tttg: c176/219 lr:0.000093 t:21.5s
+tttg: c177/219 lr:0.000089 t:21.6s
+tttg: c178/219 lr:0.000085 t:21.8s
+tttg: c179/219 lr:0.000081 t:21.9s
+tttg: c180/219 lr:0.000077 t:22.0s
+tttg: c181/219 lr:0.000073 t:22.2s
+tttg: c182/219 lr:0.000069 t:22.3s
+tttg: c183/219 lr:0.000066 t:22.4s
+tttg: c184/219 lr:0.000062 t:22.6s
+tttg: c185/219 lr:0.000059 t:22.7s
+tttg: c186/219 lr:0.000055 t:22.9s
+tttg: c187/219 lr:0.000052 t:23.0s
+tttg: c188/219 lr:0.000049 t:23.1s
+tttg: c189/219 lr:0.000046 t:23.3s
+tttg: c190/219 lr:0.000043 t:23.4s
+tttg: c191/219 lr:0.000040 t:23.5s
+tttg: c192/219 lr:0.000037 t:23.7s
+tttg: c193/219 lr:0.000035 t:23.8s
+tttg: c194/219 lr:0.000032 t:23.9s
+tttg: c195/219 lr:0.000030 t:24.1s
+tttg: c196/219 lr:0.000027 t:24.2s
+tttg: c197/219 lr:0.000025 t:24.3s
+tttg: c198/219 lr:0.000023 t:24.5s
+tttg: c199/219 lr:0.000021 t:24.6s
+tttg: c200/219 lr:0.000019 t:24.8s
+tttg: c201/219 lr:0.000017 t:24.9s
+tttg: c202/219 lr:0.000015 t:25.0s
+tttg: c203/219 lr:0.000013 t:25.2s
+tttg: c204/219 lr:0.000012 t:25.3s
+tttg: c205/219 lr:0.000010 t:25.4s
+tttg: c206/219 lr:0.000009 t:25.6s
+tttg: c207/219 lr:0.000007 t:25.7s
+tttg: c208/219 lr:0.000006 t:25.8s
+tttg: c209/219 lr:0.000005 t:26.0s
+tttg: c210/219 lr:0.000004 t:26.1s
+tttg: c211/219 lr:0.000003 t:26.2s
+tttg: c212/219 lr:0.000003 t:26.4s
+tttg: c213/219 lr:0.000002 t:26.5s
+tttg: c214/219 lr:0.000001 t:26.7s
+tttg: c215/219 lr:0.000001 t:26.8s
+tttg: c216/219 lr:0.000000 t:26.9s
+tttg: c217/219 lr:0.000000 t:27.1s
+tttg: c218/219 lr:0.000000 t:27.2s
+ttpr: phase:2/3 t:433.9s
+ttp: b741/782 bl:2.3220 bb:1.0413 rl:2.3034 rb:1.0696 dl:2686-2730 gd:0
+ttp: b740/782 bl:2.2649 bb:1.0397 rl:2.2998 rb:1.0667 dl:2653-2686 gd:0
+ttpp: phase:3/3 pd:2960 gd:2500 t:448.9s
+tttg: c1/289 lr:0.001000 t:0.1s
+tttg: c2/289 lr:0.001000 t:0.3s
+tttg: c3/289 lr:0.001000 t:0.4s
+tttg: c4/289 lr:0.001000 t:0.5s
+tttg: c5/289 lr:0.001000 t:0.7s
+tttg: c6/289 lr:0.000999 t:0.8s
+tttg: c7/289 lr:0.000999 t:1.0s
+tttg: c8/289 lr:0.000999 t:1.1s
+tttg: c9/289 lr:0.000998 t:1.2s
+tttg: c10/289 lr:0.000998 t:1.4s
+tttg: c11/289 lr:0.000997 t:1.5s
+tttg: c12/289 lr:0.000996 t:1.7s
+tttg: c13/289 lr:0.000996 t:1.8s
+tttg: c14/289 lr:0.000995 t:1.9s
+tttg: c15/289 lr:0.000994 t:2.1s
+tttg: c16/289 lr:0.000993 t:2.2s
+tttg: c17/289 lr:0.000992 t:2.3s
+tttg: c18/289 lr:0.000991 t:2.5s
+tttg: c19/289 lr:0.000990 t:2.6s
+tttg: c20/289 lr:0.000989 t:2.7s
+tttg: c21/289 lr:0.000988 t:2.9s
+tttg: c22/289 lr:0.000987 t:3.0s
+tttg: c23/289 lr:0.000986 t:3.1s
+tttg: c24/289 lr:0.000984 t:3.3s
+tttg: c25/289 lr:0.000983 t:3.4s
+tttg: c26/289 lr:0.000982 t:3.5s
+tttg: c27/289 lr:0.000980 t:3.7s
+tttg: c28/289 lr:0.000978 t:3.8s
+tttg: c29/289 lr:0.000977 t:4.0s
+tttg: c30/289 lr:0.000975 t:4.1s
+tttg: c31/289 lr:0.000973 t:4.2s
+tttg: c32/289 lr:0.000972 t:4.4s
+tttg: c33/289 lr:0.000970 t:4.5s
+tttg: c34/289 lr:0.000968 t:4.6s
+tttg: c35/289 lr:0.000966 t:4.8s
+tttg: c36/289 lr:0.000964 t:4.9s
+tttg: c37/289 lr:0.000962 t:5.0s
+tttg: c38/289 lr:0.000960 t:5.2s
+tttg: c39/289 lr:0.000958 t:5.3s
+tttg: c40/289 lr:0.000955 t:5.4s
+tttg: c41/289 lr:0.000953 t:5.6s
+tttg: c42/289 lr:0.000951 t:5.7s
+tttg: c43/289 lr:0.000948 t:5.8s
+tttg: c44/289 lr:0.000946 t:6.0s
+tttg: c45/289 lr:0.000944 t:6.1s
+tttg: c46/289 lr:0.000941 t:6.3s
+tttg: c47/289 lr:0.000938 t:6.4s
+tttg: c48/289 lr:0.000936 t:6.5s
+tttg: c49/289 lr:0.000933 t:6.7s
+tttg: c50/289 lr:0.000930 t:6.8s
+tttg: c51/289 lr:0.000927 t:6.9s
+tttg: c52/289 lr:0.000925 t:7.1s
+tttg: c53/289 lr:0.000922 t:7.2s
+tttg: c54/289 lr:0.000919 t:7.3s
+tttg: c55/289 lr:0.000916 t:7.5s
+tttg: c56/289 lr:0.000913 t:7.6s
+tttg: c57/289 lr:0.000910 t:7.7s
+tttg: c58/289 lr:0.000906 t:7.9s
+tttg: c59/289 lr:0.000903 t:8.0s
+tttg: c60/289 lr:0.000900 t:8.1s
+tttg: c61/289 lr:0.000897 t:8.3s
+tttg: c62/289 lr:0.000893 t:8.4s
+tttg: c63/289 lr:0.000890 t:8.6s
+tttg: c64/289 lr:0.000887 t:8.7s
+tttg: c65/289 lr:0.000883 t:8.8s
+tttg: c66/289 lr:0.000879 t:9.0s
+tttg: c67/289 lr:0.000876 t:9.1s
+tttg: c68/289 lr:0.000872 t:9.2s
+tttg: c69/289 lr:0.000869 t:9.4s
+tttg: c70/289 lr:0.000865 t:9.5s
+tttg: c71/289 lr:0.000861 t:9.6s
+tttg: c72/289 lr:0.000857 t:9.8s
+tttg: c73/289 lr:0.000854 t:9.9s
+tttg: c74/289 lr:0.000850 t:10.1s
+tttg: c75/289 lr:0.000846 t:10.2s
+tttg: c76/289 lr:0.000842 t:10.3s
+tttg: c77/289 lr:0.000838 t:10.5s
+tttg: c78/289 lr:0.000834 t:10.6s
+tttg: c79/289 lr:0.000830 t:10.7s
+tttg: c80/289 lr:0.000826 t:10.9s
+tttg: c81/289 lr:0.000821 t:11.0s
+tttg: c82/289 lr:0.000817 t:11.1s
+tttg: c83/289 lr:0.000813 t:11.3s
+tttg: c84/289 lr:0.000809 t:11.4s
+tttg: c85/289 lr:0.000804 t:11.5s
+tttg: c86/289 lr:0.000800 t:11.7s
+tttg: c87/289 lr:0.000796 t:11.8s
+tttg: c88/289 lr:0.000791 t:11.9s
+tttg: c89/289 lr:0.000787 t:12.1s
+tttg: c90/289 lr:0.000782 t:12.2s
+tttg: c91/289 lr:0.000778 t:12.4s
+tttg: c92/289 lr:0.000773 t:12.5s
+tttg: c93/289 lr:0.000769 t:12.6s
+tttg: c94/289 lr:0.000764 t:12.8s
+tttg: c95/289 lr:0.000759 t:12.9s
+tttg: c96/289 lr:0.000755 t:13.0s
+tttg: c97/289 lr:0.000750 t:13.2s
+tttg: c98/289 lr:0.000745 t:13.3s
+tttg: c99/289 lr:0.000740 t:13.4s
+tttg: c100/289 lr:0.000736 t:13.6s
+tttg: c101/289 lr:0.000731 t:13.7s
+tttg: c102/289 lr:0.000726 t:13.8s
+tttg: c103/289 lr:0.000721 t:14.0s
+tttg: c104/289 lr:0.000716 t:14.1s
+tttg: c105/289 lr:0.000711 t:14.3s
+tttg: c106/289 lr:0.000706 t:14.4s
+tttg: c107/289 lr:0.000701 t:14.5s
+tttg: c108/289 lr:0.000696 t:14.7s
+tttg: c109/289 lr:0.000691 t:14.8s
+tttg: c110/289 lr:0.000686 t:14.9s
+tttg: c111/289 lr:0.000681 t:15.1s
+tttg: c112/289 lr:0.000676 t:15.2s
+tttg: c113/289 lr:0.000671 t:15.3s
+tttg: c114/289 lr:0.000666 t:15.5s
+tttg: c115/289 lr:0.000661 t:15.6s
+tttg: c116/289 lr:0.000656 t:15.7s
+tttg: c117/289 lr:0.000650 t:15.9s
+tttg: c118/289 lr:0.000645 t:16.0s
+tttg: c119/289 lr:0.000640 t:16.1s
+tttg: c120/289 lr:0.000635 t:16.3s
+tttg: c121/289 lr:0.000629 t:16.4s
+tttg: c122/289 lr:0.000624 t:16.6s
+tttg: c123/289 lr:0.000619 t:16.7s
+tttg: c124/289 lr:0.000614 t:16.8s
+tttg: c125/289 lr:0.000608 t:17.0s
+tttg: c126/289 lr:0.000603 t:17.1s
+tttg: c127/289 lr:0.000598 t:17.2s
+tttg: c128/289 lr:0.000592 t:17.4s
+tttg: c129/289 lr:0.000587 t:17.5s
+tttg: c130/289 lr:0.000581 t:17.6s
+tttg: c131/289 lr:0.000576 t:17.8s
+tttg: c132/289 lr:0.000571 t:17.9s
+tttg: c133/289 lr:0.000565 t:18.1s
+tttg: c134/289 lr:0.000560 t:18.2s
+tttg: c135/289 lr:0.000554 t:18.3s
+tttg: c136/289 lr:0.000549 t:18.5s
+tttg: c137/289 lr:0.000544 t:18.6s
+tttg: c138/289 lr:0.000538 t:18.7s
+tttg: c139/289 lr:0.000533 t:18.9s
+tttg: c140/289 lr:0.000527 t:19.0s
+tttg: c141/289 lr:0.000522 t:19.1s
+tttg: c142/289 lr:0.000516 t:19.3s
+tttg: c143/289 lr:0.000511 t:19.4s
+tttg: c144/289 lr:0.000505 t:19.5s
+tttg: c145/289 lr:0.000500 t:19.7s
+tttg: c146/289 lr:0.000495 t:19.8s
+tttg: c147/289 lr:0.000489 t:20.0s
+tttg: c148/289 lr:0.000484 t:20.1s
+tttg: c149/289 lr:0.000478 t:20.2s
+tttg: c150/289 lr:0.000473 t:20.4s
+tttg: c151/289 lr:0.000467 t:20.5s
+tttg: c152/289 lr:0.000462 t:20.6s
+tttg: c153/289 lr:0.000456 t:20.8s
+tttg: c154/289 lr:0.000451 t:20.9s
+tttg: c155/289 lr:0.000446 t:21.0s
+tttg: c156/289 lr:0.000440 t:21.2s
+tttg: c157/289 lr:0.000435 t:21.3s
+tttg: c158/289 lr:0.000429 t:21.5s
+tttg: c159/289 lr:0.000424 t:21.6s
+tttg: c160/289 lr:0.000419 t:21.7s
+tttg: c161/289 lr:0.000413 t:21.9s
+tttg: c162/289 lr:0.000408 t:22.0s
+tttg: c163/289 lr:0.000402 t:22.1s
+tttg: c164/289 lr:0.000397 t:22.3s
+tttg: c165/289 lr:0.000392 t:22.4s
+tttg: c166/289 lr:0.000386 t:22.5s
+tttg: c167/289 lr:0.000381 t:22.7s
+tttg: c168/289 lr:0.000376 t:22.8s
+tttg: c169/289 lr:0.000371 t:22.9s
+tttg: c170/289 lr:0.000365 t:23.1s
+tttg: c171/289 lr:0.000360 t:23.2s
+tttg: c172/289 lr:0.000355 t:23.4s
+tttg: c173/289 lr:0.000350 t:23.5s
+tttg: c174/289 lr:0.000344 t:23.6s
+tttg: c175/289 lr:0.000339 t:23.8s
+tttg: c176/289 lr:0.000334 t:23.9s
+tttg: c177/289 lr:0.000329 t:24.0s
+tttg: c178/289 lr:0.000324 t:24.2s
+tttg: c179/289 lr:0.000319 t:24.3s
+tttg: c180/289 lr:0.000314 t:24.4s
+tttg: c181/289 lr:0.000309 t:24.6s
+tttg: c182/289 lr:0.000304 t:24.7s
+tttg: c183/289 lr:0.000299 t:24.9s
+tttg: c184/289 lr:0.000294 t:25.0s
+tttg: c185/289 lr:0.000289 t:25.1s
+tttg: c186/289 lr:0.000284 t:25.3s
+tttg: c187/289 lr:0.000279 t:25.4s
+tttg: c188/289 lr:0.000274 t:25.5s
+tttg: c189/289 lr:0.000269 t:25.7s
+tttg: c190/289 lr:0.000264 t:25.8s
+tttg: c191/289 lr:0.000260 t:25.9s
+tttg: c192/289 lr:0.000255 t:26.1s
+tttg: c193/289 lr:0.000250 t:26.2s
+tttg: c194/289 lr:0.000245 t:26.4s
+tttg: c195/289 lr:0.000241 t:26.5s
+tttg: c196/289 lr:0.000236 t:26.6s
+tttg: c197/289 lr:0.000231 t:26.8s
+tttg: c198/289 lr:0.000227 t:26.9s
+tttg: c199/289 lr:0.000222 t:27.0s
+tttg: c200/289 lr:0.000218 t:27.2s
+tttg: c201/289 lr:0.000213 t:27.3s
+tttg: c202/289 lr:0.000209 t:27.4s
+tttg: c203/289 lr:0.000204 t:27.6s
+tttg: c204/289 lr:0.000200 t:27.7s
+tttg: c205/289 lr:0.000196 t:27.8s
+tttg: c206/289 lr:0.000191 t:28.0s
+tttg: c207/289 lr:0.000187 t:28.1s
+tttg: c208/289 lr:0.000183 t:28.3s
+tttg: c209/289 lr:0.000179 t:28.4s
+tttg: c210/289 lr:0.000174 t:28.5s
+tttg: c211/289 lr:0.000170 t:28.7s
+tttg: c212/289 lr:0.000166 t:28.8s
+tttg: c213/289 lr:0.000162 t:28.9s
+tttg: c214/289 lr:0.000158 t:29.1s
+tttg: c215/289 lr:0.000154 t:29.2s
+tttg: c216/289 lr:0.000150 t:29.3s
+tttg: c217/289 lr:0.000146 t:29.5s
+tttg: c218/289 lr:0.000143 t:29.6s
+tttg: c219/289 lr:0.000139 t:29.7s
+tttg: c220/289 lr:0.000135 t:29.9s
+tttg: c221/289 lr:0.000131 t:30.0s
+tttg: c222/289 lr:0.000128 t:30.2s
+tttg: c223/289 lr:0.000124 t:30.3s
+tttg: c224/289 lr:0.000121 t:30.4s
+tttg: c225/289 lr:0.000117 t:30.6s
+tttg: c226/289 lr:0.000113 t:30.7s
+tttg: c227/289 lr:0.000110 t:30.8s
+tttg: c228/289 lr:0.000107 t:31.0s
+tttg: c229/289 lr:0.000103 t:31.1s
+tttg: c230/289 lr:0.000100 t:31.2s
+tttg: c231/289 lr:0.000097 t:31.4s
+tttg: c232/289 lr:0.000094 t:31.5s
+tttg: c233/289 lr:0.000090 t:31.7s
+tttg: c234/289 lr:0.000087 t:31.8s
+tttg: c235/289 lr:0.000084 t:31.9s
+tttg: c236/289 lr:0.000081 t:32.1s
+tttg: c237/289 lr:0.000078 t:32.2s
+tttg: c238/289 lr:0.000075 t:32.3s
+tttg: c239/289 lr:0.000073 t:32.5s
+tttg: c240/289 lr:0.000070 t:32.6s
+tttg: c241/289 lr:0.000067 t:32.7s
+tttg: c242/289 lr:0.000064 t:32.9s
+tttg: c243/289 lr:0.000062 t:33.0s
+tttg: c244/289 lr:0.000059 t:33.2s
+tttg: c245/289 lr:0.000056 t:33.3s
+tttg: c246/289 lr:0.000054 t:33.4s
+tttg: c247/289 lr:0.000052 t:33.6s
+tttg: c248/289 lr:0.000049 t:33.7s
+tttg: c249/289 lr:0.000047 t:33.8s
+tttg: c250/289 lr:0.000045 t:34.0s
+tttg: c251/289 lr:0.000042 t:34.1s
+tttg: c252/289 lr:0.000040 t:34.3s
+tttg: c253/289 lr:0.000038 t:34.4s
+tttg: c254/289 lr:0.000036 t:34.5s
+tttg: c255/289 lr:0.000034 t:34.7s
+tttg: c256/289 lr:0.000032 t:34.8s
+tttg: c257/289 lr:0.000030 t:34.9s
+tttg: c258/289 lr:0.000028 t:35.1s
+tttg: c259/289 lr:0.000027 t:35.2s
+tttg: c260/289 lr:0.000025 t:35.3s
+tttg: c261/289 lr:0.000023 t:35.5s
+tttg: c262/289 lr:0.000022 t:35.6s
+tttg: c263/289 lr:0.000020 t:35.7s
+tttg: c264/289 lr:0.000018 t:35.9s
+tttg: c265/289 lr:0.000017 t:36.0s
+tttg: c266/289 lr:0.000016 t:36.2s
+tttg: c267/289 lr:0.000014 t:36.3s
+tttg: c268/289 lr:0.000013 t:36.4s
+tttg: c269/289 lr:0.000012 t:36.6s
+tttg: c270/289 lr:0.000011 t:36.7s
+tttg: c271/289 lr:0.000010 t:36.8s
+tttg: c272/289 lr:0.000009 t:37.0s
+tttg: c273/289 lr:0.000008 t:37.1s
+tttg: c274/289 lr:0.000007 t:37.2s
+tttg: c275/289 lr:0.000006 t:37.4s
+tttg: c276/289 lr:0.000005 t:37.5s
+tttg: c277/289 lr:0.000004 t:37.7s
+tttg: c278/289 lr:0.000004 t:37.8s
+tttg: c279/289 lr:0.000003 t:37.9s
+tttg: c280/289 lr:0.000002 t:38.1s
+tttg: c281/289 lr:0.000002 t:38.2s
+tttg: c282/289 lr:0.000001 t:38.3s
+tttg: c283/289 lr:0.000001 t:38.5s
+tttg: c284/289 lr:0.000001 t:38.6s
+tttg: c285/289 lr:0.000000 t:38.8s
+tttg: c286/289 lr:0.000000 t:38.9s
+tttg: c287/289 lr:0.000000 t:39.0s
+tttg: c288/289 lr:0.000000 t:39.2s
+ttpr: phase:3/3 t:489.8s
+ttp: b728/782 bl:2.3657 bb:1.0831 rl:2.3048 rb:1.0679 dl:2306-2324 gd:1
+ttp: b725/782 bl:2.3239 bb:1.0454 rl:2.3061 rb:1.0663 dl:2232-2254 gd:1
+ttp: b715/782 bl:2.3622 bb:1.0298 rl:2.3094 rb:1.0641 dl:2036-2053 gd:1
+ttp: b705/782 bl:2.3665 bb:1.0637 rl:2.3124 rb:1.0640 dl:1885-1898 gd:1
+ttp: b698/782 bl:2.2531 bb:1.0313 rl:2.3096 rb:1.0625 dl:1803-1814 gd:1
+ttp: b690/782 bl:2.2980 bb:1.0668 rl:2.3091 rb:1.0627 dl:1715-1725 gd:1
+ttp: b682/782 bl:2.3470 bb:1.0591 rl:2.3106 rb:1.0625 dl:1638-1646 gd:1
+ttp: b673/782 bl:2.3655 bb:1.0619 rl:2.3126 rb:1.0625 dl:1562-1571 gd:1
+ttp: b664/782 bl:2.3450 bb:1.0291 rl:2.3137 rb:1.0613 dl:1493-1499 gd:1
+ttp: b656/782 bl:2.3347 bb:1.1138 rl:2.3143 rb:1.0629 dl:1439-1445 gd:1
+ttp: b648/782 bl:2.2863 bb:1.0089 rl:2.3135 rb:1.0613 dl:1387-1392 gd:1
+ttp: b640/782 bl:2.3068 bb:1.0508 rl:2.3133 rb:1.0610 dl:1337-1343 gd:1
+ttp: b634/782 bl:2.3856 bb:1.0502 rl:2.3152 rb:1.0607 dl:1302-1308 gd:1
+ttp: b624/782 bl:2.3594 bb:1.0680 rl:2.3163 rb:1.0609 dl:1249-1255 gd:1
+ttp: b616/782 bl:2.4052 bb:1.0433 rl:2.3183 rb:1.0605 dl:1205-1211 gd:1
+ttp: b608/782 bl:2.3522 bb:1.0807 rl:2.3191 rb:1.0609 dl:1168-1172 gd:1
+ttp: b600/782 bl:2.2643 bb:1.0146 rl:2.3179 rb:1.0599 dl:1133-1137 gd:1
+ttp: b592/782 bl:2.2250 bb:0.9934 rl:2.3161 rb:1.0586 dl:1098-1103 gd:1
+ttp: b584/782 bl:2.2979 bb:1.0389 rl:2.3158 rb:1.0582 dl:1064-1069 gd:1
+ttp: b576/782 bl:2.3797 bb:1.0946 rl:2.3169 rb:1.0589 dl:1033-1037 gd:1
+ttp: b568/782 bl:2.3608 bb:1.0838 rl:2.3176 rb:1.0593 dl:1004-1007 gd:1
+ttp: b560/782 bl:2.2693 bb:1.0098 rl:2.3169 rb:1.0585 dl:975-979 gd:1
+ttp: b552/782 bl:2.2780 bb:1.0205 rl:2.3163 rb:1.0578 dl:949-952 gd:1
+ttp: b543/782 bl:2.3381 bb:1.0585 rl:2.3166 rb:1.0579 dl:921-924 gd:1
+ttp: b535/782 bl:2.3788 bb:1.0317 rl:2.3175 rb:1.0575 dl:896-899 gd:1
+ttp: b526/782 bl:2.3270 bb:1.0256 rl:2.3176 rb:1.0570 dl:869-872 gd:1
+ttp: b518/782 bl:2.2436 bb:1.0099 rl:2.3166 rb:1.0564 dl:846-850 gd:1
+ttp: b510/782 bl:2.3871 bb:1.0754 rl:2.3175 rb:1.0566 dl:823-826 gd:1
+ttp: b502/782 bl:2.3216 bb:1.0288 rl:2.3176 rb:1.0563 dl:802-804 gd:1
+ttp: b494/782 bl:2.3229 bb:1.0588 rl:2.3176 rb:1.0563 dl:780-783 gd:1
+ttp: b486/782 bl:2.4089 bb:1.0823 rl:2.3186 rb:1.0566 dl:761-764 gd:1
+ttp: b477/782 bl:2.4047 bb:1.0356 rl:2.3196 rb:1.0564 dl:740-742 gd:1
+ttp: b468/782 bl:2.3633 bb:1.0637 rl:2.3200 rb:1.0564 dl:719-721 gd:1
+ttp: b460/782 bl:2.2572 bb:1.0559 rl:2.3194 rb:1.0564 dl:701-703 gd:1
+ttp: b452/782 bl:2.2712 bb:1.0165 rl:2.3189 rb:1.0561 dl:685-687 gd:1
+ttp: b444/782 bl:2.3125 bb:1.0654 rl:2.3189 rb:1.0561 dl:668-670 gd:1
+ttp: b436/782 bl:2.2744 bb:1.0506 rl:2.3185 rb:1.0561 dl:651-653 gd:1
+ttp: b427/782 bl:2.2561 bb:1.0621 rl:2.3179 rb:1.0561 dl:634-636 gd:1
+ttp: b417/782 bl:2.2638 bb:1.0458 rl:2.3175 rb:1.0561 dl:615-617 gd:1
+ttp: b406/782 bl:2.3155 bb:1.0663 rl:2.3175 rb:1.0561 dl:593-595 gd:1
+ttp: b398/782 bl:2.2479 bb:1.0038 rl:2.3169 rb:1.0557 dl:579-581 gd:1
+ttp: b389/782 bl:2.2907 bb:1.0849 rl:2.3167 rb:1.0559 dl:563-564 gd:1
+ttp: b381/782 bl:2.4256 bb:1.1026 rl:2.3175 rb:1.0563 dl:549-550 gd:1
+ttp: b372/782 bl:2.3378 bb:1.0500 rl:2.3177 rb:1.0562 dl:533-535 gd:1
+ttp: b363/782 bl:2.3839 bb:1.0670 rl:2.3181 rb:1.0563 dl:518-521 gd:1
+ttp: b355/782 bl:2.3076 bb:1.0708 rl:2.3180 rb:1.0564 dl:504-506 gd:1
+ttp: b347/782 bl:2.3389 bb:1.1116 rl:2.3182 rb:1.0567 dl:492-494 gd:1
+ttp: b339/782 bl:2.3397 bb:1.0803 rl:2.3183 rb:1.0569 dl:480-482 gd:1
+ttp: b329/782 bl:2.2836 bb:1.0820 rl:2.3181 rb:1.0570 dl:465-466 gd:1
+ttp: b321/782 bl:2.3606 bb:1.0776 rl:2.3183 rb:1.0571 dl:453-455 gd:1
+ttp: b312/782 bl:2.3160 bb:1.0549 rl:2.3183 rb:1.0571 dl:439-440 gd:1
+ttp: b303/782 bl:2.3971 bb:1.0934 rl:2.3187 rb:1.0573 dl:426-427 gd:1
+ttp: b294/782 bl:2.3182 bb:1.0829 rl:2.3187 rb:1.0574 dl:412-414 gd:1
+ttp: b286/782 bl:2.3835 bb:1.1118 rl:2.3191 rb:1.0577 dl:400-402 gd:1
+ttp: b279/782 bl:2.3238 bb:1.0980 rl:2.3191 rb:1.0579 dl:391-392 gd:1
+ttp: b272/782 bl:2.3676 bb:1.0936 rl:2.3193 rb:1.0581 dl:382-383 gd:1
+ttp: b264/782 bl:2.4212 bb:1.1033 rl:2.3198 rb:1.0583 dl:371-372 gd:1
+ttp: b256/782 bl:2.5420 bb:1.1221 rl:2.3208 rb:1.0586 dl:361-362 gd:1
+ttp: b249/782 bl:2.4505 bb:1.1038 rl:2.3213 rb:1.0588 dl:352-354 gd:1
+ttp: b242/782 bl:2.3823 bb:1.1028 rl:2.3216 rb:1.0589 dl:344-345 gd:1
+ttp: b234/782 bl:2.4203 bb:1.1469 rl:2.3220 rb:1.0593 dl:334-335 gd:1
+ttp: b224/782 bl:2.3859 bb:1.0933 rl:2.3222 rb:1.0594 dl:322-323 gd:1
+ttp: b216/782 bl:2.4712 bb:1.1460 rl:2.3228 rb:1.0597 dl:313-314 gd:1
+ttp: b209/782 bl:2.4167 bb:1.1304 rl:2.3231 rb:1.0600 dl:305-306 gd:1
+ttp: b201/782 bl:2.2910 bb:1.0929 rl:2.3230 rb:1.0601 dl:297-298 gd:1
+ttp: b190/782 bl:2.3520 bb:1.0814 rl:2.3231 rb:1.0602 dl:284-285 gd:1
+ttp: b182/782 bl:2.3520 bb:1.1182 rl:2.3232 rb:1.0603 dl:276-277 gd:1
+ttp: b174/782 bl:2.4500 bb:1.1555 rl:2.3236 rb:1.0606 dl:268-269 gd:1
+ttp: b166/782 bl:2.4857 bb:1.1111 rl:2.3241 rb:1.0608 dl:260-262 gd:1
+ttp: b156/782 bl:2.3198 bb:1.1583 rl:2.3241 rb:1.0610 dl:251-252 gd:1
+ttp: b147/782 bl:2.4643 bb:1.1208 rl:2.3245 rb:1.0612 dl:242-243 gd:1
+ttp: b138/782 bl:2.3881 bb:1.1111 rl:2.3246 rb:1.0613 dl:233-234 gd:1
+ttp: b128/782 bl:2.3912 bb:1.1557 rl:2.3248 rb:1.0616 dl:224-225 gd:1
+ttp: b118/782 bl:2.4666 bb:1.1259 rl:2.3251 rb:1.0617 dl:215-216 gd:1
+ttp: b110/782 bl:2.3778 bb:1.1285 rl:2.3253 rb:1.0619 dl:208-208 gd:1
+ttp: b100/782 bl:2.4217 bb:1.1586 rl:2.3255 rb:1.0621 dl:199-200 gd:1
+ttp: b91/782 bl:2.4604 bb:1.1532 rl:2.3258 rb:1.0623 dl:190-191 gd:1
+ttp: b81/782 bl:2.4814 bb:1.1261 rl:2.3261 rb:1.0624 dl:182-183 gd:1
+ttp: b73/782 bl:2.5395 bb:1.2465 rl:2.3265 rb:1.0628 dl:174-175 gd:1
+ttp: b64/782 bl:2.5241 bb:1.1512 rl:2.3269 rb:1.0629 dl:166-167 gd:1
+ttp: b56/782 bl:2.5446 bb:1.2197 rl:2.3273 rb:1.0632 dl:159-160 gd:1
+ttp: b47/782 bl:2.4469 bb:1.1423 rl:2.3275 rb:1.0633 dl:150-151 gd:1
+ttp: b38/782 bl:2.6033 bb:1.1940 rl:2.3279 rb:1.0635 dl:141-142 gd:1
+ttp: b28/782 bl:2.6186 bb:1.2145 rl:2.3284 rb:1.0638 dl:131-132 gd:1
+ttp: b18/782 bl:2.6413 bb:1.2044 rl:2.3288 rb:1.0639 dl:119-121 gd:1
+ttp: b9/782 bl:2.7643 bb:1.2613 rl:2.3293 rb:1.0642 dl:105-107 gd:1
+quantized_ttt_phased val_loss:2.32435698 val_bpb:1.06214044 eval_time:592904ms
+total_eval_time:592.9s

--- a/records/track_10min_16mb/2026-04-30_AdaptiveHessianClip_PR1855_1.0631/train_seed999.log
+++ b/records/track_10min_16mb/2026-04-30_AdaptiveHessianClip_PR1855_1.0631/train_seed999.log
@@ -1,0 +1,1005 @@
+W0430 04:37:43.554000 280873 torch/distributed/run.py:803] 
+W0430 04:37:43.554000 280873 torch/distributed/run.py:803] *****************************************
+W0430 04:37:43.554000 280873 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0430 04:37:43.554000 280873 torch/distributed/run.py:803] *****************************************
+Hyperparameters:
+  adam_eps: 1e-08
+  adam_wd: 0.02
+  adaptive_hessian_clip: True
+  artifact_dir: 
+  attn_clip_sigmas: 13.0
+  attn_out_gate_enabled: False
+  attn_out_gate_src: proj
+  beta1: 0.9
+  beta2: 0.99
+  caseops_enabled: True
+  compressor: pergroup
+  data_dir: ./data/
+  datasets_dir: /workspace/parameter-golf/data/datasets/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved
+  distributed: True
+  ema_decay: 0.9965
+  embed_bits: 7
+  embed_clip_sigmas: 14.0
+  embed_lr: 0.6
+  embed_wd: 0.085
+  enable_looping_at: 0.35
+  eval_seq_len: 2048
+  eval_stride: 64
+  fused_ce_enabled: True
+  gate_window: 12
+  gated_attn_enabled: False
+  gated_attn_init_std: 0.01
+  gated_attn_quant_gate: False
+  global_ttt_batch_seqs: 32
+  global_ttt_chunk_tokens: 32768
+  global_ttt_epochs: 1
+  global_ttt_grad_clip: 1.0
+  global_ttt_lr: 0.001
+  global_ttt_momentum: 0.9
+  global_ttt_respect_doc_boundaries: True
+  global_ttt_warmup_chunks: 0
+  global_ttt_warmup_start_lr: 0.0
+  gptq_calibration_batches: 16
+  gptq_reserve_seconds: 4.0
+  grad_accum_steps: 1
+  grad_clip_norm: 0.3
+  is_main_process: True
+  iterations: 20000
+  ln_scale: True
+  local_rank: 0
+  logfile: logs/65930498-0d77-4ebf-8641-d19a7fcf8f7d.txt
+  logit_softcap: 30.0
+  loop_end: 5
+  loop_start: 3
+  lqer_asym_enabled: True
+  lqer_asym_group: 64
+  lqer_enabled: True
+  lqer_factor_bits: 4
+  lqer_rank: 4
+  lqer_top_k: 3
+  matrix_bits: 6
+  matrix_clip_sigmas: 12.85
+  matrix_lr: 0.026
+  max_wallclock_seconds: 600.0
+  min_lr: 0.1
+  mixed_precision_bits_high: 7
+  mixed_precision_bits_low: 5
+  mixed_precision_hessian: False
+  mixed_precision_high_frac: 0.25
+  mixed_precision_low_frac: 0.25
+  mlp_clip_sigmas: 11.5
+  mlp_mult: 4.0
+  model_dim: 512
+  model_path: final_model.pt
+  muon_backend_steps: 5
+  muon_momentum: 0.97
+  muon_momentum_warmup_start: 0.92
+  muon_momentum_warmup_steps: 1500
+  muon_row_normalize: True
+  muon_wd: 0.095
+  num_heads: 8
+  num_kv_heads: 4
+  num_layers: 11
+  num_loops: 2
+  parallel_final_lane: mean
+  parallel_start_layer: 8
+  phased_ttt_num_phases: 3
+  phased_ttt_prefix_docs: 2500
+  qk_gain_init: 5.0
+  quantized_model_path: final_model.int6.ptz
+  rank: 0
+  rope_base: 10000.0
+  rope_dims: 16
+  rope_train_seq_len: 2048
+  rope_yarn: False
+  run_id: 65930498-0d77-4ebf-8641-d19a7fcf8f7d
+  scalar_lr: 0.02
+  seed: 999
+  skip_gates_enabled: True
+  smear_gate_enabled: True
+  sparse_attn_gate_enabled: True
+  sparse_attn_gate_init_std: 0.0
+  sparse_attn_gate_scale: 0.5
+  tie_embeddings: True
+  tied_embed_init_std: 0.005
+  tied_embed_lr: 0.03
+  tokenizer_path: /workspace/parameter-golf/data/datasets/datasets/tokenizers/fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model
+  train_batch_tokens: 786432
+  train_files: /workspace/parameter-golf/data/datasets/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_train_*.bin
+  train_log_every: 500
+  train_seq_len: 2048
+  ttt_batch_size: 64
+  ttt_beta1: 0.0
+  ttt_beta2: 0.99
+  ttt_chunk_size: 48
+  ttt_enabled: True
+  ttt_eval_batches: 
+  ttt_eval_seq_len: 2048
+  ttt_grad_steps: 1
+  ttt_k_lora: True
+  ttt_lora_lr: 0.0001
+  ttt_lora_rank: 56
+  ttt_mlp_lora: True
+  ttt_o_lora: True
+  ttt_optimizer: adam
+  ttt_weight_decay: 0.5
+  val_batch_tokens: 524288
+  val_bytes_files: /workspace/parameter-golf/data/datasets/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_val_bytes_*.bin
+  val_doc_fraction: 1.0
+  val_files: /workspace/parameter-golf/data/datasets/datasets/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved/fineweb_val_*.bin
+  val_loss_every: 4000
+  vocab_size: 8192
+  warmdown_frac: 0.85
+  warmup_steps: 20
+  world_size: 8
+  xsa_last_n: 11
+train_shards: 80
+val_tokens: 47851520
+model_params:35945671
+gptq:reserving 4s, effective=596000ms
+warmup_cu_buckets:64,128,192,256 iters_each:3
+warmup_step: 1/20
+warmup_step: 2/20
+warmup_step: 3/20
+warmup_step: 4/20
+warmup_step: 5/20
+warmup_step: 6/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup:enabled encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+loop_warmup_step: 1/20
+loop_warmup_step: 2/20
+loop_warmup_step: 3/20
+loop_warmup_step: 4/20
+loop_warmup_step: 5/20
+loop_warmup_step: 6/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+0/20000 val_loss: 9.0149 val_bpb: 4.1192
+1/20000 train_loss: 9.0152 train_time: 0.0m tok/s: 17476299
+2/20000 train_loss: 12.8881 train_time: 0.0m tok/s: 11030855
+3/20000 train_loss: 10.2094 train_time: 0.0m tok/s: 9692480
+4/20000 train_loss: 8.6681 train_time: 0.0m tok/s: 9191367
+5/20000 train_loss: 7.9130 train_time: 0.0m tok/s: 8896068
+500/20000 train_loss: 2.5702 train_time: 0.8m tok/s: 8100825
+1000/20000 train_loss: 2.8012 train_time: 1.6m tok/s: 8042976
+1500/20000 train_loss: 2.6192 train_time: 2.5m tok/s: 8024449
+2000/20000 train_loss: 2.6527 train_time: 3.3m tok/s: 8013387
+layer_loop:enabled step:2125 frac:0.350 encoder:[0, 1, 2, 3, 4, 5, 3, 4] decoder:[5, 3, 4, 5, 6, 7, 8, 9, 10]
+2500/20000 train_loss: 2.5366 train_time: 4.4m tok/s: 7492273
+3000/20000 train_loss: 2.5484 train_time: 5.6m tok/s: 7003086
+3500/20000 train_loss: 2.5526 train_time: 6.8m tok/s: 6720752
+4000/20000 train_loss: 2.3957 train_time: 8.0m tok/s: 6538146
+4000/20000 val_loss: 2.4168 val_bpb: 1.1043
+4500/20000 train_loss: 2.2676 train_time: 9.2m tok/s: 6404553
+4805/20000 val_loss: 2.3590 val_bpb: 1.0779
+stopping_early: wallclock_cap train_time: 596142ms step: 4805/20000
+peak memory allocated: 41707 MiB reserved: 47048 MiB
+ema:applying EMA weights
+diagnostic pre-quantization post-ema val_loss:2.33320104 val_bpb:1.06611260 eval_time:9420ms
+Serialized model: 135417533 bytes
+Code size (uncompressed): 164676 bytes
+Code size (compressed): 33102 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 3.6s
+GPTQ adaptive clip_sigmas (Hessian-sensitivity, 66 tensors):
+    blocks.0.attn.c_q.weight: 8.77
+    blocks.0.attn.proj.weight: 11.06
+    blocks.1.attn.c_q.weight: 9.81
+    blocks.1.attn.proj.weight: 13.16
+    blocks.2.attn.c_q.weight: 10.47
+    blocks.2.attn.proj.weight: 15.40
+    blocks.3.attn.c_q.weight: 9.24
+    blocks.3.attn.proj.weight: 13.53
+    blocks.4.attn.c_q.weight: 9.57
+    blocks.4.attn.proj.weight: 14.27
+    blocks.5.attn.c_q.weight: 9.78
+    blocks.5.attn.proj.weight: 13.90
+    blocks.6.attn.c_q.weight: 11.78
+    blocks.6.attn.proj.weight: 18.36
+    blocks.7.attn.c_q.weight: 12.00
+    blocks.7.attn.proj.weight: 18.92
+    blocks.8.attn.c_q.weight: 12.30
+    blocks.8.attn.proj.weight: 21.93
+    blocks.9.attn.c_q.weight: 12.52
+    blocks.9.attn.proj.weight: 21.52
+    blocks.10.attn.c_q.weight: 12.80
+    blocks.10.attn.proj.weight: 24.00
+    blocks.0.attn.c_k.weight: 8.57
+    blocks.0.attn.c_v.weight: 8.35
+    blocks.1.attn.c_k.weight: 9.56
+    blocks.1.attn.c_v.weight: 9.32
+    blocks.2.attn.c_k.weight: 9.99
+    blocks.2.attn.c_v.weight: 9.98
+    blocks.3.attn.c_k.weight: 9.00
+    blocks.3.attn.c_v.weight: 8.77
+    blocks.4.attn.c_k.weight: 9.23
+    blocks.4.attn.c_v.weight: 9.08
+    blocks.5.attn.c_k.weight: 9.58
+    blocks.5.attn.c_v.weight: 9.39
+    blocks.6.attn.c_k.weight: 11.43
+    blocks.6.attn.c_v.weight: 11.23
+    blocks.7.attn.c_k.weight: 11.71
+    blocks.7.attn.c_v.weight: 11.43
+    blocks.8.attn.c_k.weight: 11.81
+    blocks.8.attn.c_v.weight: 11.47
+    blocks.9.attn.c_k.weight: 12.03
+    blocks.9.attn.c_v.weight: 11.53
+    blocks.10.attn.c_k.weight: 12.43
+    blocks.10.attn.c_v.weight: 11.67
+    blocks.0.mlp.fc.weight: 8.37
+    blocks.1.mlp.fc.weight: 9.23
+    blocks.2.mlp.fc.weight: 9.79
+    blocks.3.mlp.fc.weight: 8.74
+    blocks.4.mlp.fc.weight: 9.05
+    blocks.5.mlp.fc.weight: 9.25
+    blocks.6.mlp.fc.weight: 11.09
+    blocks.7.mlp.fc.weight: 11.34
+    blocks.8.mlp.fc.weight: 11.60
+    blocks.9.mlp.fc.weight: 11.80
+    blocks.10.mlp.fc.weight: 12.09
+    blocks.0.mlp.proj.weight: 9.23
+    blocks.1.mlp.proj.weight: 11.35
+    blocks.2.mlp.proj.weight: 12.23
+    blocks.3.mlp.proj.weight: 11.34
+    blocks.4.mlp.proj.weight: 11.89
+    blocks.5.mlp.proj.weight: 12.57
+    blocks.6.mlp.proj.weight: 14.67
+    blocks.7.mlp.proj.weight: 16.79
+    blocks.8.mlp.proj.weight: 17.35
+    blocks.9.mlp.proj.weight: 18.08
+    blocks.10.mlp.proj.weight: 19.10
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int6)+lqer_asym: blocks.mlp.fc.weight
+  gptq (int7)+lqer_asym: tok_emb.weight
+  passthrough (float16): blocks.attn.attn_gate_w, blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, skip_gates, skip_weights, smear_gate.weight, smear_lambda
+Serialize: per-group lrzip compression...
+Serialize: per-group compression done in 120.9s
+Serialized model quantized+pergroup: 15868050 bytes
+Total submission size quantized+pergroup: 15901152 bytes
+Deserialize: per-group lrzip decompression...
+Deserialize: decompression done in 19.9s
+diagnostic quantized val_loss:2.35418772 val_bpb:1.07570206 eval_time:13792ms
+Deserialize: per-group lrzip decompression...
+Deserialize: decompression done in 20.2s
+ttt_lora:warming up compile (random tokens, no val data)
+ttt_lora:compile warmup done (102.7s)
+
+beginning TTT eval timer
+ttt_phased: total_docs:50000 prefix_docs:2500 suffix_docs:47500 num_phases:3 boundaries:[833, 1666, 2500]
+ttp: b779/782 bl:2.2317 bb:1.0558 rl:2.2317 rb:1.0558 dl:10442-13079 gd:0
+ttp: b770/782 bl:2.2943 bb:1.0831 rl:2.2515 rb:1.0644 dl:5311-5522 gd:0
+ttp: b765/782 bl:2.3239 bb:1.0869 rl:2.2665 rb:1.0691 dl:4393-4510 gd:0
+ttpp: phase:1/3 pd:1296 gd:833 t:170.3s
+tttg: c1/131 lr:0.001000 t:0.3s
+tttg: c2/131 lr:0.001000 t:0.4s
+tttg: c3/131 lr:0.000999 t:0.5s
+tttg: c4/131 lr:0.000999 t:0.7s
+tttg: c5/131 lr:0.000998 t:0.8s
+tttg: c6/131 lr:0.000996 t:0.9s
+tttg: c7/131 lr:0.000995 t:1.0s
+tttg: c8/131 lr:0.000993 t:1.1s
+tttg: c9/131 lr:0.000991 t:1.3s
+tttg: c10/131 lr:0.000988 t:1.4s
+tttg: c11/131 lr:0.000985 t:1.5s
+tttg: c12/131 lr:0.000982 t:1.6s
+tttg: c13/131 lr:0.000979 t:1.8s
+tttg: c14/131 lr:0.000976 t:1.9s
+tttg: c15/131 lr:0.000972 t:2.0s
+tttg: c16/131 lr:0.000968 t:2.1s
+tttg: c17/131 lr:0.000963 t:2.2s
+tttg: c18/131 lr:0.000958 t:2.4s
+tttg: c19/131 lr:0.000953 t:2.5s
+tttg: c20/131 lr:0.000948 t:2.6s
+tttg: c21/131 lr:0.000943 t:2.7s
+tttg: c22/131 lr:0.000937 t:2.8s
+tttg: c23/131 lr:0.000931 t:3.0s
+tttg: c24/131 lr:0.000925 t:3.1s
+tttg: c25/131 lr:0.000918 t:3.2s
+tttg: c26/131 lr:0.000911 t:3.3s
+tttg: c27/131 lr:0.000905 t:3.5s
+tttg: c28/131 lr:0.000897 t:3.6s
+tttg: c29/131 lr:0.000890 t:3.7s
+tttg: c30/131 lr:0.000882 t:3.8s
+tttg: c31/131 lr:0.000874 t:3.9s
+tttg: c32/131 lr:0.000866 t:4.1s
+tttg: c33/131 lr:0.000858 t:4.2s
+tttg: c34/131 lr:0.000849 t:4.3s
+tttg: c35/131 lr:0.000841 t:4.4s
+tttg: c36/131 lr:0.000832 t:4.6s
+tttg: c37/131 lr:0.000822 t:4.7s
+tttg: c38/131 lr:0.000813 t:4.8s
+tttg: c39/131 lr:0.000804 t:4.9s
+tttg: c40/131 lr:0.000794 t:5.0s
+tttg: c41/131 lr:0.000784 t:5.2s
+tttg: c42/131 lr:0.000774 t:5.3s
+tttg: c43/131 lr:0.000764 t:5.4s
+tttg: c44/131 lr:0.000753 t:5.5s
+tttg: c45/131 lr:0.000743 t:5.7s
+tttg: c46/131 lr:0.000732 t:5.8s
+tttg: c47/131 lr:0.000722 t:5.9s
+tttg: c48/131 lr:0.000711 t:6.0s
+tttg: c49/131 lr:0.000700 t:6.1s
+tttg: c50/131 lr:0.000689 t:6.3s
+tttg: c51/131 lr:0.000677 t:6.4s
+tttg: c52/131 lr:0.000666 t:6.5s
+tttg: c53/131 lr:0.000655 t:6.6s
+tttg: c54/131 lr:0.000643 t:6.8s
+tttg: c55/131 lr:0.000631 t:6.9s
+tttg: c56/131 lr:0.000620 t:7.0s
+tttg: c57/131 lr:0.000608 t:7.1s
+tttg: c58/131 lr:0.000596 t:7.2s
+tttg: c59/131 lr:0.000584 t:7.4s
+tttg: c60/131 lr:0.000572 t:7.5s
+tttg: c61/131 lr:0.000560 t:7.6s
+tttg: c62/131 lr:0.000548 t:7.7s
+tttg: c63/131 lr:0.000536 t:7.9s
+tttg: c64/131 lr:0.000524 t:8.0s
+tttg: c65/131 lr:0.000512 t:8.1s
+tttg: c66/131 lr:0.000500 t:8.2s
+tttg: c67/131 lr:0.000488 t:8.3s
+tttg: c68/131 lr:0.000476 t:8.5s
+tttg: c69/131 lr:0.000464 t:8.6s
+tttg: c70/131 lr:0.000452 t:8.7s
+tttg: c71/131 lr:0.000440 t:8.8s
+tttg: c72/131 lr:0.000428 t:8.9s
+tttg: c73/131 lr:0.000416 t:9.1s
+tttg: c74/131 lr:0.000404 t:9.2s
+tttg: c75/131 lr:0.000392 t:9.3s
+tttg: c76/131 lr:0.000380 t:9.4s
+tttg: c77/131 lr:0.000369 t:9.5s
+tttg: c78/131 lr:0.000357 t:9.7s
+tttg: c79/131 lr:0.000345 t:9.8s
+tttg: c80/131 lr:0.000334 t:9.9s
+tttg: c81/131 lr:0.000323 t:10.0s
+tttg: c82/131 lr:0.000311 t:10.2s
+tttg: c83/131 lr:0.000300 t:10.3s
+tttg: c84/131 lr:0.000289 t:10.4s
+tttg: c85/131 lr:0.000278 t:10.5s
+tttg: c86/131 lr:0.000268 t:10.6s
+tttg: c87/131 lr:0.000257 t:10.8s
+tttg: c88/131 lr:0.000247 t:10.9s
+tttg: c89/131 lr:0.000236 t:11.0s
+tttg: c90/131 lr:0.000226 t:11.1s
+tttg: c91/131 lr:0.000216 t:11.2s
+tttg: c92/131 lr:0.000206 t:11.4s
+tttg: c93/131 lr:0.000196 t:11.5s
+tttg: c94/131 lr:0.000187 t:11.6s
+tttg: c95/131 lr:0.000178 t:11.7s
+tttg: c96/131 lr:0.000168 t:11.8s
+tttg: c97/131 lr:0.000159 t:12.0s
+tttg: c98/131 lr:0.000151 t:12.1s
+tttg: c99/131 lr:0.000142 t:12.2s
+tttg: c100/131 lr:0.000134 t:12.3s
+tttg: c101/131 lr:0.000126 t:12.5s
+tttg: c102/131 lr:0.000118 t:12.6s
+tttg: c103/131 lr:0.000110 t:12.7s
+tttg: c104/131 lr:0.000103 t:12.8s
+tttg: c105/131 lr:0.000095 t:12.9s
+tttg: c106/131 lr:0.000089 t:13.1s
+tttg: c107/131 lr:0.000082 t:13.2s
+tttg: c108/131 lr:0.000075 t:13.3s
+tttg: c109/131 lr:0.000069 t:13.4s
+tttg: c110/131 lr:0.000063 t:13.6s
+tttg: c111/131 lr:0.000057 t:13.7s
+tttg: c112/131 lr:0.000052 t:13.8s
+tttg: c113/131 lr:0.000047 t:13.9s
+tttg: c114/131 lr:0.000042 t:14.1s
+tttg: c115/131 lr:0.000037 t:14.2s
+tttg: c116/131 lr:0.000032 t:14.3s
+tttg: c117/131 lr:0.000028 t:14.4s
+tttg: c118/131 lr:0.000024 t:14.5s
+tttg: c119/131 lr:0.000021 t:14.7s
+tttg: c120/131 lr:0.000018 t:14.8s
+tttg: c121/131 lr:0.000015 t:14.9s
+tttg: c122/131 lr:0.000012 t:15.0s
+tttg: c123/131 lr:0.000009 t:15.1s
+tttg: c124/131 lr:0.000007 t:15.3s
+tttg: c125/131 lr:0.000005 t:15.4s
+tttg: c126/131 lr:0.000004 t:15.5s
+tttg: c127/131 lr:0.000002 t:15.6s
+tttg: c128/131 lr:0.000001 t:15.7s
+tttg: c129/131 lr:0.000001 t:15.9s
+tttg: c130/131 lr:0.000000 t:16.0s
+ttpr: phase:1/3 t:188.1s
+ttp: b754/782 bl:2.2949 bb:1.0615 rl:2.2703 rb:1.0681 dl:3345-3397 gd:0
+ttp: b750/782 bl:2.3912 bb:1.0744 rl:2.2838 rb:1.0688 dl:3090-3149 gd:0
+ttpp: phase:2/3 pd:2128 gd:1666 t:261.0s
+tttg: c1/219 lr:0.001000 t:0.1s
+tttg: c2/219 lr:0.001000 t:0.2s
+tttg: c3/219 lr:0.001000 t:0.3s
+tttg: c4/219 lr:0.001000 t:0.5s
+tttg: c5/219 lr:0.000999 t:0.6s
+tttg: c6/219 lr:0.000999 t:0.7s
+tttg: c7/219 lr:0.000998 t:0.8s
+tttg: c8/219 lr:0.000997 t:0.9s
+tttg: c9/219 lr:0.000997 t:1.0s
+tttg: c10/219 lr:0.000996 t:1.2s
+tttg: c11/219 lr:0.000995 t:1.3s
+tttg: c12/219 lr:0.000994 t:1.4s
+tttg: c13/219 lr:0.000993 t:1.5s
+tttg: c14/219 lr:0.000991 t:1.6s
+tttg: c15/219 lr:0.000990 t:1.7s
+tttg: c16/219 lr:0.000988 t:1.9s
+tttg: c17/219 lr:0.000987 t:2.0s
+tttg: c18/219 lr:0.000985 t:2.1s
+tttg: c19/219 lr:0.000983 t:2.2s
+tttg: c20/219 lr:0.000981 t:2.3s
+tttg: c21/219 lr:0.000979 t:2.4s
+tttg: c22/219 lr:0.000977 t:2.6s
+tttg: c23/219 lr:0.000975 t:2.7s
+tttg: c24/219 lr:0.000973 t:2.8s
+tttg: c25/219 lr:0.000970 t:2.9s
+tttg: c26/219 lr:0.000968 t:3.0s
+tttg: c27/219 lr:0.000965 t:3.1s
+tttg: c28/219 lr:0.000963 t:3.3s
+tttg: c29/219 lr:0.000960 t:3.4s
+tttg: c30/219 lr:0.000957 t:3.5s
+tttg: c31/219 lr:0.000954 t:3.6s
+tttg: c32/219 lr:0.000951 t:3.7s
+tttg: c33/219 lr:0.000948 t:3.8s
+tttg: c34/219 lr:0.000945 t:4.0s
+tttg: c35/219 lr:0.000941 t:4.1s
+tttg: c36/219 lr:0.000938 t:4.2s
+tttg: c37/219 lr:0.000934 t:4.3s
+tttg: c38/219 lr:0.000931 t:4.4s
+tttg: c39/219 lr:0.000927 t:4.5s
+tttg: c40/219 lr:0.000923 t:4.7s
+tttg: c41/219 lr:0.000919 t:4.8s
+tttg: c42/219 lr:0.000915 t:4.9s
+tttg: c43/219 lr:0.000911 t:5.0s
+tttg: c44/219 lr:0.000907 t:5.1s
+tttg: c45/219 lr:0.000903 t:5.3s
+tttg: c46/219 lr:0.000898 t:5.4s
+tttg: c47/219 lr:0.000894 t:5.5s
+tttg: c48/219 lr:0.000890 t:5.6s
+tttg: c49/219 lr:0.000885 t:5.7s
+tttg: c50/219 lr:0.000880 t:5.8s
+tttg: c51/219 lr:0.000876 t:6.0s
+tttg: c52/219 lr:0.000871 t:6.1s
+tttg: c53/219 lr:0.000866 t:6.2s
+tttg: c54/219 lr:0.000861 t:6.3s
+tttg: c55/219 lr:0.000856 t:6.4s
+tttg: c56/219 lr:0.000851 t:6.5s
+tttg: c57/219 lr:0.000846 t:6.7s
+tttg: c58/219 lr:0.000841 t:6.8s
+tttg: c59/219 lr:0.000835 t:6.9s
+tttg: c60/219 lr:0.000830 t:7.0s
+tttg: c61/219 lr:0.000824 t:7.1s
+tttg: c62/219 lr:0.000819 t:7.2s
+tttg: c63/219 lr:0.000813 t:7.4s
+tttg: c64/219 lr:0.000808 t:7.5s
+tttg: c65/219 lr:0.000802 t:7.6s
+tttg: c66/219 lr:0.000796 t:7.7s
+tttg: c67/219 lr:0.000790 t:7.8s
+tttg: c68/219 lr:0.000784 t:8.0s
+tttg: c69/219 lr:0.000779 t:8.1s
+tttg: c70/219 lr:0.000773 t:8.2s
+tttg: c71/219 lr:0.000766 t:8.3s
+tttg: c72/219 lr:0.000760 t:8.4s
+tttg: c73/219 lr:0.000754 t:8.5s
+tttg: c74/219 lr:0.000748 t:8.6s
+tttg: c75/219 lr:0.000742 t:8.8s
+tttg: c76/219 lr:0.000735 t:8.9s
+tttg: c77/219 lr:0.000729 t:9.0s
+tttg: c78/219 lr:0.000722 t:9.1s
+tttg: c79/219 lr:0.000716 t:9.2s
+tttg: c80/219 lr:0.000709 t:9.4s
+tttg: c81/219 lr:0.000703 t:9.5s
+tttg: c82/219 lr:0.000696 t:9.6s
+tttg: c83/219 lr:0.000690 t:9.7s
+tttg: c84/219 lr:0.000683 t:9.8s
+tttg: c85/219 lr:0.000676 t:9.9s
+tttg: c86/219 lr:0.000670 t:10.1s
+tttg: c87/219 lr:0.000663 t:10.2s
+tttg: c88/219 lr:0.000656 t:10.3s
+tttg: c89/219 lr:0.000649 t:10.4s
+tttg: c90/219 lr:0.000642 t:10.5s
+tttg: c91/219 lr:0.000635 t:10.6s
+tttg: c92/219 lr:0.000628 t:10.8s
+tttg: c93/219 lr:0.000621 t:10.9s
+tttg: c94/219 lr:0.000614 t:11.0s
+tttg: c95/219 lr:0.000607 t:11.1s
+tttg: c96/219 lr:0.000600 t:11.2s
+tttg: c97/219 lr:0.000593 t:11.3s
+tttg: c98/219 lr:0.000586 t:11.5s
+tttg: c99/219 lr:0.000579 t:11.6s
+tttg: c100/219 lr:0.000572 t:11.7s
+tttg: c101/219 lr:0.000565 t:11.8s
+tttg: c102/219 lr:0.000558 t:11.9s
+tttg: c103/219 lr:0.000550 t:12.0s
+tttg: c104/219 lr:0.000543 t:12.2s
+tttg: c105/219 lr:0.000536 t:12.3s
+tttg: c106/219 lr:0.000529 t:12.4s
+tttg: c107/219 lr:0.000522 t:12.5s
+tttg: c108/219 lr:0.000514 t:12.6s
+tttg: c109/219 lr:0.000507 t:12.8s
+tttg: c110/219 lr:0.000500 t:12.9s
+tttg: c111/219 lr:0.000493 t:13.0s
+tttg: c112/219 lr:0.000486 t:13.1s
+tttg: c113/219 lr:0.000478 t:13.2s
+tttg: c114/219 lr:0.000471 t:13.3s
+tttg: c115/219 lr:0.000464 t:13.5s
+tttg: c116/219 lr:0.000457 t:13.6s
+tttg: c117/219 lr:0.000450 t:13.7s
+tttg: c118/219 lr:0.000442 t:13.8s
+tttg: c119/219 lr:0.000435 t:13.9s
+tttg: c120/219 lr:0.000428 t:14.0s
+tttg: c121/219 lr:0.000421 t:14.2s
+tttg: c122/219 lr:0.000414 t:14.3s
+tttg: c123/219 lr:0.000407 t:14.4s
+tttg: c124/219 lr:0.000400 t:14.5s
+tttg: c125/219 lr:0.000393 t:14.6s
+tttg: c126/219 lr:0.000386 t:14.7s
+tttg: c127/219 lr:0.000379 t:14.9s
+tttg: c128/219 lr:0.000372 t:15.0s
+tttg: c129/219 lr:0.000365 t:15.1s
+tttg: c130/219 lr:0.000358 t:15.2s
+tttg: c131/219 lr:0.000351 t:15.3s
+tttg: c132/219 lr:0.000344 t:15.4s
+tttg: c133/219 lr:0.000337 t:15.6s
+tttg: c134/219 lr:0.000330 t:15.7s
+tttg: c135/219 lr:0.000324 t:15.8s
+tttg: c136/219 lr:0.000317 t:15.9s
+tttg: c137/219 lr:0.000310 t:16.0s
+tttg: c138/219 lr:0.000304 t:16.2s
+tttg: c139/219 lr:0.000297 t:16.3s
+tttg: c140/219 lr:0.000291 t:16.4s
+tttg: c141/219 lr:0.000284 t:16.5s
+tttg: c142/219 lr:0.000278 t:16.6s
+tttg: c143/219 lr:0.000271 t:16.7s
+tttg: c144/219 lr:0.000265 t:16.9s
+tttg: c145/219 lr:0.000258 t:17.0s
+tttg: c146/219 lr:0.000252 t:17.1s
+tttg: c147/219 lr:0.000246 t:17.2s
+tttg: c148/219 lr:0.000240 t:17.3s
+tttg: c149/219 lr:0.000234 t:17.4s
+tttg: c150/219 lr:0.000227 t:17.6s
+tttg: c151/219 lr:0.000221 t:17.7s
+tttg: c152/219 lr:0.000216 t:17.8s
+tttg: c153/219 lr:0.000210 t:17.9s
+tttg: c154/219 lr:0.000204 t:18.0s
+tttg: c155/219 lr:0.000198 t:18.1s
+tttg: c156/219 lr:0.000192 t:18.3s
+tttg: c157/219 lr:0.000187 t:18.4s
+tttg: c158/219 lr:0.000181 t:18.5s
+tttg: c159/219 lr:0.000176 t:18.6s
+tttg: c160/219 lr:0.000170 t:18.7s
+tttg: c161/219 lr:0.000165 t:18.9s
+tttg: c162/219 lr:0.000159 t:19.0s
+tttg: c163/219 lr:0.000154 t:19.1s
+tttg: c164/219 lr:0.000149 t:19.2s
+tttg: c165/219 lr:0.000144 t:19.3s
+tttg: c166/219 lr:0.000139 t:19.5s
+tttg: c167/219 lr:0.000134 t:19.6s
+tttg: c168/219 lr:0.000129 t:19.7s
+tttg: c169/219 lr:0.000124 t:19.8s
+tttg: c170/219 lr:0.000120 t:19.9s
+tttg: c171/219 lr:0.000115 t:20.1s
+tttg: c172/219 lr:0.000110 t:20.2s
+tttg: c173/219 lr:0.000106 t:20.3s
+tttg: c174/219 lr:0.000102 t:20.4s
+tttg: c175/219 lr:0.000097 t:20.6s
+tttg: c176/219 lr:0.000093 t:20.7s
+tttg: c177/219 lr:0.000089 t:20.8s
+tttg: c178/219 lr:0.000085 t:20.9s
+tttg: c179/219 lr:0.000081 t:21.1s
+tttg: c180/219 lr:0.000077 t:21.2s
+tttg: c181/219 lr:0.000073 t:21.3s
+tttg: c182/219 lr:0.000069 t:21.4s
+tttg: c183/219 lr:0.000066 t:21.6s
+tttg: c184/219 lr:0.000062 t:21.7s
+tttg: c185/219 lr:0.000059 t:21.8s
+tttg: c186/219 lr:0.000055 t:21.9s
+tttg: c187/219 lr:0.000052 t:22.1s
+tttg: c188/219 lr:0.000049 t:22.2s
+tttg: c189/219 lr:0.000046 t:22.3s
+tttg: c190/219 lr:0.000043 t:22.5s
+tttg: c191/219 lr:0.000040 t:22.6s
+tttg: c192/219 lr:0.000037 t:22.7s
+tttg: c193/219 lr:0.000035 t:22.8s
+tttg: c194/219 lr:0.000032 t:23.0s
+tttg: c195/219 lr:0.000030 t:23.1s
+tttg: c196/219 lr:0.000027 t:23.2s
+tttg: c197/219 lr:0.000025 t:23.3s
+tttg: c198/219 lr:0.000023 t:23.5s
+tttg: c199/219 lr:0.000021 t:23.6s
+tttg: c200/219 lr:0.000019 t:23.7s
+tttg: c201/219 lr:0.000017 t:23.9s
+tttg: c202/219 lr:0.000015 t:24.0s
+tttg: c203/219 lr:0.000013 t:24.1s
+tttg: c204/219 lr:0.000012 t:24.2s
+tttg: c205/219 lr:0.000010 t:24.3s
+tttg: c206/219 lr:0.000009 t:24.5s
+tttg: c207/219 lr:0.000007 t:24.6s
+tttg: c208/219 lr:0.000006 t:24.7s
+tttg: c209/219 lr:0.000005 t:24.9s
+tttg: c210/219 lr:0.000004 t:25.0s
+tttg: c211/219 lr:0.000003 t:25.1s
+tttg: c212/219 lr:0.000003 t:25.2s
+tttg: c213/219 lr:0.000002 t:25.4s
+tttg: c214/219 lr:0.000001 t:25.5s
+tttg: c215/219 lr:0.000001 t:25.6s
+tttg: c216/219 lr:0.000000 t:25.7s
+tttg: c217/219 lr:0.000000 t:25.9s
+tttg: c218/219 lr:0.000000 t:26.0s
+ttpr: phase:2/3 t:288.7s
+ttp: b741/782 bl:2.3254 bb:1.0429 rl:2.2874 rb:1.0664 dl:2686-2730 gd:0
+ttp: b740/782 bl:2.2685 bb:1.0414 rl:2.2859 rb:1.0644 dl:2653-2686 gd:0
+ttpp: phase:3/3 pd:2960 gd:2500 t:303.8s
+tttg: c1/289 lr:0.001000 t:0.1s
+tttg: c2/289 lr:0.001000 t:0.3s
+tttg: c3/289 lr:0.001000 t:0.4s
+tttg: c4/289 lr:0.001000 t:0.5s
+tttg: c5/289 lr:0.001000 t:0.7s
+tttg: c6/289 lr:0.000999 t:0.8s
+tttg: c7/289 lr:0.000999 t:0.9s
+tttg: c8/289 lr:0.000999 t:1.1s
+tttg: c9/289 lr:0.000998 t:1.2s
+tttg: c10/289 lr:0.000998 t:1.3s
+tttg: c11/289 lr:0.000997 t:1.5s
+tttg: c12/289 lr:0.000996 t:1.6s
+tttg: c13/289 lr:0.000996 t:1.8s
+tttg: c14/289 lr:0.000995 t:1.9s
+tttg: c15/289 lr:0.000994 t:2.0s
+tttg: c16/289 lr:0.000993 t:2.2s
+tttg: c17/289 lr:0.000992 t:2.3s
+tttg: c18/289 lr:0.000991 t:2.4s
+tttg: c19/289 lr:0.000990 t:2.6s
+tttg: c20/289 lr:0.000989 t:2.7s
+tttg: c21/289 lr:0.000988 t:2.8s
+tttg: c22/289 lr:0.000987 t:3.0s
+tttg: c23/289 lr:0.000986 t:3.1s
+tttg: c24/289 lr:0.000984 t:3.2s
+tttg: c25/289 lr:0.000983 t:3.4s
+tttg: c26/289 lr:0.000982 t:3.5s
+tttg: c27/289 lr:0.000980 t:3.7s
+tttg: c28/289 lr:0.000978 t:3.8s
+tttg: c29/289 lr:0.000977 t:3.9s
+tttg: c30/289 lr:0.000975 t:4.1s
+tttg: c31/289 lr:0.000973 t:4.2s
+tttg: c32/289 lr:0.000972 t:4.3s
+tttg: c33/289 lr:0.000970 t:4.5s
+tttg: c34/289 lr:0.000968 t:4.6s
+tttg: c35/289 lr:0.000966 t:4.7s
+tttg: c36/289 lr:0.000964 t:4.9s
+tttg: c37/289 lr:0.000962 t:5.0s
+tttg: c38/289 lr:0.000960 t:5.2s
+tttg: c39/289 lr:0.000958 t:5.3s
+tttg: c40/289 lr:0.000955 t:5.4s
+tttg: c41/289 lr:0.000953 t:5.6s
+tttg: c42/289 lr:0.000951 t:5.7s
+tttg: c43/289 lr:0.000948 t:5.8s
+tttg: c44/289 lr:0.000946 t:6.0s
+tttg: c45/289 lr:0.000944 t:6.1s
+tttg: c46/289 lr:0.000941 t:6.2s
+tttg: c47/289 lr:0.000938 t:6.4s
+tttg: c48/289 lr:0.000936 t:6.5s
+tttg: c49/289 lr:0.000933 t:6.7s
+tttg: c50/289 lr:0.000930 t:6.8s
+tttg: c51/289 lr:0.000927 t:6.9s
+tttg: c52/289 lr:0.000925 t:7.1s
+tttg: c53/289 lr:0.000922 t:7.2s
+tttg: c54/289 lr:0.000919 t:7.3s
+tttg: c55/289 lr:0.000916 t:7.5s
+tttg: c56/289 lr:0.000913 t:7.6s
+tttg: c57/289 lr:0.000910 t:7.7s
+tttg: c58/289 lr:0.000906 t:7.9s
+tttg: c59/289 lr:0.000903 t:8.0s
+tttg: c60/289 lr:0.000900 t:8.1s
+tttg: c61/289 lr:0.000897 t:8.3s
+tttg: c62/289 lr:0.000893 t:8.4s
+tttg: c63/289 lr:0.000890 t:8.6s
+tttg: c64/289 lr:0.000887 t:8.7s
+tttg: c65/289 lr:0.000883 t:8.8s
+tttg: c66/289 lr:0.000879 t:9.0s
+tttg: c67/289 lr:0.000876 t:9.1s
+tttg: c68/289 lr:0.000872 t:9.2s
+tttg: c69/289 lr:0.000869 t:9.4s
+tttg: c70/289 lr:0.000865 t:9.5s
+tttg: c71/289 lr:0.000861 t:9.6s
+tttg: c72/289 lr:0.000857 t:9.8s
+tttg: c73/289 lr:0.000854 t:9.9s
+tttg: c74/289 lr:0.000850 t:10.0s
+tttg: c75/289 lr:0.000846 t:10.2s
+tttg: c76/289 lr:0.000842 t:10.3s
+tttg: c77/289 lr:0.000838 t:10.4s
+tttg: c78/289 lr:0.000834 t:10.6s
+tttg: c79/289 lr:0.000830 t:10.7s
+tttg: c80/289 lr:0.000826 t:10.8s
+tttg: c81/289 lr:0.000821 t:11.0s
+tttg: c82/289 lr:0.000817 t:11.1s
+tttg: c83/289 lr:0.000813 t:11.3s
+tttg: c84/289 lr:0.000809 t:11.4s
+tttg: c85/289 lr:0.000804 t:11.5s
+tttg: c86/289 lr:0.000800 t:11.7s
+tttg: c87/289 lr:0.000796 t:11.8s
+tttg: c88/289 lr:0.000791 t:11.9s
+tttg: c89/289 lr:0.000787 t:12.1s
+tttg: c90/289 lr:0.000782 t:12.2s
+tttg: c91/289 lr:0.000778 t:12.4s
+tttg: c92/289 lr:0.000773 t:12.5s
+tttg: c93/289 lr:0.000769 t:12.6s
+tttg: c94/289 lr:0.000764 t:12.8s
+tttg: c95/289 lr:0.000759 t:12.9s
+tttg: c96/289 lr:0.000755 t:13.0s
+tttg: c97/289 lr:0.000750 t:13.2s
+tttg: c98/289 lr:0.000745 t:13.3s
+tttg: c99/289 lr:0.000740 t:13.4s
+tttg: c100/289 lr:0.000736 t:13.6s
+tttg: c101/289 lr:0.000731 t:13.7s
+tttg: c102/289 lr:0.000726 t:13.8s
+tttg: c103/289 lr:0.000721 t:14.0s
+tttg: c104/289 lr:0.000716 t:14.1s
+tttg: c105/289 lr:0.000711 t:14.3s
+tttg: c106/289 lr:0.000706 t:14.4s
+tttg: c107/289 lr:0.000701 t:14.5s
+tttg: c108/289 lr:0.000696 t:14.7s
+tttg: c109/289 lr:0.000691 t:14.8s
+tttg: c110/289 lr:0.000686 t:14.9s
+tttg: c111/289 lr:0.000681 t:15.1s
+tttg: c112/289 lr:0.000676 t:15.2s
+tttg: c113/289 lr:0.000671 t:15.3s
+tttg: c114/289 lr:0.000666 t:15.5s
+tttg: c115/289 lr:0.000661 t:15.6s
+tttg: c116/289 lr:0.000656 t:15.8s
+tttg: c117/289 lr:0.000650 t:15.9s
+tttg: c118/289 lr:0.000645 t:16.0s
+tttg: c119/289 lr:0.000640 t:16.2s
+tttg: c120/289 lr:0.000635 t:16.3s
+tttg: c121/289 lr:0.000629 t:16.4s
+tttg: c122/289 lr:0.000624 t:16.6s
+tttg: c123/289 lr:0.000619 t:16.7s
+tttg: c124/289 lr:0.000614 t:16.9s
+tttg: c125/289 lr:0.000608 t:17.0s
+tttg: c126/289 lr:0.000603 t:17.1s
+tttg: c127/289 lr:0.000598 t:17.3s
+tttg: c128/289 lr:0.000592 t:17.4s
+tttg: c129/289 lr:0.000587 t:17.5s
+tttg: c130/289 lr:0.000581 t:17.7s
+tttg: c131/289 lr:0.000576 t:17.8s
+tttg: c132/289 lr:0.000571 t:18.0s
+tttg: c133/289 lr:0.000565 t:18.1s
+tttg: c134/289 lr:0.000560 t:18.2s
+tttg: c135/289 lr:0.000554 t:18.4s
+tttg: c136/289 lr:0.000549 t:18.5s
+tttg: c137/289 lr:0.000544 t:18.6s
+tttg: c138/289 lr:0.000538 t:18.8s
+tttg: c139/289 lr:0.000533 t:18.9s
+tttg: c140/289 lr:0.000527 t:19.0s
+tttg: c141/289 lr:0.000522 t:19.2s
+tttg: c142/289 lr:0.000516 t:19.3s
+tttg: c143/289 lr:0.000511 t:19.5s
+tttg: c144/289 lr:0.000505 t:19.6s
+tttg: c145/289 lr:0.000500 t:19.7s
+tttg: c146/289 lr:0.000495 t:19.9s
+tttg: c147/289 lr:0.000489 t:20.0s
+tttg: c148/289 lr:0.000484 t:20.1s
+tttg: c149/289 lr:0.000478 t:20.3s
+tttg: c150/289 lr:0.000473 t:20.4s
+tttg: c151/289 lr:0.000467 t:20.6s
+tttg: c152/289 lr:0.000462 t:20.7s
+tttg: c153/289 lr:0.000456 t:20.8s
+tttg: c154/289 lr:0.000451 t:21.0s
+tttg: c155/289 lr:0.000446 t:21.1s
+tttg: c156/289 lr:0.000440 t:21.2s
+tttg: c157/289 lr:0.000435 t:21.4s
+tttg: c158/289 lr:0.000429 t:21.5s
+tttg: c159/289 lr:0.000424 t:21.7s
+tttg: c160/289 lr:0.000419 t:21.8s
+tttg: c161/289 lr:0.000413 t:21.9s
+tttg: c162/289 lr:0.000408 t:22.1s
+tttg: c163/289 lr:0.000402 t:22.2s
+tttg: c164/289 lr:0.000397 t:22.3s
+tttg: c165/289 lr:0.000392 t:22.5s
+tttg: c166/289 lr:0.000386 t:22.6s
+tttg: c167/289 lr:0.000381 t:22.8s
+tttg: c168/289 lr:0.000376 t:22.9s
+tttg: c169/289 lr:0.000371 t:23.0s
+tttg: c170/289 lr:0.000365 t:23.2s
+tttg: c171/289 lr:0.000360 t:23.3s
+tttg: c172/289 lr:0.000355 t:23.4s
+tttg: c173/289 lr:0.000350 t:23.6s
+tttg: c174/289 lr:0.000344 t:23.7s
+tttg: c175/289 lr:0.000339 t:23.8s
+tttg: c176/289 lr:0.000334 t:24.0s
+tttg: c177/289 lr:0.000329 t:24.1s
+tttg: c178/289 lr:0.000324 t:24.3s
+tttg: c179/289 lr:0.000319 t:24.4s
+tttg: c180/289 lr:0.000314 t:24.5s
+tttg: c181/289 lr:0.000309 t:24.7s
+tttg: c182/289 lr:0.000304 t:24.8s
+tttg: c183/289 lr:0.000299 t:24.9s
+tttg: c184/289 lr:0.000294 t:25.1s
+tttg: c185/289 lr:0.000289 t:25.2s
+tttg: c186/289 lr:0.000284 t:25.4s
+tttg: c187/289 lr:0.000279 t:25.5s
+tttg: c188/289 lr:0.000274 t:25.6s
+tttg: c189/289 lr:0.000269 t:25.8s
+tttg: c190/289 lr:0.000264 t:25.9s
+tttg: c191/289 lr:0.000260 t:26.0s
+tttg: c192/289 lr:0.000255 t:26.2s
+tttg: c193/289 lr:0.000250 t:26.3s
+tttg: c194/289 lr:0.000245 t:26.5s
+tttg: c195/289 lr:0.000241 t:26.6s
+tttg: c196/289 lr:0.000236 t:26.7s
+tttg: c197/289 lr:0.000231 t:26.9s
+tttg: c198/289 lr:0.000227 t:27.0s
+tttg: c199/289 lr:0.000222 t:27.2s
+tttg: c200/289 lr:0.000218 t:27.3s
+tttg: c201/289 lr:0.000213 t:27.4s
+tttg: c202/289 lr:0.000209 t:27.6s
+tttg: c203/289 lr:0.000204 t:27.7s
+tttg: c204/289 lr:0.000200 t:27.8s
+tttg: c205/289 lr:0.000196 t:28.0s
+tttg: c206/289 lr:0.000191 t:28.1s
+tttg: c207/289 lr:0.000187 t:28.3s
+tttg: c208/289 lr:0.000183 t:28.4s
+tttg: c209/289 lr:0.000179 t:28.5s
+tttg: c210/289 lr:0.000174 t:28.7s
+tttg: c211/289 lr:0.000170 t:28.8s
+tttg: c212/289 lr:0.000166 t:29.0s
+tttg: c213/289 lr:0.000162 t:29.1s
+tttg: c214/289 lr:0.000158 t:29.2s
+tttg: c215/289 lr:0.000154 t:29.4s
+tttg: c216/289 lr:0.000150 t:29.5s
+tttg: c217/289 lr:0.000146 t:29.6s
+tttg: c218/289 lr:0.000143 t:29.8s
+tttg: c219/289 lr:0.000139 t:29.9s
+tttg: c220/289 lr:0.000135 t:30.1s
+tttg: c221/289 lr:0.000131 t:30.2s
+tttg: c222/289 lr:0.000128 t:30.3s
+tttg: c223/289 lr:0.000124 t:30.5s
+tttg: c224/289 lr:0.000121 t:30.6s
+tttg: c225/289 lr:0.000117 t:30.8s
+tttg: c226/289 lr:0.000113 t:30.9s
+tttg: c227/289 lr:0.000110 t:31.0s
+tttg: c228/289 lr:0.000107 t:31.2s
+tttg: c229/289 lr:0.000103 t:31.3s
+tttg: c230/289 lr:0.000100 t:31.4s
+tttg: c231/289 lr:0.000097 t:31.6s
+tttg: c232/289 lr:0.000094 t:31.7s
+tttg: c233/289 lr:0.000090 t:31.9s
+tttg: c234/289 lr:0.000087 t:32.0s
+tttg: c235/289 lr:0.000084 t:32.1s
+tttg: c236/289 lr:0.000081 t:32.3s
+tttg: c237/289 lr:0.000078 t:32.4s
+tttg: c238/289 lr:0.000075 t:32.5s
+tttg: c239/289 lr:0.000073 t:32.7s
+tttg: c240/289 lr:0.000070 t:32.8s
+tttg: c241/289 lr:0.000067 t:33.0s
+tttg: c242/289 lr:0.000064 t:33.1s
+tttg: c243/289 lr:0.000062 t:33.2s
+tttg: c244/289 lr:0.000059 t:33.4s
+tttg: c245/289 lr:0.000056 t:33.5s
+tttg: c246/289 lr:0.000054 t:33.6s
+tttg: c247/289 lr:0.000052 t:33.8s
+tttg: c248/289 lr:0.000049 t:33.9s
+tttg: c249/289 lr:0.000047 t:34.1s
+tttg: c250/289 lr:0.000045 t:34.2s
+tttg: c251/289 lr:0.000042 t:34.3s
+tttg: c252/289 lr:0.000040 t:34.5s
+tttg: c253/289 lr:0.000038 t:34.6s
+tttg: c254/289 lr:0.000036 t:34.8s
+tttg: c255/289 lr:0.000034 t:34.9s
+tttg: c256/289 lr:0.000032 t:35.0s
+tttg: c257/289 lr:0.000030 t:35.2s
+tttg: c258/289 lr:0.000028 t:35.3s
+tttg: c259/289 lr:0.000027 t:35.4s
+tttg: c260/289 lr:0.000025 t:35.6s
+tttg: c261/289 lr:0.000023 t:35.7s
+tttg: c262/289 lr:0.000022 t:35.9s
+tttg: c263/289 lr:0.000020 t:36.0s
+tttg: c264/289 lr:0.000018 t:36.1s
+tttg: c265/289 lr:0.000017 t:36.3s
+tttg: c266/289 lr:0.000016 t:36.4s
+tttg: c267/289 lr:0.000014 t:36.5s
+tttg: c268/289 lr:0.000013 t:36.7s
+tttg: c269/289 lr:0.000012 t:36.8s
+tttg: c270/289 lr:0.000011 t:37.0s
+tttg: c271/289 lr:0.000010 t:37.1s
+tttg: c272/289 lr:0.000009 t:37.2s
+tttg: c273/289 lr:0.000008 t:37.4s
+tttg: c274/289 lr:0.000007 t:37.5s
+tttg: c275/289 lr:0.000006 t:37.6s
+tttg: c276/289 lr:0.000005 t:37.8s
+tttg: c277/289 lr:0.000004 t:37.9s
+tttg: c278/289 lr:0.000004 t:38.1s
+tttg: c279/289 lr:0.000003 t:38.2s
+tttg: c280/289 lr:0.000002 t:38.3s
+tttg: c281/289 lr:0.000002 t:38.5s
+tttg: c282/289 lr:0.000001 t:38.6s
+tttg: c283/289 lr:0.000001 t:38.8s
+tttg: c284/289 lr:0.000001 t:38.9s
+tttg: c285/289 lr:0.000000 t:39.0s
+tttg: c286/289 lr:0.000000 t:39.2s
+tttg: c287/289 lr:0.000000 t:39.3s
+tttg: c288/289 lr:0.000000 t:39.4s
+ttpr: phase:3/3 t:345.0s
+ttp: b728/782 bl:2.3647 bb:1.0826 rl:2.2910 rb:1.0656 dl:2306-2324 gd:1
+ttp: b726/782 bl:2.3356 bb:1.0389 rl:2.2937 rb:1.0639 dl:2254-2276 gd:1
+ttp: b712/782 bl:2.3407 bb:1.0616 rl:2.2960 rb:1.0638 dl:1984-2002 gd:1
+ttp: b708/782 bl:2.3117 bb:1.0340 rl:2.2967 rb:1.0624 dl:1924-1937 gd:1
+ttp: b697/782 bl:2.3287 bb:1.0332 rl:2.2981 rb:1.0611 dl:1790-1803 gd:1
+ttp: b688/782 bl:2.4054 bb:1.0769 rl:2.3021 rb:1.0617 dl:1696-1706 gd:1
+ttp: b680/782 bl:2.2850 bb:1.0290 rl:2.3015 rb:1.0606 dl:1618-1628 gd:1
+ttp: b672/782 bl:2.3347 bb:1.0506 rl:2.3026 rb:1.0603 dl:1553-1562 gd:1
+ttp: b664/782 bl:2.3418 bb:1.0277 rl:2.3037 rb:1.0592 dl:1493-1499 gd:1
+ttp: b656/782 bl:2.3347 bb:1.1138 rl:2.3046 rb:1.0607 dl:1439-1445 gd:1
+ttp: b648/782 bl:2.2850 bb:1.0083 rl:2.3041 rb:1.0593 dl:1387-1392 gd:1
+ttp: b640/782 bl:2.3136 bb:1.0539 rl:2.3043 rb:1.0592 dl:1337-1343 gd:1
+ttp: b633/782 bl:2.2799 bb:1.0244 rl:2.3037 rb:1.0583 dl:1297-1302 gd:1
+ttp: b624/782 bl:2.3572 bb:1.0670 rl:2.3049 rb:1.0585 dl:1249-1255 gd:1
+ttp: b616/782 bl:2.4083 bb:1.0447 rl:2.3071 rb:1.0582 dl:1205-1211 gd:1
+ttp: b608/782 bl:2.3545 bb:1.0818 rl:2.3080 rb:1.0587 dl:1168-1172 gd:1
+ttp: b600/782 bl:2.2679 bb:1.0162 rl:2.3073 rb:1.0579 dl:1133-1137 gd:1
+ttp: b592/782 bl:2.2246 bb:0.9932 rl:2.3058 rb:1.0567 dl:1098-1103 gd:1
+ttp: b584/782 bl:2.3031 bb:1.0413 rl:2.3057 rb:1.0564 dl:1064-1069 gd:1
+ttp: b576/782 bl:2.3850 bb:1.0970 rl:2.3070 rb:1.0571 dl:1033-1037 gd:1
+ttp: b568/782 bl:2.3650 bb:1.0857 rl:2.3079 rb:1.0575 dl:1004-1007 gd:1
+ttp: b561/782 bl:2.2510 bb:1.0154 rl:2.3071 rb:1.0569 dl:979-983 gd:1
+ttp: b552/782 bl:2.2839 bb:1.0232 rl:2.3067 rb:1.0564 dl:949-952 gd:1
+ttp: b544/782 bl:2.3536 bb:1.0725 rl:2.3074 rb:1.0566 dl:924-927 gd:1
+ttp: b535/782 bl:2.3800 bb:1.0322 rl:2.3083 rb:1.0563 dl:896-899 gd:1
+ttp: b528/782 bl:2.3399 bb:1.0459 rl:2.3087 rb:1.0561 dl:875-878 gd:1
+ttp: b520/782 bl:2.3326 bb:1.0058 rl:2.3090 rb:1.0555 dl:852-854 gd:1
+ttp: b512/782 bl:2.3114 bb:1.0674 rl:2.3091 rb:1.0556 dl:829-832 gd:1
+ttp: b504/782 bl:2.3258 bb:1.0376 rl:2.3092 rb:1.0554 dl:807-809 gd:1
+ttp: b496/782 bl:2.4259 bb:1.0502 rl:2.3105 rb:1.0553 dl:785-788 gd:1
+ttp: b485/782 bl:2.2924 bb:1.0326 rl:2.3103 rb:1.0551 dl:759-761 gd:1
+ttp: b477/782 bl:2.4084 bb:1.0372 rl:2.3113 rb:1.0549 dl:740-742 gd:1
+ttp: b468/782 bl:2.3659 bb:1.0649 rl:2.3118 rb:1.0550 dl:719-721 gd:1
+ttp: b460/782 bl:2.2550 bb:1.0549 rl:2.3113 rb:1.0550 dl:701-703 gd:1
+ttp: b451/782 bl:2.4109 bb:1.0909 rl:2.3122 rb:1.0553 dl:682-685 gd:1
+ttp: b443/782 bl:2.2403 bb:1.0541 rl:2.3116 rb:1.0553 dl:666-668 gd:1
+ttp: b434/782 bl:2.3747 bb:1.0542 rl:2.3121 rb:1.0553 dl:647-648 gd:1
+ttp: b425/782 bl:2.3726 bb:1.0612 rl:2.3126 rb:1.0554 dl:630-632 gd:1
+ttp: b404/782 bl:2.3740 bb:1.0631 rl:2.3130 rb:1.0554 dl:590-592 gd:1
+ttp: b398/782 bl:2.2551 bb:1.0070 rl:2.3126 rb:1.0551 dl:579-581 gd:1
+ttp: b391/782 bl:2.3121 bb:1.0650 rl:2.3126 rb:1.0551 dl:566-568 gd:1
+ttp: b383/782 bl:2.2793 bb:1.0450 rl:2.3124 rb:1.0551 dl:552-554 gd:1
+ttp: b376/782 bl:2.3315 bb:1.0457 rl:2.3125 rb:1.0550 dl:540-542 gd:1
+ttp: b368/782 bl:2.3758 bb:1.1065 rl:2.3129 rb:1.0553 dl:527-528 gd:1
+ttp: b358/782 bl:2.4041 bb:1.0789 rl:2.3135 rb:1.0555 dl:510-512 gd:1
+ttp: b349/782 bl:2.3595 bb:1.0290 rl:2.3138 rb:1.0553 dl:495-496 gd:1
+ttp: b341/782 bl:2.3042 bb:1.0793 rl:2.3137 rb:1.0555 dl:483-485 gd:1
+ttp: b330/782 bl:2.2433 bb:1.0689 rl:2.3133 rb:1.0555 dl:466-468 gd:1
+ttp: b322/782 bl:2.3733 bb:1.0593 rl:2.3136 rb:1.0555 dl:455-457 gd:1
+ttp: b314/782 bl:2.2517 bb:1.0620 rl:2.3133 rb:1.0556 dl:442-444 gd:1
+ttp: b305/782 bl:2.3418 bb:1.0885 rl:2.3135 rb:1.0557 dl:429-430 gd:1
+ttp: b296/782 bl:2.3848 bb:1.0980 rl:2.3138 rb:1.0559 dl:415-417 gd:1
+ttp: b287/782 bl:2.4138 bb:1.0997 rl:2.3143 rb:1.0562 dl:402-403 gd:1
+ttp: b278/782 bl:2.2694 bb:1.0630 rl:2.3141 rb:1.0562 dl:389-391 gd:1
+ttp: b270/782 bl:2.3128 bb:1.0582 rl:2.3141 rb:1.0562 dl:379-380 gd:1
+ttp: b261/782 bl:2.4279 bb:1.1176 rl:2.3146 rb:1.0564 dl:367-369 gd:1
+ttp: b252/782 bl:2.3916 bb:1.0719 rl:2.3149 rb:1.0565 dl:356-357 gd:1
+ttp: b244/782 bl:2.3431 bb:1.1150 rl:2.3150 rb:1.0567 dl:346-347 gd:1
+ttp: b236/782 bl:2.3350 bb:1.0746 rl:2.3151 rb:1.0568 dl:336-337 gd:1
+ttp: b227/782 bl:2.4928 bb:1.1573 rl:2.3157 rb:1.0572 dl:325-327 gd:1
+ttp: b218/782 bl:2.4623 bb:1.1106 rl:2.3162 rb:1.0574 dl:315-316 gd:1
+ttp: b208/782 bl:2.3957 bb:1.1340 rl:2.3165 rb:1.0576 dl:304-305 gd:1
+ttp: b200/782 bl:2.3687 bb:1.0952 rl:2.3167 rb:1.0577 dl:296-297 gd:1
+ttp: b189/782 bl:2.4298 bb:1.1463 rl:2.3171 rb:1.0580 dl:283-284 gd:1
+ttp: b181/782 bl:2.3428 bb:1.1313 rl:2.3171 rb:1.0582 dl:275-276 gd:1
+ttp: b173/782 bl:2.4726 bb:1.1321 rl:2.3176 rb:1.0584 dl:267-268 gd:1
+ttp: b162/782 bl:2.4046 bb:1.1195 rl:2.3178 rb:1.0586 dl:256-257 gd:1
+ttp: b154/782 bl:2.4730 bb:1.2061 rl:2.3183 rb:1.0590 dl:249-250 gd:1
+ttp: b146/782 bl:2.4579 bb:1.1744 rl:2.3186 rb:1.0593 dl:241-242 gd:1
+ttp: b137/782 bl:2.4125 bb:1.1526 rl:2.3189 rb:1.0595 dl:233-233 gd:1
+ttp: b127/782 bl:2.4791 bb:1.1891 rl:2.3193 rb:1.0598 dl:223-224 gd:1
+ttp: b119/782 bl:2.3758 bb:1.1567 rl:2.3194 rb:1.0600 dl:216-217 gd:1
+ttp: b110/782 bl:2.3649 bb:1.1224 rl:2.3195 rb:1.0602 dl:208-208 gd:1
+ttp: b98/782 bl:2.5849 bb:1.2129 rl:2.3201 rb:1.0605 dl:197-198 gd:1
+ttp: b89/782 bl:2.4906 bb:1.1509 rl:2.3204 rb:1.0607 dl:189-190 gd:1
+ttp: b81/782 bl:2.4858 bb:1.1281 rl:2.3208 rb:1.0608 dl:182-183 gd:1
+ttp: b73/782 bl:2.5457 bb:1.2495 rl:2.3212 rb:1.0611 dl:174-175 gd:1
+ttp: b64/782 bl:2.5348 bb:1.1561 rl:2.3216 rb:1.0613 dl:166-167 gd:1
+ttp: b54/782 bl:2.4846 bb:1.2188 rl:2.3218 rb:1.0616 dl:157-158 gd:1
+ttp: b45/782 bl:2.4636 bb:1.1789 rl:2.3221 rb:1.0617 dl:148-149 gd:1
+ttp: b36/782 bl:2.5417 bb:1.2264 rl:2.3224 rb:1.0620 dl:139-140 gd:1
+ttp: b26/782 bl:2.5993 bb:1.2939 rl:2.3228 rb:1.0623 dl:129-130 gd:1
+ttp: b18/782 bl:2.6319 bb:1.2001 rl:2.3232 rb:1.0624 dl:119-121 gd:1
+ttp: b9/782 bl:2.7678 bb:1.2629 rl:2.3237 rb:1.0627 dl:105-107 gd:1
+quantized_ttt_phased val_loss:2.32624735 val_bpb:1.06300426 eval_time:456534ms
+total_eval_time:456.5s


### PR DESCRIPTION
## Summary

Follow-up to PR #1689 by the same author. Ports adaptive Hessian-sensitivity GPTQ clipping (introduced in #1689 at 1.0822 BPB on the PR #1394 base) onto PR #1855's stack to test composability with LQER asymmetric quantization, the 9-hparam greedy stack, CaseOps, and the rest of the modern pipeline.

**val_bpb: 1.06310** (3-seed mean, std 0.00102) | ~15.9 MB | 8×H100 SXM, 600 s wallclock | seeds 42, 1337, 999.

vs current SOTA (PR #1855, 1.06108): **+0.00203 BPB / +0.00444 nats**.

## What's new

The technique replaces three hand-tuned per-group GPTQ clip sigmas (`MLP_CLIP_SIGMAS=11.5`, `ATTN_CLIP_SIGMAS=13.0`, `MATRIX_CLIP_SIGMAS=12.85`) with one automated **per-tensor** selection:

```
σ(name) = clamp( exp( -0.15·log(H_diag(name).mean()·row_var(W(name))) + offset ),  6.0,  24.0 )
```

`offset` is determined by binary search such that the numel-weighted log-average of σ across all matrix tensors equals PR #1855's hand-tuned log-average — i.e. the **overall compression budget is preserved exactly**, only the per-tensor distribution shifts according to Hessian sensitivity. See README §"Adaptive Hessian-Sensitivity GPTQ Clipping" for the derivation, intuition, and the full per-tensor σ allocation table from seed 42.

Reproduces hand-tuned within ~2σ at +0.00203 BPB. **Eliminates 3 hyperparameters from the search space.** TTT recovery dynamics match PR #1855's exactly (-0.01272 mean across 3 seeds in both submissions, four decimals identical) — adaptive clip composes cleanly with phased TTT.

## Mixed-precision ablation (gated, negative result)

A second technique — Hessian-sensitivity-driven mixed-precision GPTQ (bottom 25 % of tensors → int5, middle 50 % → int6, top 25 % → int7, 6.0 avg bits preserved) — was implemented in the same codebase under `MIXED_PRECISION_HESSIAN=1`. Single-seed test on PR #1855's stack: post-quant penalty +0.01310 vs PR #1855's +0.00858 (i.e. **+0.0045 worse**). The 16 int5 tensors lose more precision than the 16 int7 tensors gain on this heavily-tuned base. **Disabled in this submission**; included in the codebase as a reproducible negative result.

## Per-seed results

| Seed | Steps | Pre-quant | Post-quant | **Post-TTT** | Artifact bytes | Eval time |
|------|-------|-----------|------------|--------------|----------------|-----------|
| 42   | 4 835 | 1.06498   | 1.07480    | **1.06214**  | 15 905 000     | 592.9 s   |
| 1337 | 4 807 | 1.06711   | 1.07696    | **1.06417**  | 15 918 827     | 521.1 s   |
| 999  | 4 805 | 1.06611   | 1.07570    | **1.06300**  | 15 901 152     | 456.5 s   |

3-seed std: 0.00102 BPB / 0.00224 nats. All artifacts under 16 MB; all runs hit the 600 s wallclock cap.

## Compliance (track_10min_16mb)

- ✅ Training under 600 s (596 s mean, hit wallclock cap)
- ✅ Artifact under 16 000 000 bytes (15.90–15.92 MB)
- ✅ Eval under 600 s (456–593 s)
- ✅ Score-first phased TTT (no pre-quant TTT)
- ✅ No SLOT / no ETLB / no n-gram cache
- ✅ 3 seeds (42, 1337, 999)

## Reproduction

See `records/track_10min_16mb/2026-04-30_AdaptiveHessianClip_PR1855_1.0631/README.md` §"Reproduction". Same RunPod container as PR #1855 (`runpod/parameter-golf:latest`), CaseOps dataset from `romeerp/parameter-golf-caseops-v1` on HF Hub, FA3 wheel from `windreamer.github.io/flash-attention3-wheels/cu128_torch291/`, lrzip via apt. Two new env vars on top of PR #1855's recipe: `ADAPTIVE_HESSIAN_CLIP=1` and `TTT_LORA_RANK=56`.

## Test plan

- [x] 3-seed run completed on 8×H100 SXM (logs in `train_seed{42,1337,999}.log`)
- [x] All artifacts under 16 000 000 bytes
- [x] Local smoke test of adaptive clip math on synthetic tensors (math verified independent of CUDA stack)
- [x] Mixed-precision ablation single-seed test (negative result documented)
- [x] CaseOps dataset confirmed available on HF Hub
- [ ] Reviewer 3-seed reproduction (pending)

## Credits

Direct ancestor stack: PR #1855 → #1851 → #1797 → #1787 → #1736 → #1729 → #1626 → #1530 → #1493 → #1394. Adaptive Hessian-sensitivity GPTQ clipping is from PR #1689 by this author; `TTT_LORA_RANK=56` tweak from open PR #1935 by @vimeto. Full lineage with descriptions in README "Credits" section.
